### PR TITLE
Add MangaDex integration and enhanced library management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ python3 Mylar.py maintenance --carepackage  # Generate debug package
 - `search.py` - Comic search orchestration across multiple providers (~4,300 lines)
 - `PostProcessor.py` - Download post-processing, file validation, renaming (~3,600 lines)
 - `cv.py` - Comic Vine API integration for metadata
+- `mangadex.py` - MangaDex API integration for metadata
 - `importer.py` - Library scanning and import functionality
 - `rsscheck.py` - RSS feed monitoring for new releases
 - `weeklypull.py` - Weekly pull list management

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -15,6 +15,8 @@ import {
   Check,
   Loader2,
   ImageOff,
+  Book,
+  BookOpen,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -22,8 +24,13 @@ import { useAddComic, useAddManga } from "@/hooks/useSearch";
 import { useToast } from "@/components/ui/toast";
 import type { SearchResult, ContentType } from "@/types";
 
+// Extended search result with content_type for unified search
+interface ExtendedSearchResult extends SearchResult {
+  content_type?: ContentType;
+}
+
 // Lazy-loaded cover thumbnail component
-function CoverThumbnail({ comic }: { comic: SearchResult }) {
+function CoverThumbnail({ comic }: { comic: ExtendedSearchResult }) {
   const [imageError, setImageError] = useState(false);
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -55,10 +62,11 @@ function CoverThumbnail({ comic }: { comic: SearchResult }) {
 }
 
 interface SearchResultsTableProps {
-  results: SearchResult[];
+  results: ExtendedSearchResult[];
   currentSort: string;
   onSortChange: (sort: string) => void;
   contentType?: ContentType;
+  showTypeColumn?: boolean;
 }
 
 interface AddByIdEventDetail {
@@ -86,8 +94,26 @@ function getColumnSort(
   return false;
 }
 
+// Type badge component
+function TypeBadge({ contentType }: { contentType: ContentType }) {
+  if (contentType === "manga") {
+    return (
+      <Badge variant="secondary" className="text-xs px-1.5 py-0">
+        <BookOpen className="w-3 h-3 mr-1" />
+        Manga
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="text-xs px-1.5 py-0">
+      <Book className="w-3 h-3 mr-1" />
+      Comic
+    </Badge>
+  );
+}
+
 // Action cell component to handle add-to-library logic
-function ActionCell({ comic, contentType = "comic" }: { comic: SearchResult; contentType?: ContentType }) {
+function ActionCell({ comic, contentType = "comic" }: { comic: ExtendedSearchResult; contentType?: ContentType }) {
   const [isAdded, setIsAdded] = useState(comic.in_library ?? false);
   const [isProcessing, setIsProcessing] = useState(false);
   const addComicMutation = useAddComic();
@@ -96,7 +122,9 @@ function ActionCell({ comic, contentType = "comic" }: { comic: SearchResult; con
   const navigate = useNavigate();
   const comicIdRef = useRef<string | null>(null);
 
-  const isManga = contentType === "manga";
+  // Use content_type from result if available (for unified search), otherwise use prop
+  const effectiveContentType = comic.content_type || contentType;
+  const isManga = effectiveContentType === "manga";
   const itemLabel = isManga ? "Manga" : "Comic";
 
   // Listen for SSE events when a comic is being added
@@ -211,9 +239,11 @@ export default function SearchResultsTable({
   currentSort,
   onSortChange,
   contentType = "comic",
+  showTypeColumn = false,
 }: SearchResultsTableProps) {
   const isManga = contentType === "manga";
-  const issuesLabel = isManga ? "Chapters" : "Issues";
+  const issuesLabel = showTypeColumn ? "Issues/Ch." : isManga ? "Chapters" : "Issues";
+
   // Handle column header click for sorting
   const handleSortClick = (columnId: string) => {
     const mapping = SORT_COLUMN_MAP[columnId];
@@ -230,14 +260,14 @@ export default function SearchResultsTable({
     }
   };
 
-  const columns = useMemo<ColumnDef<SearchResult>[]>(
-    () => [
+  const columns = useMemo<ColumnDef<ExtendedSearchResult>[]>(() => {
+    const cols: ColumnDef<ExtendedSearchResult>[] = [
       {
         id: "cover",
         header: "",
         enableSorting: false,
         size: 50,
-        cell: ({ row }: CellContext<SearchResult, unknown>) => (
+        cell: ({ row }: CellContext<ExtendedSearchResult, unknown>) => (
           <CoverThumbnail comic={row.original} />
         ),
       },
@@ -245,7 +275,7 @@ export default function SearchResultsTable({
         id: "series",
         accessorKey: "name",
         header: "Series",
-        cell: ({ row }: CellContext<SearchResult, unknown>) => (
+        cell: ({ row }: CellContext<ExtendedSearchResult, unknown>) => (
           <div>
             <div className="font-medium">{row.original.name}</div>
             {row.original.comicyear && (
@@ -256,11 +286,26 @@ export default function SearchResultsTable({
           </div>
         ),
       },
+    ];
+
+    // Add type column when showing unified results
+    if (showTypeColumn) {
+      cols.push({
+        id: "type",
+        header: "Type",
+        enableSorting: false,
+        cell: ({ row }: CellContext<ExtendedSearchResult, unknown>) => (
+          <TypeBadge contentType={row.original.content_type || "comic"} />
+        ),
+      });
+    }
+
+    cols.push(
       {
         id: "year",
         accessorKey: "comicyear",
         header: "Year",
-        cell: ({ getValue }: CellContext<SearchResult, unknown>) => (
+        cell: ({ getValue }: CellContext<ExtendedSearchResult, unknown>) => (
           <span>{(getValue() as string) || "—"}</span>
         ),
       },
@@ -268,7 +313,7 @@ export default function SearchResultsTable({
         id: "issues",
         accessorKey: "issues",
         header: issuesLabel,
-        cell: ({ row }: CellContext<SearchResult, unknown>) => {
+        cell: ({ row }: CellContext<ExtendedSearchResult, unknown>) => {
           const issues = row.original.issues ?? row.original.count_of_issues;
           return <span>{issues !== undefined ? issues : "—"}</span>;
         },
@@ -277,7 +322,7 @@ export default function SearchResultsTable({
         id: "status",
         header: "Status",
         enableSorting: false,
-        cell: ({ row }: CellContext<SearchResult, unknown>) =>
+        cell: ({ row }: CellContext<ExtendedSearchResult, unknown>) =>
           row.original.in_library ? (
             <Badge variant="default">In Library</Badge>
           ) : null,
@@ -286,15 +331,19 @@ export default function SearchResultsTable({
         id: "actions",
         header: "",
         enableSorting: false,
-        cell: ({ row }: CellContext<SearchResult, unknown>) => (
+        cell: ({ row }: CellContext<ExtendedSearchResult, unknown>) => (
           <div className="text-right">
-            <ActionCell comic={row.original} contentType={contentType} />
+            <ActionCell
+              comic={row.original}
+              contentType={row.original.content_type || contentType}
+            />
           </div>
         ),
       },
-    ],
-    [contentType, issuesLabel],
-  );
+    );
+
+    return cols;
+  }, [contentType, issuesLabel, showTypeColumn]);
 
   const table = useReactTable({
     data: results,

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -113,7 +113,13 @@ function TypeBadge({ contentType }: { contentType: ContentType }) {
 }
 
 // Action cell component to handle add-to-library logic
-function ActionCell({ comic, contentType = "comic" }: { comic: ExtendedSearchResult; contentType?: ContentType }) {
+function ActionCell({
+  comic,
+  contentType = "comic",
+}: {
+  comic: ExtendedSearchResult;
+  contentType?: ContentType;
+}) {
   const [isAdded, setIsAdded] = useState(comic.in_library ?? false);
   const [isProcessing, setIsProcessing] = useState(false);
   const addComicMutation = useAddComic();
@@ -219,7 +225,9 @@ function ActionCell({ comic, contentType = "comic" }: { comic: ExtendedSearchRes
   }
 
   // Default - Add button with primary outline style
-  const isPending = isManga ? addMangaMutation.isPending : addComicMutation.isPending;
+  const isPending = isManga
+    ? addMangaMutation.isPending
+    : addComicMutation.isPending;
   return (
     <Button
       onClick={handleAddComic}
@@ -242,7 +250,11 @@ export default function SearchResultsTable({
   showTypeColumn = false,
 }: SearchResultsTableProps) {
   const isManga = contentType === "manga";
-  const issuesLabel = showTypeColumn ? "Issues/Ch." : isManga ? "Chapters" : "Issues";
+  const issuesLabel = showTypeColumn
+    ? "Issues/Ch."
+    : isManga
+      ? "Chapters"
+      : "Issues";
 
   // Handle column header click for sorting
   const handleSortClick = (columnId: string) => {

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -18,9 +18,9 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { useAddComic } from "@/hooks/useSearch";
+import { useAddComic, useAddManga } from "@/hooks/useSearch";
 import { useToast } from "@/components/ui/toast";
-import type { SearchResult } from "@/types";
+import type { SearchResult, ContentType } from "@/types";
 
 // Lazy-loaded cover thumbnail component
 function CoverThumbnail({ comic }: { comic: SearchResult }) {
@@ -58,6 +58,7 @@ interface SearchResultsTableProps {
   results: SearchResult[];
   currentSort: string;
   onSortChange: (sort: string) => void;
+  contentType?: ContentType;
 }
 
 interface AddByIdEventDetail {
@@ -86,13 +87,17 @@ function getColumnSort(
 }
 
 // Action cell component to handle add-to-library logic
-function ActionCell({ comic }: { comic: SearchResult }) {
+function ActionCell({ comic, contentType = "comic" }: { comic: SearchResult; contentType?: ContentType }) {
   const [isAdded, setIsAdded] = useState(comic.in_library ?? false);
   const [isProcessing, setIsProcessing] = useState(false);
   const addComicMutation = useAddComic();
+  const addMangaMutation = useAddManga();
   const { addToast } = useToast();
   const navigate = useNavigate();
   const comicIdRef = useRef<string | null>(null);
+
+  const isManga = contentType === "manga";
+  const itemLabel = isManga ? "Manga" : "Comic";
 
   // Listen for SSE events when a comic is being added
   useEffect(() => {
@@ -138,14 +143,18 @@ function ActionCell({ comic }: { comic: SearchResult }) {
     e.stopPropagation();
 
     try {
-      comicIdRef.current = comic.comicid ?? null;
+      comicIdRef.current = comic.comicid ?? comic.id ?? null;
       setIsProcessing(true);
 
-      await addComicMutation.mutateAsync(comic.comicid ?? comic.id);
+      if (isManga) {
+        await addMangaMutation.mutateAsync(comic.comicid ?? comic.id);
+      } else {
+        await addComicMutation.mutateAsync(comic.comicid ?? comic.id);
+      }
       setIsAdded(true);
       addToast({
         type: "success",
-        title: "Adding Comic...",
+        title: `Adding ${itemLabel}...`,
         description: `${comic.name} is being added to your library. Please wait...`,
         duration: 5000,
       });
@@ -155,7 +164,7 @@ function ActionCell({ comic }: { comic: SearchResult }) {
       comicIdRef.current = null;
       addToast({
         type: "error",
-        title: "Failed to Add Comic",
+        title: `Failed to Add ${itemLabel}`,
         description: err instanceof Error ? err.message : "Unknown error",
       });
     }
@@ -182,16 +191,17 @@ function ActionCell({ comic }: { comic: SearchResult }) {
   }
 
   // Default - Add button with primary outline style
+  const isPending = isManga ? addMangaMutation.isPending : addComicMutation.isPending;
   return (
     <Button
       onClick={handleAddComic}
-      disabled={addComicMutation.isPending}
+      disabled={isPending}
       variant="outline"
       size="sm"
       className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
     >
       <Plus className="w-3 h-3 mr-1" />
-      {addComicMutation.isPending ? "Adding..." : "Add"}
+      {isPending ? "Adding..." : "Add"}
     </Button>
   );
 }
@@ -200,7 +210,10 @@ export default function SearchResultsTable({
   results,
   currentSort,
   onSortChange,
+  contentType = "comic",
 }: SearchResultsTableProps) {
+  const isManga = contentType === "manga";
+  const issuesLabel = isManga ? "Chapters" : "Issues";
   // Handle column header click for sorting
   const handleSortClick = (columnId: string) => {
     const mapping = SORT_COLUMN_MAP[columnId];
@@ -254,7 +267,7 @@ export default function SearchResultsTable({
       {
         id: "issues",
         accessorKey: "issues",
-        header: "Issues",
+        header: issuesLabel,
         cell: ({ row }: CellContext<SearchResult, unknown>) => {
           const issues = row.original.issues ?? row.original.count_of_issues;
           return <span>{issues !== undefined ? issues : "—"}</span>;
@@ -275,12 +288,12 @@ export default function SearchResultsTable({
         enableSorting: false,
         cell: ({ row }: CellContext<SearchResult, unknown>) => (
           <div className="text-right">
-            <ActionCell comic={row.original} />
+            <ActionCell comic={row.original} contentType={contentType} />
           </div>
         ),
       },
     ],
-    [],
+    [contentType, issuesLabel],
   );
 
   const table = useReactTable({

--- a/frontend/src/components/series/IssuesTable.tsx
+++ b/frontend/src/components/series/IssuesTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import React, { useState, useMemo } from "react";
 import {
   useReactTable,
   getCoreRowModel,

--- a/frontend/src/components/series/IssuesTable.tsx
+++ b/frontend/src/components/series/IssuesTable.tsx
@@ -73,7 +73,7 @@ function groupByVolume(issues: Issue[]): VolumeGroup[] {
 
   sortedVolumes.forEach(([volumeNum, chapters]) => {
     const downloadedCount = chapters.filter(
-      (ch) => (ch.status ?? ch.Status)?.toLowerCase() === "downloaded"
+      (ch) => (ch.status ?? ch.Status)?.toLowerCase() === "downloaded",
     ).length;
     const totalCount = chapters.length;
 
@@ -100,7 +100,7 @@ function groupByVolume(issues: Issue[]): VolumeGroup[] {
   // Add issues without volume at the end
   if (noVolumeIssues.length > 0) {
     const downloadedCount = noVolumeIssues.filter(
-      (ch) => (ch.status ?? ch.Status)?.toLowerCase() === "downloaded"
+      (ch) => (ch.status ?? ch.Status)?.toLowerCase() === "downloaded",
     ).length;
 
     volumes.push({
@@ -110,7 +110,12 @@ function groupByVolume(issues: Issue[]): VolumeGroup[] {
         const numB = parseFloat(b.chapterNumber || b.number || "0") || 0;
         return numA - numB;
       }),
-      status: downloadedCount === noVolumeIssues.length ? "Complete" : downloadedCount > 0 ? "Partial" : "Missing",
+      status:
+        downloadedCount === noVolumeIssues.length
+          ? "Complete"
+          : downloadedCount > 0
+            ? "Partial"
+            : "Missing",
       downloadedCount,
       totalCount: noVolumeIssues.length,
     });
@@ -138,7 +143,10 @@ function getChapterRange(chapters: Issue[]): string {
   return `Ch. ${first}–${last}`;
 }
 
-export default function IssuesTable({ issues = [], isManga = false }: IssuesTableProps) {
+export default function IssuesTable({
+  issues = [],
+  isManga = false,
+}: IssuesTableProps) {
   // Dynamic labels based on content type
   const itemLabel = isManga ? "chapter" : "issue";
   const itemLabelPlural = isManga ? "chapters" : "issues";
@@ -273,240 +281,262 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
   };
 
   // Chapters view columns
-  const chapterColumns: ColumnDef<Issue>[] = useMemo(() => [
-    {
-      id: "select",
-      header: ({ table }: HeaderContext<Issue, unknown>) => (
-        <Checkbox
-          checked={table.getIsAllPageRowsSelected()}
-          indeterminate={
-            table.getIsSomePageRowsSelected() &&
-            !table.getIsAllPageRowsSelected()
-          }
-          onChange={table.getToggleAllPageRowsSelectedHandler()}
-        />
-      ),
-      cell: ({ row }: CellContext<Issue, unknown>) => (
-        <Checkbox
-          checked={row.getIsSelected()}
-          onChange={row.getToggleSelectedHandler()}
-        />
-      ),
-      size: 40,
-      enableSorting: false,
-    },
-    {
-      accessorKey: "number",
-      header: "#",
-      cell: ({ getValue }: CellContext<Issue, unknown>) => (
-        <span className="font-mono text-sm">
-          {(getValue() as string) || "N/A"}
-        </span>
-      ),
-    },
-    // Show volume column if manga has volume data
-    ...(isManga && hasVolumeData ? [{
-      id: "volume",
-      accessorKey: "volumeNumber",
-      header: "Vol",
-      cell: ({ row }: CellContext<Issue, unknown>) => (
-        <span className="font-mono text-sm text-muted-foreground">
-          {row.original.volumeNumber || "—"}
-        </span>
-      ),
-    }] : []),
-    {
-      accessorKey: "name",
-      header: `${itemLabelCapitalized} Name`,
-      cell: ({ row }: CellContext<Issue, unknown>) => (
-        <div>
-          <div className="font-medium">{row.original.number}</div>
-          {row.original.name && (
-            <div className="text-sm text-muted-foreground">
-              {row.original.name}
-            </div>
-          )}
-        </div>
-      ),
-    },
-    {
-      accessorKey: "releaseDate",
-      header: "Release Date",
-      cell: ({ getValue }: CellContext<Issue, unknown>) => {
-        const date = getValue() as string | undefined;
-        if (!date) return <span className="text-muted-foreground/70">N/A</span>;
-        return <span className="text-sm">{date}</span>;
+  const chapterColumns: ColumnDef<Issue>[] = useMemo(
+    () => [
+      {
+        id: "select",
+        header: ({ table }: HeaderContext<Issue, unknown>) => (
+          <Checkbox
+            checked={table.getIsAllPageRowsSelected()}
+            indeterminate={
+              table.getIsSomePageRowsSelected() &&
+              !table.getIsAllPageRowsSelected()
+            }
+            onChange={table.getToggleAllPageRowsSelectedHandler()}
+          />
+        ),
+        cell: ({ row }: CellContext<Issue, unknown>) => (
+          <Checkbox
+            checked={row.getIsSelected()}
+            onChange={row.getToggleSelectedHandler()}
+          />
+        ),
+        size: 40,
+        enableSorting: false,
       },
-    },
-    {
-      accessorKey: "status",
-      header: "Status",
-      cell: ({ row }: CellContext<Issue, unknown>) => (
-        <StatusBadge status={row.original.status ?? row.original.Status} />
-      ),
-    },
-    {
-      id: "actions",
-      header: "Actions",
-      cell: ({ row }: CellContext<Issue, unknown>) => {
-        const status = (
-          row.original.status ?? row.original.Status
-        )?.toLowerCase();
-        const issueId = row.original.id ?? row.original.IssueID;
-
-        return (
-          <div className="flex items-center space-x-2">
-            {status === "wanted" || status === "skipped" ? (
-              <>
-                {status === "wanted" && issueId && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={(e) => handleUnqueueIssue(e, issueId)}
-                    disabled={unqueueIssueMutation.isPending}
-                    className="text-xs"
-                  >
-                    <X className="w-3 h-3 mr-1" />
-                    Skip
-                  </Button>
-                )}
-                {status === "skipped" && issueId && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={(e) => handleQueueIssue(e, issueId)}
-                    disabled={queueIssueMutation.isPending}
-                    className="text-xs"
-                  >
-                    <Download className="w-3 h-3 mr-1" />
-                    Want
-                  </Button>
-                )}
-              </>
-            ) : status !== "downloaded" && status !== "snatched" && issueId ? (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={(e) => handleQueueIssue(e, issueId)}
-                disabled={queueIssueMutation.isPending}
-                className="text-xs"
-              >
-                <Download className="w-3 h-3 mr-1" />
-                Want
-              </Button>
-            ) : null}
+      {
+        accessorKey: "number",
+        header: "#",
+        cell: ({ getValue }: CellContext<Issue, unknown>) => (
+          <span className="font-mono text-sm">
+            {(getValue() as string) || "N/A"}
+          </span>
+        ),
+      },
+      // Show volume column if manga has volume data
+      ...(isManga && hasVolumeData
+        ? [
+            {
+              id: "volume",
+              accessorKey: "volumeNumber",
+              header: "Vol",
+              cell: ({ row }: CellContext<Issue, unknown>) => (
+                <span className="font-mono text-sm text-muted-foreground">
+                  {row.original.volumeNumber || "—"}
+                </span>
+              ),
+            },
+          ]
+        : []),
+      {
+        accessorKey: "name",
+        header: `${itemLabelCapitalized} Name`,
+        cell: ({ row }: CellContext<Issue, unknown>) => (
+          <div>
+            <div className="font-medium">{row.original.number}</div>
+            {row.original.name && (
+              <div className="text-sm text-muted-foreground">
+                {row.original.name}
+              </div>
+            )}
           </div>
-        );
+        ),
       },
-    },
-  ], [isManga, hasVolumeData, itemLabelCapitalized, queueIssueMutation.isPending, unqueueIssueMutation.isPending]);
+      {
+        accessorKey: "releaseDate",
+        header: "Release Date",
+        cell: ({ getValue }: CellContext<Issue, unknown>) => {
+          const date = getValue() as string | undefined;
+          if (!date)
+            return <span className="text-muted-foreground/70">N/A</span>;
+          return <span className="text-sm">{date}</span>;
+        },
+      },
+      {
+        accessorKey: "status",
+        header: "Status",
+        cell: ({ row }: CellContext<Issue, unknown>) => (
+          <StatusBadge status={row.original.status ?? row.original.Status} />
+        ),
+      },
+      {
+        id: "actions",
+        header: "Actions",
+        cell: ({ row }: CellContext<Issue, unknown>) => {
+          const status = (
+            row.original.status ?? row.original.Status
+          )?.toLowerCase();
+          const issueId = row.original.id ?? row.original.IssueID;
+
+          return (
+            <div className="flex items-center space-x-2">
+              {status === "wanted" || status === "skipped" ? (
+                <>
+                  {status === "wanted" && issueId && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={(e) => handleUnqueueIssue(e, issueId)}
+                      disabled={unqueueIssueMutation.isPending}
+                      className="text-xs"
+                    >
+                      <X className="w-3 h-3 mr-1" />
+                      Skip
+                    </Button>
+                  )}
+                  {status === "skipped" && issueId && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={(e) => handleQueueIssue(e, issueId)}
+                      disabled={queueIssueMutation.isPending}
+                      className="text-xs"
+                    >
+                      <Download className="w-3 h-3 mr-1" />
+                      Want
+                    </Button>
+                  )}
+                </>
+              ) : status !== "downloaded" &&
+                status !== "snatched" &&
+                issueId ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={(e) => handleQueueIssue(e, issueId)}
+                  disabled={queueIssueMutation.isPending}
+                  className="text-xs"
+                >
+                  <Download className="w-3 h-3 mr-1" />
+                  Want
+                </Button>
+              ) : null}
+            </div>
+          );
+        },
+      },
+    ],
+    [
+      isManga,
+      hasVolumeData,
+      itemLabelCapitalized,
+      queueIssueMutation.isPending,
+      unqueueIssueMutation.isPending,
+    ],
+  );
 
   // Volume view columns
-  const volumeColumns: ColumnDef<VolumeGroup>[] = useMemo(() => [
-    {
-      id: "expander",
-      header: "",
-      cell: ({ row }: CellContext<VolumeGroup, unknown>) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => row.toggleExpanded()}
-          className="p-1 h-6 w-6"
-        >
-          <ChevronRight
-            className={`w-4 h-4 transition-transform ${row.getIsExpanded() ? "rotate-90" : ""}`}
-          />
-        </Button>
-      ),
-      size: 40,
-    },
-    {
-      accessorKey: "volume",
-      header: "Volume",
-      cell: ({ getValue }: CellContext<VolumeGroup, unknown>) => (
-        <span className="font-medium">Vol. {getValue() as string}</span>
-      ),
-    },
-    {
-      id: "chapters",
-      header: "Chapters",
-      cell: ({ row }: CellContext<VolumeGroup, unknown>) => (
-        <span className="text-sm text-muted-foreground">
-          {getChapterRange(row.original.chapters)}
-        </span>
-      ),
-    },
-    {
-      accessorKey: "status",
-      header: "Status",
-      cell: ({ row }: CellContext<VolumeGroup, unknown>) => {
-        const { status } = row.original;
-        return (
-          <Badge
-            variant={
-              status === "Complete"
-                ? "default"
-                : status === "Partial"
-                  ? "secondary"
-                  : "outline"
-            }
-          >
-            {status}
-          </Badge>
-        );
-      },
-    },
-    {
-      id: "progress",
-      header: "Progress",
-      cell: ({ row }: CellContext<VolumeGroup, unknown>) => {
-        const { downloadedCount, totalCount } = row.original;
-        const percentage = totalCount > 0 ? Math.round((downloadedCount / totalCount) * 100) : 0;
-
-        return (
-          <div className="flex items-center space-x-2">
-            <div className="flex-1 bg-muted rounded-full h-2 overflow-hidden min-w-[60px]">
-              <div
-                className="h-full rounded-full transition-all"
-                style={{
-                  width: `${percentage}%`,
-                  background: "var(--gradient-brand)",
-                }}
-              />
-            </div>
-            <span className="text-xs text-muted-foreground min-w-[4rem]">
-              {downloadedCount}/{totalCount}
-            </span>
-          </div>
-        );
-      },
-    },
-    {
-      id: "actions",
-      header: "",
-      cell: ({ row }: CellContext<VolumeGroup, unknown>) => {
-        const hasWantable = row.original.chapters.some((ch) => {
-          const status = (ch.status ?? ch.Status)?.toLowerCase();
-          return status !== "downloaded" && status !== "snatched";
-        });
-
-        if (!hasWantable) return null;
-
-        return (
+  const volumeColumns: ColumnDef<VolumeGroup>[] = useMemo(
+    () => [
+      {
+        id: "expander",
+        header: "",
+        cell: ({ row }: CellContext<VolumeGroup, unknown>) => (
           <Button
+            variant="ghost"
             size="sm"
-            variant="outline"
-            onClick={() => handleWantVolume(row.original)}
-            disabled={bulkQueueMutation.isPending}
-            className="text-xs"
+            onClick={() => row.toggleExpanded()}
+            className="p-1 h-6 w-6"
           >
-            <Download className="w-3 h-3 mr-1" />
-            Want All
+            <ChevronRight
+              className={`w-4 h-4 transition-transform ${row.getIsExpanded() ? "rotate-90" : ""}`}
+            />
           </Button>
-        );
+        ),
+        size: 40,
       },
-    },
-  ], [bulkQueueMutation.isPending]);
+      {
+        accessorKey: "volume",
+        header: "Volume",
+        cell: ({ getValue }: CellContext<VolumeGroup, unknown>) => (
+          <span className="font-medium">Vol. {getValue() as string}</span>
+        ),
+      },
+      {
+        id: "chapters",
+        header: "Chapters",
+        cell: ({ row }: CellContext<VolumeGroup, unknown>) => (
+          <span className="text-sm text-muted-foreground">
+            {getChapterRange(row.original.chapters)}
+          </span>
+        ),
+      },
+      {
+        accessorKey: "status",
+        header: "Status",
+        cell: ({ row }: CellContext<VolumeGroup, unknown>) => {
+          const { status } = row.original;
+          return (
+            <Badge
+              variant={
+                status === "Complete"
+                  ? "default"
+                  : status === "Partial"
+                    ? "secondary"
+                    : "outline"
+              }
+            >
+              {status}
+            </Badge>
+          );
+        },
+      },
+      {
+        id: "progress",
+        header: "Progress",
+        cell: ({ row }: CellContext<VolumeGroup, unknown>) => {
+          const { downloadedCount, totalCount } = row.original;
+          const percentage =
+            totalCount > 0
+              ? Math.round((downloadedCount / totalCount) * 100)
+              : 0;
+
+          return (
+            <div className="flex items-center space-x-2">
+              <div className="flex-1 bg-muted rounded-full h-2 overflow-hidden min-w-[60px]">
+                <div
+                  className="h-full rounded-full transition-all"
+                  style={{
+                    width: `${percentage}%`,
+                    background: "var(--gradient-brand)",
+                  }}
+                />
+              </div>
+              <span className="text-xs text-muted-foreground min-w-[4rem]">
+                {downloadedCount}/{totalCount}
+              </span>
+            </div>
+          );
+        },
+      },
+      {
+        id: "actions",
+        header: "",
+        cell: ({ row }: CellContext<VolumeGroup, unknown>) => {
+          const hasWantable = row.original.chapters.some((ch) => {
+            const status = (ch.status ?? ch.Status)?.toLowerCase();
+            return status !== "downloaded" && status !== "snatched";
+          });
+
+          if (!hasWantable) return null;
+
+          return (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => handleWantVolume(row.original)}
+              disabled={bulkQueueMutation.isPending}
+              className="text-xs"
+            >
+              <Download className="w-3 h-3 mr-1" />
+              Want All
+            </Button>
+          );
+        },
+      },
+    ],
+    [bulkQueueMutation.isPending],
+  );
 
   // Status counts for filter badges
   const statusCounts = useMemo(() => {
@@ -567,7 +597,9 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
           <table className="w-full">
             <tbody>
               {volume.chapters.map((chapter) => {
-                const status = (chapter.status ?? chapter.Status)?.toLowerCase();
+                const status = (
+                  chapter.status ?? chapter.Status
+                )?.toLowerCase();
                 const issueId = chapter.id ?? chapter.IssueID;
 
                 return (
@@ -588,18 +620,20 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
                     </td>
                     <td className="px-6 py-2"></td>
                     <td className="px-6 py-2">
-                      {status !== "downloaded" && status !== "snatched" && issueId && (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={(e) => handleQueueIssue(e, issueId)}
-                          disabled={queueIssueMutation.isPending}
-                          className="text-xs h-6"
-                        >
-                          <Download className="w-3 h-3 mr-1" />
-                          Want
-                        </Button>
-                      )}
+                      {status !== "downloaded" &&
+                        status !== "snatched" &&
+                        issueId && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={(e) => handleQueueIssue(e, issueId)}
+                            disabled={queueIssueMutation.isPending}
+                            className="text-xs h-6"
+                          >
+                            <Download className="w-3 h-3 mr-1" />
+                            Want
+                          </Button>
+                        )}
                     </td>
                   </tr>
                 );
@@ -701,7 +735,9 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
       {viewMode === "chapters" && selectedIssueIds.length > 0 && (
         <div className="flex items-center gap-4 px-4 py-3 bg-primary/10 border border-primary/20 rounded-lg">
           <span className="text-sm font-medium">
-            {selectedIssueIds.length} {selectedIssueIds.length !== 1 ? itemLabelPlural : itemLabel} selected
+            {selectedIssueIds.length}{" "}
+            {selectedIssueIds.length !== 1 ? itemLabelPlural : itemLabel}{" "}
+            selected
           </span>
           <div className="flex items-center gap-2">
             <Button
@@ -830,7 +866,10 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
                       onClick={() => row.toggleExpanded()}
                     >
                       {row.getVisibleCells().map((cell) => (
-                        <td key={cell.id} className="px-6 py-4 whitespace-nowrap">
+                        <td
+                          key={cell.id}
+                          className="px-6 py-4 whitespace-nowrap"
+                        >
                           {flexRender(
                             cell.column.columnDef.cell,
                             cell.getContext(),
@@ -838,7 +877,8 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
                         </td>
                       ))}
                     </tr>
-                    {row.getIsExpanded() && renderExpandedChapters(row.original)}
+                    {row.getIsExpanded() &&
+                      renderExpandedChapters(row.original)}
                   </>
                 ))}
               </tbody>
@@ -860,7 +900,8 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
                   chaptersTable.getState().pagination.pageSize,
                 chaptersTable.getFilteredRowModel().rows.length,
               )}{" "}
-              of {chaptersTable.getFilteredRowModel().rows.length} {itemLabelPlural}
+              of {chaptersTable.getFilteredRowModel().rows.length}{" "}
+              {itemLabelPlural}
               {globalFilter && ` (filtered from ${filteredByStatus.length})`}
             </div>
             <div className="flex items-center space-x-2">
@@ -892,7 +933,8 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
         {viewMode === "volumes" && (
           <div className="border-t border-card-border px-6 py-3 bg-muted/50">
             <div className="text-sm text-muted-foreground">
-              {volumeGroups.length} volumes • {issues.length} total {itemLabelPlural}
+              {volumeGroups.length} volumes • {issues.length} total{" "}
+              {itemLabelPlural}
             </div>
           </div>
         )}

--- a/frontend/src/components/series/IssuesTable.tsx
+++ b/frontend/src/components/series/IssuesTable.tsx
@@ -5,12 +5,15 @@ import {
   getSortedRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
+  getExpandedRowModel,
   flexRender,
   ColumnDef,
   SortingState,
   RowSelectionState,
+  ExpandedState,
   CellContext,
   HeaderContext,
+  Row,
 } from "@tanstack/react-table";
 import {
   Download,
@@ -20,22 +23,119 @@ import {
   ChevronsUpDown,
   Search,
   Filter,
+  List,
+  Layers,
+  ChevronRight,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
 import StatusBadge from "@/components/StatusBadge";
 import EmptyState from "@/components/ui/EmptyState";
 import { useQueueIssue, useUnqueueIssue } from "@/hooks/useSeries";
 import { useBulkQueueIssues, useBulkUnqueueIssues } from "@/hooks/useQueue";
 import { useToast } from "@/components/ui/toast";
-import type { Issue } from "@/types";
+import type { Issue, VolumeGroup } from "@/types";
 
 type StatusFilter = "all" | "wanted" | "downloaded" | "skipped" | "other";
+type ViewMode = "chapters" | "volumes";
 
 interface IssuesTableProps {
   issues?: Issue[];
   isManga?: boolean;
+}
+
+// Helper to group issues by volume
+function groupByVolume(issues: Issue[]): VolumeGroup[] {
+  const volumeMap = new Map<string, Issue[]>();
+  const noVolumeIssues: Issue[] = [];
+
+  issues.forEach((issue) => {
+    const volumeNum = issue.volumeNumber;
+    if (volumeNum) {
+      const existing = volumeMap.get(volumeNum) || [];
+      existing.push(issue);
+      volumeMap.set(volumeNum, existing);
+    } else {
+      noVolumeIssues.push(issue);
+    }
+  });
+
+  const volumes: VolumeGroup[] = [];
+
+  // Sort volumes numerically
+  const sortedVolumes = Array.from(volumeMap.entries()).sort((a, b) => {
+    const numA = parseFloat(a[0]) || 0;
+    const numB = parseFloat(b[0]) || 0;
+    return numA - numB;
+  });
+
+  sortedVolumes.forEach(([volumeNum, chapters]) => {
+    const downloadedCount = chapters.filter(
+      (ch) => (ch.status ?? ch.Status)?.toLowerCase() === "downloaded"
+    ).length;
+    const totalCount = chapters.length;
+
+    let status: VolumeGroup["status"] = "Missing";
+    if (downloadedCount === totalCount) {
+      status = "Complete";
+    } else if (downloadedCount > 0) {
+      status = "Partial";
+    }
+
+    volumes.push({
+      volume: volumeNum,
+      chapters: chapters.sort((a, b) => {
+        const numA = parseFloat(a.chapterNumber || a.number || "0") || 0;
+        const numB = parseFloat(b.chapterNumber || b.number || "0") || 0;
+        return numA - numB;
+      }),
+      status,
+      downloadedCount,
+      totalCount,
+    });
+  });
+
+  // Add issues without volume at the end
+  if (noVolumeIssues.length > 0) {
+    const downloadedCount = noVolumeIssues.filter(
+      (ch) => (ch.status ?? ch.Status)?.toLowerCase() === "downloaded"
+    ).length;
+
+    volumes.push({
+      volume: "No Volume",
+      chapters: noVolumeIssues.sort((a, b) => {
+        const numA = parseFloat(a.chapterNumber || a.number || "0") || 0;
+        const numB = parseFloat(b.chapterNumber || b.number || "0") || 0;
+        return numA - numB;
+      }),
+      status: downloadedCount === noVolumeIssues.length ? "Complete" : downloadedCount > 0 ? "Partial" : "Missing",
+      downloadedCount,
+      totalCount: noVolumeIssues.length,
+    });
+  }
+
+  return volumes;
+}
+
+// Get chapter range string for a volume
+function getChapterRange(chapters: Issue[]): string {
+  if (chapters.length === 0) return "—";
+  if (chapters.length === 1) {
+    return `Ch. ${chapters[0].chapterNumber || chapters[0].number || "?"}`;
+  }
+
+  const numbers = chapters
+    .map((ch) => ch.chapterNumber || ch.number)
+    .filter(Boolean);
+
+  if (numbers.length === 0) return "—";
+
+  const first = numbers[0];
+  const last = numbers[numbers.length - 1];
+
+  return `Ch. ${first}–${last}`;
 }
 
 export default function IssuesTable({ issues = [], isManga = false }: IssuesTableProps) {
@@ -43,18 +143,32 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
   const itemLabel = isManga ? "chapter" : "issue";
   const itemLabelPlural = isManga ? "chapters" : "issues";
   const itemLabelCapitalized = isManga ? "Chapter" : "Issue";
+
   const [sorting, setSorting] = useState<SortingState>([
     { id: "number", desc: false },
   ]);
   const [globalFilter, setGlobalFilter] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [viewMode, setViewMode] = useState<ViewMode>("chapters");
+  const [expanded, setExpanded] = useState<ExpandedState>({});
 
   const queueIssueMutation = useQueueIssue();
   const unqueueIssueMutation = useUnqueueIssue();
   const bulkQueueMutation = useBulkQueueIssues();
   const bulkUnqueueMutation = useBulkUnqueueIssues();
   const { addToast } = useToast();
+
+  // Check if any issues have volume numbers (determines if volume view is available)
+  const hasVolumeData = useMemo(() => {
+    return issues.some((issue) => issue.volumeNumber);
+  }, [issues]);
+
+  // Group issues by volume for volume view
+  const volumeGroups = useMemo(() => {
+    if (viewMode !== "volumes") return [];
+    return groupByVolume(issues);
+  }, [issues, viewMode]);
 
   // Filter issues by status
   const filteredByStatus = useMemo(() => {
@@ -140,7 +254,26 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
     }
   };
 
-  const columns: ColumnDef<Issue>[] = [
+  const handleWantVolume = async (volume: VolumeGroup) => {
+    const ids = volume.chapters
+      .map((ch) => ch.id ?? ch.IssueID)
+      .filter(Boolean) as string[];
+    try {
+      await bulkQueueMutation.mutateAsync(ids);
+      addToast({
+        type: "success",
+        message: `${ids.length} chapters from Volume ${volume.volume} marked as wanted`,
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to mark chapters: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+    }
+  };
+
+  // Chapters view columns
+  const chapterColumns: ColumnDef<Issue>[] = useMemo(() => [
     {
       id: "select",
       header: ({ table }: HeaderContext<Issue, unknown>) => (
@@ -171,6 +304,17 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
         </span>
       ),
     },
+    // Show volume column if manga has volume data
+    ...(isManga && hasVolumeData ? [{
+      id: "volume",
+      accessorKey: "volumeNumber",
+      header: "Vol",
+      cell: ({ row }: CellContext<Issue, unknown>) => (
+        <span className="font-mono text-sm text-muted-foreground">
+          {row.original.volumeNumber || "—"}
+        </span>
+      ),
+    }] : []),
     {
       accessorKey: "name",
       header: `${itemLabelCapitalized} Name`,
@@ -255,9 +399,116 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
         );
       },
     },
-  ];
+  ], [isManga, hasVolumeData, itemLabelCapitalized, queueIssueMutation.isPending, unqueueIssueMutation.isPending]);
 
-  // Status counts for filter badges (must be before early return for hooks rules)
+  // Volume view columns
+  const volumeColumns: ColumnDef<VolumeGroup>[] = useMemo(() => [
+    {
+      id: "expander",
+      header: "",
+      cell: ({ row }: CellContext<VolumeGroup, unknown>) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => row.toggleExpanded()}
+          className="p-1 h-6 w-6"
+        >
+          <ChevronRight
+            className={`w-4 h-4 transition-transform ${row.getIsExpanded() ? "rotate-90" : ""}`}
+          />
+        </Button>
+      ),
+      size: 40,
+    },
+    {
+      accessorKey: "volume",
+      header: "Volume",
+      cell: ({ getValue }: CellContext<VolumeGroup, unknown>) => (
+        <span className="font-medium">Vol. {getValue() as string}</span>
+      ),
+    },
+    {
+      id: "chapters",
+      header: "Chapters",
+      cell: ({ row }: CellContext<VolumeGroup, unknown>) => (
+        <span className="text-sm text-muted-foreground">
+          {getChapterRange(row.original.chapters)}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "status",
+      header: "Status",
+      cell: ({ row }: CellContext<VolumeGroup, unknown>) => {
+        const { status } = row.original;
+        return (
+          <Badge
+            variant={
+              status === "Complete"
+                ? "default"
+                : status === "Partial"
+                  ? "secondary"
+                  : "outline"
+            }
+          >
+            {status}
+          </Badge>
+        );
+      },
+    },
+    {
+      id: "progress",
+      header: "Progress",
+      cell: ({ row }: CellContext<VolumeGroup, unknown>) => {
+        const { downloadedCount, totalCount } = row.original;
+        const percentage = totalCount > 0 ? Math.round((downloadedCount / totalCount) * 100) : 0;
+
+        return (
+          <div className="flex items-center space-x-2">
+            <div className="flex-1 bg-muted rounded-full h-2 overflow-hidden min-w-[60px]">
+              <div
+                className="h-full rounded-full transition-all"
+                style={{
+                  width: `${percentage}%`,
+                  background: "var(--gradient-brand)",
+                }}
+              />
+            </div>
+            <span className="text-xs text-muted-foreground min-w-[4rem]">
+              {downloadedCount}/{totalCount}
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      id: "actions",
+      header: "",
+      cell: ({ row }: CellContext<VolumeGroup, unknown>) => {
+        const hasWantable = row.original.chapters.some((ch) => {
+          const status = (ch.status ?? ch.Status)?.toLowerCase();
+          return status !== "downloaded" && status !== "snatched";
+        });
+
+        if (!hasWantable) return null;
+
+        return (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => handleWantVolume(row.original)}
+            disabled={bulkQueueMutation.isPending}
+            className="text-xs"
+          >
+            <Download className="w-3 h-3 mr-1" />
+            Want All
+          </Button>
+        );
+      },
+    },
+  ], [bulkQueueMutation.isPending]);
+
+  // Status counts for filter badges
   const statusCounts = useMemo(() => {
     const counts: Record<string, number> = { all: issues.length };
     issues.forEach((issue) => {
@@ -267,9 +518,10 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
     return counts;
   }, [issues]);
 
-  const table = useReactTable({
+  // Chapters table
+  const chaptersTable = useReactTable({
     data: filteredByStatus,
-    columns,
+    columns: chapterColumns,
     state: {
       sorting,
       globalFilter,
@@ -290,70 +542,163 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
     },
   });
 
+  // Volumes table
+  const volumesTable = useReactTable({
+    data: volumeGroups,
+    columns: volumeColumns,
+    state: {
+      expanded,
+    },
+    onExpandedChange: setExpanded,
+    getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getRowCanExpand: () => true,
+  });
+
   if (issues.length === 0) {
     return <EmptyState variant="issues" />;
   }
+
+  // Render expanded chapter rows for volume view
+  const renderExpandedChapters = (volume: VolumeGroup) => (
+    <tr>
+      <td colSpan={volumeColumns.length} className="p-0">
+        <div className="bg-muted/30 border-y border-card-border">
+          <table className="w-full">
+            <tbody>
+              {volume.chapters.map((chapter) => {
+                const status = (chapter.status ?? chapter.Status)?.toLowerCase();
+                const issueId = chapter.id ?? chapter.IssueID;
+
+                return (
+                  <tr key={issueId} className="hover:bg-accent/30">
+                    <td className="pl-12 pr-6 py-2 w-10"></td>
+                    <td className="px-6 py-2">
+                      <span className="font-mono text-sm">
+                        Ch. {chapter.chapterNumber || chapter.number || "?"}
+                      </span>
+                    </td>
+                    <td className="px-6 py-2">
+                      <span className="text-sm text-muted-foreground">
+                        {chapter.name || "—"}
+                      </span>
+                    </td>
+                    <td className="px-6 py-2">
+                      <StatusBadge status={chapter.status ?? chapter.Status} />
+                    </td>
+                    <td className="px-6 py-2"></td>
+                    <td className="px-6 py-2">
+                      {status !== "downloaded" && status !== "snatched" && issueId && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={(e) => handleQueueIssue(e, issueId)}
+                          disabled={queueIssueMutation.isPending}
+                          className="text-xs h-6"
+                        >
+                          <Download className="w-3 h-3 mr-1" />
+                          Want
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </td>
+    </tr>
+  );
 
   return (
     <div className="space-y-4">
       {/* Toolbar */}
       <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
-        {/* Search */}
-        <div className="relative flex-1 max-w-md">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-          <Input
-            placeholder={`Search ${itemLabelPlural} by number or name...`}
-            value={globalFilter}
-            onChange={(e) => setGlobalFilter(e.target.value)}
-            className="pl-9"
-          />
+        {/* Search & View Toggle */}
+        <div className="flex items-center gap-4 flex-1">
+          <div className="relative flex-1 max-w-md">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <Input
+              placeholder={`Search ${itemLabelPlural} by number or name...`}
+              value={globalFilter}
+              onChange={(e) => setGlobalFilter(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+
+          {/* View Toggle - only show if manga has volume data */}
+          {isManga && hasVolumeData && (
+            <div className="flex items-center gap-1 bg-muted rounded-lg p-1">
+              <Button
+                variant={viewMode === "chapters" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => setViewMode("chapters")}
+                className="h-7 text-xs"
+              >
+                <List className="w-3 h-3 mr-1" />
+                Chapters
+              </Button>
+              <Button
+                variant={viewMode === "volumes" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => setViewMode("volumes")}
+                className="h-7 text-xs"
+              >
+                <Layers className="w-3 h-3 mr-1" />
+                Volumes
+              </Button>
+            </div>
+          )}
         </div>
 
         {/* Status Filter & Quick Actions */}
-        <div className="flex items-center gap-2 flex-wrap">
-          <div className="flex items-center gap-1 bg-muted rounded-lg p-1">
-            <Filter className="w-4 h-4 ml-2 text-muted-foreground" />
-            {(
-              [
-                ["all", "All"],
-                ["wanted", "Wanted"],
-                ["downloaded", "Downloaded"],
-                ["skipped", "Skipped"],
-              ] as const
-            ).map(([value, label]) => (
-              <Button
-                key={value}
-                variant={statusFilter === value ? "default" : "ghost"}
-                size="sm"
-                onClick={() => setStatusFilter(value)}
-                className="h-7 text-xs"
-              >
-                {label}
-                {statusCounts[value] !== undefined && (
-                  <span className="ml-1 text-muted-foreground">
-                    ({statusCounts[value]})
-                  </span>
-                )}
-              </Button>
-            ))}
-          </div>
+        {viewMode === "chapters" && (
+          <div className="flex items-center gap-2 flex-wrap">
+            <div className="flex items-center gap-1 bg-muted rounded-lg p-1">
+              <Filter className="w-4 h-4 ml-2 text-muted-foreground" />
+              {(
+                [
+                  ["all", "All"],
+                  ["wanted", "Wanted"],
+                  ["downloaded", "Downloaded"],
+                  ["skipped", "Skipped"],
+                ] as const
+              ).map(([value, label]) => (
+                <Button
+                  key={value}
+                  variant={statusFilter === value ? "default" : "ghost"}
+                  size="sm"
+                  onClick={() => setStatusFilter(value)}
+                  className="h-7 text-xs"
+                >
+                  {label}
+                  {statusCounts[value] !== undefined && (
+                    <span className="ml-1 text-muted-foreground">
+                      ({statusCounts[value]})
+                    </span>
+                  )}
+                </Button>
+              ))}
+            </div>
 
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleWantAll}
-            disabled={
-              bulkQueueMutation.isPending || filteredByStatus.length === 0
-            }
-          >
-            <Download className="w-3 h-3 mr-1" />
-            Want All
-          </Button>
-        </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleWantAll}
+              disabled={
+                bulkQueueMutation.isPending || filteredByStatus.length === 0
+              }
+            >
+              <Download className="w-3 h-3 mr-1" />
+              Want All
+            </Button>
+          </div>
+        )}
       </div>
 
-      {/* Bulk Action Bar */}
-      {selectedIssueIds.length > 0 && (
+      {/* Bulk Action Bar (chapters view only) */}
+      {viewMode === "chapters" && selectedIssueIds.length > 0 && (
         <div className="flex items-center gap-4 px-4 py-3 bg-primary/10 border border-primary/20 rounded-lg">
           <span className="text-sm font-medium">
             {selectedIssueIds.length} {selectedIssueIds.length !== 1 ? itemLabelPlural : itemLabel} selected
@@ -390,109 +735,167 @@ export default function IssuesTable({ issues = [], isManga = false }: IssuesTabl
       {/* Table */}
       <div className="rounded-lg border border-card-border bg-card card-shadow overflow-hidden">
         <div className="overflow-x-auto custom-scrollbar">
-          <table className="w-full">
-            <thead className="bg-muted/50 border-card-border backdrop-blur-sm border-b">
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <th
-                      key={header.id}
-                      className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider"
-                    >
-                      {header.isPlaceholder ? null : (
-                        <div
-                          className={
-                            header.column.getCanSort()
-                              ? "flex items-center space-x-1 cursor-pointer select-none hover:text-foreground"
-                              : ""
-                          }
-                          onClick={header.column.getToggleSortingHandler()}
-                        >
-                          <span>
-                            {flexRender(
+          {viewMode === "chapters" ? (
+            // Chapters View
+            <table className="w-full">
+              <thead className="bg-muted/50 border-card-border backdrop-blur-sm border-b">
+                {chaptersTable.getHeaderGroups().map((headerGroup) => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <th
+                        key={header.id}
+                        className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider"
+                      >
+                        {header.isPlaceholder ? null : (
+                          <div
+                            className={
+                              header.column.getCanSort()
+                                ? "flex items-center space-x-1 cursor-pointer select-none hover:text-foreground"
+                                : ""
+                            }
+                            onClick={header.column.getToggleSortingHandler()}
+                          >
+                            <span>
+                              {flexRender(
+                                header.column.columnDef.header,
+                                header.getContext(),
+                              )}
+                            </span>
+                            {header.column.getCanSort() && (
+                              <span className="text-muted-foreground">
+                                {header.column.getIsSorted() === "asc" ? (
+                                  <ChevronUp className="w-4 h-4" />
+                                ) : header.column.getIsSorted() === "desc" ? (
+                                  <ChevronDown className="w-4 h-4" />
+                                ) : (
+                                  <ChevronsUpDown className="w-4 h-4 opacity-50" />
+                                )}
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+              </thead>
+              <tbody className="bg-card divide-y divide-card-border">
+                {chaptersTable.getRowModel().rows.map((row) => (
+                  <tr
+                    key={row.id}
+                    className={`hover:bg-accent/50 transition-colors ${
+                      row.getIsSelected() ? "bg-primary/5" : ""
+                    }`}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id} className="px-6 py-4 whitespace-nowrap">
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            // Volumes View
+            <table className="w-full">
+              <thead className="bg-muted/50 border-card-border backdrop-blur-sm border-b">
+                {volumesTable.getHeaderGroups().map((headerGroup) => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <th
+                        key={header.id}
+                        className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider"
+                      >
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
                               header.column.columnDef.header,
                               header.getContext(),
                             )}
-                          </span>
-                          {header.column.getCanSort() && (
-                            <span className="text-muted-foreground">
-                              {header.column.getIsSorted() === "asc" ? (
-                                <ChevronUp className="w-4 h-4" />
-                              ) : header.column.getIsSorted() === "desc" ? (
-                                <ChevronDown className="w-4 h-4" />
-                              ) : (
-                                <ChevronsUpDown className="w-4 h-4 opacity-50" />
-                              )}
-                            </span>
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+              </thead>
+              <tbody className="bg-card divide-y divide-card-border">
+                {volumesTable.getRowModel().rows.map((row) => (
+                  <>
+                    <tr
+                      key={row.id}
+                      className="hover:bg-accent/50 transition-colors cursor-pointer"
+                      onClick={() => row.toggleExpanded()}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <td key={cell.id} className="px-6 py-4 whitespace-nowrap">
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
                           )}
-                        </div>
-                      )}
-                    </th>
-                  ))}
-                </tr>
-              ))}
-            </thead>
-            <tbody className="bg-card divide-y divide-card-border">
-              {table.getRowModel().rows.map((row) => (
-                <tr
-                  key={row.id}
-                  className={`hover:bg-accent/50 transition-colors ${
-                    row.getIsSelected() ? "bg-primary/5" : ""
-                  }`}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id} className="px-6 py-4 whitespace-nowrap">
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
+                        </td>
+                      ))}
+                    </tr>
+                    {row.getIsExpanded() && renderExpandedChapters(row.original)}
+                  </>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
 
-        {/* Pagination */}
-        <div className="border-t border-card-border px-6 py-3 flex items-center justify-between bg-muted/50">
-          <div className="text-sm text-muted-foreground">
-            Showing{" "}
-            {table.getState().pagination.pageIndex *
-              table.getState().pagination.pageSize +
-              1}{" "}
-            to{" "}
-            {Math.min(
-              (table.getState().pagination.pageIndex + 1) *
-                table.getState().pagination.pageSize,
-              table.getFilteredRowModel().rows.length,
-            )}{" "}
-            of {table.getFilteredRowModel().rows.length} {itemLabelPlural}
-            {globalFilter && ` (filtered from ${filteredByStatus.length})`}
+        {/* Pagination (chapters view only) */}
+        {viewMode === "chapters" && (
+          <div className="border-t border-card-border px-6 py-3 flex items-center justify-between bg-muted/50">
+            <div className="text-sm text-muted-foreground">
+              Showing{" "}
+              {chaptersTable.getState().pagination.pageIndex *
+                chaptersTable.getState().pagination.pageSize +
+                1}{" "}
+              to{" "}
+              {Math.min(
+                (chaptersTable.getState().pagination.pageIndex + 1) *
+                  chaptersTable.getState().pagination.pageSize,
+                chaptersTable.getFilteredRowModel().rows.length,
+              )}{" "}
+              of {chaptersTable.getFilteredRowModel().rows.length} {itemLabelPlural}
+              {globalFilter && ` (filtered from ${filteredByStatus.length})`}
+            </div>
+            <div className="flex items-center space-x-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => chaptersTable.previousPage()}
+                disabled={!chaptersTable.getCanPreviousPage()}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                Page {chaptersTable.getState().pagination.pageIndex + 1} of{" "}
+                {chaptersTable.getPageCount()}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => chaptersTable.nextPage()}
+                disabled={!chaptersTable.getCanNextPage()}
+              >
+                Next
+              </Button>
+            </div>
           </div>
-          <div className="flex items-center space-x-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              Previous
-            </Button>
-            <span className="text-sm text-muted-foreground">
-              Page {table.getState().pagination.pageIndex + 1} of{" "}
-              {table.getPageCount()}
-            </span>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              Next
-            </Button>
+        )}
+
+        {/* Volume count (volumes view) */}
+        {viewMode === "volumes" && (
+          <div className="border-t border-card-border px-6 py-3 bg-muted/50">
+            <div className="text-sm text-muted-foreground">
+              {volumeGroups.length} volumes • {issues.length} total {itemLabelPlural}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/series/IssuesTable.tsx
+++ b/frontend/src/components/series/IssuesTable.tsx
@@ -35,9 +35,14 @@ type StatusFilter = "all" | "wanted" | "downloaded" | "skipped" | "other";
 
 interface IssuesTableProps {
   issues?: Issue[];
+  isManga?: boolean;
 }
 
-export default function IssuesTable({ issues = [] }: IssuesTableProps) {
+export default function IssuesTable({ issues = [], isManga = false }: IssuesTableProps) {
+  // Dynamic labels based on content type
+  const itemLabel = isManga ? "chapter" : "issue";
+  const itemLabelPlural = isManga ? "chapters" : "issues";
+  const itemLabelCapitalized = isManga ? "Chapter" : "Issue";
   const [sorting, setSorting] = useState<SortingState>([
     { id: "number", desc: false },
   ]);
@@ -90,13 +95,13 @@ export default function IssuesTable({ issues = [] }: IssuesTableProps) {
       await bulkQueueMutation.mutateAsync(selectedIssueIds);
       addToast({
         type: "success",
-        message: `${selectedIssueIds.length} issue${selectedIssueIds.length !== 1 ? "s" : ""} marked as wanted`,
+        message: `${selectedIssueIds.length} ${selectedIssueIds.length !== 1 ? itemLabelPlural : itemLabel} marked as wanted`,
       });
       setRowSelection({});
     } catch (err) {
       addToast({
         type: "error",
-        message: `Failed to mark issues: ${err instanceof Error ? err.message : "Unknown error"}`,
+        message: `Failed to mark ${itemLabelPlural}: ${err instanceof Error ? err.message : "Unknown error"}`,
       });
     }
   };
@@ -106,13 +111,13 @@ export default function IssuesTable({ issues = [] }: IssuesTableProps) {
       await bulkUnqueueMutation.mutateAsync(selectedIssueIds);
       addToast({
         type: "success",
-        message: `${selectedIssueIds.length} issue${selectedIssueIds.length !== 1 ? "s" : ""} skipped`,
+        message: `${selectedIssueIds.length} ${selectedIssueIds.length !== 1 ? itemLabelPlural : itemLabel} skipped`,
       });
       setRowSelection({});
     } catch (err) {
       addToast({
         type: "error",
-        message: `Failed to skip issues: ${err instanceof Error ? err.message : "Unknown error"}`,
+        message: `Failed to skip ${itemLabelPlural}: ${err instanceof Error ? err.message : "Unknown error"}`,
       });
     }
   };
@@ -125,12 +130,12 @@ export default function IssuesTable({ issues = [] }: IssuesTableProps) {
       await bulkQueueMutation.mutateAsync(allIds);
       addToast({
         type: "success",
-        message: `${allIds.length} issues marked as wanted`,
+        message: `${allIds.length} ${itemLabelPlural} marked as wanted`,
       });
     } catch (err) {
       addToast({
         type: "error",
-        message: `Failed to mark issues: ${err instanceof Error ? err.message : "Unknown error"}`,
+        message: `Failed to mark ${itemLabelPlural}: ${err instanceof Error ? err.message : "Unknown error"}`,
       });
     }
   };
@@ -168,7 +173,7 @@ export default function IssuesTable({ issues = [] }: IssuesTableProps) {
     },
     {
       accessorKey: "name",
-      header: "Issue Name",
+      header: `${itemLabelCapitalized} Name`,
       cell: ({ row }: CellContext<Issue, unknown>) => (
         <div>
           <div className="font-medium">{row.original.number}</div>
@@ -297,7 +302,7 @@ export default function IssuesTable({ issues = [] }: IssuesTableProps) {
         <div className="relative flex-1 max-w-md">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input
-            placeholder="Search issues by number or name..."
+            placeholder={`Search ${itemLabelPlural} by number or name...`}
             value={globalFilter}
             onChange={(e) => setGlobalFilter(e.target.value)}
             className="pl-9"
@@ -351,8 +356,7 @@ export default function IssuesTable({ issues = [] }: IssuesTableProps) {
       {selectedIssueIds.length > 0 && (
         <div className="flex items-center gap-4 px-4 py-3 bg-primary/10 border border-primary/20 rounded-lg">
           <span className="text-sm font-medium">
-            {selectedIssueIds.length} issue
-            {selectedIssueIds.length !== 1 ? "s" : ""} selected
+            {selectedIssueIds.length} {selectedIssueIds.length !== 1 ? itemLabelPlural : itemLabel} selected
           </span>
           <div className="flex items-center gap-2">
             <Button
@@ -463,7 +467,7 @@ export default function IssuesTable({ issues = [] }: IssuesTableProps) {
                 table.getState().pagination.pageSize,
               table.getFilteredRowModel().rows.length,
             )}{" "}
-            of {table.getFilteredRowModel().rows.length} issues
+            of {table.getFilteredRowModel().rows.length} {itemLabelPlural}
             {globalFilter && ` (filtered from ${filteredByStatus.length})`}
           </div>
           <div className="flex items-center space-x-2">

--- a/frontend/src/components/series/IssuesTable.tsx
+++ b/frontend/src/components/series/IssuesTable.tsx
@@ -13,7 +13,6 @@ import {
   ExpandedState,
   CellContext,
   HeaderContext,
-  Row,
 } from "@tanstack/react-table";
 import {
   Download,

--- a/frontend/src/components/series/IssuesTable.tsx
+++ b/frontend/src/components/series/IssuesTable.tsx
@@ -421,6 +421,8 @@ export default function IssuesTable({
       itemLabelCapitalized,
       queueIssueMutation.isPending,
       unqueueIssueMutation.isPending,
+      handleQueueIssue,
+      handleUnqueueIssue,
     ],
   );
 
@@ -534,7 +536,7 @@ export default function IssuesTable({
         },
       },
     ],
-    [bulkQueueMutation.isPending],
+    [bulkQueueMutation.isPending, handleWantVolume],
   );
 
   // Status counts for filter badges
@@ -858,9 +860,8 @@ export default function IssuesTable({
               </thead>
               <tbody className="bg-card divide-y divide-card-border">
                 {volumesTable.getRowModel().rows.map((row) => (
-                  <>
+                  <React.Fragment key={row.id}>
                     <tr
-                      key={row.id}
                       className="hover:bg-accent/50 transition-colors cursor-pointer"
                       onClick={() => row.toggleExpanded()}
                     >
@@ -878,7 +879,7 @@ export default function IssuesTable({
                     </tr>
                     {row.getIsExpanded() &&
                       renderExpandedChapters(row.original)}
-                  </>
+                  </React.Fragment>
                 ))}
               </tbody>
             </table>

--- a/frontend/src/components/series/SeriesFilters.tsx
+++ b/frontend/src/components/series/SeriesFilters.tsx
@@ -1,0 +1,149 @@
+import { Book, BookOpen, Library } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export type TypeFilter = "all" | "comic" | "manga";
+export type ProgressFilter = "all" | "0" | "partial" | "100";
+export type StatusFilter = "all" | "Active" | "Paused" | "Ended";
+
+interface SeriesFiltersProps {
+  typeFilter: TypeFilter;
+  progressFilter: ProgressFilter;
+  statusFilter: StatusFilter;
+  onTypeChange: (value: TypeFilter) => void;
+  onProgressChange: (value: ProgressFilter) => void;
+  onStatusChange: (value: StatusFilter) => void;
+  counts?: {
+    type: Record<TypeFilter, number>;
+    progress: Record<ProgressFilter, number>;
+    status: Record<StatusFilter, number>;
+  };
+}
+
+export default function SeriesFilters({
+  typeFilter,
+  progressFilter,
+  statusFilter,
+  onTypeChange,
+  onProgressChange,
+  onStatusChange,
+  counts,
+}: SeriesFiltersProps) {
+  // Helper to format count
+  const formatCount = (count: number | undefined) => {
+    if (count === undefined || count === 0) return "";
+    return ` (${count})`;
+  };
+
+  return (
+    <div className="flex flex-wrap gap-3 items-center">
+      {/* Type Filter - Segmented Control */}
+      <div className="inline-flex rounded-lg border border-border p-0.5 bg-muted/50">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onTypeChange("all")}
+          className={`h-8 px-3 rounded-md text-sm font-medium transition-colors ${
+            typeFilter === "all"
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          <Library className="w-4 h-4 mr-1.5" />
+          All{formatCount(counts?.type.all)}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onTypeChange("comic")}
+          className={`h-8 px-3 rounded-md text-sm font-medium transition-colors ${
+            typeFilter === "comic"
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          <Book className="w-4 h-4 mr-1.5" />
+          Comics{formatCount(counts?.type.comic)}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onTypeChange("manga")}
+          className={`h-8 px-3 rounded-md text-sm font-medium transition-colors ${
+            typeFilter === "manga"
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          <BookOpen className="w-4 h-4 mr-1.5" />
+          Manga{formatCount(counts?.type.manga)}
+        </Button>
+      </div>
+
+      {/* Progress Filter - Dropdown */}
+      <Select
+        value={progressFilter}
+        onValueChange={(value) => onProgressChange(value as ProgressFilter)}
+      >
+        <SelectTrigger className="w-[140px] h-9">
+          <SelectValue placeholder="Progress" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All Progress</SelectItem>
+          <SelectItem value="0">
+            Not Started{formatCount(counts?.progress["0"])}
+          </SelectItem>
+          <SelectItem value="partial">
+            In Progress{formatCount(counts?.progress.partial)}
+          </SelectItem>
+          <SelectItem value="100">
+            Complete{formatCount(counts?.progress["100"])}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+
+      {/* Status Filter - Dropdown */}
+      <Select
+        value={statusFilter}
+        onValueChange={(value) => onStatusChange(value as StatusFilter)}
+      >
+        <SelectTrigger className="w-[130px] h-9">
+          <SelectValue placeholder="Status" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All Status</SelectItem>
+          <SelectItem value="Active">
+            Active{formatCount(counts?.status.Active)}
+          </SelectItem>
+          <SelectItem value="Paused">
+            Paused{formatCount(counts?.status.Paused)}
+          </SelectItem>
+          <SelectItem value="Ended">
+            Ended{formatCount(counts?.status.Ended)}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+
+      {/* Active Filters Indicator */}
+      {(progressFilter !== "all" || statusFilter !== "all") && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            onProgressChange("all");
+            onStatusChange("all");
+          }}
+          className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground"
+        >
+          Clear filters
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -11,7 +11,13 @@ import {
   SortingState,
   CellContext,
 } from "@tanstack/react-table";
-import { ChevronUp, ChevronDown, ChevronsUpDown, Book, BookOpen } from "lucide-react";
+import {
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+  Book,
+  BookOpen,
+} from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -56,7 +62,8 @@ export default function SeriesTable({
 
   // Get filters from URL params
   const typeFilter = (searchParams.get("type") as TypeFilter) || "all";
-  const progressFilter = (searchParams.get("progress") as ProgressFilter) || "all";
+  const progressFilter =
+    (searchParams.get("progress") as ProgressFilter) || "all";
   const statusFilter = (searchParams.get("status") as StatusFilter) || "all";
 
   // Update URL params when filters change
@@ -73,9 +80,18 @@ export default function SeriesTable({
   // Calculate filter counts
   const filterCounts = useMemo(() => {
     const counts = {
-      type: { all: data.length, comic: 0, manga: 0 } as Record<TypeFilter, number>,
-      progress: { all: data.length, "0": 0, partial: 0, "100": 0 } as Record<ProgressFilter, number>,
-      status: { all: data.length, Active: 0, Paused: 0, Ended: 0 } as Record<StatusFilter, number>,
+      type: { all: data.length, comic: 0, manga: 0 } as Record<
+        TypeFilter,
+        number
+      >,
+      progress: { all: data.length, "0": 0, partial: 0, "100": 0 } as Record<
+        ProgressFilter,
+        number
+      >,
+      status: { all: data.length, Active: 0, Paused: 0, Ended: 0 } as Record<
+        StatusFilter,
+        number
+      >,
     };
 
     data.forEach((comic) => {

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, SyntheticEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   useReactTable,
   getCoreRowModel,
@@ -11,12 +11,18 @@ import {
   SortingState,
   CellContext,
 } from "@tanstack/react-table";
-import { ChevronUp, ChevronDown, ChevronsUpDown } from "lucide-react";
+import { ChevronUp, ChevronDown, ChevronsUpDown, Book, BookOpen } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import StatusBadge from "@/components/StatusBadge";
 import { Skeleton } from "@/components/ui/skeleton";
 import EmptyState from "@/components/ui/EmptyState";
+import SeriesFilters, {
+  type TypeFilter,
+  type ProgressFilter,
+  type StatusFilter,
+} from "./SeriesFilters";
 import type { Comic } from "@/types";
 
 interface SeriesTableProps {
@@ -24,19 +30,107 @@ interface SeriesTableProps {
   isLoading?: boolean;
 }
 
+// Helper to calculate progress percentage
+function getProgressPercentage(comic: Comic): number {
+  const total = parseInt(String(comic.Total)) || 0;
+  const have = parseInt(String(comic.Have)) || 0;
+  return total > 0 ? Math.round((have / total) * 100) : 0;
+}
+
+// Helper to get progress category
+function getProgressCategory(comic: Comic): "0" | "partial" | "100" {
+  const percentage = getProgressPercentage(comic);
+  if (percentage === 0) return "0";
+  if (percentage === 100) return "100";
+  return "partial";
+}
+
 export default function SeriesTable({
   data = [],
   isLoading,
 }: SeriesTableProps) {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [sorting, setSorting] = useState<SortingState>([]);
   const [globalFilter, setGlobalFilter] = useState("");
+
+  // Get filters from URL params
+  const typeFilter = (searchParams.get("type") as TypeFilter) || "all";
+  const progressFilter = (searchParams.get("progress") as ProgressFilter) || "all";
+  const statusFilter = (searchParams.get("status") as StatusFilter) || "all";
+
+  // Update URL params when filters change
+  const updateFilter = (key: string, value: string) => {
+    const params = new URLSearchParams(searchParams);
+    if (value === "all") {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+    setSearchParams(params, { replace: true });
+  };
+
+  // Calculate filter counts
+  const filterCounts = useMemo(() => {
+    const counts = {
+      type: { all: data.length, comic: 0, manga: 0 } as Record<TypeFilter, number>,
+      progress: { all: data.length, "0": 0, partial: 0, "100": 0 } as Record<ProgressFilter, number>,
+      status: { all: data.length, Active: 0, Paused: 0, Ended: 0 } as Record<StatusFilter, number>,
+    };
+
+    data.forEach((comic) => {
+      // Type counts
+      const contentType = comic.ContentType?.toLowerCase();
+      if (contentType === "manga") {
+        counts.type.manga++;
+      } else {
+        counts.type.comic++;
+      }
+
+      // Progress counts
+      const progressCategory = getProgressCategory(comic);
+      counts.progress[progressCategory]++;
+
+      // Status counts
+      const status = comic.Status;
+      if (status === "Active" || status === "Paused" || status === "Ended") {
+        counts.status[status]++;
+      }
+    });
+
+    return counts;
+  }, [data]);
+
+  // Filter data based on selected filters
+  const filteredData = useMemo(() => {
+    return data.filter((comic) => {
+      // Type filter
+      if (typeFilter !== "all") {
+        const contentType = comic.ContentType?.toLowerCase();
+        if (typeFilter === "manga" && contentType !== "manga") return false;
+        if (typeFilter === "comic" && contentType === "manga") return false;
+      }
+
+      // Progress filter
+      if (progressFilter !== "all") {
+        const progressCategory = getProgressCategory(comic);
+        if (progressCategory !== progressFilter) return false;
+      }
+
+      // Status filter
+      if (statusFilter !== "all") {
+        if (comic.Status !== statusFilter) return false;
+      }
+
+      return true;
+    });
+  }, [data, typeFilter, progressFilter, statusFilter]);
 
   const columns = useMemo<ColumnDef<Comic>[]>(
     () => [
       {
         accessorKey: "ComicName",
-        header: "Comic",
+        header: "Series",
         cell: ({ row }: CellContext<Comic, unknown>) => (
           <div className="flex items-center space-x-3">
             {row.original.ComicImage && (
@@ -50,7 +144,15 @@ export default function SeriesTable({
               />
             )}
             <div>
-              <div className="font-medium">{row.original.ComicName}</div>
+              <div className="flex items-center gap-2">
+                <span className="font-medium">{row.original.ComicName}</span>
+                {row.original.ContentType?.toLowerCase() === "manga" ? (
+                  <Badge variant="secondary" className="text-xs px-1.5 py-0">
+                    <BookOpen className="w-3 h-3 mr-1" />
+                    Manga
+                  </Badge>
+                ) : null}
+              </div>
               {row.original.ComicYear && (
                 <div className="text-sm text-gray-500">
                   ({row.original.ComicYear})
@@ -88,9 +190,7 @@ export default function SeriesTable({
         id: "progress",
         header: "Progress",
         cell: ({ row }: CellContext<Comic, unknown>) => {
-          const total = parseInt(String(row.original.Total)) || 0;
-          const have = parseInt(String(row.original.Have)) || 0;
-          const percentage = total > 0 ? Math.round((have / total) * 100) : 0;
+          const percentage = getProgressPercentage(row.original);
 
           return (
             <div className="flex items-center space-x-2">
@@ -115,7 +215,7 @@ export default function SeriesTable({
   );
 
   const table = useReactTable({
-    data,
+    data: filteredData,
     columns,
     state: {
       sorting,
@@ -151,17 +251,30 @@ export default function SeriesTable({
 
   return (
     <div className="space-y-4">
-      {/* Search */}
-      <div className="flex items-center space-x-2">
-        <Input
-          placeholder="Search series..."
-          value={globalFilter ?? ""}
-          onChange={(e) => setGlobalFilter(e.target.value)}
-          className="max-w-sm"
+      {/* Filters & Search Row */}
+      <div className="flex flex-wrap items-center gap-3 justify-between">
+        <SeriesFilters
+          typeFilter={typeFilter}
+          progressFilter={progressFilter}
+          statusFilter={statusFilter}
+          onTypeChange={(value) => updateFilter("type", value)}
+          onProgressChange={(value) => updateFilter("progress", value)}
+          onStatusChange={(value) => updateFilter("status", value)}
+          counts={filterCounts}
         />
-        <span className="text-sm text-muted-foreground">
-          {table.getFilteredRowModel().rows.length} series
-        </span>
+
+        {/* Search */}
+        <div className="flex items-center gap-2">
+          <Input
+            placeholder="Search series..."
+            value={globalFilter ?? ""}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            className="w-[200px]"
+          />
+          <span className="text-sm text-muted-foreground whitespace-nowrap">
+            {table.getFilteredRowModel().rows.length} series
+          </span>
+        </div>
       </div>
 
       {/* Table */}

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -15,7 +15,6 @@ import {
   ChevronUp,
   ChevronDown,
   ChevronsUpDown,
-  Book,
   BookOpen,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -11,12 +11,7 @@ import {
   SortingState,
   CellContext,
 } from "@tanstack/react-table";
-import {
-  ChevronUp,
-  ChevronDown,
-  ChevronsUpDown,
-  BookOpen,
-} from "lucide-react";
+import { ChevronUp, ChevronDown, ChevronsUpDown, BookOpen } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -3,6 +3,8 @@ import { cn } from "@/lib/utils";
 
 type BadgeVariant =
   | "default"
+  | "secondary"
+  | "outline"
   | "active"
   | "paused"
   | "ended"
@@ -19,6 +21,8 @@ const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
   ({ className, variant = "default", ...props }, ref) => {
     const variants: Record<BadgeVariant, string> = {
       default: "bg-muted text-muted-foreground",
+      secondary: "bg-secondary text-secondary-foreground",
+      outline: "border border-input bg-background text-foreground",
       active: "bg-[var(--status-active-bg)] text-[var(--status-active)]",
       paused: "bg-[var(--status-paused-bg)] text-[var(--status-paused)]",
       ended: "bg-[var(--status-ended-bg)] text-[var(--status-ended)]",

--- a/frontend/src/hooks/useSearch.ts
+++ b/frontend/src/hooks/useSearch.ts
@@ -86,6 +86,61 @@ export function useSearchComics(
 }
 
 /**
+ * Search for manga using MangaDex
+ */
+export function useSearchManga(
+  query: string,
+  page = 1,
+  sortBy = "relevance",
+  options: Partial<
+    UseQueryOptions<RawSearchResponse, Error, SearchResponse>
+  > = {},
+): UseQueryResult<SearchResponse> {
+  const limit = 50; // Results per page
+  const offset = (page - 1) * limit;
+
+  return useQuery({
+    queryKey: ["search", "manga", query, page, sortBy], // Include type in cache key
+    queryFn: () =>
+      apiCall<RawSearchResponse>("findManga", {
+        name: query,
+        limit: limit.toString(),
+        offset: offset.toString(),
+        sort: sortBy,
+      }),
+    // Transform backend field names to match frontend expectations
+    select: (data: RawSearchResponse): SearchResponse => {
+      // Handle old format (array) for backward compatibility
+      if (Array.isArray(data)) {
+        return {
+          results: data.map((manga) => ({
+            ...manga,
+            image: manga.comicimage || manga.comicthumb || null,
+          })) as SearchResult[],
+          pagination: {
+            total: data.length,
+            limit,
+            offset,
+            returned: data.length,
+          },
+        };
+      }
+      // Handle new format (object with pagination)
+      return {
+        results: (data.results || []).map((manga) => ({
+          ...manga,
+          image: manga.comicimage || manga.comicthumb || null,
+        })) as SearchResult[],
+        pagination: data.pagination || { total: 0, limit, offset, returned: 0 },
+      };
+    },
+    enabled: !!query && query.length > 2, // Only search if query is more than 2 chars
+    staleTime: 10 * 60 * 1000, // 10 minutes - search results don't change often
+    ...options,
+  });
+}
+
+/**
  * Add a comic to the library
  */
 export function useAddComic(): UseMutationResult<unknown, Error, string> {
@@ -95,6 +150,21 @@ export function useAddComic(): UseMutationResult<unknown, Error, string> {
     mutationFn: (comicId: string) => apiCall("addComic", { id: comicId }),
     onSuccess: () => {
       // Invalidate series list to show the newly added comic
+      queryClient.invalidateQueries({ queryKey: ["series"] });
+    },
+  });
+}
+
+/**
+ * Add a manga to the library
+ */
+export function useAddManga(): UseMutationResult<unknown, Error, string> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (mangaId: string) => apiCall("addManga", { id: mangaId }),
+    onSuccess: () => {
+      // Invalidate series list to show the newly added manga
       queryClient.invalidateQueries({ queryKey: ["series"] });
     },
   });

--- a/frontend/src/hooks/useUnifiedSearch.ts
+++ b/frontend/src/hooks/useUnifiedSearch.ts
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+import { useSearchComics, useSearchManga } from "./useSearch";
+import type { SearchResult, PaginationMeta, ContentType } from "@/types";
+
+export interface UnifiedSearchResult extends SearchResult {
+  content_type: ContentType;
+}
+
+export interface UnifiedSearchResponse {
+  results: UnifiedSearchResult[];
+  pagination: PaginationMeta;
+  comicPagination?: PaginationMeta;
+  mangaPagination?: PaginationMeta;
+}
+
+/**
+ * Unified search hook that combines comic and manga search results
+ * Fetches from both APIs in parallel and merges results
+ */
+export function useUnifiedSearch(
+  query: string,
+  page = 1,
+  comicSort = "start_year:desc",
+  mangaSort = "relevance",
+) {
+  // Fetch both comics and manga in parallel
+  const comicSearch = useSearchComics(query, page, comicSort);
+  const mangaSearch = useSearchManga(query, page, mangaSort);
+
+  // Combine loading states
+  const isLoading = comicSearch.isLoading || mangaSearch.isLoading;
+
+  // Combine errors (prioritize comic error if both fail)
+  const error = comicSearch.error || mangaSearch.error;
+
+  // Merge and interleave results
+  const data = useMemo<UnifiedSearchResponse | undefined>(() => {
+    // If both are still loading, return undefined
+    if (!comicSearch.data && !mangaSearch.data) {
+      return undefined;
+    }
+
+    const comicResults = comicSearch.data?.results || [];
+    const mangaResults = mangaSearch.data?.results || [];
+
+    // Tag results with content type
+    const taggedComics: UnifiedSearchResult[] = comicResults.map((r) => ({
+      ...r,
+      content_type: "comic" as ContentType,
+    }));
+
+    const taggedManga: UnifiedSearchResult[] = mangaResults.map((r) => ({
+      ...r,
+      content_type: "manga" as ContentType,
+    }));
+
+    // Interleave results (comic, manga, comic, manga...)
+    const merged: UnifiedSearchResult[] = [];
+    const maxLength = Math.max(taggedComics.length, taggedManga.length);
+
+    for (let i = 0; i < maxLength; i++) {
+      if (i < taggedComics.length) {
+        merged.push(taggedComics[i]);
+      }
+      if (i < taggedManga.length) {
+        merged.push(taggedManga[i]);
+      }
+    }
+
+    // Calculate combined pagination
+    const comicTotal = comicSearch.data?.pagination?.total || 0;
+    const mangaTotal = mangaSearch.data?.pagination?.total || 0;
+    const limit = comicSearch.data?.pagination?.limit || 50;
+
+    return {
+      results: merged,
+      pagination: {
+        total: comicTotal + mangaTotal,
+        limit: limit * 2, // Combined limit from both sources
+        offset: (page - 1) * limit,
+        returned: merged.length,
+      },
+      comicPagination: comicSearch.data?.pagination,
+      mangaPagination: mangaSearch.data?.pagination,
+    };
+  }, [comicSearch.data, mangaSearch.data, page]);
+
+  return {
+    data,
+    isLoading,
+    error,
+    comicSearch,
+    mangaSearch,
+  };
+}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Search as SearchIcon, ChevronLeft, ChevronRight } from "lucide-react";
+import { Search as SearchIcon, ChevronLeft, ChevronRight, BookOpen, Book } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { useSearchComics } from "@/hooks/useSearch";
+import { useSearchComics, useSearchManga } from "@/hooks/useSearch";
 import SearchResultsTable from "@/components/search/SearchResultsTable";
 import { Skeleton } from "@/components/ui/skeleton";
+import type { ContentType } from "@/types/entities";
 
 export default function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -14,12 +15,14 @@ export default function SearchPage() {
   const urlQuery = searchParams.get("q") || "";
   const urlPage = parseInt(searchParams.get("page") || "1") || 1;
   const urlSort = searchParams.get("sort") || "year_desc";
+  const urlContentType = (searchParams.get("type") as ContentType) || "comic";
 
   // Initialize search query from URL parameter
   const [searchQuery, setSearchQuery] = useState(urlQuery);
+  const [contentType, setContentType] = useState<ContentType>(urlContentType);
 
-  // Map frontend sort values to ComicVine API format
-  const sortMapping: Record<string, string> = {
+  // Map frontend sort values to ComicVine API format (for comics)
+  const comicSortMapping: Record<string, string> = {
     year_desc: "start_year:desc",
     year_asc: "start_year:asc",
     issues_desc: "count_of_issues:desc",
@@ -28,21 +31,52 @@ export default function SearchPage() {
     name_desc: "name:desc",
   };
 
-  const apiSort = sortMapping[urlSort] || urlSort;
+  // Map frontend sort values to MangaDex API format (for manga)
+  const mangaSortMapping: Record<string, string> = {
+    year_desc: "year_desc",
+    year_asc: "year_asc",
+    name_asc: "title_asc",
+    name_desc: "title_desc",
+    relevance: "relevance",
+    latest: "latest",
+    follows: "follows",
+  };
 
-  // Use server-side pagination
-  const { data, isLoading, error } = useSearchComics(
-    urlQuery,
+  const apiSort = contentType === "manga"
+    ? mangaSortMapping[urlSort] || "relevance"
+    : comicSortMapping[urlSort] || urlSort;
+
+  // Use server-side pagination for comics
+  const comicSearch = useSearchComics(
+    contentType === "comic" ? urlQuery : "",
     urlPage,
     apiSort,
   );
+
+  // Use server-side pagination for manga
+  const mangaSearch = useSearchManga(
+    contentType === "manga" ? urlQuery : "",
+    urlPage,
+    apiSort,
+  );
+
+  // Select the active search based on content type
+  const { data, isLoading, error } = contentType === "manga" ? mangaSearch : comicSearch;
   const searchResults = data?.results || [];
   const pagination = data?.pagination;
 
   const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (searchQuery.trim().length > 2) {
-      setSearchParams({ q: searchQuery.trim(), page: "1", sort: urlSort });
+      setSearchParams({ q: searchQuery.trim(), page: "1", sort: urlSort, type: contentType });
+    }
+  };
+
+  const handleContentTypeChange = (newType: ContentType) => {
+    setContentType(newType);
+    // If there's a query, re-search with new content type
+    if (urlQuery) {
+      setSearchParams({ q: urlQuery, page: "1", sort: newType === "manga" ? "relevance" : urlSort, type: newType });
     }
   };
 
@@ -72,13 +106,33 @@ export default function SearchPage() {
   return (
     <div className="space-y-4 page-transition">
       {/* Page Title */}
-      <h1 className="text-3xl font-bold">Search Comics</h1>
+      <h1 className="text-3xl font-bold">Search {contentType === "manga" ? "Manga" : "Comics"}</h1>
+
+      {/* Content Type Toggle */}
+      <div className="flex gap-2">
+        <Button
+          variant={contentType === "comic" ? "default" : "outline"}
+          onClick={() => handleContentTypeChange("comic")}
+          className="flex items-center"
+        >
+          <Book className="w-4 h-4 mr-2" />
+          Comics
+        </Button>
+        <Button
+          variant={contentType === "manga" ? "default" : "outline"}
+          onClick={() => handleContentTypeChange("manga")}
+          className="flex items-center"
+        >
+          <BookOpen className="w-4 h-4 mr-2" />
+          Manga
+        </Button>
+      </div>
 
       {/* Search Form */}
       <form onSubmit={handleSearch} className="flex gap-2 max-w-2xl">
         <Input
           type="text"
-          placeholder="Enter comic name..."
+          placeholder={`Enter ${contentType === "manga" ? "manga" : "comic"} name...`}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="flex-1"
@@ -151,6 +205,7 @@ export default function SearchPage() {
             results={searchResults}
             currentSort={urlSort}
             onSortChange={handleSortChange}
+            contentType={contentType}
           />
 
           {/* Pagination Controls */}
@@ -187,7 +242,7 @@ export default function SearchPage() {
         <div className="text-center py-12">
           <SearchIcon className="w-16 h-16 text-gray-300 mx-auto mb-4" />
           <p className="text-muted-foreground text-lg">
-            Enter a search term to find comics
+            Enter a search term to find {contentType === "manga" ? "manga" : "comics"}
           </p>
           <p className="text-gray-400 text-sm mt-2">
             Search requires at least 3 characters

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Search as SearchIcon, ChevronLeft, ChevronRight, BookOpen, Book, Library } from "lucide-react";
+import {
+  Search as SearchIcon,
+  ChevronLeft,
+  ChevronRight,
+  BookOpen,
+  Book,
+  Library,
+} from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useSearchComics, useSearchManga } from "@/hooks/useSearch";
@@ -71,11 +78,12 @@ export default function SearchPage() {
   );
 
   // Select the active search based on search mode
-  const activeSearch = searchMode === "all"
-    ? unifiedSearch
-    : searchMode === "manga"
-      ? mangaSearch
-      : comicSearch;
+  const activeSearch =
+    searchMode === "all"
+      ? unifiedSearch
+      : searchMode === "manga"
+        ? mangaSearch
+        : comicSearch;
 
   const { data, isLoading, error } = activeSearch;
   const searchResults = data?.results || [];
@@ -84,7 +92,12 @@ export default function SearchPage() {
   const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (searchQuery.trim().length > 2) {
-      setSearchParams({ q: searchQuery.trim(), page: "1", sort: urlSort, type: searchMode });
+      setSearchParams({
+        q: searchQuery.trim(),
+        page: "1",
+        sort: urlSort,
+        type: searchMode,
+      });
     }
   };
 
@@ -195,7 +208,10 @@ export default function SearchPage() {
               results for "{urlQuery}"
               {searchMode === "all" && unifiedSearch.data && (
                 <span className="text-xs ml-2">
-                  ({unifiedSearch.comicSearch.data?.pagination?.total || 0} comics, {unifiedSearch.mangaSearch.data?.pagination?.total || 0} manga)
+                  ({unifiedSearch.comicSearch.data?.pagination?.total || 0}{" "}
+                  comics,{" "}
+                  {unifiedSearch.mangaSearch.data?.pagination?.total || 0}{" "}
+                  manga)
                 </span>
               )}
             </>
@@ -285,7 +301,12 @@ export default function SearchPage() {
         <div className="text-center py-12">
           <SearchIcon className="w-16 h-16 text-gray-300 mx-auto mb-4" />
           <p className="text-muted-foreground text-lg">
-            Enter a search term to find {searchMode === "all" ? "comics and manga" : searchMode === "manga" ? "manga" : "comics"}
+            Enter a search term to find{" "}
+            {searchMode === "all"
+              ? "comics and manga"
+              : searchMode === "manga"
+                ? "manga"
+                : "comics"}
           </p>
           <p className="text-gray-400 text-sm mt-2">
             Search requires at least 3 characters

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,12 +1,15 @@
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Search as SearchIcon, ChevronLeft, ChevronRight, BookOpen, Book } from "lucide-react";
+import { Search as SearchIcon, ChevronLeft, ChevronRight, BookOpen, Book, Library } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useSearchComics, useSearchManga } from "@/hooks/useSearch";
+import { useUnifiedSearch } from "@/hooks/useUnifiedSearch";
 import SearchResultsTable from "@/components/search/SearchResultsTable";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ContentType } from "@/types/entities";
+
+type SearchMode = "all" | ContentType;
 
 export default function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -15,11 +18,11 @@ export default function SearchPage() {
   const urlQuery = searchParams.get("q") || "";
   const urlPage = parseInt(searchParams.get("page") || "1") || 1;
   const urlSort = searchParams.get("sort") || "year_desc";
-  const urlContentType = (searchParams.get("type") as ContentType) || "comic";
+  const urlSearchMode = (searchParams.get("type") as SearchMode) || "all";
 
   // Initialize search query from URL parameter
   const [searchQuery, setSearchQuery] = useState(urlQuery);
-  const [contentType, setContentType] = useState<ContentType>(urlContentType);
+  const [searchMode, setSearchMode] = useState<SearchMode>(urlSearchMode);
 
   // Map frontend sort values to ComicVine API format (for comics)
   const comicSortMapping: Record<string, string> = {
@@ -42,41 +45,55 @@ export default function SearchPage() {
     follows: "follows",
   };
 
-  const apiSort = contentType === "manga"
-    ? mangaSortMapping[urlSort] || "relevance"
-    : comicSortMapping[urlSort] || urlSort;
+  const comicApiSort = comicSortMapping[urlSort] || urlSort;
+  const mangaApiSort = mangaSortMapping[urlSort] || "relevance";
 
-  // Use server-side pagination for comics
+  // Use unified search for "all" mode
+  const unifiedSearch = useUnifiedSearch(
+    searchMode === "all" ? urlQuery : "",
+    urlPage,
+    comicApiSort,
+    mangaApiSort,
+  );
+
+  // Use comic search for comic-only mode
   const comicSearch = useSearchComics(
-    contentType === "comic" ? urlQuery : "",
+    searchMode === "comic" ? urlQuery : "",
     urlPage,
-    apiSort,
+    comicApiSort,
   );
 
-  // Use server-side pagination for manga
+  // Use manga search for manga-only mode
   const mangaSearch = useSearchManga(
-    contentType === "manga" ? urlQuery : "",
+    searchMode === "manga" ? urlQuery : "",
     urlPage,
-    apiSort,
+    mangaApiSort,
   );
 
-  // Select the active search based on content type
-  const { data, isLoading, error } = contentType === "manga" ? mangaSearch : comicSearch;
+  // Select the active search based on search mode
+  const activeSearch = searchMode === "all"
+    ? unifiedSearch
+    : searchMode === "manga"
+      ? mangaSearch
+      : comicSearch;
+
+  const { data, isLoading, error } = activeSearch;
   const searchResults = data?.results || [];
   const pagination = data?.pagination;
 
   const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (searchQuery.trim().length > 2) {
-      setSearchParams({ q: searchQuery.trim(), page: "1", sort: urlSort, type: contentType });
+      setSearchParams({ q: searchQuery.trim(), page: "1", sort: urlSort, type: searchMode });
     }
   };
 
-  const handleContentTypeChange = (newType: ContentType) => {
-    setContentType(newType);
-    // If there's a query, re-search with new content type
+  const handleSearchModeChange = (newMode: SearchMode) => {
+    setSearchMode(newMode);
+    // If there's a query, re-search with new mode
     if (urlQuery) {
-      setSearchParams({ q: urlQuery, page: "1", sort: newType === "manga" ? "relevance" : urlSort, type: newType });
+      const newSort = newMode === "manga" ? "relevance" : urlSort;
+      setSearchParams({ q: urlQuery, page: "1", sort: newSort, type: newMode });
     }
   };
 
@@ -103,24 +120,44 @@ export default function SearchPage() {
     ? pagination.offset + (pagination.returned ?? 0)
     : 0;
 
+  // Get title based on search mode
+  const getTitle = () => {
+    switch (searchMode) {
+      case "all":
+        return "Search All";
+      case "manga":
+        return "Search Manga";
+      default:
+        return "Search Comics";
+    }
+  };
+
   return (
     <div className="space-y-4 page-transition">
       {/* Page Title */}
-      <h1 className="text-3xl font-bold">Search {contentType === "manga" ? "Manga" : "Comics"}</h1>
+      <h1 className="text-3xl font-bold">{getTitle()}</h1>
 
       {/* Content Type Toggle */}
       <div className="flex gap-2">
         <Button
-          variant={contentType === "comic" ? "default" : "outline"}
-          onClick={() => handleContentTypeChange("comic")}
+          variant={searchMode === "all" ? "default" : "outline"}
+          onClick={() => handleSearchModeChange("all")}
+          className="flex items-center"
+        >
+          <Library className="w-4 h-4 mr-2" />
+          All
+        </Button>
+        <Button
+          variant={searchMode === "comic" ? "default" : "outline"}
+          onClick={() => handleSearchModeChange("comic")}
           className="flex items-center"
         >
           <Book className="w-4 h-4 mr-2" />
           Comics
         </Button>
         <Button
-          variant={contentType === "manga" ? "default" : "outline"}
-          onClick={() => handleContentTypeChange("manga")}
+          variant={searchMode === "manga" ? "default" : "outline"}
+          onClick={() => handleSearchModeChange("manga")}
           className="flex items-center"
         >
           <BookOpen className="w-4 h-4 mr-2" />
@@ -132,7 +169,7 @@ export default function SearchPage() {
       <form onSubmit={handleSearch} className="flex gap-2 max-w-2xl">
         <Input
           type="text"
-          placeholder={`Enter ${contentType === "manga" ? "manga" : "comic"} name...`}
+          placeholder={`Enter ${searchMode === "all" ? "comic or manga" : searchMode} name...`}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="flex-1"
@@ -156,6 +193,11 @@ export default function SearchPage() {
             <>
               Showing {startIndex}-{endIndex} of {pagination?.total || 0}{" "}
               results for "{urlQuery}"
+              {searchMode === "all" && unifiedSearch.data && (
+                <span className="text-xs ml-2">
+                  ({unifiedSearch.comicSearch.data?.pagination?.total || 0} comics, {unifiedSearch.mangaSearch.data?.pagination?.total || 0} manga)
+                </span>
+              )}
             </>
           )}
         </p>
@@ -205,7 +247,8 @@ export default function SearchPage() {
             results={searchResults}
             currentSort={urlSort}
             onSortChange={handleSortChange}
-            contentType={contentType}
+            contentType={searchMode === "all" ? undefined : searchMode}
+            showTypeColumn={searchMode === "all"}
           />
 
           {/* Pagination Controls */}
@@ -242,7 +285,7 @@ export default function SearchPage() {
         <div className="text-center py-12">
           <SearchIcon className="w-16 h-16 text-gray-300 mx-auto mb-4" />
           <p className="text-muted-foreground text-lg">
-            Enter a search term to find {contentType === "manga" ? "manga" : "comics"}
+            Enter a search term to find {searchMode === "all" ? "comics and manga" : searchMode === "manga" ? "manga" : "comics"}
           </p>
           <p className="text-gray-400 text-sm mt-2">
             Search requires at least 3 characters

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   RefreshCw,
   Trash2,
   Home,
+  BookOpen,
 } from "lucide-react";
 import {
   useSeriesDetail,
@@ -19,7 +20,8 @@ import { Button } from "@/components/ui/button";
 import StatusBadge from "@/components/StatusBadge";
 import IssuesTable from "@/components/series/IssuesTable";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { Comic } from "@/types";
+import { Badge } from "@/components/ui/badge";
+import type { ComicOrManga } from "@/types";
 
 export default function SeriesDetailPage() {
   const { comicId } = useParams<{ comicId: string }>();
@@ -62,11 +64,15 @@ export default function SeriesDetailPage() {
     );
   }
 
-  const comic: Comic = Array.isArray(seriesData.comic)
+  const comic: ComicOrManga = Array.isArray(seriesData.comic)
     ? seriesData.comic[0]
     : seriesData.comic;
   const issues = seriesData.issues || [];
   const isPaused = comic.Status?.toLowerCase() === "paused";
+
+  // Check if this is a manga (either by ContentType field or ComicID prefix)
+  const isManga = comic.ContentType === "manga" || comicId?.startsWith("md-");
+  const itemLabel = isManga ? "Chapters" : "Issues";
 
   const handlePauseResume = async () => {
     if (!comicId) return;
@@ -167,9 +173,15 @@ export default function SeriesDetailPage() {
               )}
 
               <div className="flex items-center space-x-4 text-sm">
+                {isManga && (
+                  <Badge variant="default" className="flex items-center gap-1">
+                    <BookOpen className="w-3 h-3" />
+                    Manga
+                  </Badge>
+                )}
                 <div>
                   <span className="font-medium text-foreground">
-                    Total Issues:
+                    Total {itemLabel}:
                   </span>{" "}
                   <span className="text-muted-foreground">
                     {comic.Total || 0}
@@ -253,10 +265,10 @@ export default function SeriesDetailPage() {
         </div>
       </div>
 
-      {/* Issues */}
+      {/* Issues/Chapters */}
       <div className="space-y-4">
-        <h2 className="text-2xl font-bold">Issues</h2>
-        <IssuesTable issues={issues} />
+        <h2 className="text-2xl font-bold">{itemLabel}</h2>
+        <IssuesTable issues={issues} isManga={isManga} />
       </div>
     </div>
   );

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -102,3 +102,52 @@ export interface SeriesDetail {
   issues: Issue[];
   annuals?: Issue[];
 }
+
+/** Content type for comic/manga distinction */
+export type ContentType = "comic" | "manga";
+
+/** Reading direction for manga */
+export type ReadingDirection = "ltr" | "rtl";
+
+/** Manga search result with manga-specific fields */
+export interface MangaSearchResult extends SearchResult {
+  content_type: "manga";
+  reading_direction: ReadingDirection;
+  metadata_source: "mangadex";
+  external_id?: string;
+  status?: "ongoing" | "completed" | "hiatus" | "cancelled" | "unknown";
+  content_rating?: "safe" | "suggestive" | "erotica" | "pornographic";
+}
+
+/** Manga chapter (equivalent to Issue for manga) */
+export interface MangaChapter {
+  id: string;
+  chapter: string | null;
+  volume: string | null;
+  title: string | null;
+  language: string;
+  pages: number;
+  publish_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  scanlation_group: string | null;
+  external_url: string | null;
+  // Mapped to Mylar issue structure
+  issue_number: string | null;
+  issue_name: string | null;
+  release_date: string | null;
+}
+
+/** Extended Comic interface with manga support */
+export interface ComicOrManga extends Comic {
+  ContentType?: ContentType;
+  ReadingDirection?: ReadingDirection;
+  MetadataSource?: string | null;
+  ExternalID?: string | null;
+}
+
+/** Extended Issue interface with manga chapter support */
+export interface IssueOrChapter extends Issue {
+  ChapterNumber?: string | null;
+  VolumeNumber?: string | null;
+}

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -144,7 +144,7 @@ export interface MangaChapter {
 
 /** Extended Comic interface with manga support */
 export interface ComicOrManga extends Comic {
-  ContentType?: ContentType;
+  ContentType?: ContentType | null;
   ReadingDirection?: ReadingDirection;
   MetadataSource?: string | null;
   ExternalID?: string | null;

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -34,6 +34,7 @@ export interface Comic {
   ForceContinuing?: boolean;
   AlternateSearch?: string | null;
   ComicVersion?: string | null;
+  ContentType?: ContentType | null;
 }
 
 /** Issue entity */
@@ -52,6 +53,9 @@ export interface Issue {
   ImageURL?: string | null;
   ImageURL_ALT?: string | null;
   Int_IssueNumber?: number | null;
+  // Chapter/Volume fields for manga support
+  chapterNumber?: string | null;
+  volumeNumber?: string | null;
   // Alternative property names used in some API responses
   id?: string;
   number?: string;
@@ -150,4 +154,13 @@ export interface ComicOrManga extends Comic {
 export interface IssueOrChapter extends Issue {
   ChapterNumber?: string | null;
   VolumeNumber?: string | null;
+}
+
+/** Volume group for chapters/volumes view */
+export interface VolumeGroup {
+  volume: string;
+  chapters: IssueOrChapter[];
+  status: "Complete" | "Partial" | "Missing";
+  downloadedCount: number;
+  totalCount: number;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -31,6 +31,7 @@ export type {
   MangaChapter,
   ComicOrManga,
   IssueOrChapter,
+  VolumeGroup,
 } from "./entities";
 
 // Auth types

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -25,6 +25,12 @@ export type {
   WantedIssue,
   UpcomingIssue,
   SeriesDetail,
+  ContentType,
+  ReadingDirection,
+  MangaSearchResult,
+  MangaChapter,
+  ComicOrManga,
+  IssueOrChapter,
 } from "./entities";
 
 // Auth types

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -1153,6 +1153,28 @@ def dbcheck():
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE comics ADD COLUMN cv_removed INT')
 
+    # -- Manga Support Columns --
+
+    try:
+        c.execute('SELECT ContentType from comics')
+    except sqlite3.OperationalError:
+        c.execute("ALTER TABLE comics ADD COLUMN ContentType TEXT DEFAULT 'comic'")
+
+    try:
+        c.execute('SELECT ReadingDirection from comics')
+    except sqlite3.OperationalError:
+        c.execute("ALTER TABLE comics ADD COLUMN ReadingDirection TEXT DEFAULT 'ltr'")
+
+    try:
+        c.execute('SELECT MetadataSource from comics')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE comics ADD COLUMN MetadataSource TEXT')
+
+    try:
+        c.execute('SELECT ExternalID from comics')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE comics ADD COLUMN ExternalID TEXT')
+
     try:
         c.execute('SELECT DynamicComicName from comics')
         if CONFIG.DYNAMIC_UPDATE < 3:
@@ -1204,6 +1226,18 @@ def dbcheck():
         c.execute('SELECT forced_file from issues')
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE issues ADD COLUMN forced_file INT')
+
+    # -- Manga Support Columns for Issues --
+
+    try:
+        c.execute('SELECT ChapterNumber from issues')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE issues ADD COLUMN ChapterNumber TEXT')
+
+    try:
+        c.execute('SELECT VolumeNumber from issues')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE issues ADD COLUMN VolumeNumber TEXT')
 
     ## -- ImportResults Table --
 

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -41,7 +41,8 @@ cmd_list = ['getIndex', 'getComic', 'getUpcoming', 'getWanted', 'getHistory',
             'refreshSeriesjson', 'seriesjsonListing', 'checkGlobalMessages',
             'listProviders', 'changeProvider', 'addProvider', 'delProvider',
             'downloadNZB', 'getReadList', 'getStoryArc', 'addStoryArc', 'listAnnualSeries',
-            'getConfig', 'setConfig', 'getSeriesImage']
+            'getConfig', 'setConfig', 'getSeriesImage',
+            'findManga', 'addManga', 'getMangaInfo']
 
 class Api(object):
 
@@ -1190,7 +1191,7 @@ class Api(object):
             else:
                 self.data = self._failureResponse('Failed to return a image')
 
-    def _findComic(self, name, issue=None, type_=None, mode=None, serinfo=None, limit=None, offset=None, sort=None):
+    def _findComic(self, name, issue=None, type_=None, mode=None, serinfo=None, limit=None, offset=None, sort=None, content_type=None):
         # set defaults
         if type_ is None:
             type_ = 'comic'
@@ -1206,12 +1207,19 @@ class Api(object):
         parsed_limit = int(limit) if limit else None
         parsed_offset = int(offset) if offset else None
 
-        if type_ == 'comic' and mode == 'series':
-            searchresults = mb.findComic(name, mode, issue=issue, limit=parsed_limit, offset=parsed_offset, sort=sort)
+        # Handle manga search via content_type parameter
+        if content_type == 'manga':
+            if not mylar.CONFIG.MANGADEX_ENABLED:
+                self.data = self._failureResponse('MangaDex integration is not enabled')
+                return
+            from mylar import mangadex
+            searchresults = mangadex.search_manga(name, limit=parsed_limit, offset=parsed_offset, sort=sort)
+        elif type_ == 'comic' and mode == 'series':
+            searchresults = mb.findComic(name, mode, issue=issue, limit=parsed_limit, offset=parsed_offset, sort=sort, content_type=content_type)
         elif type_ == 'comic' and mode == 'pullseries':
-            searchresults = mb.findComic(name, mode, issue=issue, limit=parsed_limit, offset=parsed_offset, sort=sort)
+            searchresults = mb.findComic(name, mode, issue=issue, limit=parsed_limit, offset=parsed_offset, sort=sort, content_type=content_type)
         elif type_ == 'comic' and mode == 'want':
-            searchresults = mb.findComic(name, mode, issue=issue, limit=parsed_limit, offset=parsed_offset, sort=sort)
+            searchresults = mb.findComic(name, mode, issue=issue, limit=parsed_limit, offset=parsed_offset, sort=sort, content_type=content_type)
         elif type_ == 'story_arc':
             searchresults = mb.findComic(name, mode, issue=None, search_type='story_arc', limit=parsed_limit, offset=parsed_offset, sort=sort)
 
@@ -2100,6 +2108,150 @@ class Api(object):
         image_url = metron.get_series_image(series_id)
 
         self.data = self._successResponse({'image': image_url})
+
+    def _findManga(self, **kwargs):
+        """
+        Search for manga using MangaDex API.
+
+        Parameters:
+            name: Manga name to search for (required)
+            limit: Number of results per page (optional)
+            offset: Offset for pagination (optional)
+            sort: Sort order (optional) - relevance, latest, oldest, title_asc, title_desc, year_desc, year_asc, follows
+
+        Returns:
+            Search results with pagination metadata
+        """
+        if 'name' not in kwargs or not kwargs['name']:
+            self.data = self._failureResponse('Missing parameter: name')
+            return
+
+        name = kwargs['name']
+        limit = kwargs.get('limit')
+        offset = kwargs.get('offset')
+        sort = kwargs.get('sort')
+
+        # Check if MangaDex is enabled
+        if not mylar.CONFIG.MANGADEX_ENABLED:
+            self.data = self._failureResponse('MangaDex integration is not enabled')
+            return
+
+        # Parse pagination parameters
+        parsed_limit = int(limit) if limit else None
+        parsed_offset = int(offset) if offset else None
+
+        from mylar import mangadex
+        searchresults = mangadex.search_manga(name, limit=parsed_limit, offset=parsed_offset, sort=sort)
+
+        # Transform haveit field to in_library boolean for frontend
+        def add_in_library(manga):
+            manga['in_library'] = manga.get('haveit') != "No"
+            return manga
+
+        if isinstance(searchresults, dict) and 'results' in searchresults:
+            searchresults['results'] = [add_in_library(m) for m in searchresults['results']]
+            self.data = searchresults
+        else:
+            self.data = self._failureResponse('Search returned no results')
+
+    def _addManga(self, **kwargs):
+        """
+        Add a manga to the library by MangaDex ID.
+
+        Parameters:
+            id: MangaDex manga ID (with or without 'md-' prefix) (required)
+
+        Returns:
+            Success/failure response
+        """
+        if 'id' not in kwargs:
+            self.data = self._failureResponse('Missing parameter: id')
+            return
+
+        manga_id = kwargs['id']
+
+        # Ensure the ID has the md- prefix
+        if not str(manga_id).startswith('md-'):
+            manga_id = 'md-' + manga_id
+
+        # Check if MangaDex is enabled
+        if not mylar.CONFIG.MANGADEX_ENABLED:
+            self.data = self._failureResponse('MangaDex integration is not enabled')
+            return
+
+        try:
+            from mylar import importer
+            result = importer.addMangaToDB(manga_id)
+
+            if result and result.get('status') == 'complete':
+                self.data = self._successResponse({
+                    'message': 'Successfully added manga: %s' % result.get('comicname', manga_id),
+                    'comicid': manga_id,
+                    'content_type': 'manga'
+                })
+            else:
+                self.data = self._failureResponse('Failed to add manga: %s' % manga_id)
+        except Exception as e:
+            logger.error('[API][addManga] Error adding manga %s: %s' % (manga_id, e))
+            self.data = self._failureResponse('Error adding manga: %s' % str(e))
+
+    def _getMangaInfo(self, **kwargs):
+        """
+        Get detailed information about a manga from MangaDex.
+
+        Parameters:
+            id: MangaDex manga ID (with or without 'md-' prefix) (required)
+            include_chapters: Whether to include chapter list (optional, default False)
+
+        Returns:
+            Manga details and optionally chapter list
+        """
+        if 'id' not in kwargs:
+            self.data = self._failureResponse('Missing parameter: id')
+            return
+
+        manga_id = kwargs['id']
+        include_chapters = kwargs.get('include_chapters', 'false').lower() == 'true'
+
+        # Check if MangaDex is enabled
+        if not mylar.CONFIG.MANGADEX_ENABLED:
+            self.data = self._failureResponse('MangaDex integration is not enabled')
+            return
+
+        from mylar import mangadex
+
+        # Get manga details
+        details = mangadex.get_manga_details(manga_id)
+
+        if not details:
+            self.data = self._failureResponse('Manga not found: %s' % manga_id)
+            return
+
+        response_data = {
+            'manga': details
+        }
+
+        # Optionally include chapters
+        if include_chapters:
+            chapters = mangadex.get_all_chapters(manga_id)
+            response_data['chapters'] = chapters
+            response_data['chapter_count'] = len(chapters)
+
+        # Check if manga is in library
+        myDB = db.DBConnection()
+        if str(manga_id).startswith('md-'):
+            db_manga = myDB.selectone('SELECT * FROM comics WHERE ComicID=?', [manga_id]).fetchone()
+        else:
+            db_manga = myDB.selectone('SELECT * FROM comics WHERE ComicID=?', ['md-' + manga_id]).fetchone()
+
+        response_data['in_library'] = db_manga is not None
+        if db_manga:
+            response_data['library_status'] = db_manga['Status']
+            response_data['have'] = db_manga['Have']
+            response_data['total'] = db_manga['Total']
+
+        self.data = self._successResponse(response_data)
+
 
 class REST(object):
 

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -1207,8 +1207,12 @@ class Api(object):
             return
 
         # Parse pagination parameters
-        parsed_limit = int(limit) if limit else None
-        parsed_offset = int(offset) if offset else None
+        try:
+            parsed_limit = int(limit) if limit else None
+            parsed_offset = int(offset) if offset else None
+        except ValueError:
+            self.data = self._failureResponse('Invalid pagination parameters: limit and offset must be integers')
+            return
 
         # Handle manga search via content_type parameter
         if content_type == 'manga':
@@ -2140,8 +2144,12 @@ class Api(object):
             return
 
         # Parse pagination parameters
-        parsed_limit = int(limit) if limit else None
-        parsed_offset = int(offset) if offset else None
+        try:
+            parsed_limit = int(limit) if limit else None
+            parsed_offset = int(offset) if offset else None
+        except ValueError:
+            self.data = self._failureResponse('Invalid pagination parameters: limit and offset must be integers')
+            return
 
         from mylar import mangadex
         searchresults = mangadex.search_manga(name, limit=parsed_limit, offset=parsed_offset, sort=sort)

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -307,7 +307,8 @@ class Api(object):
             LatestIssue as LatestIssue,\
             Total as Total,\
             Have as Have,\
-            DetailURL as DetailURL\
+            DetailURL as DetailURL,\
+            ContentType as ContentType\
         FROM comics'
 
     def _selectForIssues(self):
@@ -319,7 +320,9 @@ class Api(object):
             ReleaseDate as releaseDate,\
             IssueDate as issueDate,\
             Status as status,\
-            ComicName as comicName\
+            ComicName as comicName,\
+            ChapterNumber as chapterNumber,\
+            VolumeNumber as volumeNumber\
         FROM issues'
 
     def _selectForAnnuals(self):

--- a/mylar/config.py
+++ b/mylar/config.py
@@ -172,6 +172,10 @@ _CONFIG_DEFINITIONS = OrderedDict({
     'METRON_PASSWORD': (str, 'Metron', None),
     'USE_METRON_SEARCH': (bool, 'Metron', False),
 
+    'MANGADEX_ENABLED': (bool, 'MangaDex', False),
+    'MANGADEX_LANGUAGES': (str, 'MangaDex', 'en'),
+    'MANGADEX_CONTENT_RATING': (str, 'MangaDex', 'safe,suggestive'),
+
     'LOG_DIR' : (str, 'Logs', None),
     'MAX_LOGSIZE' : (int, 'Logs', 10000000),
     'MAX_LOGFILES': (int, 'Logs', 5),

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -358,6 +358,37 @@ class FileChecker(object):
         #the remaining strings should be the series title and/or issue title if present (has to be detected properly)
         modseries = modfilename
 
+        # Manga-specific chapter/volume detection patterns
+        # Common manga naming formats:
+        # [Group] Title - c001 (v01).cbz
+        # Title Chapter 001.cbz
+        # Title Vol.01 Ch.001.cbz
+        # Title - Vol. 01 Ch. 001.cbz
+        # Title v01 c001.cbz
+        manga_chapter = None
+        manga_volume = None
+
+        # Pattern: c001, c1, ch001, ch.001, chapter001, chapter 001
+        manga_chapter_match = re.search(r'(?:ch(?:apter)?\.?\s*|c)(\d+(?:\.\d+)?)', modfilename, re.IGNORECASE)
+        if manga_chapter_match:
+            manga_chapter = manga_chapter_match.group(1)
+            logger.fdebug('[MANGA] Chapter detected: %s' % manga_chapter)
+
+        # Pattern: v01, vol01, vol.01, volume01, volume 01
+        manga_volume_match = re.search(r'(?:v(?:ol(?:ume)?)?\.?\s*)(\d+)', modfilename, re.IGNORECASE)
+        if manga_volume_match:
+            manga_volume = manga_volume_match.group(1)
+            logger.fdebug('[MANGA] Volume detected: %s' % manga_volume)
+
+        # Detect scanlation group pattern: [Group Name]
+        scanlation_group_match = re.search(r'^\s*\[([^\]]+)\]', modfilename)
+        if scanlation_group_match:
+            if scangroup is None:
+                scangroup = scanlation_group_match.group(1)
+                logger.fdebug('[MANGA] Scanlation group detected: %s' % scangroup)
+            # Remove the group tag from modfilename for cleaner series name extraction
+            modfilename = re.sub(r'^\s*\[[^\]]+\]\s*', '', modfilename).strip()
+
         #try and remove /remember unicode character strings here (multiline ones get seperated/removed in below regex)
         pat = re.compile('[\x00-\x7f]{3,}', re.UNICODE)
         replack = pat.sub('XCV', modfilename)
@@ -471,6 +502,11 @@ class FileChecker(object):
         lastissue_position = 0
         lastmod_position = 0
         booktype = 'issue'
+
+        # Set booktype to manga if manga chapter pattern was detected
+        if manga_chapter is not None:
+            booktype = 'manga'
+            logger.fdebug('[MANGA] Detected manga chapter format, booktype set to manga')
 
         file_length = 0
         validcountchk = False
@@ -1351,6 +1387,11 @@ class FileChecker(object):
                             'reading_order':       None}
 
         if self.justparse:
+            # For manga, use chapter as issue number if not already detected
+            final_issue_number = issue_number
+            if manga_chapter is not None and (issue_number is None or booktype == 'manga'):
+                final_issue_number = manga_chapter
+
             return {'parse_status':           'success',
                     'type':                   re.sub('\.','', filetype).strip(),
                     'sub':                    path_list,
@@ -1362,12 +1403,19 @@ class FileChecker(object):
                     'alt_series':             alt_series,
                     'alt_issue':              alt_issue,
                     'dynamic_name':           self.dynamic_replace(series_name)['mod_seriesname'],
-                    'series_volume':          issue_volume,
+                    'series_volume':          issue_volume if manga_volume is None else 'v%s' % manga_volume,
                     'issue_year':             issue_year,
-                    'issue_number':           issue_number,
+                    'issue_number':           final_issue_number,
                     'scangroup':              scangroup,
                     'booktype':               booktype,
-                    'reading_order':          reading_order}
+                    'reading_order':          reading_order,
+                    'manga_chapter':          manga_chapter,
+                    'manga_volume':           manga_volume}
+
+        # For manga, use chapter as issue number if not already detected
+        final_issue_number = issue_number
+        if manga_chapter is not None and (issue_number is None or booktype == 'manga'):
+            final_issue_number = manga_chapter
 
         series_info = {}
         series_info = {'sub':                    path_list,
@@ -1379,11 +1427,13 @@ class FileChecker(object):
                        'issueid':                issueid,
                        'alt_series':             alt_series,
                        'alt_issue':              alt_issue,
-                       'series_volume':          issue_volume,
+                       'series_volume':          issue_volume if manga_volume is None else 'v%s' % manga_volume,
                        'issue_year':             issue_year,
-                       'issue_number':           issue_number,
+                       'issue_number':           final_issue_number,
                        'scangroup':              scangroup,
-                       'booktype':               booktype}
+                       'booktype':               booktype,
+                       'manga_chapter':          manga_chapter,
+                       'manga_volume':           manga_volume}
 
         return self.matchIT(series_info)
 

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -927,9 +927,26 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
             issue_count += 1
 
             # Track latest chapter
-            if latest_chapter is None or float(chapter_num) > float(latest_chapter):
-                latest_chapter = chapter_num
-                latest_date = release_date
+            try:
+                chapter_float = float(chapter_num)
+                if latest_chapter is None:
+                    latest_chapter = chapter_num
+                    latest_date = release_date
+                else:
+                    try:
+                        if chapter_float > float(latest_chapter):
+                            latest_chapter = chapter_num
+                            latest_date = release_date
+                    except ValueError:
+                        # latest_chapter is non-numeric, update anyway
+                        latest_chapter = chapter_num
+                        latest_date = release_date
+            except ValueError:
+                # chapter_num is non-numeric (e.g., "oneshot", "special", "prologue")
+                # Skip numeric comparison but still track if it's the first chapter
+                if latest_chapter is None:
+                    latest_chapter = chapter_num
+                    latest_date = release_date
 
         # Update comic with issue count and latest info
         update_values = {

--- a/mylar/importer.py
+++ b/mylar/importer.py
@@ -118,6 +118,10 @@ def markIssueWantedById(issueId):
 def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=None, calledfrom=None, annload=None, chkwant=None, issuechk=None, issuetype=None, latestissueinfo=None, csyear=None, fixed_type=None, suppress_addall=None):
     myDB = db.DBConnection()
 
+    # Check if this is a MangaDex manga ID (prefixed with 'md-')
+    if str(comicid).startswith('md-'):
+        return addMangaToDB(comicid, imported=imported, calledfrom=calledfrom)
+
     controlValueDict = {"ComicID":     comicid}
 
     dbcomic = myDB.selectone('SELECT * FROM comics WHERE ComicID=?', [comicid]).fetchone()
@@ -757,6 +761,198 @@ def addComictoDB(comicid, mismatch=None, pullupd=None, imported=None, ogcname=No
 #                            "SRID":             result['SRID'],
 #                            "ComicID":          comicid}
 #                myDB.upsert("importresults", newValue, controlValue)
+
+
+def addMangaToDB(mangaid, imported=None, calledfrom=None):
+    """
+    Add a manga from MangaDex to the database.
+
+    Args:
+        mangaid: MangaDex manga ID (prefixed with 'md-')
+        imported: Import information if coming from file import
+        calledfrom: Calling context
+
+    Returns:
+        dict with status information
+    """
+    from mylar import mangadex
+
+    myDB = db.DBConnection()
+    logger.info('[MANGADEX] Adding manga with ID: %s' % mangaid)
+
+    # Get the raw MangaDex UUID (without md- prefix)
+    mangadex_uuid = mangadex.strip_manga_prefix(mangaid)
+
+    controlValueDict = {"ComicID": mangaid}
+
+    # Check if manga already exists
+    dbmanga = myDB.selectone('SELECT * FROM comics WHERE ComicID=?', [mangaid]).fetchone()
+
+    if dbmanga is not None:
+        if dbmanga['Status'] == 'Active':
+            series_status = 'Active'
+        elif dbmanga['Status'] == 'Paused':
+            series_status = 'Paused'
+        else:
+            series_status = 'Loading'
+        comlocation = dbmanga['ComicLocation']
+    else:
+        series_status = 'Loading'
+        comlocation = None
+
+    # Set loading status
+    myDB.upsert("comics", {"Status": "Loading"}, controlValueDict)
+
+    # Fetch manga details from MangaDex
+    manga = mangadex.get_manga_details(mangaid)
+
+    if not manga:
+        logger.error('[MANGADEX] Error fetching manga details for: %s' % mangaid)
+        myDB.upsert("comics", {
+            "ComicName": "Fetch failed, try refreshing. (%s)" % mangaid,
+            "Status": "Active"
+        }, controlValueDict)
+        return {'status': 'incomplete'}
+
+    manga_name = manga.get('name', 'Unknown')
+    manga_year = manga.get('year') or '0000'
+    description = manga.get('description', 'No description available')
+
+    logger.info('[MANGADEX] Now adding: %s (%s)' % (manga_name, manga_year))
+
+    # Generate sort name
+    if manga_name.startswith('The '):
+        sortname = manga_name[4:]
+    else:
+        sortname = manga_name
+
+    # Generate dynamic name for matching
+    dynamic_name = helpers.filesafe(re.sub(r'[\'\!\@\#\$\%\:\;\/\\]', '', manga_name).lower())
+
+    # Build folder path if destination directory is set
+    if mylar.CONFIG.DESTINATION_DIR:
+        folder_format = mylar.CONFIG.FOLDER_FORMAT or '$Series ($Year)'
+        folder_name = folder_format.replace('$Series', manga_name).replace('$Year', str(manga_year))
+        folder_name = helpers.filesafe(folder_name)
+        comlocation = os.path.join(mylar.CONFIG.DESTINATION_DIR, folder_name)
+
+        if mylar.CONFIG.CREATE_FOLDERS:
+            checkdirectory = filechecker.validateAndCreateDirectory(comlocation, True)
+            if not checkdirectory:
+                logger.warn('[MANGADEX] Error creating directory for %s' % manga_name)
+    elif comlocation is None:
+        comlocation = None
+
+    # Map MangaDex status to Mylar status format
+    md_status = manga.get('status', 'unknown')
+    status_mapping = {
+        'ongoing': 'Continuing',
+        'completed': 'Ended',
+        'hiatus': 'Continuing',
+        'cancelled': 'Ended'
+    }
+    comic_published = status_mapping.get(md_status, 'Unknown')
+
+    # Prepare comic values
+    comic_values = {
+        "ComicID": mangaid,
+        "ComicName": manga_name,
+        "ComicSortName": sortname,
+        "ComicYear": str(manga_year),
+        "Status": series_status if series_status != 'Loading' else 'Active',
+        "ComicPublished": comic_published,
+        "ComicPublisher": manga.get('author', 'Unknown'),
+        "Description": description[:4000] if description else None,
+        "ComicImage": manga.get('cover_url', 'cache/blankcover.jpg'),
+        "ComicImageURL": manga.get('cover_url'),
+        "DetailURL": manga.get('url'),
+        "DynamicComicName": dynamic_name,
+        "ComicLocation": comlocation,
+        "Type": 'Manga',
+        "ContentType": 'manga',
+        "ReadingDirection": 'rtl',
+        "MetadataSource": 'mangadex',
+        "ExternalID": mangadex_uuid,
+        "LastUpdated": helpers.now(),
+        "DateAdded": helpers.today() if dbmanga is None else dbmanga.get('DateAdded', helpers.today()),
+    }
+
+    # Store alternate titles as AlternateSearch
+    alt_titles = manga.get('alt_titles', [])
+    if alt_titles:
+        comic_values["AlternateSearch"] = '##'.join(alt_titles[:5])  # Limit to 5 alt titles
+
+    myDB.upsert("comics", comic_values, controlValueDict)
+
+    # Now fetch and add chapters as issues
+    logger.info('[MANGADEX] Fetching chapters for: %s' % manga_name)
+    chapters = mangadex.get_all_chapters(mangaid)
+
+    if chapters:
+        issue_count = 0
+        latest_chapter = None
+        latest_date = None
+
+        for chapter in chapters:
+            chapter_num = chapter.get('chapter')
+            if chapter_num is None:
+                continue
+
+            # Create a unique issue ID using manga ID and chapter
+            issue_id = '%s-ch%s' % (mangaid, chapter_num)
+
+            # Determine issue status
+            issue_status = 'Skipped'
+            if mylar.CONFIG.AUTOWANT_ALL:
+                issue_status = 'Wanted'
+
+            release_date = chapter.get('release_date') or chapter.get('publish_at', '')[:10] if chapter.get('publish_at') else None
+
+            issue_values = {
+                "IssueID": issue_id,
+                "ComicID": mangaid,
+                "ComicName": manga_name,
+                "Issue_Number": str(chapter_num),
+                "IssueName": chapter.get('title') or ('Chapter %s' % chapter_num),
+                "ReleaseDate": release_date,
+                "IssueDate": release_date,
+                "Status": issue_status,
+                "Int_IssueNumber": helpers.issuedigits(chapter_num),
+                "ChapterNumber": str(chapter_num),
+                "VolumeNumber": str(chapter.get('volume')) if chapter.get('volume') else None,
+                "DateAdded": helpers.now(),
+            }
+
+            myDB.upsert("issues", issue_values, {"IssueID": issue_id})
+            issue_count += 1
+
+            # Track latest chapter
+            if latest_chapter is None or float(chapter_num) > float(latest_chapter):
+                latest_chapter = chapter_num
+                latest_date = release_date
+
+        # Update comic with issue count and latest info
+        update_values = {
+            "Total": issue_count,
+            "Have": 0,
+            "LatestIssue": str(latest_chapter) if latest_chapter else '0',
+            "LatestDate": latest_date or 'Unknown',
+        }
+        myDB.upsert("comics", update_values, controlValueDict)
+
+        logger.info('[MANGADEX] Added %d chapters for %s' % (issue_count, manga_name))
+
+    # Update sort order
+    helpers.ComicSort(comicorder=mylar.COMICSORT, imported=mangaid)
+
+    logger.info('[MANGADEX] Successfully added manga: %s' % manga_name)
+
+    return {
+        'status': 'complete',
+        'comicid': mangaid,
+        'comicname': manga_name,
+        'content_type': 'manga'
+    }
 
 
 def GCDimport(gcomicid, pullupd=None, imported=None, ogcname=None):

--- a/mylar/mangadex.py
+++ b/mylar/mangadex.py
@@ -476,7 +476,7 @@ def get_manga_chapters(manga_id, languages=None, limit=100, offset=0):
     Args:
         manga_id: MangaDex manga UUID (without md- prefix)
         languages: List of language codes to filter by (defaults to config)
-        limit: Number of chapters per request (max 500)
+        limit: Number of chapters per request (max 100)
         offset: Offset for pagination
 
     Returns:
@@ -494,7 +494,7 @@ def get_manga_chapters(manga_id, languages=None, limit=100, offset=0):
     params = {
         'manga': manga_id,
         'translatedLanguage[]': languages,
-        'limit': min(limit, 500),
+        'limit': min(limit, 100),  # MangaDex chapter endpoint max is 100
         'offset': offset,
         'order[chapter]': 'asc',
         'includes[]': ['scanlation_group']
@@ -555,13 +555,54 @@ def get_manga_chapters(manga_id, languages=None, limit=100, offset=0):
     }
 
 
-def get_all_chapters(manga_id, languages=None):
+def get_manga_aggregate(manga_id, languages=None):
+    """
+    Get aggregate chapter/volume info for a manga (includes unavailable chapters).
+
+    This endpoint returns ALL chapter numbers even if they don't have uploads,
+    which is useful for tracking series like Naruto where most chapters are
+    licensed and not available on MangaDex.
+
+    Args:
+        manga_id: MangaDex manga UUID (with or without md- prefix)
+        languages: List of language codes to filter by
+
+    Returns:
+        dict with volume/chapter structure
+    """
+    # Remove md- prefix if present
+    if manga_id.startswith('md-'):
+        manga_id = manga_id[3:]
+
+    if languages is None:
+        languages = _get_languages()
+
+    logger.info('[MANGADEX] Fetching aggregate for manga: %s' % manga_id)
+
+    params = {
+        'translatedLanguage[]': languages,
+    }
+
+    data = _make_request(f'/manga/{manga_id}/aggregate', params=params)
+
+    if not data or data.get('result') != 'ok':
+        logger.error('[MANGADEX] Failed to fetch aggregate for manga %s' % manga_id)
+        return {'volumes': {}}
+
+    return data
+
+
+def get_all_chapters(manga_id, languages=None, include_unavailable=True):
     """
     Get all chapters for a manga (handles pagination automatically).
+
+    When include_unavailable=True, generates entries for ALL chapters up to
+    lastChapter from manga metadata, even if they don't have uploads.
 
     Args:
         manga_id: MangaDex manga UUID (without md- prefix)
         languages: List of language codes to filter by
+        include_unavailable: If True, include chapters without uploads
 
     Returns:
         List of all chapters
@@ -571,21 +612,22 @@ def get_all_chapters(manga_id, languages=None):
         manga_id = manga_id[3:]
 
     # Check cache first
-    cache_key = f"{manga_id}:{','.join(languages or _get_languages())}"
+    cache_key = f"{manga_id}:{','.join(languages or _get_languages())}:{include_unavailable}"
     if cache_key in _CHAPTER_CACHE:
         cache_entry = _CHAPTER_CACHE[cache_key]
         if time.time() - cache_entry['timestamp'] < CACHE_TTL:
             logger.fdebug('[MANGADEX] Cache hit for chapters of manga %s' % manga_id)
             return cache_entry['data']
 
-    all_chapters = []
+    # First, get available chapters with full metadata (filtered by language)
+    available_chapters = []
     offset = 0
-    limit = 500
+    limit = 100  # MangaDex chapter endpoint max is 100
 
     while True:
         result = get_manga_chapters(manga_id, languages=languages, limit=limit, offset=offset)
         chapters = result.get('chapters', [])
-        all_chapters.extend(chapters)
+        available_chapters.extend(chapters)
 
         pagination = result.get('pagination', {})
         total = pagination.get('total', 0)
@@ -595,13 +637,75 @@ def get_all_chapters(manga_id, languages=None):
 
         offset += limit
 
+    # Create a map of available chapters by chapter number
+    available_map = {}
+    for ch in available_chapters:
+        ch_num = ch.get('chapter')
+        if ch_num is not None:
+            available_map[str(ch_num)] = ch
+
+    all_chapters = list(available_chapters)
+
+    # If requested, add unavailable chapters based on manga's lastChapter metadata
+    if include_unavailable:
+        # Get manga details to find total chapter count
+        manga_details = get_manga_details(manga_id)
+        last_chapter_str = manga_details.get('last_chapter')
+
+        if last_chapter_str:
+            try:
+                last_chapter = int(float(last_chapter_str))
+                logger.info('[MANGADEX] Manga has %d total chapters (lastChapter from metadata)' % last_chapter)
+
+                # Generate placeholder entries for all chapters from 1 to lastChapter
+                for ch_num in range(1, last_chapter + 1):
+                    ch_num_str = str(ch_num)
+                    # Skip if we already have this chapter
+                    if ch_num_str in available_map:
+                        continue
+
+                    # Create a placeholder entry for unavailable chapter
+                    all_chapters.append({
+                        'id': f'unavailable-{manga_id}-{ch_num}',
+                        'chapter': ch_num_str,
+                        'volume': None,
+                        'title': None,
+                        'language': 'en',
+                        'pages': 0,
+                        'publish_at': None,
+                        'created_at': None,
+                        'updated_at': None,
+                        'scanlation_group': None,
+                        'external_url': None,
+                        'unavailable': True,  # Flag to indicate no upload available
+                    })
+            except (ValueError, TypeError) as e:
+                logger.warning('[MANGADEX] Could not parse lastChapter "%s": %s' % (last_chapter_str, e))
+
+    # Sort chapters by chapter number
+    def sort_key(ch):
+        ch_num = ch.get('chapter')
+        if ch_num is None:
+            return float('inf')
+        try:
+            return float(ch_num)
+        except (ValueError, TypeError):
+            return float('inf')
+
+    all_chapters.sort(key=sort_key)
+
     # Cache the result
     _CHAPTER_CACHE[cache_key] = {
         'data': all_chapters,
         'timestamp': time.time()
     }
 
-    logger.info('[MANGADEX] Retrieved total of %d chapters for manga %s' % (len(all_chapters), manga_id))
+    logger.info('[MANGADEX] Retrieved total of %d chapters (%d available, %d unavailable) for manga %s' % (
+        len(all_chapters),
+        len(available_chapters),
+        len(all_chapters) - len(available_chapters),
+        manga_id
+    ))
     return all_chapters
 
 

--- a/mylar/mangadex.py
+++ b/mylar/mangadex.py
@@ -1,0 +1,670 @@
+#  This file is part of Mylar.
+#
+#  Mylar is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Mylar is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Mylar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+MangaDex API integration for manga search and metadata functionality.
+
+Uses the MangaDex API v5 to search for manga series and retrieve chapter information.
+Provides chapter-level tracking which aligns with Mylar's issue-level tracking model.
+
+API Documentation: https://api.mangadex.org/docs/
+"""
+
+import time
+import requests
+from datetime import datetime
+
+import mylar
+from mylar import logger
+from mylar.helpers import listLibrary
+
+# MangaDex API base URL
+MANGADEX_API_BASE = 'https://api.mangadex.org'
+
+# In-memory cache for manga images and metadata to avoid repeated API calls
+_IMAGE_CACHE = {}  # {manga_id: cover_url}
+_MANGA_CACHE = {}  # {manga_id: manga_details}
+_CHAPTER_CACHE = {}  # {manga_id: chapters_list}
+
+# Cache TTL in seconds
+CACHE_TTL = 3600  # 1 hour
+
+# Rate limiter state
+_last_request_time = 0
+_rate_limit_interval = 0.2  # 5 requests per second
+
+# Content rating mapping
+CONTENT_RATING_MAP = {
+    'safe': 'safe',
+    'suggestive': 'suggestive',
+    'erotica': 'erotica',
+    'pornographic': 'pornographic'
+}
+
+
+def _rate_limit():
+    """
+    Implement rate limiting for MangaDex API (5 requests/second max).
+    """
+    global _last_request_time
+    current_time = time.time()
+    elapsed = current_time - _last_request_time
+    if elapsed < _rate_limit_interval:
+        time.sleep(_rate_limit_interval - elapsed)
+    _last_request_time = time.time()
+
+
+def _make_request(endpoint, params=None, method='GET'):
+    """
+    Make a rate-limited request to the MangaDex API.
+
+    Args:
+        endpoint: API endpoint (without base URL)
+        params: Query parameters
+        method: HTTP method (GET, POST, etc.)
+
+    Returns:
+        JSON response data or None on error
+    """
+    _rate_limit()
+
+    url = f"{MANGADEX_API_BASE}{endpoint}"
+    headers = {
+        'User-Agent': mylar.CONFIG.CV_USER_AGENT if mylar.CONFIG else 'Mylar3/1.0'
+    }
+
+    try:
+        if method == 'GET':
+            response = requests.get(url, params=params, headers=headers, timeout=30)
+        else:
+            response = requests.request(method, url, params=params, headers=headers, timeout=30)
+
+        response.raise_for_status()
+        return response.json()
+
+    except requests.exceptions.Timeout:
+        logger.error('[MANGADEX] Request timeout for %s' % endpoint)
+        return None
+    except requests.exceptions.RequestException as e:
+        logger.error('[MANGADEX] Request failed: %s' % e)
+        return None
+    except Exception as e:
+        logger.error('[MANGADEX] Unexpected error: %s' % e)
+        return None
+
+
+def _get_content_ratings():
+    """
+    Get the list of content ratings to include based on config.
+
+    Returns:
+        List of content rating strings for the API
+    """
+    if not mylar.CONFIG or not mylar.CONFIG.MANGADEX_CONTENT_RATING:
+        return ['safe', 'suggestive']
+
+    ratings = mylar.CONFIG.MANGADEX_CONTENT_RATING.split(',')
+    return [r.strip().lower() for r in ratings if r.strip().lower() in CONTENT_RATING_MAP]
+
+
+def _get_languages():
+    """
+    Get the list of languages to filter by from config.
+
+    Returns:
+        List of language codes (ISO 639-1)
+    """
+    if not mylar.CONFIG or not mylar.CONFIG.MANGADEX_LANGUAGES:
+        return ['en']
+
+    languages = mylar.CONFIG.MANGADEX_LANGUAGES.split(',')
+    return [lang.strip().lower() for lang in languages if lang.strip()]
+
+
+def _extract_cover_url(manga_data):
+    """
+    Extract cover image URL from manga data.
+
+    Args:
+        manga_data: Manga object from API response
+
+    Returns:
+        Cover URL string or default placeholder
+    """
+    manga_id = manga_data.get('id')
+    relationships = manga_data.get('relationships', [])
+
+    for rel in relationships:
+        if rel.get('type') == 'cover_art':
+            cover_filename = rel.get('attributes', {}).get('fileName')
+            if cover_filename:
+                return f"https://uploads.mangadex.org/covers/{manga_id}/{cover_filename}.256.jpg"
+
+    return 'cache/blankcover.jpg'
+
+
+def _extract_author(manga_data):
+    """
+    Extract author name from manga relationships.
+
+    Args:
+        manga_data: Manga object from API response
+
+    Returns:
+        Author name string or 'Unknown'
+    """
+    relationships = manga_data.get('relationships', [])
+
+    for rel in relationships:
+        if rel.get('type') == 'author':
+            return rel.get('attributes', {}).get('name', 'Unknown')
+
+    return 'Unknown'
+
+
+def _extract_artist(manga_data):
+    """
+    Extract artist name from manga relationships.
+
+    Args:
+        manga_data: Manga object from API response
+
+    Returns:
+        Artist name string or 'Unknown'
+    """
+    relationships = manga_data.get('relationships', [])
+
+    for rel in relationships:
+        if rel.get('type') == 'artist':
+            return rel.get('attributes', {}).get('name', 'Unknown')
+
+    return 'Unknown'
+
+
+def _get_localized_string(localized_dict, preferred_languages=None):
+    """
+    Get a string from a localized dictionary, preferring certain languages.
+
+    Args:
+        localized_dict: Dictionary with language codes as keys
+        preferred_languages: List of preferred language codes
+
+    Returns:
+        String value in preferred language or first available
+    """
+    if not localized_dict:
+        return None
+
+    if preferred_languages is None:
+        preferred_languages = _get_languages() + ['en', 'ja', 'ja-ro']
+
+    for lang in preferred_languages:
+        if lang in localized_dict:
+            return localized_dict[lang]
+
+    # Fall back to first available
+    if localized_dict:
+        return next(iter(localized_dict.values()))
+
+    return None
+
+
+def search_manga(name, limit=None, offset=None, sort=None):
+    """
+    Search for manga series using MangaDex API.
+
+    Args:
+        name: Manga name to search for
+        limit: Number of results per page
+        offset: Offset for pagination
+        sort: Sort order (relevance, latestUploadedChapter, followedCount, etc.)
+
+    Returns:
+        dict with 'results' list and 'pagination' metadata
+    """
+    search_start_time = time.time()
+    logger.info('[MANGADEX] Starting search for: %s (limit=%s, offset=%s, sort=%s)' % (name, limit, offset, sort))
+
+    if not mylar.CONFIG.MANGADEX_ENABLED:
+        logger.warn('[MANGADEX] MangaDex integration is not enabled')
+        return {'results': [], 'pagination': {'total': 0, 'limit': limit or 50, 'offset': offset or 0, 'returned': 0}}
+
+    # Get library for "haveit" status
+    comicLibrary = listLibrary()
+
+    # Set pagination defaults
+    page_limit = min(limit, 100) if limit else 50
+    page_offset = offset if offset else 0
+
+    # Build API parameters
+    params = {
+        'title': name,
+        'limit': page_limit,
+        'offset': page_offset,
+        'includes[]': ['cover_art', 'author', 'artist'],
+        'contentRating[]': _get_content_ratings(),
+        'order[relevance]': 'desc'
+    }
+
+    # Apply sort if provided
+    if sort:
+        # Clear default sort
+        params.pop('order[relevance]', None)
+        sort_mapping = {
+            'relevance': {'order[relevance]': 'desc'},
+            'latest': {'order[latestUploadedChapter]': 'desc'},
+            'oldest': {'order[latestUploadedChapter]': 'asc'},
+            'title_asc': {'order[title]': 'asc'},
+            'title_desc': {'order[title]': 'desc'},
+            'year_desc': {'order[year]': 'desc'},
+            'year_asc': {'order[year]': 'asc'},
+            'follows': {'order[followedCount]': 'desc'},
+        }
+        if sort in sort_mapping:
+            params.update(sort_mapping[sort])
+        else:
+            params['order[relevance]'] = 'desc'
+
+    try:
+        data = _make_request('/manga', params=params)
+
+        if not data or data.get('result') != 'ok':
+            logger.error('[MANGADEX] Search failed or returned no results')
+            return {'results': [], 'pagination': {'total': 0, 'limit': page_limit, 'offset': page_offset, 'returned': 0}}
+
+        manga_list = data.get('data', [])
+        total_results = data.get('total', 0)
+        comiclist = []
+
+        for manga in manga_list:
+            manga_id = manga.get('id')
+            attributes = manga.get('attributes', {})
+
+            # Extract title (prefer English, fall back to other languages)
+            title = _get_localized_string(attributes.get('title', {}))
+            if not title:
+                # Try altTitles
+                alt_titles = attributes.get('altTitles', [])
+                for alt in alt_titles:
+                    title = _get_localized_string(alt)
+                    if title:
+                        break
+            if not title:
+                title = 'Unknown'
+
+            # Extract other metadata
+            year = attributes.get('year') or '0000'
+            status = attributes.get('status', 'unknown')  # ongoing, completed, hiatus, cancelled
+            content_rating = attributes.get('contentRating', 'safe')
+            description = _get_localized_string(attributes.get('description', {})) or 'No description available'
+
+            # Get cover URL
+            cover_url = _extract_cover_url(manga)
+
+            # Get author/artist
+            author = _extract_author(manga)
+
+            # Check if we already have this manga (using md- prefix)
+            haveit = 'No'
+            mangadex_id = 'md-' + manga_id
+            if mangadex_id in comicLibrary:
+                haveit = comicLibrary[mangadex_id]
+            # Also check by name and year
+            elif title and year:
+                name_key = 'name:' + title.lower().strip() + ':' + str(year).strip()
+                if name_key in comicLibrary:
+                    haveit = comicLibrary[name_key]
+
+            # Build year range
+            yearRange = [str(year)]
+            if str(year).isdigit():
+                current_year = datetime.now().year
+                for y in range(int(year), min(int(year) + 30, current_year + 1)):
+                    if str(y) not in yearRange:
+                        yearRange.append(str(y))
+
+            comiclist.append({
+                'name': title,
+                'comicyear': str(year) if year else '0000',
+                'comicid': mangadex_id,  # Use md- prefix for MangaDex IDs
+                'cv_comicid': None,  # No ComicVine ID
+                'url': f'https://mangadex.org/title/{manga_id}',
+                'issues': '0',  # Will be populated separately if needed
+                'comicimage': cover_url,
+                'comicthumb': cover_url,
+                'publisher': author,  # Use author as publisher equivalent
+                'description': description[:500] if description else 'None',  # Truncate long descriptions
+                'deck': None,
+                'type': 'Manga',
+                'haveit': haveit,
+                'lastissueid': None,
+                'firstissueid': None,
+                'volume': None,
+                'imprint': None,
+                'seriesrange': yearRange,
+                'status': status,
+                'content_rating': content_rating,
+                'content_type': 'manga',
+                'reading_direction': 'rtl',  # Right-to-left for manga
+                'metadata_source': 'mangadex',
+                'external_id': manga_id,
+            })
+
+        search_duration = time.time() - search_start_time
+        logger.info('[MANGADEX] Search completed in %.2f seconds (%d results)' % (search_duration, len(comiclist)))
+
+        return {
+            'results': comiclist,
+            'pagination': {
+                'total': total_results,
+                'limit': page_limit,
+                'offset': page_offset,
+                'returned': len(comiclist)
+            }
+        }
+
+    except Exception as e:
+        logger.error('[MANGADEX] Search failed: %s' % e)
+        import traceback
+        logger.error('[MANGADEX] Traceback: %s' % traceback.format_exc())
+        return {'results': [], 'pagination': {'total': 0, 'limit': page_limit, 'offset': page_offset, 'returned': 0}}
+
+
+def get_manga_details(manga_id):
+    """
+    Get detailed information about a specific manga.
+
+    Args:
+        manga_id: MangaDex manga UUID (without md- prefix)
+
+    Returns:
+        dict with manga details or None on error
+    """
+    # Remove md- prefix if present
+    if manga_id.startswith('md-'):
+        manga_id = manga_id[3:]
+
+    # Check cache first
+    cache_key = manga_id
+    if cache_key in _MANGA_CACHE:
+        cache_entry = _MANGA_CACHE[cache_key]
+        if time.time() - cache_entry['timestamp'] < CACHE_TTL:
+            logger.fdebug('[MANGADEX] Cache hit for manga %s' % manga_id)
+            return cache_entry['data']
+
+    logger.info('[MANGADEX] Fetching details for manga: %s' % manga_id)
+
+    params = {
+        'includes[]': ['cover_art', 'author', 'artist', 'tag']
+    }
+
+    data = _make_request(f'/manga/{manga_id}', params=params)
+
+    if not data or data.get('result') != 'ok':
+        logger.error('[MANGADEX] Failed to fetch manga details for %s' % manga_id)
+        return None
+
+    manga = data.get('data', {})
+    attributes = manga.get('attributes', {})
+
+    # Extract all relevant metadata
+    title = _get_localized_string(attributes.get('title', {}))
+    alt_titles = []
+    for alt in attributes.get('altTitles', []):
+        alt_title = _get_localized_string(alt)
+        if alt_title and alt_title != title:
+            alt_titles.append(alt_title)
+
+    description = _get_localized_string(attributes.get('description', {}))
+
+    # Extract tags/genres
+    tags = []
+    for tag in attributes.get('tags', []):
+        tag_name = _get_localized_string(tag.get('attributes', {}).get('name', {}))
+        if tag_name:
+            tags.append(tag_name)
+
+    details = {
+        'id': 'md-' + manga_id,
+        'mangadex_id': manga_id,
+        'name': title,
+        'alt_titles': alt_titles,
+        'description': description,
+        'year': attributes.get('year'),
+        'status': attributes.get('status', 'unknown'),
+        'content_rating': attributes.get('contentRating', 'safe'),
+        'original_language': attributes.get('originalLanguage', 'ja'),
+        'last_chapter': attributes.get('lastChapter'),
+        'last_volume': attributes.get('lastVolume'),
+        'tags': tags,
+        'author': _extract_author(manga),
+        'artist': _extract_artist(manga),
+        'cover_url': _extract_cover_url(manga),
+        'url': f'https://mangadex.org/title/{manga_id}',
+        'content_type': 'manga',
+        'reading_direction': 'rtl',
+        'metadata_source': 'mangadex',
+        'created_at': attributes.get('createdAt'),
+        'updated_at': attributes.get('updatedAt'),
+    }
+
+    # Cache the result
+    _MANGA_CACHE[cache_key] = {
+        'data': details,
+        'timestamp': time.time()
+    }
+
+    return details
+
+
+def get_manga_chapters(manga_id, languages=None, limit=100, offset=0):
+    """
+    Get chapter list for a manga.
+
+    Args:
+        manga_id: MangaDex manga UUID (without md- prefix)
+        languages: List of language codes to filter by (defaults to config)
+        limit: Number of chapters per request (max 500)
+        offset: Offset for pagination
+
+    Returns:
+        dict with 'chapters' list and 'pagination' metadata
+    """
+    # Remove md- prefix if present
+    if manga_id.startswith('md-'):
+        manga_id = manga_id[3:]
+
+    logger.info('[MANGADEX] Fetching chapters for manga: %s (offset=%s, limit=%s)' % (manga_id, offset, limit))
+
+    if languages is None:
+        languages = _get_languages()
+
+    params = {
+        'manga': manga_id,
+        'translatedLanguage[]': languages,
+        'limit': min(limit, 500),
+        'offset': offset,
+        'order[chapter]': 'asc',
+        'includes[]': ['scanlation_group']
+    }
+
+    data = _make_request('/chapter', params=params)
+
+    if not data or data.get('result') != 'ok':
+        logger.error('[MANGADEX] Failed to fetch chapters for manga %s' % manga_id)
+        return {'chapters': [], 'pagination': {'total': 0, 'limit': limit, 'offset': offset, 'returned': 0}}
+
+    chapter_list = data.get('data', [])
+    total_chapters = data.get('total', 0)
+    chapters = []
+
+    for chapter in chapter_list:
+        chapter_id = chapter.get('id')
+        attributes = chapter.get('attributes', {})
+
+        # Get scanlation group name
+        group_name = None
+        for rel in chapter.get('relationships', []):
+            if rel.get('type') == 'scanlation_group':
+                group_name = rel.get('attributes', {}).get('name')
+                break
+
+        chapter_num = attributes.get('chapter')
+        volume_num = attributes.get('volume')
+
+        chapters.append({
+            'id': chapter_id,
+            'chapter': chapter_num,
+            'volume': volume_num,
+            'title': attributes.get('title'),
+            'language': attributes.get('translatedLanguage'),
+            'pages': attributes.get('pages', 0),
+            'publish_at': attributes.get('publishAt'),
+            'created_at': attributes.get('createdAt'),
+            'updated_at': attributes.get('updatedAt'),
+            'scanlation_group': group_name,
+            'external_url': attributes.get('externalUrl'),
+            # Map to Mylar's issue structure
+            'issue_number': chapter_num,
+            'issue_name': attributes.get('title') or f'Chapter {chapter_num}',
+            'release_date': attributes.get('publishAt', '')[:10] if attributes.get('publishAt') else None,
+        })
+
+    logger.info('[MANGADEX] Found %d chapters for manga %s' % (len(chapters), manga_id))
+
+    return {
+        'chapters': chapters,
+        'pagination': {
+            'total': total_chapters,
+            'limit': limit,
+            'offset': offset,
+            'returned': len(chapters)
+        }
+    }
+
+
+def get_all_chapters(manga_id, languages=None):
+    """
+    Get all chapters for a manga (handles pagination automatically).
+
+    Args:
+        manga_id: MangaDex manga UUID (without md- prefix)
+        languages: List of language codes to filter by
+
+    Returns:
+        List of all chapters
+    """
+    # Remove md- prefix if present
+    if manga_id.startswith('md-'):
+        manga_id = manga_id[3:]
+
+    # Check cache first
+    cache_key = f"{manga_id}:{','.join(languages or _get_languages())}"
+    if cache_key in _CHAPTER_CACHE:
+        cache_entry = _CHAPTER_CACHE[cache_key]
+        if time.time() - cache_entry['timestamp'] < CACHE_TTL:
+            logger.fdebug('[MANGADEX] Cache hit for chapters of manga %s' % manga_id)
+            return cache_entry['data']
+
+    all_chapters = []
+    offset = 0
+    limit = 500
+
+    while True:
+        result = get_manga_chapters(manga_id, languages=languages, limit=limit, offset=offset)
+        chapters = result.get('chapters', [])
+        all_chapters.extend(chapters)
+
+        pagination = result.get('pagination', {})
+        total = pagination.get('total', 0)
+
+        if offset + limit >= total or not chapters:
+            break
+
+        offset += limit
+
+    # Cache the result
+    _CHAPTER_CACHE[cache_key] = {
+        'data': all_chapters,
+        'timestamp': time.time()
+    }
+
+    logger.info('[MANGADEX] Retrieved total of %d chapters for manga %s' % (len(all_chapters), manga_id))
+    return all_chapters
+
+
+def get_cover_image(manga_id):
+    """
+    Get cover image URL for a manga.
+
+    Args:
+        manga_id: MangaDex manga UUID (without md- prefix)
+
+    Returns:
+        Cover URL string or None
+    """
+    # Remove md- prefix if present
+    if manga_id.startswith('md-'):
+        manga_id = manga_id[3:]
+
+    # Check cache first
+    if manga_id in _IMAGE_CACHE:
+        return _IMAGE_CACHE[manga_id]
+
+    # Get manga details which includes cover
+    details = get_manga_details(manga_id)
+    if details:
+        cover_url = details.get('cover_url')
+        _IMAGE_CACHE[manga_id] = cover_url
+        return cover_url
+
+    return None
+
+
+def clear_cache():
+    """Clear all in-memory caches."""
+    global _IMAGE_CACHE, _MANGA_CACHE, _CHAPTER_CACHE
+    _IMAGE_CACHE = {}
+    _MANGA_CACHE = {}
+    _CHAPTER_CACHE = {}
+    logger.info('[MANGADEX] Caches cleared')
+
+
+def is_manga_id(comic_id):
+    """
+    Check if a comic ID is a MangaDex manga ID.
+
+    Args:
+        comic_id: Comic/Manga ID string
+
+    Returns:
+        True if it's a MangaDex ID (starts with 'md-')
+    """
+    return comic_id and str(comic_id).startswith('md-')
+
+
+def strip_manga_prefix(manga_id):
+    """
+    Remove the 'md-' prefix from a manga ID if present.
+
+    Args:
+        manga_id: Manga ID string
+
+    Returns:
+        Raw MangaDex UUID without prefix
+    """
+    if manga_id and str(manga_id).startswith('md-'):
+        return manga_id[3:]
+    return manga_id

--- a/mylar/mb.py
+++ b/mylar/mb.py
@@ -102,10 +102,16 @@ def pullsearch(comicapi, comicquery, offset, search_type, sort=None, limit=None)
     else:
         return dom
 
-def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=False, limit=None, offset=None, sort=None):
+def findComic(name, mode, issue, limityear=None, search_type=None, annual_check=False, limit=None, offset=None, sort=None, content_type=None):
     import time
     search_start_time = time.time()
-    logger.info('[SEARCH PERFORMANCE] Starting search for: %s (limit=%s, offset=%s, sort=%s)' % (name, limit, offset, sort))
+    logger.info('[SEARCH PERFORMANCE] Starting search for: %s (limit=%s, offset=%s, sort=%s, content_type=%s)' % (name, limit, offset, sort, content_type))
+
+    # Check if manga search is requested and MangaDex is enabled
+    if content_type == 'manga' and mylar.CONFIG.MANGADEX_ENABLED:
+        logger.info('[MANGADEX] Using MangaDex API for manga search')
+        from mylar import mangadex
+        return mangadex.search_manga(name, limit=limit, offset=offset, sort=sort)
 
     # Check if Metron search is enabled and configured (only for volume/series search, not story arcs)
     if search_type != 'story_arc' and mylar.CONFIG.USE_METRON_SEARCH and mylar.METRON_API:


### PR DESCRIPTION
## Summary

- Add MangaDex integration for searching and managing manga series
- Add unified search with All/Comics/Manga toggle that searches both sources in parallel
- Add My Series page filters for type, progress, and status with URL persistence
- Add Chapters/Volumes view toggle for manga series with expandable volume rows

## Changes

### MangaDex Integration
- New `findManga` and `addManga` API endpoints
- MangaDex metadata fetching and chapter management
- Manga-specific UI adaptations (chapters vs issues, reading direction)

### Unified Search
- "All" mode searches comics and manga simultaneously
- Results display with type badges (Comic/Manga)
- Seamless switching between All/Comics/Manga modes

### My Series Filters
- Type filter: All | Comics | Manga (segmented control)
- Progress filter: All Progress | Not Started | In Progress | Complete (dropdown)
- Status filter: All Status | Active | Paused | Ended (dropdown)
- Filter state persisted in URL for bookmarking/sharing

### Chapters/Volumes View
- Toggle between flat chapters list and grouped volumes view
- Volume rows show chapter range, completion status, and progress bar
- Expandable rows reveal individual chapters
- "Want All" action per volume

## Test plan

- [ ] Search for manga using MangaDex (e.g., "One Piece")
- [ ] Add a manga to library and verify chapters are fetched
- [ ] Test unified search shows both comics and manga with type badges
- [ ] Verify My Series filters work correctly and persist in URL
- [ ] Test Chapters/Volumes toggle on a manga series with volume data
- [ ] Verify volume grouping shows correct status and progress

🤖 Generated with [Claude Code](https://claude.ai/code)