### PR TITLE
fix: Skip unexpanded git export-subst placeholders in version display

### DIFF
--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -181,7 +181,9 @@ def get_safe_config(ctx):
         if val is not None:
             result[key] = val
     version = ctx.current_version
-    if not version:
+    # Fall back to package metadata if version is missing or contains
+    # unexpanded git export-subst placeholders (e.g. "%H$")
+    if not version or "%" in version or "$" in version:
         try:
             from importlib.metadata import version as get_version
 

--- a/comicarr/versioncheck.py
+++ b/comicarr/versioncheck.py
@@ -237,9 +237,15 @@ def getVersion(ptv):
                 if not os.path.isfile(version_file):
                     current_version = None
                 else:
-                    cnt = 0
+                    # Check if .LAST_RELEASE has unexpanded export-subst placeholders
+                    # (happens when installed via git clone or Docker COPY instead of git archive)
                     with open(version_file, "r") as f:
-                        for i in f.readlines():
+                        raw = f.read()
+                    if "$Format:" in raw or "%H" in raw:
+                        logger.info("[LAST_RELEASE] File contains unexpanded git export-subst placeholders, skipping")
+                    else:
+                        cnt = 0
+                        for i in raw.splitlines():
                             logger.info("i: %s" % (i))
                             i.split()
                             if cnt == 0:

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "comicarr"
-version = "0.9.1"
+version = "0.9.4"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary
- `.LAST_RELEASE` uses git `export-subst` which only expands via `git archive` — in Docker/git clone installs, raw placeholders like `%H$` were parsed as the version, displaying `v%H$` on Settings
- Detect unexpanded placeholders in `.LAST_RELEASE` and skip the file entirely
- Add defense-in-depth in `get_safe_config` to fall back to `importlib.metadata` when the version contains `%` or `$` characters

## Test plan
- [ ] Deploy Docker image and verify Settings page shows correct version (e.g. `v0.9.4`)
- [ ] Verify git clone installs still detect version correctly via `git describe`
- [ ] Verify `git archive` installs still parse `.LAST_RELEASE` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)