### PR TITLE
fix: Remove deprecated Vitest 4 poolOptions config

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -35,11 +35,6 @@ export default defineConfig({
     isolate: true,
     // Pool configuration for parallel execution
     pool: 'threads',
-    poolOptions: {
-      threads: {
-        singleThread: false,
-      },
-    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Removes deprecated `test.poolOptions` from `vitest.config.ts` — this option was removed in Vitest 4, where all pool options are now top-level
- The `singleThread: false` setting was the default behavior, so this is a no-op change that eliminates the deprecation warning

## Test plan

- [x] `npm run test:run` — 26/26 tests pass, no deprecation warning
- [x] No functional change to test execution behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)