### PR TITLE
ci: Auto-sync uv.lock on release-please PRs

### DIFF
--- a/.github/workflows/sync-uv-lock.yml
+++ b/.github/workflows/sync-uv-lock.yml
@@ -1,0 +1,33 @@
+name: Sync uv.lock on Release PR
+
+on:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+
+permissions:
+  contents: write
+
+jobs:
+  sync-uv-lock:
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Update uv.lock
+        run: uv lock
+
+      - name: Commit updated lockfile
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git diff --cached --quiet || git commit -m "chore: sync uv.lock with pyproject.toml version"
+          git push


### PR DESCRIPTION
## Summary
- Adds a workflow that runs `uv lock` when release-please modifies `pyproject.toml`
- Commits the updated `uv.lock` back to the release PR branch automatically
- Prevents version drift between `pyproject.toml` and `uv.lock` (fixes the issue from PR #71)

## How it works
1. Triggers on PRs that modify `pyproject.toml`
2. Only runs on release-please branches (`release-please--*`)
3. Runs `uv lock` to regenerate the lockfile
4. Commits and pushes if there are changes (no-op if already in sync)

## Test plan
- [ ] Next release-please PR should trigger this workflow
- [ ] Verify `uv.lock` version matches `pyproject.toml` after the workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)