### PR TITLE
fix: Dark mode issues in settings and remove placeholder UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,6 @@ import SearchPage from "@/pages/SearchPage";
 import UpcomingPage from "@/pages/UpcomingPage";
 import WantedPage from "@/pages/WantedPage";
 import SettingsPage from "@/pages/SettingsPage";
-import StoryArcsPage from "@/pages/StoryArcsPage";
 import ImportPage from "@/pages/ImportPage";
 import { ToastProvider } from "@/components/ui/toast";
 import ErrorBoundary from "@/components/ErrorBoundary";
@@ -60,7 +59,6 @@ function AppContent() {
                   <Route path="/search" element={<SearchPage />} />
                   <Route path="/upcoming" element={<UpcomingPage />} />
                   <Route path="/wanted" element={<WantedPage />} />
-                  <Route path="/story-arcs" element={<StoryArcsPage />} />
                   <Route path="/import" element={<ImportPage />} />
                   <Route path="/settings" element={<SettingsPage />} />
                   <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -28,7 +28,6 @@ import {
   ListTodo,
   Settings,
   LogOut,
-  BookMarked,
   Moon,
   Sun,
   FolderInput,
@@ -67,7 +66,6 @@ export default function AppSidebar() {
     { path: "/", label: "Series", icon: Home },
     { path: "/upcoming", label: "Upcoming", icon: Calendar },
     { path: "/wanted", label: "Wanted", icon: ListTodo },
-    { path: "/story-arcs", label: "Story Arcs", icon: BookMarked },
     { path: "/import", label: "Import", icon: FolderInput },
   ];
 

--- a/frontend/src/components/settings/DownloadClientsTab.tsx
+++ b/frontend/src/components/settings/DownloadClientsTab.tsx
@@ -13,14 +13,14 @@ export function DownloadClientsTab({ config }: DownloadClientsTabProps) {
         description="Currently configured download clients (read-only)"
       >
         <div className="space-y-4">
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <div className="bg-blue-50 dark:bg-blue-950/40 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
             <div className="flex items-start space-x-3">
-              <AlertCircle className="h-5 w-5 text-blue-600 mt-0.5" />
+              <AlertCircle className="h-5 w-5 text-blue-600 dark:text-blue-400 mt-0.5" />
               <div>
-                <h4 className="text-sm font-semibold text-blue-900 mb-1">
+                <h4 className="text-sm font-semibold text-blue-900 dark:text-blue-100 mb-1">
                   Current Configuration
                 </h4>
-                <div className="text-sm text-blue-800 space-y-2">
+                <div className="text-sm text-blue-800 dark:text-blue-200 space-y-2">
                   <p>
                     <span className="font-medium">NZB Client:</span>{" "}
                     {(config.nzb_downloader_label as string) ||
@@ -38,12 +38,12 @@ export function DownloadClientsTab({ config }: DownloadClientsTabProps) {
 
           <div className="bg-background border border-card-border rounded-lg p-4">
             <div className="flex items-start space-x-3">
-              <AlertCircle className="h-5 w-5 text-gray-600 mt-0.5" />
+              <AlertCircle className="h-5 w-5 text-muted-foreground mt-0.5" />
               <div>
-                <h4 className="text-sm font-semibold text-gray-900 mb-1">
+                <h4 className="text-sm font-semibold text-foreground mb-1">
                   Advanced Configuration Coming Soon
                 </h4>
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-muted-foreground">
                   Full download client configuration (SABnzbd, NZBGet,
                   qBittorrent, etc.) will be available in a future update. For
                   now, please configure these settings in your config.ini file

--- a/frontend/src/components/settings/InterfaceTab.tsx
+++ b/frontend/src/components/settings/InterfaceTab.tsx
@@ -12,11 +12,6 @@ export function InterfaceTab({
   formData,
   onChange,
 }: InterfaceTabProps) {
-  const interfaceOptions = [
-    { value: "carbon", label: "Carbon (Modern)" },
-    { value: "default", label: "Default (Classic)" },
-  ];
-
   return (
     <div className="space-y-6">
       <SettingGroup
@@ -50,14 +45,6 @@ export function InterfaceTab({
         title="Interface Preferences"
         description="Customize the look and behavior of the web interface"
       >
-        <SettingField
-          label="Theme"
-          value={formData.interface as string | undefined}
-          type="select"
-          options={interfaceOptions}
-          onChange={(value) => onChange("interface", value as string)}
-          helpText="Choose your preferred interface theme"
-        />
         <SettingField
           label="Launch Browser"
           type="checkbox"

--- a/frontend/src/components/settings/SaveButton.tsx
+++ b/frontend/src/components/settings/SaveButton.tsx
@@ -16,7 +16,7 @@ export function SaveButton({
   if (!isDirty) return null;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 p-4 flex justify-end space-x-3 shadow-lg z-10">
+    <div className="fixed bottom-0 left-0 right-0 bg-background border-t border-border p-4 flex justify-end space-x-3 shadow-lg z-10">
       <Button variant="outline" onClick={onCancel} disabled={isSaving}>
         Cancel
       </Button>


### PR DESCRIPTION
## Summary
- Fix save button bar using hardcoded `bg-white` — now uses theme-aware `bg-background`
- Fix download clients tab with unreadable light-mode-only blue/gray colors in dark mode
- Remove non-functional legacy theme dropdown (Carbon/Default) from interface settings
- Hide Story Arcs page/route until frontend implementation is built

## Test plan
- [ ] Toggle dark mode and change a setting — verify save bar blends with dark theme
- [ ] Check Download Clients tab in dark mode — info boxes should be readable
- [ ] Verify Interface settings no longer show Theme dropdown
- [ ] Verify Story Arcs is gone from sidebar navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)