### PR TITLE
refactor: Move series list from / to /series route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ import { useServerEvents } from "@/hooks/useServerEvents";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 
 const LoginPage = lazy(() => import("@/pages/LoginPage"));
-const HomePage = lazy(() => import("@/pages/HomePage"));
+const SeriesListPage = lazy(() => import("@/pages/SeriesListPage"));
 const SeriesDetailPage = lazy(() => import("@/pages/SeriesDetailPage"));
 const SearchPage = lazy(() => import("@/pages/SearchPage"));
 const UpcomingPage = lazy(() => import("@/pages/UpcomingPage"));
@@ -59,7 +59,11 @@ function AppContent() {
                   <Layout>
                     <Suspense fallback={null}>
                       <Routes>
-                        <Route path="/" element={<HomePage />} />
+                        <Route
+                          path="/"
+                          element={<Navigate to="/series" replace />}
+                        />
+                        <Route path="/series" element={<SeriesListPage />} />
                         <Route
                           path="/series/:comicId"
                           element={<SeriesDetailPage />}

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -22,7 +22,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
-  Home,
+  BookOpen,
   Search,
   Calendar,
   ListTodo,
@@ -63,16 +63,13 @@ export default function AppSidebar() {
   }
 
   const navItems: NavItem[] = [
-    { path: "/", label: "Series", icon: Home },
+    { path: "/series", label: "Series", icon: BookOpen },
     { path: "/upcoming", label: "Upcoming", icon: Calendar },
     { path: "/wanted", label: "Wanted", icon: ListTodo },
     { path: "/import", label: "Import", icon: FolderInput },
   ];
 
   const isActive = (path: string): boolean => {
-    if (path === "/") {
-      return location.pathname === "/";
-    }
     return location.pathname.startsWith(path);
   };
 

--- a/frontend/src/pages/SeriesListPage.tsx
+++ b/frontend/src/pages/SeriesListPage.tsx
@@ -5,7 +5,7 @@ import SeriesTable from "@/components/series/SeriesTable";
 import { Button } from "@/components/ui/button";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 
-export default function HomePage() {
+export default function SeriesListPage() {
   const { data: series = [], isLoading, error } = useSeries();
 
   if (error) {


### PR DESCRIPTION
## Summary

- Renames `HomePage` → `SeriesListPage` and moves the series list from `/` to `/series`
- Root path (`/`) temporarily redirects to `/series` — will be replaced by a home dashboard in the BYOK AI Suite feature
- Updates sidebar nav link and icon (`Home` → `BookOpen`)
- Simplifies `isActive()` logic now that Series is no longer at the root path

## Context

This is a preparatory refactor for the BYOK AI Suite plan (Unit 3: Home Dashboard & Route Migration). The plan recommends shipping the route migration independently since it has no AI dependency.

## Test plan

- [x] Frontend tests pass (26/26)
- [x] Lint clean (0 errors)
- [x] TypeScript typecheck passes
- [ ] Manual: Navigate to `/` → redirects to `/series`
- [ ] Manual: Series list renders at `/series` with identical functionality
- [ ] Manual: Sidebar "Series" link points to `/series` and highlights correctly
- [ ] Manual: Series detail pages at `/series/:comicId` still work
- [ ] Manual: Catch-all redirect still sends unknown routes to `/`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this is a frontend-only route change with no backend impact. Verify via browser that navigation works after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)