### PR TITLE
fix: sync uv.lock and prevent stale lockfile on release

### DIFF
--- a/.github/workflows/sync-lockfile.yml
+++ b/.github/workflows/sync-lockfile.yml
@@ -1,0 +1,33 @@
+name: Sync uv.lock on Release PR
+
+on:
+  pull_request:
+    paths:
+      - pyproject.toml
+
+permissions:
+  contents: write
+
+jobs:
+  sync-lockfile:
+    if: startsWith(github.head_ref, 'release-please-')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Update uv.lock
+        run: uv lock
+
+      - name: Commit updated lockfile
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git diff --cached --quiet || git commit -m "chore: sync uv.lock with pyproject.toml version"
+          git push

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "comicarr"
-version = "0.1.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary
- The v0.4.0 Docker build failed because `uv sync --locked` found a stale `uv.lock` — release-please bumped `pyproject.toml` to 0.4.0 but the lockfile still referenced 0.1.0
- Updates `uv.lock` to match the current version
- Adds a new workflow (`sync-lockfile.yml`) that automatically runs `uv lock` and commits the result to release-please PRs, preventing this from happening on future releases

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, confirm release-please creates a v0.4.1 release PR
- [ ] Verify the v0.4.1 Docker build succeeds on GHCR
- [ ] Confirm Watchtower picks up the new image on the NAS

🤖 Generated with [Claude Code](https://claude.com/claude-code)