### PR TITLE
fix(ui): enlarge sidebar logo

### DIFF
--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -95,7 +95,9 @@ export default function AppSidebar() {
                 onClick={handleNavClick}
                 className="flex items-center gap-3"
               >
-                <Logo className="h-6 text-foreground" />
+                <div className="w-full">
+                  <Logo className="h-full w-full text-foreground" />
+                </div>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>


### PR DESCRIPTION
## Summary
- The `SidebarMenuButton`'s `[&>svg]:size-4` CSS rule was clamping the logo SVG to 16px, making it nearly unreadable
- Wrapped the Logo in a `div` so it's no longer a direct child SVG and can fill the container width

## Test plan
- [ ] Verify the sidebar logo renders at full container width
- [ ] Verify collapsed sidebar still looks correct
- [ ] Verify mobile sidebar logo looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)