### PR TITLE
fix: Resolve asyncio.get_event_loop() errors in all system router endpoints

### DIFF
--- a/comicarr/app/system/router.py
+++ b/comicarr/app/system/router.py
@@ -39,17 +39,13 @@ router = APIRouter(prefix="/api", tags=["system"])
 # ---------------------------------------------------------------------------
 
 
-# Login MUST be sync def — bcrypt takes ~250ms on NAS ARM hardware.
-# If async def, it blocks the entire event loop. FastAPI runs sync
-# handlers in a threadpool where threading.Lock is safe.
+# Login is async so it can await request.json(). The blocking bcrypt
+# call (~250ms on NAS ARM hardware) is offloaded to a threadpool via
+# asyncio.to_thread so it doesn't block the event loop.
 @router.post("/auth/login")
-def login(request: Request, ctx: AppContext = Depends(get_context)):
+async def login(request: Request, ctx: AppContext = Depends(get_context)):
     """JSON login — returns JWT in HttpOnly cookie."""
-    import asyncio
-
-    loop = asyncio.get_event_loop()
-    # Read body synchronously (we're in a threadpool)
-    body = asyncio.run_coroutine_threadsafe(request.json(), loop).result(timeout=5)
+    body = await request.json()
 
     username = body.get("username")
     password = body.get("password")
@@ -61,8 +57,9 @@ def login(request: Request, ctx: AppContext = Depends(get_context)):
         )
 
     # Delegate to service (handles rate limiting, bcrypt, migration)
+    # Run in threadpool since verify_login does blocking bcrypt work
     ip = request.client.host if request.client else "unknown"
-    result = system_service.verify_login(ctx, username, password, ip)
+    result = await asyncio.to_thread(system_service.verify_login, ctx, username, password, ip)
 
     if not result["success"]:
         return JSONResponse(

--- a/comicarr/app/system/router.py
+++ b/comicarr/app/system/router.py
@@ -114,21 +114,21 @@ _setup_lock = threading.Lock()
 
 
 @router.post("/auth/setup")
-def setup(request: Request, ctx: AppContext = Depends(get_context)):
+async def setup(request: Request, ctx: AppContext = Depends(get_context)):
     """First-run credential setup. Only works if no auth is configured."""
-    import asyncio
-
-    loop = asyncio.get_event_loop()
-    body = asyncio.run_coroutine_threadsafe(request.json(), loop).result(timeout=5)
+    body = await request.json()
 
     username = body.get("username")
     password = body.get("password")
     setup_token = body.get("setup_token")
 
-    with _setup_lock:
-        result = system_service.initial_setup(ctx, username, password, setup_token)
-        status_code = 200 if result["success"] else 400
-        return JSONResponse(status_code=status_code, content=result)
+    def _run_setup():
+        with _setup_lock:
+            return system_service.initial_setup(ctx, username, password, setup_token)
+
+    result = await asyncio.to_thread(_run_setup)
+    status_code = 200 if result["success"] else 400
+    return JSONResponse(status_code=status_code, content=result)
 
 
 # ---------------------------------------------------------------------------
@@ -180,24 +180,18 @@ def get_config(ctx: AppContext = Depends(get_context)):
 
 
 @router.put("/config", dependencies=[Depends(require_session)])
-def update_config(request: Request, ctx: AppContext = Depends(get_context)):
+async def update_config(request: Request, ctx: AppContext = Depends(get_context)):
     """Update configuration key-values."""
-    import asyncio
-
-    loop = asyncio.get_event_loop()
-    body = asyncio.run_coroutine_threadsafe(request.json(), loop).result(timeout=5)
-    result = system_service.update_config(ctx, body)
+    body = await request.json()
+    result = await asyncio.to_thread(system_service.update_config, ctx, body)
     return result
 
 
 @router.put("/config/providers", dependencies=[Depends(require_session)])
-def update_providers(request: Request, ctx: AppContext = Depends(get_context)):
+async def update_providers(request: Request, ctx: AppContext = Depends(get_context)):
     """Update Newznab/Torznab provider configuration."""
-    import asyncio
-
-    loop = asyncio.get_event_loop()
-    body = asyncio.run_coroutine_threadsafe(request.json(), loop).result(timeout=5)
-    result = system_service.update_providers(ctx, body)
+    body = await request.json()
+    result = await asyncio.to_thread(system_service.update_providers, ctx, body)
     return result
 
 
@@ -268,28 +262,22 @@ def get_startup_diagnostics(ctx: AppContext = Depends(get_context)):
 
 
 @router.post("/system/migration/preview", dependencies=[Depends(require_session)])
-def preview_migration(request: Request, ctx: AppContext = Depends(get_context)):
+async def preview_migration(request: Request, ctx: AppContext = Depends(get_context)):
     """Validate a Mylar3 source path and return preview data."""
-    import asyncio
-
-    loop = asyncio.get_event_loop()
-    body = asyncio.run_coroutine_threadsafe(request.json(), loop).result(timeout=5)
+    body = await request.json()
     path = body.get("path", "")
-    result = system_service.preview_migration(ctx, path)
+    result = await asyncio.to_thread(system_service.preview_migration, ctx, path)
     if result.get("success") is False:
         return JSONResponse(status_code=400, content=result)
     return result
 
 
 @router.post("/system/migration/start", dependencies=[Depends(require_session)])
-def start_migration(request: Request, ctx: AppContext = Depends(get_context)):
+async def start_migration(request: Request, ctx: AppContext = Depends(get_context)):
     """Start a migration in a background thread."""
-    import asyncio
-
-    loop = asyncio.get_event_loop()
-    body = asyncio.run_coroutine_threadsafe(request.json(), loop).result(timeout=5)
+    body = await request.json()
     path = body.get("path", "")
-    result = system_service.start_migration(ctx, path)
+    result = await asyncio.to_thread(system_service.start_migration, ctx, path)
     if result.get("success") is False:
         return JSONResponse(status_code=400, content=result)
     return result


### PR DESCRIPTION
## Summary
- All 6 endpoints in `system/router.py` that read `request.json()` used `asyncio.get_event_loop()` + `run_coroutine_threadsafe` — a pattern that raises `RuntimeError` on Python 3.12 because AnyIO worker threads have no event loop.
- Converted all 6 to `async def` so they can `await request.json()` directly, with blocking service calls offloaded via `asyncio.to_thread`.

**Endpoints fixed:**
- `POST /api/auth/login` — was causing 500 on every login attempt
- `POST /api/auth/setup` — first-run credential setup
- `PUT /api/config` — configuration updates
- `PUT /api/config/providers` — provider configuration
- `POST /api/system/migration/preview` — migration preview
- `POST /api/system/migration/start` — migration start

## Test plan
- [ ] Verify login works without 500 error
- [ ] Verify incorrect credentials still return 401
- [ ] Verify initial setup works on fresh instance
- [ ] Verify config save works
- [ ] Verify provider config save works
- [ ] Confirm no event loop errors in container logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)