### PR TITLE
fix: auto-generate API key on startup when missing

### DIFF
--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -569,7 +569,7 @@ def initialize(config_file):
                 comicarr.CONFIG.API_KEY = secrets.token_hex(16)
                 comicarr.CONFIG.API_ENABLED = True
                 comicarr.CONFIG.WRITE_THE_CONFIG = True
-                logger.info('[STARTUP] API key was not set - auto-generated a new API key')
+                logger.info("[STARTUP] API key was not set - auto-generated a new API key")
 
             from comicarr.downloaders import external_server as des
 

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -563,6 +563,14 @@ def initialize(config_file):
 
                 comicarr.SSE_KEY = secrets.token_hex(16)
 
+            if not comicarr.CONFIG.API_KEY or len(comicarr.CONFIG.API_KEY) != 32:
+                import secrets
+
+                comicarr.CONFIG.API_KEY = secrets.token_hex(16)
+                comicarr.CONFIG.API_ENABLED = True
+                comicarr.CONFIG.WRITE_THE_CONFIG = True
+                logger.info('[STARTUP] API key was not set - auto-generated a new API key')
+
             from comicarr.downloaders import external_server as des
 
             EXT_SERVER = des.EXT_SERVER


### PR DESCRIPTION
## Summary
- `API_KEY` defaults to `None` in config and was never auto-generated, causing "API key not generated correctly" errors on every page after a fresh install or update
- Auto-generates a 32-char hex API key on startup using `secrets.token_hex(16)` (same pattern as `SSE_KEY`), enables the API, and persists to `config.ini`

## Test plan
- [ ] Start Comicarr with no `api_key` in `config.ini` — verify key is auto-generated and logged
- [ ] Confirm Settings and Series pages load without "API key not generated correctly" error
- [ ] Restart and verify the persisted key is reused (no re-generation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)