### PR TITLE
fix: Resolve SPA routing 404s on refresh and missing version display

### DIFF
--- a/comicarr/app/main.py
+++ b/comicarr/app/main.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException
 from starlette.staticfiles import StaticFiles
 
 from comicarr.app.core.context import AppContext
@@ -217,7 +218,16 @@ def create_app():
 
         class CachedStaticFiles(StaticFiles):
             async def get_response(self, path, scope):
-                response = await super().get_response(path, scope)
+                try:
+                    response = await super().get_response(path, scope)
+                except HTTPException as ex:
+                    if ex.status_code == 404:
+                        # SPA fallback: serve index.html so React Router
+                        # handles client-side routes like /settings, /login
+                        response = await super().get_response("index.html", scope)
+                        response.headers["Cache-Control"] = "no-cache"
+                        return response
+                    raise
                 if path.startswith("assets/"):
                     response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
                 else:

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -20,6 +20,7 @@ import hmac
 import json
 import os
 import platform
+from pathlib import Path
 import re
 import shlex
 import subprocess
@@ -188,6 +189,18 @@ def get_safe_config(ctx):
             from importlib.metadata import version as get_version
 
             version = get_version("comicarr")
+        except Exception:
+            version = None
+    # Final fallback: read version directly from pyproject.toml
+    if not version:
+        try:
+            import tomllib
+
+            pyproject = Path(__file__).resolve().parent.parent.parent.parent / "pyproject.toml"
+            if pyproject.is_file():
+                with open(pyproject, "rb") as f:
+                    data = tomllib.load(f)
+                version = data.get("project", {}).get("version")
         except Exception:
             version = None
     if version:

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -20,12 +20,12 @@ import hmac
 import json
 import os
 import platform
-from pathlib import Path
 import re
 import shlex
 import subprocess
 import sys
 from collections import namedtuple
+from pathlib import Path
 
 import comicarr
 from comicarr import db, logger

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -218,8 +218,8 @@ class TestConfigService:
         mock_version.assert_called_once_with("comicarr")
 
     @patch("importlib.metadata.version", side_effect=Exception("not found"))
-    @patch("tomllib.load", side_effect=Exception("not found"))
-    def test_get_safe_config_omits_version_when_unavailable(self, mock_toml, mock_version):
+    @patch("pathlib.Path.is_file", return_value=False)
+    def test_get_safe_config_omits_version_when_unavailable(self, mock_isfile, mock_version):
         """get_safe_config omits version key when all sources fail."""
         ctx = _make_test_ctx(current_version=None)
         result = system_service.get_safe_config(ctx)

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -218,8 +218,9 @@ class TestConfigService:
         mock_version.assert_called_once_with("comicarr")
 
     @patch("importlib.metadata.version", side_effect=Exception("not found"))
-    def test_get_safe_config_omits_version_when_unavailable(self, mock_version):
-        """get_safe_config omits version key when both sources fail."""
+    @patch("tomllib.load", side_effect=Exception("not found"))
+    def test_get_safe_config_omits_version_when_unavailable(self, mock_toml, mock_version):
+        """get_safe_config omits version key when all sources fail."""
         ctx = _make_test_ctx(current_version=None)
         result = system_service.get_safe_config(ctx)
         assert "version" not in result


### PR DESCRIPTION
SPA routes like `/settings` and `/login` return `{"detail":"Not Found"}` on page refresh, and the version number is missing from the settings page in Docker.

## Description
- **SPA catch-all**: Override `CachedStaticFiles.get_response` to catch 404s and serve `index.html`, so React Router handles client-side routes on refresh
- **Version fallback**: Add `pyproject.toml` as a final fallback when both `ctx.current_version` and `importlib.metadata` fail (common in Docker where `uv sync` runs before source is copied)
- Update test to mock the new `tomllib.load` fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)