### PR TITLE
fix: Constrain search result hover cards to prevent viewport overflow

### DIFF
--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -458,7 +458,8 @@ export default function SearchResultsTable({
                 <HoverCardContent
                   side="right"
                   align="start"
-                  className="w-80 text-sm"
+                  collisionPadding={16}
+                  className="w-80 max-h-[50vh] overflow-y-auto text-sm"
                 >
                   <p className="font-medium mb-1">{comic.name}</p>
                   <p className="text-muted-foreground leading-relaxed">


### PR DESCRIPTION
## Summary
- Add `max-h-[50vh] overflow-y-auto` to the description HoverCard so long comic descriptions scroll within the card instead of extending beyond the viewport
- Add `collisionPadding={16}` so Radix positions the card with breathing room from viewport edges

## Test plan
- [ ] Hover over a search result with a long description (e.g., "The Untold Legend of the Batman") — card should be scrollable, not overflowing
- [ ] Hover over a result with a short description — no scrollbar, renders normally
- [ ] Hover over a result near the bottom of the page — card should flip/shift to stay in viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)