### PR TITLE
fix: Resolve settings page showing empty pre-filled values

### DIFF
--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -192,8 +192,14 @@ def get_safe_config(ctx):
         "API_KEY",
         "ENABLE_META",
         "OPDS_ENABLE",
+        "OPDS_PAGESIZE",
         "NZB_DOWNLOADER",
         "TORRENT_DOWNLOADER",
+        "DBUPDATE_INTERVAL",
+        "MULTIPLE_DEST_DIRS",
+        "CREATE_FOLDERS",
+        "CHECK_FOLDER",
+        "STORYARC_LOCATION",
     ]
     result = {}
     for key in safe_keys:
@@ -201,9 +207,9 @@ def get_safe_config(ctx):
         if val is not None:
             result[key] = val
 
-    # Add derived download client labels
-    nzb_labels = {0: "SABnzbd", 1: "NZBGet", 2: "Blackhole"}
-    torrent_labels = {0: "qBittorrent", 1: "Deluge", 2: "Transmission", 3: "rTorrent", 4: "uTorrent"}
+    # Add derived download client labels (must match config.py enums)
+    nzb_labels = {0: "SABnzbd", 1: "NZBGet", 2: "Blackhole", 3: "Disabled"}
+    torrent_labels = {0: "Watchfolder", 1: "uTorrent", 2: "rTorrent", 3: "Transmission", 4: "Deluge", 5: "qBittorrent"}
     nzb_val = getattr(ctx.config, "NZB_DOWNLOADER", None)
     torrent_val = getattr(ctx.config, "TORRENT_DOWNLOADER", None)
     if nzb_val is not None:

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -151,10 +151,13 @@ def get_safe_config(ctx):
     safe_keys = [
         "COMIC_DIR",
         "DESTINATION_DIR",
+        "CACHE_DIR",
+        "LOG_DIR",
         "HTTP_HOST",
         "HTTP_PORT",
         "HTTP_ROOT",
         "ENABLE_HTTPS",
+        "HTTP_USERNAME",
         "AUTHENTICATION",
         "LAUNCH_BROWSER",
         "LOG_LEVEL",
@@ -173,14 +176,47 @@ def get_safe_config(ctx):
         "FOLDER_FORMAT",
         "FILE_FORMAT",
         "COMICVINE_API",
+        "COMICVINE_ENABLED",
+        "MANGADEX_ENABLED",
+        "CV_VERIFY",
+        "CV_ONLY",
+        "USE_METRON_SEARCH",
+        "METRON_USERNAME",
+        "MANGADEX_LANGUAGES",
+        "MANGADEX_CONTENT_RATING",
+        "PREFERRED_QUALITY",
+        "USE_MINSIZE",
+        "MINSIZE",
+        "USE_MAXSIZE",
+        "MAXSIZE",
+        "API_KEY",
         "ENABLE_META",
         "OPDS_ENABLE",
+        "NZB_DOWNLOADER",
+        "TORRENT_DOWNLOADER",
     ]
     result = {}
     for key in safe_keys:
         val = getattr(ctx.config, key, None)
         if val is not None:
             result[key] = val
+
+    # Add derived download client labels
+    nzb_labels = {0: "SABnzbd", 1: "NZBGet", 2: "Blackhole"}
+    torrent_labels = {0: "qBittorrent", 1: "Deluge", 2: "Transmission", 3: "rTorrent", 4: "uTorrent"}
+    nzb_val = getattr(ctx.config, "NZB_DOWNLOADER", None)
+    torrent_val = getattr(ctx.config, "TORRENT_DOWNLOADER", None)
+    if nzb_val is not None:
+        result["nzb_downloader_label"] = nzb_labels.get(nzb_val, "None")
+    if torrent_val is not None:
+        result["torrent_downloader_label"] = torrent_labels.get(torrent_val, "None")
+
+    # Add boolean indicator for METRON_PASSWORD (encrypted, not sent as plaintext)
+    metron_pw = getattr(ctx.config, "METRON_PASSWORD", None)
+    result["metron_password_set"] = bool(metron_pw)
+
+    # Lowercase all keys for frontend convention
+    result = {k.lower(): v for k, v in result.items()}
     version = ctx.current_version
     # Fall back to package metadata if version is missing or contains
     # unexpanded git export-subst placeholders (e.g. "%H$")
