### PR TITLE
fix: Surface specific migration errors and fix credential decryption on startup

### DIFF
--- a/comicarr/api.py
+++ b/comicarr/api.py
@@ -1522,7 +1522,7 @@ class Api(object):
         if result.get("valid"):
             self.data = self._successResponse(result)
         else:
-            self.data = self._failureResponse("Invalid Mylar3 data path")
+            self.data = self._failureResponse(result.get("error", "Invalid Mylar3 data path"))
 
     def _startMigration(self, **kwargs):
         if self.apitype != "normal":

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -1130,28 +1130,6 @@ class Config(object):
             else:
                 pass
 
-        # Migrate login password to bcrypt on startup (handles all three states)
-        if self.HTTP_PASSWORD and not (self.HTTP_PASSWORD.startswith("$2b$") or self.HTTP_PASSWORD.startswith("$2a$")):
-            # Backup config before credential migration
-            backup_path = os.path.join(self.SECURE_DIR, "config.ini.pre-security-migration.bak")
-            if not os.path.exists(backup_path):
-                try:
-                    import shutil
-
-                    shutil.copy2(self._config_file, backup_path)
-                    logger.info("[SECURITY] Pre-migration backup saved to %s" % backup_path)
-                except Exception as e:
-                    logger.error("[SECURITY] Failed to create pre-migration backup: %s" % e)
-
-            new_hash = encrypted.migrate_password(self.HTTP_PASSWORD)
-            if new_hash:
-                self.HTTP_PASSWORD = new_hash
-                config.set("Interface", "http_password", new_hash)
-                self.ENCRYPT_PASSWORDS = True
-                config.set("General", "encrypt_passwords", "True")
-                self.WRITE_THE_CONFIG = True
-                logger.info("[SECURITY] Login password migrated to bcrypt")
-
     def writeconfig(self, values=None, startup=False):
         logger.fdebug("Writing configuration to file")
         config.set("Newznab", "extra_newznabs", ", ".join(self.write_extras(self.EXTRA_NEWZNABS)))
@@ -1385,6 +1363,28 @@ class Config(object):
         # Encrypt plaintext credentials now that SECURE_DIR is available
         if self.ENCRYPT_PASSWORDS is True:
             self.encrypt_items(mode="encrypt")
+
+        # Migrate login password to bcrypt on startup (handles all three states)
+        if self.HTTP_PASSWORD and not (self.HTTP_PASSWORD.startswith("$2b$") or self.HTTP_PASSWORD.startswith("$2a$")):
+            # Backup config before credential migration
+            backup_path = os.path.join(self.SECURE_DIR, "config.ini.pre-security-migration.bak")
+            if not os.path.exists(backup_path):
+                try:
+                    import shutil
+
+                    shutil.copy2(self._config_file, backup_path)
+                    logger.info("[SECURITY] Pre-migration backup saved to %s" % backup_path)
+                except Exception as e:
+                    logger.error("[SECURITY] Failed to create pre-migration backup: %s" % e)
+
+            new_hash = encrypted.migrate_password(self.HTTP_PASSWORD)
+            if new_hash:
+                self.HTTP_PASSWORD = new_hash
+                config.set("Interface", "http_password", new_hash)
+                self.ENCRYPT_PASSWORDS = True
+                config.set("General", "encrypt_passwords", "True")
+                self.WRITE_THE_CONFIG = True
+                logger.info("[SECURITY] Login password migrated to bcrypt")
 
         # Startup security permission checks
         if startup and not update:

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -1130,9 +1130,6 @@ class Config(object):
             else:
                 pass
 
-        if self.ENCRYPT_PASSWORDS is True:
-            self.encrypt_items(mode="encrypt")
-
         # Migrate login password to bcrypt on startup (handles all three states)
         if self.HTTP_PASSWORD and not (self.HTTP_PASSWORD.startswith("$2b$") or self.HTTP_PASSWORD.startswith("$2a$")):
             # Backup config before credential migration
@@ -1384,6 +1381,10 @@ class Config(object):
                     "Credential encryption will not work. Fix permissions and restart." % self.SECURE_DIR
                 )
                 raise SystemExit(1)
+
+        # Encrypt plaintext credentials now that SECURE_DIR is available
+        if self.ENCRYPT_PASSWORDS is True:
+            self.encrypt_items(mode="encrypt")
 
         # Startup security permission checks
         if startup and not update:

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -1370,8 +1370,6 @@ class Config(object):
             backup_path = os.path.join(self.SECURE_DIR, "config.ini.pre-security-migration.bak")
             if not os.path.exists(backup_path):
                 try:
-                    import shutil
-
                     shutil.copy2(self._config_file, backup_path)
                     logger.info("[SECURITY] Pre-migration backup saved to %s" % backup_path)
                 except Exception as e:

--- a/comicarr/migration.py
+++ b/comicarr/migration.py
@@ -148,7 +148,7 @@ class Mylar3Migration:
     def validate(self):
         valid, result = _validate_source_path(self.source_path)
         if not valid:
-            return {"valid": False, "error": "Invalid Mylar3 data path"}
+            return {"valid": False, "error": result}
 
         self.dbfile = result
         self.real_path = os.path.realpath(self.source_path)


### PR DESCRIPTION
## Summary

- **Migration error messages**: `_validate_source_path()` returns specific errors (e.g., "Path is not a directory", "No mylar.db found at path") but both `migration.py` and `api.py` discarded them and returned a generic "Invalid Mylar3 data path". Now the specific error reaches the frontend.
- **Credential decryption on startup**: `encrypt_items(mode="encrypt")` was called at config.py:1134 before `SECURE_DIR` was initialized at line 1374. Fernet couldn't load the master key, so encrypted credentials (ComicVine API key, Comicarr API key) were never decrypted — silently breaking search and other features. Moved the call to after `SECURE_DIR` setup.

## Test plan

- [ ] Deploy Comicarr with a Mylar3 volume mount at an incorrect path — verify the UI shows the specific error (e.g., "No mylar.db found at path") instead of generic "Invalid Mylar3 data path"
- [ ] Deploy fresh Comicarr with `encrypt_passwords = True` and encrypted credentials in config.ini — verify search works after restart without manually decrypting config values
- [ ] Verify existing setups with plaintext credentials still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)