### PR TITLE
feat: Add content source toggles for comic-only or manga-only experience

### DIFF
--- a/comicarr/api.py
+++ b/comicarr/api.py
@@ -2909,6 +2909,11 @@ class Api(object):
             "api_key": ("****" + comicarr.CONFIG.API_KEY[-4:])
             if comicarr.CONFIG.API_KEY and len(comicarr.CONFIG.API_KEY) >= 4
             else "****",
+            # Content source toggles
+            "comicvine_enabled": comicarr.CONFIG.COMICVINE_ENABLED,
+            "mangadex_enabled": comicarr.CONFIG.MANGADEX_ENABLED,
+            "mangadex_languages": comicarr.CONFIG.MANGADEX_LANGUAGES,
+            "mangadex_content_rating": comicarr.CONFIG.MANGADEX_CONTENT_RATING,
             # Comic Vine
             "comicvine_api": ("****" + comicarr.CONFIG.COMICVINE_API[-4:])
             if comicarr.CONFIG.COMICVINE_API and len(comicarr.CONFIG.COMICVINE_API) >= 4
@@ -2947,6 +2952,11 @@ class Api(object):
             "api_key",
             "launch_browser",
             "interface",
+            # Content source toggles
+            "comicvine_enabled",
+            "mangadex_enabled",
+            "mangadex_languages",
+            "mangadex_content_rating",
             "comicvine_api",
             "cv_verify",
             "cv_only",

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -155,6 +155,7 @@ _CONFIG_DEFINITIONS = OrderedDict(
         "API_ENABLED": (bool, "API", False),
         "API_KEY": (str, "API", None),
         "CALENDAR_DEFAULT_DAYS": (int, "API", 90),
+        "COMICVINE_ENABLED": (bool, "CV", True),
         "CVAPI_RATE": (int, "CV", 2),
         "COMICVINE_API": (str, "CV", None),
         "IGNORED_PUBLISHERS": (str, "CV", ""),

--- a/frontend/src/components/series/SeriesFilters.tsx
+++ b/frontend/src/components/series/SeriesFilters.tsx
@@ -7,6 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useContentSources } from "@/hooks/useContentSources";
 
 export type TypeFilter = "all" | "comic" | "manga";
 export type ProgressFilter = "all" | "0" | "partial" | "100";