@@ -233,6 +269,19 @@ WRITABLE_CONFIG_KEYS = {
     "FOLDER_FORMAT",
     "FILE_FORMAT",
     "COMICVINE_API",
+    "COMICVINE_ENABLED",
+    "MANGADEX_ENABLED",
+    "CV_VERIFY",
+    "CV_ONLY",
+    "USE_METRON_SEARCH",
+    "METRON_USERNAME",
+    "MANGADEX_LANGUAGES",
+    "MANGADEX_CONTENT_RATING",
+    "PREFERRED_QUALITY",
+    "USE_MINSIZE",
+    "MINSIZE",
+    "USE_MAXSIZE",
+    "MAXSIZE",
     "ENABLE_META",
     "OPDS_ENABLE",
     "OPDS_PAGESIZE",
@@ -249,6 +298,10 @@ def update_config(ctx, key_values):
 
     if not ctx.config:
         return {"success": False, "error": "Config not loaded"}
+
+    # Normalize incoming keys to uppercase — frontend sends lowercase,
+    # but config internals use UPPERCASE.
+    key_values = {k.upper(): v for k, v in key_values.items()}
 
     # Filter to only writable keys — prevents privilege escalation via
     # overwriting HTTP_PASSWORD, API_KEY, AUTHENTICATION, etc.

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -250,13 +250,35 @@ class TestConfigService:
         assert result["metron_password_set"] is False
 
     def test_get_safe_config_includes_download_client_labels(self):
-        """get_safe_config returns derived download client labels."""
+        """get_safe_config returns derived download client labels matching config.py enums."""
         ctx = _make_test_ctx()
         ctx.config.NZB_DOWNLOADER = 0
         ctx.config.TORRENT_DOWNLOADER = 1
         result = system_service.get_safe_config(ctx)
         assert result["nzb_downloader_label"] == "SABnzbd"
-        assert result["torrent_downloader_label"] == "Deluge"
+        assert result["torrent_downloader_label"] == "uTorrent"
+
+    def test_get_safe_config_download_labels_all_values(self):
+        """Verify all download client enum values map to correct labels."""
+        ctx = _make_test_ctx()
+        # NZB: 0=SABnzbd, 1=NZBGet, 2=Blackhole, 3=Disabled
+        for val, label in [(0, "SABnzbd"), (1, "NZBGet"), (2, "Blackhole"), (3, "Disabled")]:
+            ctx.config.NZB_DOWNLOADER = val
+            result = system_service.get_safe_config(ctx)
+            assert result["nzb_downloader_label"] == label, "NZB %d should be %s" % (val, label)
+        # Torrent: 0=Watchfolder, 1=uTorrent, 2=rTorrent, 3=Transmission, 4=Deluge, 5=qBittorrent
+        for val, label in [(0, "Watchfolder"), (1, "uTorrent"), (2, "rTorrent"),
+                           (3, "Transmission"), (4, "Deluge"), (5, "qBittorrent")]:
+            ctx.config.TORRENT_DOWNLOADER = val
+            result = system_service.get_safe_config(ctx)
+            assert result["torrent_downloader_label"] == label, "Torrent %d should be %s" % (val, label)
+
+    def test_get_safe_config_unknown_downloader_value(self):
+        """Unknown downloader enum values fall back to 'None' string."""
+        ctx = _make_test_ctx()
+        ctx.config.NZB_DOWNLOADER = 99
+        result = system_service.get_safe_config(ctx)
+        assert result["nzb_downloader_label"] == "None"
 
     def test_get_safe_config_includes_version_from_context(self):
         """get_safe_config includes version when ctx.current_version is set."""
@@ -301,6 +323,18 @@ class TestConfigService:
         result = system_service.update_config(ctx, {"api_key": "hacked", "http_password": "hacked"})
         assert result["success"] is False
         assert "No valid config keys" in result["error"]
+
+    def test_update_config_filters_sensitive_keys_from_mixed_payload(self):
+        """update_config applies valid keys and silently filters sensitive ones."""
+        ctx = _make_test_ctx()
+        result = system_service.update_config(ctx, {
+            "comic_dir": "/new/path",
+            "api_key": "hacked",
+        })
+        assert result["success"] is True
+        args = ctx.config.process_kwargs.call_args[0][0]
+        assert "COMIC_DIR" in args
+        assert "API_KEY" not in args
 
     def test_update_config_accepts_new_writable_keys(self):
         """update_config accepts newly added writable keys."""

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -190,6 +190,19 @@ class TestInitialSetup:
 
 
 class TestConfigService:
+    def test_get_safe_config_returns_lowercase_keys(self):
+        """get_safe_config returns all keys in lowercase."""
+        ctx = _make_test_ctx()
+        ctx.config.COMIC_DIR = "/my/comics"
+        ctx.config.HTTP_PORT = 8090
+
+        result = system_service.get_safe_config(ctx)
+        assert "comic_dir" in result
+        assert "http_port" in result
+        # All keys should be lowercase
+        for key in result:
+            assert key == key.lower(), "Key %s should be lowercase" % key
+
     def test_get_safe_config_excludes_passwords(self):
         """get_safe_config returns config without sensitive fields."""
         ctx = _make_test_ctx()
@@ -197,11 +210,53 @@ class TestConfigService:
         ctx.config.HTTP_PORT = 8090
 
         result = system_service.get_safe_config(ctx)
-        assert "COMIC_DIR" in result
-        assert "HTTP_PORT" in result
-        # Passwords should not be present
+        assert "comic_dir" in result
+        assert "http_port" in result
+        # Passwords should not be present (check both cases)
+        assert "http_password" not in result
         assert "HTTP_PASSWORD" not in result
-        assert "API_KEY" not in result
+
+    def test_get_safe_config_includes_api_key(self):
+        """get_safe_config includes api_key for read-only display."""
+        ctx = _make_test_ctx()
+        result = system_service.get_safe_config(ctx)
+        assert "api_key" in result
+
+    def test_get_safe_config_includes_new_keys(self):
+        """get_safe_config includes all frontend-needed keys."""
+        ctx = _make_test_ctx()
+        ctx.config.COMICVINE_ENABLED = True
+        ctx.config.MANGADEX_ENABLED = False
+        ctx.config.PREFERRED_QUALITY = "high"
+
+        result = system_service.get_safe_config(ctx)
+        assert "comicvine_enabled" in result
+        assert "mangadex_enabled" in result
+        assert "preferred_quality" in result
+
+    def test_get_safe_config_includes_metron_password_set_indicator(self):
+        """get_safe_config returns metron_password_set boolean, not the actual password."""
+        ctx = _make_test_ctx()
+        ctx.config.METRON_PASSWORD = "gAAAAAsecretencrypted"
+        result = system_service.get_safe_config(ctx)
+        assert result["metron_password_set"] is True
+        assert "metron_password" not in result
+
+    def test_get_safe_config_metron_password_set_false_when_empty(self):
+        """metron_password_set is False when no password is configured."""
+        ctx = _make_test_ctx()
+        ctx.config.METRON_PASSWORD = None
+        result = system_service.get_safe_config(ctx)
+        assert result["metron_password_set"] is False
+
+    def test_get_safe_config_includes_download_client_labels(self):
+        """get_safe_config returns derived download client labels."""
+        ctx = _make_test_ctx()
+        ctx.config.NZB_DOWNLOADER = 0
+        ctx.config.TORRENT_DOWNLOADER = 1
+        result = system_service.get_safe_config(ctx)
+        assert result["nzb_downloader_label"] == "SABnzbd"
+        assert result["torrent_downloader_label"] == "Deluge"
 
     def test_get_safe_config_includes_version_from_context(self):
         """get_safe_config includes version when ctx.current_version is set."""
@@ -224,6 +279,42 @@ class TestConfigService:
         ctx = _make_test_ctx(current_version=None)
         result = system_service.get_safe_config(ctx)
         assert "version" not in result
+
+    def test_update_config_accepts_lowercase_keys(self):
+        """update_config normalizes lowercase keys to uppercase."""
+        ctx = _make_test_ctx()
+        result = system_service.update_config(ctx, {"comic_dir": "/new/path"})
+        assert result["success"] is True
+        ctx.config.process_kwargs.assert_called_once()
+        args = ctx.config.process_kwargs.call_args[0][0]
+        assert "COMIC_DIR" in args
+
+    def test_update_config_accepts_uppercase_keys(self):
+        """update_config still accepts uppercase keys (backward compat)."""
+        ctx = _make_test_ctx()
+        result = system_service.update_config(ctx, {"COMIC_DIR": "/new/path"})
+        assert result["success"] is True
+
+    def test_update_config_rejects_sensitive_keys_regardless_of_case(self):
+        """update_config rejects api_key, http_password in any casing."""
+        ctx = _make_test_ctx()
+        result = system_service.update_config(ctx, {"api_key": "hacked", "http_password": "hacked"})
+        assert result["success"] is False
+        assert "No valid config keys" in result["error"]
+
+    def test_update_config_accepts_new_writable_keys(self):
+        """update_config accepts newly added writable keys."""
+        ctx = _make_test_ctx()
+        result = system_service.update_config(ctx, {
+            "comicvine_enabled": True,
+            "preferred_quality": "high",
+            "use_minsize": True,
+            "minsize": 50,
+        })
+        assert result["success"] is True
+        args = ctx.config.process_kwargs.call_args[0][0]
+        assert "COMICVINE_ENABLED" in args
+        assert "PREFERRED_QUALITY" in args
 
     def test_get_job_info(self):
         """get_job_info returns scheduler job list."""


### PR DESCRIPTION
## Summary
- Settings page fields appeared empty despite having configured values — backend returned UPPERCASE keys but frontend reads lowercase
- Lowercased all keys in `get_safe_config()` response and normalized incoming keys to uppercase in `update_config()`
- Added ~18 missing keys to `safe_keys` and ~13 to `WRITABLE_CONFIG_KEYS` that frontend tabs need
- Added derived `nzb_downloader_label`/`torrent_downloader_label` for the Download Clients tab
- Returns `metron_password_set` boolean indicator instead of the encrypted password value
- Security: `API_KEY` is readable but not writable; passwords remain excluded from both read and write

## Testing
- 11 new tests added covering lowercase keys, new key presence, download client labels, metron password indicator, update_config case normalization, and security boundary enforcement
- All 319 unit tests pass with no regressions
- Linting passes

## Post-Deploy Monitoring & Validation
- **What to monitor**: Settings page load — all fields should display current values
- **Validation checks**: `GET /api/config` should return lowercase keys; save settings and reload to verify persistence
- **Expected healthy behavior**: All settings tabs show pre-filled values matching config.ini
- **Failure signal / rollback trigger**: Any settings field showing empty when config.ini has a value
- **Validation window & owner**: First load after deploy

---

[![Compound Engineering v2.40.0](https://img.shields.io/badge/Compound_Engineering-v2.40.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)