### PR TITLE
fix: Resolve UnboundLocalError in job_management and KeyError in DDL health check

### DIFF
--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -934,13 +934,13 @@ def ddl_health_check():
             continue
         age_minutes = (now - updated).total_seconds() / 60
         if age_minutes > threshold_minutes:
-            if item["id"] in comicarr.DDL_STUCK_NOTIFIED:
+            if item["ID"] in comicarr.DDL_STUCK_NOTIFIED:
                 continue
             logger.warn(
-                "[DDL-HEALTH] Download stuck for %d minutes: %s (%s)" % (int(age_minutes), item["series"], item["id"])
+                "[DDL-HEALTH] Download stuck for %d minutes: %s (%s)" % (int(age_minutes), item["series"], item["ID"])
             )
             notify_ddl_stuck(item, int(age_minutes))
-            comicarr.DDL_STUCK_NOTIFIED.add(item["id"])
+            comicarr.DDL_STUCK_NOTIFIED.add(item["ID"])
 
 
 def postprocess_main(queue):

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -761,6 +761,7 @@ def job_management(
         jobname = jobinfo[: jobinfo.find("(") - 1].strip()
         jobstatus = jobinfo[jobinfo.find("],") + 2 : len(jobinfo) - 1].strip()
         next_the_run = False
+        prev_run_timestamp = None
 
         if jobname == "DB Updater":
             prev_run_timestamp = comicarr.SCHED_DBUPDATE_LAST


### PR DESCRIPTION
## Summary
- **UnboundLocalError in `job_management`**: `prev_run_timestamp` was only assigned inside the `if/elif` chain for known job names. Jobs with unrecognized names (e.g., post-processor) hit line 839 with the variable unbound. Fixed by initializing `prev_run_timestamp = None` at the top of the loop.
- **KeyError in `ddl_health_check`**: The `ddl_info` table defines its primary key as `Column("ID", Text)` (uppercase), but the health check accessed `item["id"]` (lowercase). SQLAlchemy Row objects are case-sensitive for dict-style access. Fixed all three references to use `item["ID"]`.

## Test plan
- [ ] Verify DDL health check runs without `KeyError` when downloads are in "Downloading" state
- [ ] Verify scheduler job management handles unrecognized job names without `UnboundLocalError`
- [ ] Confirm container logs are clean after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)