### PR TITLE
chore: Sync uv.lock version and upgrade Docker build action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,7 +43,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
@@ -51,5 +51,5 @@ jobs:
             ghcr.io/frankieramirez/comicarr:latest
             ghcr.io/frankieramirez/comicarr:${{ needs.release-please.outputs.version }}
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/frankieramirez/comicarr:buildcache
+          cache-to: type=registry,ref=ghcr.io/frankieramirez/comicarr:buildcache,mode=max

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "comicarr"
-version = "0.7.0"
+version = "0.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary
- **uv.lock out of sync**: Still referenced version `0.7.0` while `pyproject.toml` is at `0.9.0` after release-please bumps — could cause Docker build issues
- **docker/build-push-action**: Bump v5 → v6
- **Docker cache**: Switch from GHA (`type=gha`) to registry-based (`type=registry`) for better cache hits across workflow runs

## Test plan
- [ ] Verify CI passes
- [ ] Next release-please triggered Docker build uses correct version and cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)