### PR TITLE
fix(ui): add horizontal padding to sidebar nav items

### DIFF
--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -139,7 +139,7 @@ export default function AppSidebar() {
       <SidebarSeparator />
 
       {/* Main Navigation */}
-      <SidebarContent className="pt-2">
+      <SidebarContent className="px-2 pt-2">
         <SidebarMenu>
           {navItems.map(({ path, label, icon: Icon }) => (
             <SidebarMenuItem key={path}>
@@ -161,7 +161,7 @@ export default function AppSidebar() {
       <SidebarSeparator />
 
       {/* Footer with Settings, Theme, and Logout */}
-      <SidebarFooter className="pb-4">
+      <SidebarFooter className="px-2 pb-4">
         <SidebarMenu>
           {/* Settings */}
           <SidebarMenuItem>


### PR DESCRIPTION
## Summary

- Added `px-2` to `SidebarContent` and `SidebarFooter` so active nav item highlights are inset from the sidebar edges

**Before:** Active item gradient touches both edges of the sidebar
**After:** Consistent horizontal padding around all nav items

## Testing

- [ ] Verify active nav item has padding from sidebar edges
- [ ] Verify collapsed sidebar icon mode still looks correct
- [ ] Verify footer items (Settings, Theme, Logout) also have padding

🤖 Generated with [Claude Code](https://claude.ai/code)