@@ -35,6 +36,9 @@ export default function SeriesFilters({
   onStatusChange,
   counts,
 }: SeriesFiltersProps) {
+  const { comicsEnabled, mangaEnabled } = useContentSources();
+  const showTypeFilter = comicsEnabled && mangaEnabled;
+
   // Helper to format count
   const formatCount = (count: number | undefined) => {
     if (count === undefined || count === 0) return "";
@@ -43,48 +47,50 @@ export default function SeriesFilters({
 
   return (
     <div className="flex flex-wrap gap-3 items-center">
-      {/* Type Filter - Segmented Control */}
-      <div className="inline-flex rounded-lg border border-border p-0.5 bg-muted/50">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onTypeChange("all")}
-          className={`h-8 px-3 rounded-md text-sm font-medium transition-colors ${
-            typeFilter === "all"
-              ? "bg-background text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <Library className="w-4 h-4 mr-1.5" />
-          All{formatCount(counts?.type.all)}
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onTypeChange("comic")}
-          className={`h-8 px-3 rounded-md text-sm font-medium transition-colors ${
-            typeFilter === "comic"
-              ? "bg-background text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <Book className="w-4 h-4 mr-1.5" />
-          Comics{formatCount(counts?.type.comic)}
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onTypeChange("manga")}
-          className={`h-8 px-3 rounded-md text-sm font-medium transition-colors ${
-            typeFilter === "manga"
-              ? "bg-background text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <BookOpen className="w-4 h-4 mr-1.5" />
-          Manga{formatCount(counts?.type.manga)}
-        </Button>
-      </div>
+      {/* Type Filter - only show when both content sources are enabled */}
+      {showTypeFilter && (
+        <div className="inline-flex rounded-lg border border-border p-0.5 bg-muted/50">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onTypeChange("all")}
+            className={`h-8 px-3 rounded-md text-sm font-medium transition-colors ${
+              typeFilter === "all"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Library className="w-4 h-4 mr-1.5" />
+            All{formatCount(counts?.type.all)}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onTypeChange("comic")}
+            className={`h-8 px-3 rounded-md text-sm font-medium transition-colors ${
+              typeFilter === "comic"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Book className="w-4 h-4 mr-1.5" />
+            Comics{formatCount(counts?.type.comic)}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onTypeChange("manga")}
+            className={`h-8 px-3 rounded-md text-sm font-medium transition-colors ${
+              typeFilter === "manga"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <BookOpen className="w-4 h-4 mr-1.5" />
+            Manga{formatCount(counts?.type.manga)}
+          </Button>
+        </div>
+      )}
 
       {/* Progress Filter - Dropdown */}
       <Select

--- a/frontend/src/components/settings/ApiTab.tsx
+++ b/frontend/src/components/settings/ApiTab.tsx
@@ -57,8 +57,35 @@ export function ApiTab({ config, formData, onChange }: ApiTabProps) {
     }
   };
 
+  const comicvineEnabled = (formData.comicvine_enabled as boolean) ?? true;
+  const mangadexEnabled = (formData.mangadex_enabled as boolean) ?? false;
+
   return (
     <div className="space-y-6">
+      <SettingGroup
+        title="Content Sources"
+        description="Choose which content sources to enable. At least one must be active."
+      >
+        <SettingField
+          label="Comics (Comic Vine)"
+          type="checkbox"
+          checked={comicvineEnabled}
+          onChange={(checked) =>
+            onChange("comicvine_enabled", checked as boolean)
+          }
+          helpText="Enable comic search and metadata from Comic Vine"
+        />
+        <SettingField
+          label="Manga (MangaDex)"
+          type="checkbox"
+          checked={mangadexEnabled}
+          onChange={(checked) =>
+            onChange("mangadex_enabled", checked as boolean)
+          }
+          helpText="Enable manga search and metadata from MangaDex"
+        />
+      </SettingGroup>
+
       <SettingGroup
         title="Comicarr API Key"
         description="This key is used to authenticate API requests to Comicarr"
@@ -102,63 +129,95 @@ export function ApiTab({ config, formData, onChange }: ApiTabProps) {
         </div>
       </SettingGroup>
 
-      <SettingGroup
-        title="Comic Vine API"
-        description="Configure Comic Vine integration for metadata"
-      >
-        <SettingField
-          label="Comic Vine API Key"
-          value={formData.comicvine_api as string | undefined}
-          type="text"
-          onChange={(value) => onChange("comicvine_api", value as string)}
-          placeholder="Enter your 40-character Comic Vine API key"
-          helpText="Get your API key from https://comicvine.gamespot.com/api/"
-        />
-        <SettingField
-          label="Verify SSL"
-          type="checkbox"
-          checked={formData.cv_verify as boolean | undefined}
-          onChange={(checked) => onChange("cv_verify", checked as boolean)}
-          helpText="Verify SSL certificates when connecting to Comic Vine"
-        />
-        <SettingField
-          label="Comic Vine Only"
-          type="checkbox"
-          checked={formData.cv_only as boolean | undefined}
-          onChange={(checked) => onChange("cv_only", checked as boolean)}
-          helpText="Use only Comic Vine for metadata (ignore local cache)"
-        />
-      </SettingGroup>
+      {comicvineEnabled && (
+        <SettingGroup
+          title="Comic Vine"
+          description="Configure Comic Vine integration for metadata"
+        >
+          <SettingField
+            label="Comic Vine API Key"
+            value={formData.comicvine_api as string | undefined}
+            type="text"
+            onChange={(value) => onChange("comicvine_api", value as string)}
+            placeholder="Enter your 40-character Comic Vine API key"
+            helpText="Get your API key from https://comicvine.gamespot.com/api/"
+          />
+          <SettingField
+            label="Verify SSL"
+            type="checkbox"
+            checked={formData.cv_verify as boolean | undefined}
+            onChange={(checked) => onChange("cv_verify", checked as boolean)}
+            helpText="Verify SSL certificates when connecting to Comic Vine"
+          />
+          <SettingField
+            label="Comic Vine Only"
+            type="checkbox"
+            checked={formData.cv_only as boolean | undefined}
+            onChange={(checked) => onChange("cv_only", checked as boolean)}
+            helpText="Use only Comic Vine for metadata (ignore local cache)"
+          />
+        </SettingGroup>
+      )}
 
-      <SettingGroup
-        title="Metron"
-        description="Use Metron API for comic search (fixes sorting issues)"
-      >
-        <SettingField
-          label="Use Metron for Search"
-          type="checkbox"
-          checked={formData.use_metron_search as boolean | undefined}
-          onChange={(checked) =>
-            onChange("use_metron_search", checked as boolean)
-          }
-          helpText="Use Metron API instead of Comic Vine for search results"
-        />
-        <SettingField
-          label="Metron Username"
-          value={formData.metron_username as string | undefined}
-          type="text"
-          onChange={(value) => onChange("metron_username", value as string)}
-          placeholder="Your Metron username"
-          helpText="Register at https://metron.cloud"
-        />
-        <SettingField
-          label="Metron Password"
-          value={formData.metron_password as string | undefined}
-          type="password"
-          onChange={(value) => onChange("metron_password", value as string)}
-          placeholder="Your Metron password"
-        />
-      </SettingGroup>
+      {comicvineEnabled && (
+        <SettingGroup
+          title="Metron"
+          description="Use Metron API for comic search (fixes sorting issues)"
+        >
+          <SettingField
+            label="Use Metron for Search"
+            type="checkbox"
+            checked={formData.use_metron_search as boolean | undefined}
+            onChange={(checked) =>
+              onChange("use_metron_search", checked as boolean)
+            }
+            helpText="Use Metron API instead of Comic Vine for search results"
+          />
+          <SettingField
+            label="Metron Username"
+            value={formData.metron_username as string | undefined}
+            type="text"
+            onChange={(value) => onChange("metron_username", value as string)}
+            placeholder="Your Metron username"
+            helpText="Register at https://metron.cloud"
+          />
+          <SettingField
+            label="Metron Password"
+            value={formData.metron_password as string | undefined}
+            type="password"
+            onChange={(value) => onChange("metron_password", value as string)}
+            placeholder="Your Metron password"
+          />
+        </SettingGroup>
+      )}
+
+      {mangadexEnabled && (
+        <SettingGroup
+          title="MangaDex"
+          description="Configure MangaDex integration for manga metadata"
+        >
+          <SettingField
+            label="Languages"
+            value={formData.mangadex_languages as string | undefined}
+            type="text"
+            onChange={(value) =>
+              onChange("mangadex_languages", value as string)
+            }
+            placeholder="en"
+            helpText="Comma-separated language codes (e.g., en,ja)"
+          />
+          <SettingField
+            label="Content Rating"
+            value={formData.mangadex_content_rating as string | undefined}
+            type="text"
+            onChange={(value) =>
+              onChange("mangadex_content_rating", value as string)
+            }
+            placeholder="safe,suggestive"
+            helpText="Comma-separated ratings: safe, suggestive, erotica, pornographic"
+          />
+        </SettingGroup>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useContentSources.ts
+++ b/frontend/src/hooks/useContentSources.ts
@@ -1,0 +1,10 @@
+import { useConfig } from "@/hooks/useConfig";
+
+export function useContentSources() {
+  const { data: config } = useConfig();
+  return {
+    comicsEnabled: config?.comicvine_enabled ?? true,
+    mangaEnabled: config?.mangadex_enabled ?? false,
+    isLoaded: !!config,
+  };
+}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSearchComics, useSearchManga } from "@/hooks/useSearch";
+import { useContentSources } from "@/hooks/useContentSources";
 import SearchResultsTable from "@/components/search/SearchResultsTable";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ContentType } from "@/types/entities";
@@ -77,16 +78,29 @@ const mangaSortMapping: Record<string, string> = {
 
 export default function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { comicsEnabled, mangaEnabled } = useContentSources();
+
+  // Determine the default mode based on what's enabled
+  const defaultMode: ContentType = comicsEnabled ? "comic" : "manga";
 
   // Get parameters from URL
   const urlQuery = searchParams.get("q") || "";
   const urlPage = parseInt(searchParams.get("page") || "1") || 1;
   const urlSort = searchParams.get("sort") || "relevance";
-  const urlSearchMode = (searchParams.get("type") as ContentType) || "comic";
+  const urlSearchMode =
+    (searchParams.get("type") as ContentType) || defaultMode;
+
+  // If URL requests a disabled mode, fall back to the enabled one
+  const effectiveMode =
+    urlSearchMode === "manga" && !mangaEnabled
+      ? "comic"
+      : urlSearchMode === "comic" && !comicsEnabled
+        ? "manga"
+        : urlSearchMode;
 
   // Initialize search query from URL parameter
   const [searchQuery, setSearchQuery] = useState(urlQuery);
-  const [searchMode, setSearchMode] = useState<ContentType>(urlSearchMode);
+  const [searchMode, setSearchMode] = useState<ContentType>(effectiveMode);
 
   // Map sort to API format based on mode
   const comicApiSort = comicSortMapping[urlSort] ?? urlSort;
@@ -168,25 +182,27 @@ export default function SearchPage() {
         {searchMode === "manga" ? "Search Manga" : "Search Comics"}
       </h1>
 
-      {/* Content Type Toggle */}
-      <div className="flex gap-2">
-        <Button
-          variant={searchMode === "comic" ? "default" : "outline"}
-          onClick={() => handleSearchModeChange("comic")}
-          className="flex items-center"
-        >
-          <Book className="w-4 h-4 mr-2" />
-          Comics
-        </Button>
-        <Button
-          variant={searchMode === "manga" ? "default" : "outline"}
-          onClick={() => handleSearchModeChange("manga")}
-          className="flex items-center"
-        >
-          <BookOpen className="w-4 h-4 mr-2" />
-          Manga
-        </Button>
-      </div>
+      {/* Content Type Toggle - only show when both sources are enabled */}
+      {comicsEnabled && mangaEnabled && (
+        <div className="flex gap-2">
+          <Button
+            variant={searchMode === "comic" ? "default" : "outline"}
+            onClick={() => handleSearchModeChange("comic")}
+            className="flex items-center"
+          >
+            <Book className="w-4 h-4 mr-2" />
+            Comics
+          </Button>
+          <Button
+            variant={searchMode === "manga" ? "default" : "outline"}
+            onClick={() => handleSearchModeChange("manga")}
+            className="flex items-center"
+          >
+            <BookOpen className="w-4 h-4 mr-2" />
+            Manga
+          </Button>
+        </div>
+      )}
 
       {/* Search Form */}
       <form onSubmit={handleSearch} className="flex gap-2 max-w-2xl">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -44,9 +44,17 @@ export default function SettingsPage() {
     const comicvineApi = data.comicvine_api as string | undefined;
     const minsize = data.minsize as string | number | undefined;
     const maxsize = data.maxsize as string | number | undefined;
+    const comicvineEnabled = (data.comicvine_enabled as boolean) ?? true;
+    const mangadexEnabled = (data.mangadex_enabled as boolean) ?? false;
+
+    // At least one content source must be enabled
+    if (!comicvineEnabled && !mangadexEnabled) {
+      errors.comicvine_enabled =
+        "At least one content source (Comics or Manga) must be enabled";
+    }
 
     // Validate Comic Vine API key (should be 40 characters if provided)
-    if (comicvineApi && comicvineApi.length !== 40) {
+    if (comicvineEnabled && comicvineApi && comicvineApi.length !== 40) {
       errors.comicvine_api = "Comic Vine API key must be 40 characters";
     }
 
@@ -156,7 +164,7 @@ export default function SettingsPage() {
         <TabsList className="mb-6">
           <TabsTrigger value="general">General</TabsTrigger>
           <TabsTrigger value="interface">Interface</TabsTrigger>
-          <TabsTrigger value="api">API & Comic Vine</TabsTrigger>
+          <TabsTrigger value="api">API & Providers</TabsTrigger>
           <TabsTrigger value="search">Search</TabsTrigger>
           <TabsTrigger value="clients">Download Clients</TabsTrigger>
         </TabsList>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -37,6 +37,12 @@ export interface Config {
   transmission_username?: string;
   transmission_password?: string;
 
+  // Content source toggles
+  comicvine_enabled?: boolean;
+  mangadex_enabled?: boolean;
+  mangadex_languages?: string;
+  mangadex_content_rating?: string;
+
   // Comic Vine
   comicvine_api?: string;
 


### PR DESCRIPTION
## Summary
- Adds Comics (Comic Vine) and Manga (MangaDex) enable/disable toggles to Settings > API & Providers
- Search page and series list hide comic/manga tabs when only one source is active, giving a clean single-source experience
- MangaDex settings (languages, content rating) are now configurable from the UI — no more manual config.ini edits
- Validation ensures at least one content source stays enabled
- Comic Vine settings (API key, Metron) are hidden when comics are disabled; MangaDex settings are hidden when manga is disabled

## Test plan
- [ ] Enable only Comics — verify manga tab hidden on search page and series filters
- [ ] Enable only Manga — verify comic tab hidden on search page and series filters
- [ ] Enable both — verify toggle buttons appear on search and series pages
- [ ] Try to disable both — verify validation error prevents saving
- [ ] Toggle MangaDex on — verify MangaDex settings section appears with languages/content rating
- [ ] Toggle Comics off — verify Comic Vine and Metron settings sections hide
- [ ] Existing users with no `COMICVINE_ENABLED` in config.ini — verify defaults to enabled (no migration needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)