### PR TITLE
fix: Include version in settings page config response

### DIFF
--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -184,6 +184,7 @@ def get_safe_config(ctx):
     if not version:
         try:
             from importlib.metadata import version as get_version
+
             version = get_version("comicarr")
         except Exception:
             version = None

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -180,6 +180,15 @@ def get_safe_config(ctx):
         val = getattr(ctx.config, key, None)
         if val is not None:
             result[key] = val
+    version = ctx.current_version
+    if not version:
+        try:
+            from importlib.metadata import version as get_version
+            version = get_version("comicarr")
+        except Exception:
+            version = None
+    if version:
+        result["version"] = version
     return result
 
 

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import comicarr
+
 # Ensure LOG_LEVEL is set for tests (logger.info checks LOG_LEVEL > 0)
 if comicarr.LOG_LEVEL is None:
     comicarr.LOG_LEVEL = 0
@@ -201,6 +202,27 @@ class TestConfigService:
         # Passwords should not be present
         assert "HTTP_PASSWORD" not in result
         assert "API_KEY" not in result
+
+    def test_get_safe_config_includes_version_from_context(self):
+        """get_safe_config includes version when ctx.current_version is set."""
+        ctx = _make_test_ctx(current_version="1.2.3")
+        result = system_service.get_safe_config(ctx)
+        assert result["version"] == "1.2.3"
+
+    @patch("importlib.metadata.version", return_value="0.8.0")
+    def test_get_safe_config_falls_back_to_importlib_metadata(self, mock_version):
+        """get_safe_config falls back to importlib.metadata when ctx.current_version is None."""
+        ctx = _make_test_ctx(current_version=None)
+        result = system_service.get_safe_config(ctx)
+        assert result["version"] == "0.8.0"
+        mock_version.assert_called_once_with("comicarr")
+
+    @patch("importlib.metadata.version", side_effect=Exception("not found"))
+    def test_get_safe_config_omits_version_when_unavailable(self, mock_version):
+        """get_safe_config omits version key when both sources fail."""
+        ctx = _make_test_ctx(current_version=None)
+        result = system_service.get_safe_config(ctx)
+        assert "version" not in result
 
     def test_get_job_info(self):
         """get_job_info returns scheduler job list."""


### PR DESCRIPTION
## Summary
- Settings page showed "vdev" instead of the actual app version (e.g. "v0.9.0")
- The `version` field was present in the old CherryPy `/api/config` endpoint but was lost during the FastAPI migration
- Added `version` back to `get_safe_config()` using `ctx.current_version` with an `importlib.metadata` fallback

## Test plan
- [ ] Load settings page and verify the version displays correctly (e.g. "v0.9.0")
- [ ] Confirm version falls back to `pyproject.toml` value when version check hasn't run yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)