### PR TITLE
Add interactive import mapping feature (#1337)

### DIFF
--- a/API_REFERENCE
+++ b/API_REFERENCE
@@ -73,3 +73,33 @@ addStoryArc&id=$arcid&issues=$issues (add a comma delimited list of CV issue IDs
                                       Appended in order to the end of the reading order)
 addStoryArc&storyarcname=$name&issues=$issues (create a new story arc and add a comma delimited list of CV issue IDs
                                                to it.)
+
+--- Import Management ---
+
+getImportPending[&limit=$limit][&offset=$offset][&include_ignored=true|false]
+    (List pending/unmatched import files grouped by series.
+     Returns: imports array with DynamicName, ComicName, Volume, FileCount, MatchConfidence,
+              SuggestedComicID, SuggestedComicName, files array with individual file details.
+     Pagination: total, limit, offset, has_more)
+
+matchImport&imp_ids=$ids&comic_id=$comicid[&issue_id=$issueid]
+    (Manually match import file(s) to a comic series.
+     imp_ids: comma-separated list of import IDs
+     comic_id: Comic ID to match to
+     issue_id: optional specific issue ID
+     Returns: matched count, comic_id, comic_name)
+
+ignoreImport&imp_ids=$ids[&ignore=true|false]
+    (Mark import file(s) as ignored or unignored.
+     imp_ids: comma-separated list of import IDs
+     ignore: true to ignore, false to unignore (default: true)
+     Returns: updated count, ignored status)
+
+refreshImport
+    (Trigger a re-scan of the import directory.
+     Returns: message with import path)
+
+deleteImport&imp_ids=$ids
+    (Delete import record(s) from the database. Does not delete actual files.
+     imp_ids: comma-separated list of import IDs
+     Returns: deleted count)

--- a/COMMUNITY_FEATURES.md
+++ b/COMMUNITY_FEATURES.md
@@ -14,7 +14,7 @@ This plan addresses the top feature requests from mylar3 GitHub issues that have
 
 | Feature | GitHub Issue | Votes | Effort | Status |
 |---------|--------------|-------|--------|--------|
-| Interactive Import Mapping | #1337 | 2 | Large | |
+| Interactive Import Mapping | #1337 | 2 | Large | ✅ Done |
 | iCal Calendar Feed | #1526 | - | Medium | |
 | Matrix Notifications | #1216 | - | Small | ✅ Done |
 | Bulk Metadata Actions UI | #1525 | 3 | Medium | |
@@ -46,44 +46,58 @@ This plan addresses the top feature requests from mylar3 GitHub issues that have
 
 ## Detailed Implementation Plans
 
-### 1. Interactive Import Mapping Screen
-**Issue:** #1337 | **Priority:** High | **Effort:** Large (3-5 days)
+### 1. Interactive Import Mapping Screen ✅ COMPLETED
+**Issue:** #1337 | **Priority:** High | **Effort:** Large (3-5 days) | **Status:** IMPLEMENTED
 
 **Problem:** When importing comics, Mylar often can't match files automatically. Users have to enable debug mode to find the root cause. Sonarr/Radarr have interactive import screens where users can manually map unrecognized files.
 
-**Implementation:**
+**Implementation Complete:**
 
 **Backend Changes:**
-- `mylar/api.py` - Add new endpoints:
+- `mylar/__init__.py` - Added 6 new columns to `importresults` table:
+  - `MatchConfidence` (INTEGER) - 0-100 confidence score
+  - `SuggestedComicID` (TEXT) - Best match comic ID
+  - `SuggestedComicName` (TEXT) - Best match display name
+  - `SuggestedIssueID` (TEXT) - Best issue match
+  - `IgnoreFile` (INTEGER DEFAULT 0) - 1 = ignored
+  - `MatchSource` (TEXT) - 'auto', 'manual', or 'metadata'
+
+- `mylar/api.py` - Added 5 new API commands:
   ```
-  GET  /api/v2/import/pending     - List unmatched files with suggested matches
-  POST /api/v2/import/match       - Manually match file to series/issue
-  POST /api/v2/import/ignore      - Mark file to ignore
-  POST /api/v2/import/refresh     - Re-scan import directory
+  getImportPending   - List unmatched files with pagination
+  matchImport        - Manually match file(s) to series
+  ignoreImport       - Mark file(s) as ignored
+  refreshImport      - Re-scan import directory
+  deleteImport       - Remove import record(s)
   ```
-- `mylar/importer.py` - Add functions to:
-  - Store pending imports in database with match confidence scores
-  - Support manual matching override
-  - Track ignored files
+
+- `mylar/filechecker.py` - Added `calculate_match_confidence()` function with scoring:
+  - Series Name Match: 40 pts (fuzzy matching)
+  - Year Match: 15 pts
+  - Volume Match: 15 pts
+  - Issue Number: 15 pts
+  - Metadata: 10 pts (CBZ with ComicInfo.xml)
+  - Path Hints: 5 pts
 
 **Frontend Changes:**
-- New page: `ImportPage.jsx`
-- Components:
-  - `PendingImportTable.jsx` - List of unmatched files
-  - `MatchModal.jsx` - Search and select correct series/issue
-  - `ImportActions.jsx` - Bulk actions (import all, ignore selected)
-- Features:
-  - Show file name, detected series name, confidence score
-  - Highlight low-confidence matches in yellow/red
-  - Search modal to find correct series
-  - Preview what metadata will be applied
+- New page: `frontend/src/pages/ImportPage.tsx`
+- New components in `frontend/src/components/import/`:
+  - `ImportTable.tsx` - Expandable table showing import groups and files
+  - `MatchModal.tsx` - Search modal to find correct series
+  - `ImportBulkActions.tsx` - Floating action bar for selections
+  - `ConfidenceBadge.tsx` - Color-coded confidence scores
+- New hook: `frontend/src/hooks/useImport.ts` - React Query mutations
+- Updated: `App.tsx` with `/import` route
+- Updated: `AppSidebar.tsx` with Import nav item
 
-**Files to Modify:**
-- `mylar/api.py` - Add v2 import endpoints
-- `mylar/importer.py` - Add pending import tracking
-- `mylar/db.py` - Add pending_imports table
-- `frontend/src/pages/ImportPage.jsx` - New page
-- `frontend/src/components/import/` - New components
+**Features:**
+- View pending imports grouped by series with confidence scores
+- Expand rows to see individual files
+- Color-coded confidence badges (green >80%, yellow 50-80%, red <50%)
+- Manual matching via series search modal
+- Bulk ignore/delete actions
+- Show/hide ignored files toggle
+- Re-scan import directory button
 
 ---
 
@@ -462,7 +476,7 @@ matrix_onsnatch = False
 ### Phase 3: Larger Features (Week 3-4)
 - [ ] Auto-Watch Keywords (1-2 days)
 - [ ] Advanced Search Filters (1-2 days)
-- [ ] Interactive Import Mapping (3-5 days)
+- [x] Interactive Import Mapping (3-5 days) ✅ COMPLETED
 
 ### Phase 4: Major Integration (Future)
 - [ ] SLSKD Download Source (3-4 days)
@@ -478,6 +492,7 @@ These features from the issues were already found in the codebase:
 |---------|--------|-----------------|
 | Metron metadata | ✅ Done | `metron.py`, `USE_METRON_SEARCH` |
 | MangaDex integration | ✅ Done | `mangadex.py`, `MANGADEX_ENABLED` |
+| Interactive Import Mapping | ✅ Done | `/import` page, `getImportPending` API |
 | Write metadata on import | ✅ Done | `IMP_METADATA` config |
 | Failed download handling | ✅ Done | `Failed.py` |
 | Proxy support | ✅ Done | `ENABLE_PROXY`, `HTTP_PROXY` |
@@ -510,12 +525,17 @@ These features from the issues were already found in the codebase:
 - Verify progress modal shows
 - Verify all selected issues get tagged
 
-**Import Mapping:**
-- Place unrecognized files in import folder
-- Navigate to Import page
-- Verify pending items are listed
-- Manually match a file
-- Verify file gets imported correctly
+**Import Mapping:** ✅ IMPLEMENTED
+- Navigate to Import page via sidebar
+- Verify pending imports display in grouped table
+- Expand a group to see individual files
+- Verify confidence badges are color-coded
+- Click "Match" on a group to open search modal
+- Search and select correct series
+- Verify match applied and group updates
+- Select multiple groups and use bulk ignore
+- Toggle "Show Ignored" to verify they reappear
+- Click "Scan Import Directory" to re-scan
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import UpcomingPage from "@/pages/UpcomingPage";
 import WantedPage from "@/pages/WantedPage";
 import SettingsPage from "@/pages/SettingsPage";
 import StoryArcsPage from "@/pages/StoryArcsPage";
+import ImportPage from "@/pages/ImportPage";
 import { ToastProvider } from "@/components/ui/toast";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { useServerEvents } from "@/hooks/useServerEvents";
@@ -60,6 +61,7 @@ function AppContent() {
                   <Route path="/upcoming" element={<UpcomingPage />} />
                   <Route path="/wanted" element={<WantedPage />} />
                   <Route path="/story-arcs" element={<StoryArcsPage />} />
+                  <Route path="/import" element={<ImportPage />} />
                   <Route path="/settings" element={<SettingsPage />} />
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>

--- a/frontend/src/components/import/ConfidenceBadge.tsx
+++ b/frontend/src/components/import/ConfidenceBadge.tsx
@@ -17,7 +17,7 @@ export default function ConfidenceBadge({
     );
   }
 
-  let variant: "default" | "secondary" | "destructive" | "outline" = "default";
+  const variant: "default" | "secondary" | "destructive" | "outline" = "default";
   let colorClass = "";
 
   if (confidence >= 80) {

--- a/frontend/src/components/import/ConfidenceBadge.tsx
+++ b/frontend/src/components/import/ConfidenceBadge.tsx
@@ -17,15 +17,19 @@ export default function ConfidenceBadge({
     );
   }
 
-  const variant: "default" | "secondary" | "destructive" | "outline" = "default";
+  const variant: "default" | "secondary" | "destructive" | "outline" =
+    "default";
   let colorClass = "";
 
   if (confidence >= 80) {
-    colorClass = "bg-green-500/20 text-green-700 dark:text-green-400 border-green-500/30";
+    colorClass =
+      "bg-green-500/20 text-green-700 dark:text-green-400 border-green-500/30";
   } else if (confidence >= 50) {
-    colorClass = "bg-yellow-500/20 text-yellow-700 dark:text-yellow-400 border-yellow-500/30";
+    colorClass =
+      "bg-yellow-500/20 text-yellow-700 dark:text-yellow-400 border-yellow-500/30";
   } else {
-    colorClass = "bg-red-500/20 text-red-700 dark:text-red-400 border-red-500/30";
+    colorClass =
+      "bg-red-500/20 text-red-700 dark:text-red-400 border-red-500/30";
   }
 
   return (

--- a/frontend/src/components/import/ConfidenceBadge.tsx
+++ b/frontend/src/components/import/ConfidenceBadge.tsx
@@ -1,0 +1,36 @@
+import { Badge } from "@/components/ui/badge";
+
+interface ConfidenceBadgeProps {
+  confidence: number | null;
+  showLabel?: boolean;
+}
+
+export default function ConfidenceBadge({
+  confidence,
+  showLabel = true,
+}: ConfidenceBadgeProps) {
+  if (confidence === null || confidence === undefined) {
+    return (
+      <Badge variant="secondary" className="text-xs">
+        {showLabel ? "Unknown" : "?"}
+      </Badge>
+    );
+  }
+
+  let variant: "default" | "secondary" | "destructive" | "outline" = "default";
+  let colorClass = "";
+
+  if (confidence >= 80) {
+    colorClass = "bg-green-500/20 text-green-700 dark:text-green-400 border-green-500/30";
+  } else if (confidence >= 50) {
+    colorClass = "bg-yellow-500/20 text-yellow-700 dark:text-yellow-400 border-yellow-500/30";
+  } else {
+    colorClass = "bg-red-500/20 text-red-700 dark:text-red-400 border-red-500/30";
+  }
+
+  return (
+    <Badge variant={variant} className={`text-xs ${colorClass}`}>
+      {showLabel ? `${confidence}%` : confidence}
+    </Badge>
+  );
+}

--- a/frontend/src/components/import/ImportBulkActions.tsx
+++ b/frontend/src/components/import/ImportBulkActions.tsx
@@ -1,0 +1,74 @@
+import { Button } from "@/components/ui/button";
+import { EyeOff, Eye, Trash2, X } from "lucide-react";
+
+interface ImportBulkActionsProps {
+  selectedCount: number;
+  onIgnore: () => void;
+  onUnignore: () => void;
+  onDelete: () => void;
+  onClear: () => void;
+  isLoading?: boolean;
+  showUnignore?: boolean;
+}
+
+export default function ImportBulkActions({
+  selectedCount,
+  onIgnore,
+  onUnignore,
+  onDelete,
+  onClear,
+  isLoading = false,
+  showUnignore = false,
+}: ImportBulkActionsProps) {
+  if (selectedCount === 0) return null;
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-in slide-in-from-bottom-4 duration-200">
+      <div className="bg-card border border-card-border rounded-lg shadow-lg px-4 py-3 flex items-center gap-4">
+        <span className="text-sm font-medium text-foreground">
+          {selectedCount} selected
+        </span>
+
+        <div className="h-4 w-px bg-border" />
+
+        <div className="flex items-center gap-2">
+          {showUnignore ? (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onUnignore}
+              disabled={isLoading}
+            >
+              <Eye className="w-4 h-4 mr-1" />
+              Unignore
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onIgnore}
+              disabled={isLoading}
+            >
+              <EyeOff className="w-4 h-4 mr-1" />
+              Ignore
+            </Button>
+          )}
+
+          <Button
+            size="sm"
+            variant="destructive"
+            onClick={onDelete}
+            disabled={isLoading}
+          >
+            <Trash2 className="w-4 h-4 mr-1" />
+            Delete
+          </Button>
+
+          <Button size="sm" variant="ghost" onClick={onClear} disabled={isLoading}>
+            <X className="w-4 h-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/import/ImportBulkActions.tsx
+++ b/frontend/src/components/import/ImportBulkActions.tsx
@@ -64,7 +64,12 @@ export default function ImportBulkActions({
             Delete
           </Button>
 
-          <Button size="sm" variant="ghost" onClick={onClear} disabled={isLoading}>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={onClear}
+            disabled={isLoading}
+          >
             <X className="w-4 h-4" />
           </Button>
         </div>

--- a/frontend/src/components/import/ImportTable.tsx
+++ b/frontend/src/components/import/ImportTable.tsx
@@ -33,7 +33,10 @@ function FileRow({ file }: { file: ImportFile }) {
   return (
     <div className="flex items-center gap-4 py-2 px-6 text-sm bg-muted/30 border-t border-card-border">
       <FileText className="w-4 h-4 text-muted-foreground flex-shrink-0 ml-8" />
-      <span className="font-mono text-xs truncate flex-1" title={file.ComicFilename}>
+      <span
+        className="font-mono text-xs truncate flex-1"
+        title={file.ComicFilename}
+      >
         {file.ComicFilename}
       </span>
       {file.IssueNumber && (
@@ -145,7 +148,9 @@ export default function ImportTable({
         const suggestedId = row.original.SuggestedComicID;
 
         if (!suggestedName) {
-          return <span className="text-muted-foreground/70">No match found</span>;
+          return (
+            <span className="text-muted-foreground/70">No match found</span>
+          );
         }
 
         return (

--- a/frontend/src/components/import/ImportTable.tsx
+++ b/frontend/src/components/import/ImportTable.tsx
@@ -1,0 +1,316 @@
+import { useState } from "react";
+import {
+  useReactTable,
+  getCoreRowModel,
+  getExpandedRowModel,
+  flexRender,
+  ColumnDef,
+  RowSelectionState,
+  ExpandedState,
+  Row,
+  CellContext,
+  HeaderContext,
+  Updater,
+} from "@tanstack/react-table";
+import { ChevronRight, ChevronDown, FileText, Link2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import StatusBadge from "@/components/StatusBadge";
+import EmptyState from "@/components/ui/EmptyState";
+import ConfidenceBadge from "./ConfidenceBadge";
+import type { ImportGroup, ImportFile, PaginationMeta } from "@/types";
+
+interface ImportTableProps {
+  imports?: ImportGroup[];
+  pagination?: PaginationMeta;
+  onNextPage?: () => void;
+  onPrevPage?: () => void;
+  onSelectionChange?: (selectedIds: string[]) => void;
+  onMatchClick?: (group: ImportGroup) => void;
+}
+
+function FileRow({ file }: { file: ImportFile }) {
+  return (
+    <div className="flex items-center gap-4 py-2 px-6 text-sm bg-muted/30 border-t border-card-border">
+      <FileText className="w-4 h-4 text-muted-foreground flex-shrink-0 ml-8" />
+      <span className="font-mono text-xs truncate flex-1" title={file.ComicFilename}>
+        {file.ComicFilename}
+      </span>
+      {file.IssueNumber && (
+        <span className="text-muted-foreground">#{file.IssueNumber}</span>
+      )}
+      <ConfidenceBadge confidence={file.MatchConfidence} />
+      {file.IgnoreFile === 1 && (
+        <span className="text-xs bg-gray-500/20 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded">
+          Ignored
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default function ImportTable({
+  imports = [],
+  pagination,
+  onNextPage,
+  onPrevPage,
+  onSelectionChange,
+  onMatchClick,
+}: ImportTableProps) {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [expanded, setExpanded] = useState<ExpandedState>({});
+
+  const columns: ColumnDef<ImportGroup>[] = [
+    {
+      id: "select",
+      header: ({ table }: HeaderContext<ImportGroup, unknown>) => (
+        <Checkbox
+          checked={table.getIsAllRowsSelected()}
+          indeterminate={
+            table.getIsSomeRowsSelected() && !table.getIsAllRowsSelected()
+          }
+          onChange={table.getToggleAllRowsSelectedHandler()}
+        />
+      ),
+      cell: ({ row }: CellContext<ImportGroup, unknown>) => (
+        <Checkbox
+          checked={row.getIsSelected()}
+          onChange={row.getToggleSelectedHandler()}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ),
+      size: 40,
+    },
+    {
+      id: "expander",
+      header: "",
+      cell: ({ row }: CellContext<ImportGroup, unknown>) => {
+        const canExpand = row.original.files && row.original.files.length > 0;
+        return canExpand ? (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              row.toggleExpanded();
+            }}
+            className="p-1 hover:bg-muted rounded"
+          >
+            {row.getIsExpanded() ? (
+              <ChevronDown className="w-4 h-4" />
+            ) : (
+              <ChevronRight className="w-4 h-4" />
+            )}
+          </button>
+        ) : null;
+      },
+      size: 40,
+    },
+    {
+      accessorKey: "ComicName",
+      header: "Series",
+      cell: ({ row }: CellContext<ImportGroup, unknown>) => (
+        <div>
+          <div className="font-medium">{row.original.ComicName}</div>
+          {row.original.Volume && (
+            <div className="text-sm text-muted-foreground">
+              Volume {row.original.Volume}
+            </div>
+          )}
+          {row.original.ComicYear && (
+            <div className="text-xs text-muted-foreground">
+              ({row.original.ComicYear})
+            </div>
+          )}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "FileCount",
+      header: "Files",
+      cell: ({ getValue }: CellContext<ImportGroup, unknown>) => (
+        <span className="font-mono text-sm">{getValue() as number}</span>
+      ),
+    },
+    {
+      accessorKey: "MatchConfidence",
+      header: "Confidence",
+      cell: ({ getValue }: CellContext<ImportGroup, unknown>) => (
+        <ConfidenceBadge confidence={getValue() as number | null} />
+      ),
+    },
+    {
+      accessorKey: "SuggestedComicName",
+      header: "Suggested Match",
+      cell: ({ row }: CellContext<ImportGroup, unknown>) => {
+        const suggestedName = row.original.SuggestedComicName;
+        const suggestedId = row.original.SuggestedComicID;
+
+        if (!suggestedName) {
+          return <span className="text-muted-foreground/70">No match found</span>;
+        }
+
+        return (
+          <div className="flex items-center gap-2">
+            <Link2 className="w-4 h-4 text-muted-foreground" />
+            <span className="text-sm">{suggestedName}</span>
+            {suggestedId && (
+              <span className="text-xs text-muted-foreground">
+                (ID: {suggestedId})
+              </span>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "Status",
+      header: "Status",
+      cell: ({ getValue }: CellContext<ImportGroup, unknown>) => (
+        <StatusBadge status={getValue() as string} />
+      ),
+    },
+    {
+      id: "actions",
+      header: "Actions",
+      cell: ({ row }: CellContext<ImportGroup, unknown>) => (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={(e) => {
+            e.stopPropagation();
+            onMatchClick?.(row.original);
+          }}
+        >
+          Match
+        </Button>
+      ),
+    },
+  ];
+
+  const table = useReactTable({
+    data: imports,
+    columns,
+    state: {
+      rowSelection,
+      expanded,
+    },
+    onRowSelectionChange: (updater: Updater<RowSelectionState>) => {
+      setRowSelection(updater);
+      if (onSelectionChange) {
+        const newSelection =
+          typeof updater === "function" ? updater(rowSelection) : updater;
+        // Get all impIDs from selected groups (all files within each group)
+        const selectedIds: string[] = [];
+        Object.keys(newSelection).forEach((index) => {
+          const group = imports[parseInt(index)];
+          if (group?.files) {
+            group.files.forEach((file) => selectedIds.push(file.impID));
+          }
+        });
+        onSelectionChange(selectedIds);
+      }
+    },
+    onExpandedChange: setExpanded,
+    getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getRowId: (row) => `${row.DynamicName}-${row.Volume || "null"}`,
+    enableRowSelection: true,
+    getRowCanExpand: (row: Row<ImportGroup>) =>
+      row.original.files && row.original.files.length > 0,
+  });
+
+  if (imports.length === 0) {
+    return (
+      <EmptyState
+        variant="search"
+        title="No pending imports"
+        description="All files have been imported or there are no files to import."
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-lg border-card-border bg-card card-shadow overflow-hidden">
+      <div className="overflow-x-auto custom-scrollbar">
+        <table className="w-full">
+          <thead className="bg-muted/50 border-card-border backdrop-blur-sm border-b">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider"
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody className="bg-card divide-y divide-card-border">
+            {table.getRowModel().rows.map((row) => (
+              <>
+                <tr
+                  key={row.id}
+                  className="hover:bg-muted/50 cursor-pointer transition-colors"
+                  onClick={() => row.toggleExpanded()}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="px-6 py-4 whitespace-nowrap">
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </td>
+                  ))}
+                </tr>
+                {row.getIsExpanded() && row.original.files && (
+                  <tr key={`${row.id}-expanded`}>
+                    <td colSpan={columns.length} className="p-0">
+                      <div className="bg-muted/20">
+                        {row.original.files.map((file) => (
+                          <FileRow key={file.impID} file={file} />
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {pagination && (
+        <div className="border-t border-card-border px-6 py-3 flex items-center justify-between bg-muted/50">
+          <div className="text-sm text-gray-600">
+            Showing {pagination.offset + 1} to{" "}
+            {Math.min(pagination.offset + pagination.limit, pagination.total)}{" "}
+            of {pagination.total} groups
+          </div>
+          <div className="flex items-center space-x-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onPrevPage}
+              disabled={pagination.offset === 0}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onNextPage}
+              disabled={!pagination.has_more}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/import/MatchModal.tsx
+++ b/frontend/src/components/import/MatchModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useMemo } from "react";
 import { Search, X, Check, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,29 +13,17 @@ interface MatchModalProps {
   isMatching?: boolean;
 }
 
-export default function MatchModal({
-  isOpen,
-  onClose,
+// Inner component that resets when importGroup changes
+function MatchModalContent({
   importGroup,
+  onClose,
   onMatch,
   isMatching = false,
-}: MatchModalProps) {
-  const [searchQuery, setSearchQuery] = useState("");
+}: Omit<MatchModalProps, "isOpen">) {
+  // Initialize search query from importGroup - this will reset when the key changes
+  const initialQuery = importGroup?.ComicName || "";
+  const [searchQuery, setSearchQuery] = useState(initialQuery);
   const [selectedComic, setSelectedComic] = useState<SearchResult | null>(null);
-
-  // Initialize search query with the import group's comic name
-  useEffect(() => {
-    if (importGroup?.ComicName) {
-      setSearchQuery(importGroup.ComicName);
-    }
-  }, [importGroup]);
-
-  // Reset selection when modal closes
-  useEffect(() => {
-    if (!isOpen) {
-      setSelectedComic(null);
-    }
-  }, [isOpen]);
 
   const {
     data: searchData,
@@ -50,8 +38,6 @@ export default function MatchModal({
       onMatch(comicId, comicName);
     }
   };
-
-  if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -207,5 +193,32 @@ export default function MatchModal({
         </div>
       </div>
     </div>
+  );
+}
+
+export default function MatchModal({
+  isOpen,
+  onClose,
+  importGroup,
+  onMatch,
+  isMatching = false,
+}: MatchModalProps) {
+  // Generate a unique key based on importGroup to reset internal state when it changes
+  const modalKey = useMemo(() => {
+    if (!importGroup) return "closed";
+    return `${importGroup.DynamicName}-${importGroup.Volume || "null"}-${isOpen}`;
+  }, [importGroup, isOpen]);
+
+  if (!isOpen) return null;
+
+  // Using key prop to reset the inner component's state when importGroup changes
+  return (
+    <MatchModalContent
+      key={modalKey}
+      importGroup={importGroup}
+      onClose={onClose}
+      onMatch={onMatch}
+      isMatching={isMatching}
+    />
   );
 }

--- a/frontend/src/components/import/MatchModal.tsx
+++ b/frontend/src/components/import/MatchModal.tsx
@@ -1,0 +1,211 @@
+import { useState, useEffect } from "react";
+import { Search, X, Check, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useSearchComics } from "@/hooks/useSearch";
+import type { ImportGroup, SearchResult } from "@/types";
+
+interface MatchModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  importGroup: ImportGroup | null;
+  onMatch: (comicId: string, comicName: string) => void;
+  isMatching?: boolean;
+}
+
+export default function MatchModal({
+  isOpen,
+  onClose,
+  importGroup,
+  onMatch,
+  isMatching = false,
+}: MatchModalProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedComic, setSelectedComic] = useState<SearchResult | null>(null);
+
+  // Initialize search query with the import group's comic name
+  useEffect(() => {
+    if (importGroup?.ComicName) {
+      setSearchQuery(importGroup.ComicName);
+    }
+  }, [importGroup]);
+
+  // Reset selection when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedComic(null);
+    }
+  }, [isOpen]);
+
+  const {
+    data: searchData,
+    isLoading: isSearching,
+    error: searchError,
+  } = useSearchComics(searchQuery, 1);
+
+  const handleMatch = () => {
+    if (selectedComic) {
+      const comicId = selectedComic.comicid || selectedComic.id;
+      const comicName = selectedComic.comicname || selectedComic.name;
+      onMatch(comicId, comicName);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative bg-card border border-card-border rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] overflow-hidden animate-in fade-in zoom-in-95 duration-200">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-card-border">
+          <div>
+            <h2 className="text-lg font-semibold">Match Import</h2>
+            {importGroup && (
+              <p className="text-sm text-muted-foreground">
+                {importGroup.ComicName}
+                {importGroup.Volume && ` (${importGroup.Volume})`}
+                {" - "}
+                {importGroup.FileCount} file
+                {importGroup.FileCount !== 1 ? "s" : ""}
+              </p>
+            )}
+          </div>
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            <X className="w-4 h-4" />
+          </Button>
+        </div>
+
+        {/* Search Input */}
+        <div className="p-4 border-b border-card-border">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <Input
+              placeholder="Search for a comic series..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-10"
+              autoFocus
+            />
+          </div>
+        </div>
+
+        {/* Results */}
+        <div className="overflow-y-auto max-h-[400px] p-4">
+          {isSearching && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+              <span className="ml-2 text-muted-foreground">Searching...</span>
+            </div>
+          )}
+
+          {searchError && (
+            <div className="text-center py-8 text-destructive">
+              Error searching: {searchError.message}
+            </div>
+          )}
+
+          {!isSearching && searchData?.results && searchData.results.length === 0 && (
+            <div className="text-center py-8 text-muted-foreground">
+              No results found. Try a different search term.
+            </div>
+          )}
+
+          {!isSearching && searchData?.results && searchData.results.length > 0 && (
+            <div className="space-y-2">
+              {searchData.results.map((result) => {
+                const comicId = result.comicid || result.id;
+                const isSelected = selectedComic?.id === result.id ||
+                  selectedComic?.comicid === result.comicid;
+
+                return (
+                  <div
+                    key={comicId}
+                    onClick={() => setSelectedComic(result)}
+                    className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      isSelected
+                        ? "border-primary bg-primary/10"
+                        : "border-card-border hover:bg-muted/50"
+                    }`}
+                  >
+                    {/* Cover Image */}
+                    <div className="w-12 h-16 bg-muted rounded overflow-hidden flex-shrink-0">
+                      {result.image || result.comicimage ? (
+                        <img
+                          src={result.image || result.comicimage || ""}
+                          alt=""
+                          className="w-full h-full object-cover"
+                          onError={(e) => {
+                            (e.target as HTMLImageElement).style.display = "none";
+                          }}
+                        />
+                      ) : (
+                        <div className="w-full h-full flex items-center justify-center text-muted-foreground text-xs">
+                          N/A
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Info */}
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium truncate">
+                        {result.comicname || result.name}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {result.comicyear || result.start_year}
+                        {result.publisher && ` - ${result.publisher}`}
+                      </div>
+                      {result.count_of_issues && (
+                        <div className="text-xs text-muted-foreground">
+                          {result.count_of_issues} issues
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Selection indicator */}
+                    {isSelected && (
+                      <Check className="w-5 h-5 text-primary flex-shrink-0" />
+                    )}
+
+                    {/* In library indicator */}
+                    {result.in_library && (
+                      <span className="text-xs bg-green-500/20 text-green-600 dark:text-green-400 px-2 py-1 rounded">
+                        In Library
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 p-4 border-t border-card-border bg-muted/30">
+          <Button variant="outline" onClick={onClose} disabled={isMatching}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleMatch}
+            disabled={!selectedComic || isMatching}
+          >
+            {isMatching ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Matching...
+              </>
+            ) : (
+              "Match Selected"
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/import/MatchModal.tsx
+++ b/frontend/src/components/import/MatchModal.tsx
@@ -97,79 +97,85 @@ function MatchModalContent({
             </div>
           )}
 
-          {!isSearching && searchData?.results && searchData.results.length === 0 && (
-            <div className="text-center py-8 text-muted-foreground">
-              No results found. Try a different search term.
-            </div>
-          )}
+          {!isSearching &&
+            searchData?.results &&
+            searchData.results.length === 0 && (
+              <div className="text-center py-8 text-muted-foreground">
+                No results found. Try a different search term.
+              </div>
+            )}
 
-          {!isSearching && searchData?.results && searchData.results.length > 0 && (
-            <div className="space-y-2">
-              {searchData.results.map((result) => {
-                const comicId = result.comicid || result.id;
-                const isSelected = selectedComic?.id === result.id ||
-                  selectedComic?.comicid === result.comicid;
+          {!isSearching &&
+            searchData?.results &&
+            searchData.results.length > 0 && (
+              <div className="space-y-2">
+                {searchData.results.map((result) => {
+                  const comicId = result.comicid || result.id;
+                  const isSelected =
+                    selectedComic?.id === result.id ||
+                    selectedComic?.comicid === result.comicid;
 
-                return (
-                  <div
-                    key={comicId}
-                    onClick={() => setSelectedComic(result)}
-                    className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
-                      isSelected
-                        ? "border-primary bg-primary/10"
-                        : "border-card-border hover:bg-muted/50"
-                    }`}
-                  >
-                    {/* Cover Image */}
-                    <div className="w-12 h-16 bg-muted rounded overflow-hidden flex-shrink-0">
-                      {result.image || result.comicimage ? (
-                        <img
-                          src={result.image || result.comicimage || ""}
-                          alt=""
-                          className="w-full h-full object-cover"
-                          onError={(e) => {
-                            (e.target as HTMLImageElement).style.display = "none";
-                          }}
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center text-muted-foreground text-xs">
-                          N/A
+                  return (
+                    <div
+                      key={comicId}
+                      onClick={() => setSelectedComic(result)}
+                      className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                        isSelected
+                          ? "border-primary bg-primary/10"
+                          : "border-card-border hover:bg-muted/50"
+                      }`}
+                    >
+                      {/* Cover Image */}
+                      <div className="w-12 h-16 bg-muted rounded overflow-hidden flex-shrink-0">
+                        {result.image || result.comicimage ? (
+                          <img
+                            src={result.image || result.comicimage || ""}
+                            alt=""
+                            className="w-full h-full object-cover"
+                            onError={(e) => {
+                              (e.target as HTMLImageElement).style.display =
+                                "none";
+                            }}
+                          />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-muted-foreground text-xs">
+                            N/A
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Info */}
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium truncate">
+                          {result.comicname || result.name}
                         </div>
+                        <div className="text-sm text-muted-foreground">
+                          {result.comicyear || result.start_year}
+                          {result.publisher && ` - ${result.publisher}`}
+                        </div>
+                        {result.count_of_issues && (
+                          <div className="text-xs text-muted-foreground">
+                            {result.count_of_issues} issues
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Selection indicator */}
+                      {isSelected && (
+                        <Check className="w-5 h-5 text-primary flex-shrink-0" />
+                      )}
+
+                      {/* In library indicator */}
+                      {result.in_library && (
+                        <span className="text-xs bg-green-500/20 text-green-600 dark:text-green-400 px-2 py-1 rounded">
+                          In Library
+                        </span>
                       )}
                     </div>
-
-                    {/* Info */}
-                    <div className="flex-1 min-w-0">
-                      <div className="font-medium truncate">
-                        {result.comicname || result.name}
-                      </div>
-                      <div className="text-sm text-muted-foreground">
-                        {result.comicyear || result.start_year}
-                        {result.publisher && ` - ${result.publisher}`}
-                      </div>
-                      {result.count_of_issues && (
-                        <div className="text-xs text-muted-foreground">
-                          {result.count_of_issues} issues
-                        </div>
-                      )}
-                    </div>
-
-                    {/* Selection indicator */}
-                    {isSelected && (
-                      <Check className="w-5 h-5 text-primary flex-shrink-0" />
-                    )}
-
-                    {/* In library indicator */}
-                    {result.in_library && (
-                      <span className="text-xs bg-green-500/20 text-green-600 dark:text-green-400 px-2 py-1 rounded">
-                        In Library
-                      </span>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
+                  );
+                })}
+              </div>
+            )}
         </div>
 
         {/* Footer */}
@@ -177,10 +183,7 @@ function MatchModalContent({
           <Button variant="outline" onClick={onClose} disabled={isMatching}>
             Cancel
           </Button>
-          <Button
-            onClick={handleMatch}
-            disabled={!selectedComic || isMatching}
-          >
+          <Button onClick={handleMatch} disabled={!selectedComic || isMatching}>
             {isMatching ? (
               <>
                 <Loader2 className="w-4 h-4 mr-2 animate-spin" />

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -31,6 +31,7 @@ import {
   MessageSquare,
   Moon,
   Sun,
+  FolderInput,
 } from "lucide-react";
 
 export default function AppSidebar() {
@@ -67,6 +68,7 @@ export default function AppSidebar() {
     { path: "/upcoming", label: "Upcoming", icon: Calendar },
     { path: "/wanted", label: "Wanted", icon: ListTodo },
     { path: "/story-arcs", label: "Story Arcs", icon: BookMarked },
+    { path: "/import", label: "Import", icon: FolderInput },
   ];
 
   const isActive = (path: string): boolean => {

--- a/frontend/src/hooks/useImport.ts
+++ b/frontend/src/hooks/useImport.ts
@@ -1,0 +1,123 @@
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  type UseQueryResult,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { apiCall } from "@/lib/api";
+import type { ImportGroup, PaginationMeta } from "@/types";
+
+interface ImportPendingResponse {
+  imports: ImportGroup[];
+  pagination: PaginationMeta;
+}
+
+interface MatchImportResponse {
+  matched: number;
+  comic_id: string;
+  comic_name: string;
+}
+
+interface IgnoreImportResponse {
+  updated: number;
+  ignored: boolean;
+}
+
+interface DeleteImportResponse {
+  deleted: number;
+}
+
+interface RefreshImportResponse {
+  message: string;
+}
+
+// Query Hooks
+export function useImportPending(
+  limit = 50,
+  offset = 0,
+  includeIgnored = false,
+): UseQueryResult<ImportPendingResponse> {
+  return useQuery({
+    queryKey: ["importPending", limit, offset, includeIgnored],
+    queryFn: () =>
+      apiCall<ImportPendingResponse>("getImportPending", {
+        limit,
+        offset,
+        include_ignored: includeIgnored ? "true" : "false",
+      }),
+    staleTime: 30 * 1000, // 30 seconds - imports may change frequently
+  });
+}
+
+// Mutation Hooks
+export function useMatchImport(): UseMutationResult<
+  MatchImportResponse,
+  Error,
+  { impIds: string[]; comicId: string; issueId?: string }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ impIds, comicId, issueId }) =>
+      apiCall<MatchImportResponse>("matchImport", {
+        imp_ids: impIds.join(","),
+        comic_id: comicId,
+        issue_id: issueId,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["importPending"] });
+    },
+  });
+}
+
+export function useIgnoreImport(): UseMutationResult<
+  IgnoreImportResponse,
+  Error,
+  { impIds: string[]; ignore?: boolean }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ impIds, ignore = true }) =>
+      apiCall<IgnoreImportResponse>("ignoreImport", {
+        imp_ids: impIds.join(","),
+        ignore: ignore ? "true" : "false",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["importPending"] });
+    },
+  });
+}
+
+export function useDeleteImport(): UseMutationResult<
+  DeleteImportResponse,
+  Error,
+  string[]
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (impIds: string[]) =>
+      apiCall<DeleteImportResponse>("deleteImport", {
+        imp_ids: impIds.join(","),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["importPending"] });
+    },
+  });
+}
+
+export function useRefreshImport(): UseMutationResult<
+  RefreshImportResponse,
+  Error,
+  void
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => apiCall<RefreshImportResponse>("refreshImport"),
+    onSuccess: () => {
+      // Delay invalidation to give scan time to start
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["importPending"] });
+      }, 2000);
+    },
+  });
+}

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -1,0 +1,251 @@
+import { useState } from "react";
+import { RefreshCw, EyeOff, Eye } from "lucide-react";
+import {
+  useImportPending,
+  useMatchImport,
+  useIgnoreImport,
+  useDeleteImport,
+  useRefreshImport,
+} from "@/hooks/useImport";
+import { useToast } from "@/components/ui/toast";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import ImportTable from "@/components/import/ImportTable";
+import ImportBulkActions from "@/components/import/ImportBulkActions";
+import MatchModal from "@/components/import/MatchModal";
+import ErrorDisplay from "@/components/ui/ErrorDisplay";
+import type { ImportGroup } from "@/types";
+
+export default function ImportPage() {
+  const [page, setPage] = useState(0);
+  const [showIgnored, setShowIgnored] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [matchModalOpen, setMatchModalOpen] = useState(false);
+  const [matchingGroup, setMatchingGroup] = useState<ImportGroup | null>(null);
+  const limit = 50;
+  const offset = page * limit;
+
+  const { data, isLoading, error, refetch } = useImportPending(
+    limit,
+    offset,
+    showIgnored,
+  );
+  const imports = data?.imports || [];
+  const pagination = data?.pagination;
+
+  const matchImportMutation = useMatchImport();
+  const ignoreImportMutation = useIgnoreImport();
+  const deleteImportMutation = useDeleteImport();
+  const refreshImportMutation = useRefreshImport();
+  const { addToast } = useToast();
+
+  const handleRefreshImport = async () => {
+    try {
+      await refreshImportMutation.mutateAsync();
+      addToast({
+        type: "info",
+        message: "Import scan started. This may take a few moments.",
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to start import scan: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+    }
+  };
+
+  const handleMatchClick = (group: ImportGroup) => {
+    setMatchingGroup(group);
+    setMatchModalOpen(true);
+  };
+
+  const handleMatch = async (comicId: string, comicName: string) => {
+    if (!matchingGroup) return;
+
+    const impIds = matchingGroup.files.map((f) => f.impID);
+
+    try {
+      await matchImportMutation.mutateAsync({ impIds, comicId });
+      addToast({
+        type: "success",
+        message: `Matched ${impIds.length} file${impIds.length !== 1 ? "s" : ""} to ${comicName}`,
+      });
+      setMatchModalOpen(false);
+      setMatchingGroup(null);
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to match: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+    }
+  };
+
+  const handleBulkIgnore = async () => {
+    try {
+      await ignoreImportMutation.mutateAsync({ impIds: selectedIds, ignore: true });
+      addToast({
+        type: "success",
+        message: `${selectedIds.length} file${selectedIds.length !== 1 ? "s" : ""} ignored`,
+      });
+      setSelectedIds([]);
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to ignore files: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+    }
+  };
+
+  const handleBulkUnignore = async () => {
+    try {
+      await ignoreImportMutation.mutateAsync({ impIds: selectedIds, ignore: false });
+      addToast({
+        type: "success",
+        message: `${selectedIds.length} file${selectedIds.length !== 1 ? "s" : ""} unignored`,
+      });
+      setSelectedIds([]);
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to unignore files: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+    }
+  };
+
+  const handleBulkDelete = async () => {
+    if (
+      !window.confirm(
+        `Are you sure you want to delete ${selectedIds.length} import record${selectedIds.length !== 1 ? "s" : ""}? This will not delete the actual files.`,
+      )
+    ) {
+      return;
+    }
+
+    try {
+      await deleteImportMutation.mutateAsync(selectedIds);
+      addToast({
+        type: "success",
+        message: `${selectedIds.length} import record${selectedIds.length !== 1 ? "s" : ""} deleted`,
+      });
+      setSelectedIds([]);
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to delete records: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+    }
+  };
+
+  const handleClearSelection = () => {
+    setSelectedIds([]);
+  };
+
+  const handleNextPage = () => {
+    setPage((p) => p + 1);
+    setSelectedIds([]);
+  };
+
+  const handlePrevPage = () => {
+    setPage((p) => Math.max(0, p - 1));
+    setSelectedIds([]);
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-6 page-transition">
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold text-foreground mb-2">
+          Import Management
+        </h1>
+        <p className="text-muted-foreground">
+          {pagination?.total || imports.length} pending import
+          {(pagination?.total || imports.length) !== 1 ? "s" : ""}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-4">
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="show-ignored"
+              checked={showIgnored}
+              onChange={() => setShowIgnored(!showIgnored)}
+            />
+            <Label htmlFor="show-ignored" className="text-sm cursor-pointer">
+              {showIgnored ? (
+                <span className="flex items-center gap-1">
+                  <Eye className="w-4 h-4" /> Show Ignored
+                </span>
+              ) : (
+                <span className="flex items-center gap-1">
+                  <EyeOff className="w-4 h-4" /> Hide Ignored
+                </span>
+              )}
+            </Label>
+          </div>
+        </div>
+
+        <Button
+          onClick={handleRefreshImport}
+          disabled={refreshImportMutation.isPending}
+        >
+          <RefreshCw
+            className={`w-4 h-4 mr-2 ${refreshImportMutation.isPending ? "animate-spin" : ""}`}
+          />
+          Scan Import Directory
+        </Button>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-4">
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+          <Skeleton className="h-16" />
+        </div>
+      )}
+
+      {error && (
+        <ErrorDisplay
+          error={error}
+          title="Unable to load pending imports"
+          onRetry={() => refetch()}
+        />
+      )}
+
+      {!isLoading && !error && (
+        <ImportTable
+          imports={imports}
+          pagination={pagination}
+          onNextPage={handleNextPage}
+          onPrevPage={handlePrevPage}
+          onSelectionChange={setSelectedIds}
+          onMatchClick={handleMatchClick}
+        />
+      )}
+
+      <ImportBulkActions
+        selectedCount={selectedIds.length}
+        onIgnore={handleBulkIgnore}
+        onUnignore={handleBulkUnignore}
+        onDelete={handleBulkDelete}
+        onClear={handleClearSelection}
+        isLoading={
+          ignoreImportMutation.isPending || deleteImportMutation.isPending
+        }
+        showUnignore={showIgnored}
+      />
+
+      <MatchModal
+        isOpen={matchModalOpen}
+        onClose={() => {
+          setMatchModalOpen(false);
+          setMatchingGroup(null);
+        }}
+        importGroup={matchingGroup}
+        onMatch={handleMatch}
+        isMatching={matchImportMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -84,7 +84,10 @@ export default function ImportPage() {
 
   const handleBulkIgnore = async () => {
     try {
-      await ignoreImportMutation.mutateAsync({ impIds: selectedIds, ignore: true });
+      await ignoreImportMutation.mutateAsync({
+        impIds: selectedIds,
+        ignore: true,
+      });
       addToast({
         type: "success",
         message: `${selectedIds.length} file${selectedIds.length !== 1 ? "s" : ""} ignored`,
@@ -100,7 +103,10 @@ export default function ImportPage() {
 
   const handleBulkUnignore = async () => {
     try {
-      await ignoreImportMutation.mutateAsync({ impIds: selectedIds, ignore: false });
+      await ignoreImportMutation.mutateAsync({
+        impIds: selectedIds,
+        ignore: false,
+      });
       addToast({
         type: "success",
         message: `${selectedIds.length} file${selectedIds.length !== 1 ? "s" : ""} unignored`,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -71,7 +71,12 @@ export type ApiCommand =
   | "getWanted"
   | "getUpcoming"
   | "forceSearch"
-  | "checkGlobalMessages";
+  | "checkGlobalMessages"
+  | "getImportPending"
+  | "matchImport"
+  | "ignoreImport"
+  | "refreshImport"
+  | "deleteImport";
 
 /** API call parameters */
 export type ApiParams = Record<

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -164,3 +164,35 @@ export interface VolumeGroup {
   downloadedCount: number;
   totalCount: number;
 }
+
+/** Import file entity */
+export interface ImportFile {
+  impID: string;
+  ComicFilename: string;
+  ComicLocation: string;
+  IssueNumber: string | null;
+  ComicYear: string | null;
+  Status: string;
+  IgnoreFile: number;
+  MatchConfidence: number | null;
+  SuggestedComicID: string | null;
+  SuggestedComicName: string | null;
+  SuggestedIssueID: string | null;
+  MatchSource: string | null;
+}
+
+/** Import group (grouped by DynamicName + Volume) */
+export interface ImportGroup {
+  DynamicName: string;
+  ComicName: string;
+  Volume: string | null;
+  ComicYear: string | null;
+  FileCount: number;
+  Status: string;
+  SRID: string | null;
+  ComicID: string | null;
+  MatchConfidence: number | null;
+  SuggestedComicID: string | null;
+  SuggestedComicName: string | null;
+  files: ImportFile[];
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -32,6 +32,8 @@ export type {
   ComicOrManga,
   IssueOrChapter,
   VolumeGroup,
+  ImportFile,
+  ImportGroup,
 } from "./entities";
 
 // Auth types

--- a/mylar/__init__.py
+++ b/mylar/__init__.py
@@ -1306,6 +1306,36 @@ def dbcheck():
     except sqlite3.OperationalError:
         c.execute('ALTER TABLE importresults ADD COLUMN DynamicName TEXT')
 
+    try:
+        c.execute('SELECT MatchConfidence from importresults')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE importresults ADD COLUMN MatchConfidence INTEGER')
+
+    try:
+        c.execute('SELECT SuggestedComicID from importresults')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE importresults ADD COLUMN SuggestedComicID TEXT')
+
+    try:
+        c.execute('SELECT SuggestedComicName from importresults')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE importresults ADD COLUMN SuggestedComicName TEXT')
+
+    try:
+        c.execute('SELECT SuggestedIssueID from importresults')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE importresults ADD COLUMN SuggestedIssueID TEXT')
+
+    try:
+        c.execute('SELECT IgnoreFile from importresults')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE importresults ADD COLUMN IgnoreFile INTEGER DEFAULT 0')
+
+    try:
+        c.execute('SELECT MatchSource from importresults')
+    except sqlite3.OperationalError:
+        c.execute('ALTER TABLE importresults ADD COLUMN MatchSource TEXT')
+
     ## -- Readlist Table --
 
     try:

--- a/mylar/api.py
+++ b/mylar/api.py
@@ -42,7 +42,8 @@ cmd_list = ['getIndex', 'getComic', 'getUpcoming', 'getWanted', 'getHistory',
             'listProviders', 'changeProvider', 'addProvider', 'delProvider',
             'downloadNZB', 'getReadList', 'getStoryArc', 'addStoryArc', 'listAnnualSeries',
             'getConfig', 'setConfig', 'getSeriesImage',
-            'findManga', 'addManga', 'getMangaInfo']
+            'findManga', 'addManga', 'getMangaInfo',
+            'getImportPending', 'matchImport', 'ignoreImport', 'refreshImport', 'deleteImport']
 
 class Api(object):
 
@@ -2262,6 +2263,298 @@ class Api(object):
             response_data['total'] = db_manga['Total']
 
         self.data = self._successResponse(response_data)
+
+    def _getImportPending(self, **kwargs):
+        """
+        Get list of pending import files with suggested matches and confidence scores.
+
+        Parameters:
+            limit: Maximum number of results (optional, default 50)
+            offset: Offset for pagination (optional, default 0)
+            include_ignored: Include ignored files (optional, default 'false')
+
+        Returns:
+            List of import groups with files and pagination info
+        """
+        myDB = db.DBConnection()
+
+        limit = int(kwargs.get('limit', 50))
+        offset = int(kwargs.get('offset', 0))
+        include_ignored = kwargs.get('include_ignored', 'false').lower() == 'true'
+
+        # Build query for pending imports - group by DynamicName and Volume
+        if include_ignored:
+            base_query = """
+                SELECT *, COUNT(*) as FileCount
+                FROM importresults
+                WHERE (WatchMatch IS NULL OR WatchMatch LIKE 'C%')
+                  AND Status != 'Imported'
+                GROUP BY DynamicName, Volume
+                ORDER BY ComicName COLLATE NOCASE
+            """
+            count_query = """
+                SELECT COUNT(DISTINCT DynamicName || COALESCE(Volume, ''))
+                FROM importresults
+                WHERE (WatchMatch IS NULL OR WatchMatch LIKE 'C%')
+                  AND Status != 'Imported'
+            """
+        else:
+            base_query = """
+                SELECT *, COUNT(*) as FileCount
+                FROM importresults
+                WHERE (WatchMatch IS NULL OR WatchMatch LIKE 'C%')
+                  AND Status != 'Imported'
+                  AND (IgnoreFile IS NULL OR IgnoreFile = 0)
+                GROUP BY DynamicName, Volume
+                ORDER BY ComicName COLLATE NOCASE
+            """
+            count_query = """
+                SELECT COUNT(DISTINCT DynamicName || COALESCE(Volume, ''))
+                FROM importresults
+                WHERE (WatchMatch IS NULL OR WatchMatch LIKE 'C%')
+                  AND Status != 'Imported'
+                  AND (IgnoreFile IS NULL OR IgnoreFile = 0)
+            """
+
+        # Get total count
+        total_result = myDB.selectone(count_query).fetchone()
+        total = total_result[0] if total_result else 0
+
+        # Get paginated results
+        paginated_query = base_query + " LIMIT ? OFFSET ?"
+        results = myDB.select(paginated_query, [limit, offset])
+
+        imports = []
+        for result in results:
+            dynamic_name = result['DynamicName']
+            volume = result['Volume']
+
+            # Get all files for this group
+            if volume is None or volume == 'None':
+                files_query = """
+                    SELECT * FROM importresults
+                    WHERE DynamicName=? AND (Volume IS NULL OR Volume='None')
+                    AND (WatchMatch IS NULL OR WatchMatch LIKE 'C%')
+                    AND Status != 'Imported'
+                """
+                if not include_ignored:
+                    files_query += " AND (IgnoreFile IS NULL OR IgnoreFile = 0)"
+                files = myDB.select(files_query, [dynamic_name])
+            else:
+                files_query = """
+                    SELECT * FROM importresults
+                    WHERE DynamicName=? AND Volume=?
+                    AND (WatchMatch IS NULL OR WatchMatch LIKE 'C%')
+                    AND Status != 'Imported'
+                """
+                if not include_ignored:
+                    files_query += " AND (IgnoreFile IS NULL OR IgnoreFile = 0)"
+                files = myDB.select(files_query, [dynamic_name, volume])
+
+            file_list = []
+            for f in files:
+                file_list.append({
+                    'impID': f['impID'],
+                    'ComicFilename': f['ComicFilename'],
+                    'ComicLocation': f['ComicLocation'],
+                    'IssueNumber': f['IssueNumber'],
+                    'ComicYear': f['ComicYear'],
+                    'Status': f['Status'],
+                    'IgnoreFile': f['IgnoreFile'] or 0,
+                    'MatchConfidence': f['MatchConfidence'],
+                    'SuggestedComicID': f['SuggestedComicID'],
+                    'SuggestedComicName': f['SuggestedComicName'],
+                    'SuggestedIssueID': f['SuggestedIssueID'],
+                    'MatchSource': f['MatchSource']
+                })
+
+            # Calculate average confidence for the group
+            confidences = [f['MatchConfidence'] for f in file_list if f['MatchConfidence'] is not None]
+            avg_confidence = sum(confidences) // len(confidences) if confidences else None
+
+            imports.append({
+                'DynamicName': dynamic_name,
+                'ComicName': result['ComicName'],
+                'Volume': volume,
+                'ComicYear': result['ComicYear'],
+                'FileCount': result['FileCount'],
+                'Status': result['Status'],
+                'SRID': result['SRID'],
+                'ComicID': result['ComicID'],
+                'MatchConfidence': avg_confidence,
+                'SuggestedComicID': result['SuggestedComicID'],
+                'SuggestedComicName': result['SuggestedComicName'],
+                'files': file_list
+            })
+
+        self.data = self._successResponse({
+            'imports': imports,
+            'pagination': {
+                'total': total,
+                'limit': limit,
+                'offset': offset,
+                'has_more': (offset + limit) < total
+            }
+        })
+
+    def _matchImport(self, **kwargs):
+        """
+        Manually match import file(s) to a comic series.
+
+        Parameters:
+            imp_ids: Comma-separated list of import IDs to match (required)
+            comic_id: Comic ID to match to (required)
+            issue_id: Specific issue ID to match to (optional)
+
+        Returns:
+            Number of matched imports
+        """
+        if 'imp_ids' not in kwargs:
+            self.data = self._failureResponse('Missing parameter: imp_ids')
+            return
+
+        if 'comic_id' not in kwargs:
+            self.data = self._failureResponse('Missing parameter: comic_id')
+            return
+
+        imp_ids = kwargs['imp_ids'].split(',')
+        comic_id = kwargs['comic_id']
+        issue_id = kwargs.get('issue_id')
+
+        myDB = db.DBConnection()
+
+        # Get comic name for display
+        comic = myDB.selectone('SELECT ComicName FROM comics WHERE ComicID=?', [comic_id]).fetchone()
+        comic_name = comic['ComicName'] if comic else 'Unknown'
+
+        matched = 0
+        for imp_id in imp_ids:
+            imp_id = imp_id.strip()
+            if not imp_id:
+                continue
+
+            update_values = {
+                'ComicID': comic_id,
+                'SuggestedComicID': comic_id,
+                'SuggestedComicName': comic_name,
+                'MatchSource': 'manual',
+                'MatchConfidence': 100,
+                'WatchMatch': 'C' + comic_id
+            }
+
+            if issue_id:
+                update_values['IssueID'] = issue_id
+                update_values['SuggestedIssueID'] = issue_id
+
+            myDB.upsert('importresults', update_values, {'impID': imp_id})
+            matched += 1
+
+        self.data = self._successResponse({
+            'matched': matched,
+            'comic_id': comic_id,
+            'comic_name': comic_name
+        })
+
+    def _ignoreImport(self, **kwargs):
+        """
+        Mark import file(s) as ignored or unignored.
+
+        Parameters:
+            imp_ids: Comma-separated list of import IDs to update (required)
+            ignore: Whether to ignore (true) or unignore (false) (optional, default 'true')
+
+        Returns:
+            Number of updated imports
+        """
+        if 'imp_ids' not in kwargs:
+            self.data = self._failureResponse('Missing parameter: imp_ids')
+            return
+
+        imp_ids = kwargs['imp_ids'].split(',')
+        ignore = kwargs.get('ignore', 'true').lower() == 'true'
+        ignore_value = 1 if ignore else 0
+
+        myDB = db.DBConnection()
+
+        updated = 0
+        for imp_id in imp_ids:
+            imp_id = imp_id.strip()
+            if not imp_id:
+                continue
+
+            myDB.upsert('importresults', {'IgnoreFile': ignore_value}, {'impID': imp_id})
+            updated += 1
+
+        self.data = self._successResponse({
+            'updated': updated,
+            'ignored': ignore
+        })
+
+    def _refreshImport(self, **kwargs):
+        """
+        Trigger a refresh of the import directory scan.
+
+        Returns:
+            Success message
+        """
+        import mylar
+        from mylar import librarysync
+
+        # Get import directory from config
+        import_dir = mylar.CONFIG.IMPORT_DIR if hasattr(mylar.CONFIG, 'IMPORT_DIR') else None
+
+        if not import_dir:
+            self.data = self._failureResponse('Import directory not configured')
+            return
+
+        # Queue import scan
+        try:
+            logger.info('[API][refreshImport] Starting import directory scan for: %s' % import_dir)
+            # Use existing import functionality - scanLibrary expects scan=path and queue=queue object
+            import_queue = queue.Queue()
+            threading.Thread(
+                target=librarysync.scanLibrary,
+                name="API-ImportScan",
+                args=[import_dir, import_queue]
+            ).start()
+
+            self.data = self._successResponse({
+                'message': 'Import scan started for: %s' % import_dir
+            })
+        except Exception as e:
+            logger.error('[API][refreshImport] Error: %s' % e)
+            self.data = self._failureResponse('Failed to start import scan: %s' % str(e))
+
+    def _deleteImport(self, **kwargs):
+        """
+        Delete import record(s) from the database.
+
+        Parameters:
+            imp_ids: Comma-separated list of import IDs to delete (required)
+
+        Returns:
+            Number of deleted imports
+        """
+        if 'imp_ids' not in kwargs:
+            self.data = self._failureResponse('Missing parameter: imp_ids')
+            return
+
+        imp_ids = kwargs['imp_ids'].split(',')
+
+        myDB = db.DBConnection()
+
+        deleted = 0
+        for imp_id in imp_ids:
+            imp_id = imp_id.strip()
+            if not imp_id:
+                continue
+
+            myDB.action('DELETE FROM importresults WHERE impID=?', [imp_id])
+            deleted += 1
+
+        self.data = self._successResponse({
+            'deleted': deleted
+        })
 
 
 class REST(object):

--- a/mylar/filechecker.py
+++ b/mylar/filechecker.py
@@ -1931,6 +1931,125 @@ class FileChecker(object):
 
         return dateline
 
+
+def calculate_match_confidence(parsed_info, comic_info):
+    """
+    Calculate a confidence score (0-100) for how well a parsed file matches a comic series.
+
+    Scoring breakdown:
+    - Series Name Match: 40 pts (fuzzy match)
+    - Year Match: 15 pts (exact or +/- 1 year)
+    - Volume Match: 15 pts (exact volume number)
+    - Issue Number: 15 pts (issue number extractable)
+    - Metadata: 10 pts (CBZ has ComicInfo.xml)
+    - Path Hints: 5 pts (series name in folder path)
+
+    Args:
+        parsed_info: Dict from FileChecker.parseit() with keys like:
+            - series_name, series_volume, issue_number, issue_year
+            - comiclocation, comicfilename
+        comic_info: Dict with comic series info from DB with keys like:
+            - ComicName, ComicYear, ComicID, Volume
+
+    Returns:
+        Integer confidence score from 0-100
+    """
+    import difflib
+
+    score = 0
+
+    # Normalize strings for comparison
+    def normalize(s):
+        if s is None:
+            return ''
+        s = str(s).lower().strip()
+        # Remove common punctuation and normalize spaces
+        s = re.sub(r'[^\w\s]', '', s)
+        s = re.sub(r'\s+', ' ', s)
+        return s
+
+    parsed_name = normalize(parsed_info.get('series_name') or parsed_info.get('ComicName'))
+    comic_name = normalize(comic_info.get('ComicName'))
+
+    # 1. Series Name Match (40 pts) - using sequence matcher for fuzzy matching
+    if parsed_name and comic_name:
+        ratio = difflib.SequenceMatcher(None, parsed_name, comic_name).ratio()
+        name_score = int(ratio * 40)
+        score += name_score
+        if mylar.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
+            logger.fdebug('[CONFIDENCE] Name match: "%s" vs "%s" = %.2f (%d pts)' % (
+                parsed_name, comic_name, ratio, name_score))
+
+    # 2. Year Match (15 pts)
+    parsed_year = parsed_info.get('issue_year') or parsed_info.get('ComicYear')
+    comic_year = comic_info.get('ComicYear')
+
+    if parsed_year and comic_year:
+        try:
+            py = int(str(parsed_year)[:4])
+            cy = int(str(comic_year)[:4])
+            year_diff = abs(py - cy)
+            if year_diff == 0:
+                score += 15
+            elif year_diff == 1:
+                score += 10
+            elif year_diff <= 3:
+                score += 5
+        except (ValueError, TypeError):
+            pass
+
+    # 3. Volume Match (15 pts)
+    parsed_volume = parsed_info.get('series_volume') or parsed_info.get('Volume')
+    comic_volume = comic_info.get('Volume') or comic_info.get('ComicVersion')
+
+    if parsed_volume and comic_volume:
+        pv = normalize(str(parsed_volume)).replace('v', '').strip()
+        cv = normalize(str(comic_volume)).replace('v', '').strip()
+        if pv == cv:
+            score += 15
+        elif pv and cv:
+            # Partial match
+            try:
+                if int(pv) == int(cv):
+                    score += 15
+            except ValueError:
+                pass
+    elif not parsed_volume and not comic_volume:
+        # Both have no volume, considered a match
+        score += 10
+
+    # 4. Issue Number (15 pts)
+    parsed_issue = parsed_info.get('issue_number') or parsed_info.get('IssueNumber')
+    if parsed_issue and parsed_issue != 'None' and parsed_issue != '':
+        score += 15
+    elif parsed_issue is None or parsed_issue == 'None' or parsed_issue == '':
+        # Partial credit for at least having file parsed
+        score += 5
+
+    # 5. Metadata (10 pts) - Check if CBZ has ComicInfo.xml
+    comic_location = parsed_info.get('comiclocation') or parsed_info.get('ComicLocation')
+    comic_filename = parsed_info.get('comicfilename') or parsed_info.get('ComicFilename')
+
+    if comic_location and comic_filename:
+        full_path = os.path.join(comic_location, comic_filename)
+        if os.path.exists(full_path) and full_path.lower().endswith('.cbz'):
+            try:
+                import zipfile
+                with zipfile.ZipFile(full_path, 'r') as zf:
+                    if 'ComicInfo.xml' in zf.namelist():
+                        score += 10
+            except Exception:
+                pass
+
+    # 6. Path Hints (5 pts) - series name appears in folder path
+    if comic_location and comic_name:
+        path_lower = normalize(comic_location)
+        if comic_name in path_lower:
+            score += 5
+
+    return min(100, score)
+
+
 def validateAndCreateDirectory(dir, create=False, module=None, dmode=None):
     if module is None:
         module = ''


### PR DESCRIPTION
## Summary

Implements an interactive import management screen that allows users to view, match, and manage unmatched import files. This addresses GitHub issue #1337 from the mylar3 community feature requests.

### Features
- View pending imports grouped by series with confidence scores
- Color-coded confidence badges (green >80%, yellow 50-80%, red <50%)
- Manual matching via series search modal
- Bulk ignore/delete actions
- Show/hide ignored files toggle
- Re-scan import directory

### Backend Changes
- Add 6 new columns to `importresults` table (MatchConfidence, SuggestedComicID, SuggestedComicName, SuggestedIssueID, IgnoreFile, MatchSource)
- Add 5 new API commands:
  - `getImportPending` - List unmatched files with pagination
  - `matchImport` - Manually match file(s) to series
  - `ignoreImport` - Mark file(s) as ignored
  - `refreshImport` - Re-scan import directory
  - `deleteImport` - Remove import record(s)
- Add `calculate_match_confidence()` function with weighted scoring

### Frontend Changes
- New `/import` page with paginated table
- New components: ImportTable, MatchModal, ImportBulkActions, ConfidenceBadge
- New useImport hook with React Query mutations
- Import nav item added to sidebar

## Test plan
- [ ] Navigate to Import page via sidebar
- [ ] Verify pending imports display in grouped table
- [ ] Expand a group to see individual files
- [ ] Verify confidence badges are color-coded
- [ ] Click "Match" to open search modal and match to series
- [ ] Select multiple groups and use bulk ignore
- [ ] Toggle "Show Ignored" to verify ignored items reappear
- [ ] Click "Scan Import Directory" to trigger re-scan


🤖 Generated with [Claude Code](https://claude.com/claude-code)