### PR TITLE
fix: Resolve startup errors in git detection and job scheduler

### DIFF
--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -917,6 +917,7 @@ def job_management(
                 comicarr.MONITOR_STATUS = "Paused"
             sched_status = comicarr.MONITOR_STATUS
 
+        jtime = None
         try:
             jobtimetmp = jobinfo.split("at: ")[1].split(".")[0].strip()
         except Exception:
@@ -941,7 +942,7 @@ def job_management(
                 "jobname": jobname,
                 "next_run_datetime": jobtime,
                 "prev_run_datetime": prev_run_time_utc,
-                "next_run_timestamp": jobtime,
+                "next_run_timestamp": jtime,
                 "prev_run_timestamp": prev_run_timestamp,
                 "status": sched_status,
             }

--- a/comicarr/versioncheck.py
+++ b/comicarr/versioncheck.py
@@ -117,13 +117,18 @@ def getVersion(ptv):
 
     elif os.path.isdir(os.path.join(comicarr.PROG_DIR, ".git")):
         comicarr.INSTALL_TYPE = "git"
-        output = runGit("describe --exact-match --tags 2> %s && git rev-parse HEAD --abbrev-ref HEAD" % os.devnull, ptv)
-        # output, err = runGit('rev-parse HEAD --abbrev-ref HEAD')
+        # Try exact tag match first, then get branch name separately
+        output = runGit("describe --exact-match --tags", ptv)
+        if output:
+            branch_output = runGit("rev-parse --abbrev-ref HEAD", ptv)
+            if branch_output:
+                output = output.strip() + "\n" + branch_output.strip() + "\n"
+            else:
+                output = None
 
         if not output:
-            output = runGit(
-                "describe --exact-match --tags 2> %s || git rev-parse HEAD --abbrev-ref HEAD" % os.devnull, ptv
-            )
+            # Not on a tag — get commit hash and branch
+            output = runGit("rev-parse HEAD --abbrev-ref HEAD", ptv)
             if not output:
                 logger.error("Couldn't find latest installed version.")
                 cur_commit_hash = None

--- a/comicarr/versioncheck.py
+++ b/comicarr/versioncheck.py
@@ -38,7 +38,7 @@ from comicarr import db, logger
 from comicarr.tables import jobhistory
 
 
-def runGit(args, ptv=None):
+def runGit(args, ptv=None, suppress_errors=False):
 
     git_locations = []
     if ptv is not None:
@@ -68,13 +68,15 @@ def runGit(args, ptv=None):
             logger.debug("Git output: %s" % output)
             gitworked = True
         except Exception as e:
-            logger.error("Command %s didn't work [%s]" % (cmd_list, e))
+            if not suppress_errors:
+                logger.error("Command %s didn't work [%s]" % (cmd_list, e))
             gitworked = False
             output = None
             continue
         else:
             if all([output.stderr is not None, output.stderr != "", output.returncode > 0]):
-                logger.error("Encountered error: %s" % output.stderr)
+                if not suppress_errors:
+                    logger.error("Encountered error: %s" % output.stderr)
                 gitworked = False
 
         if all(
@@ -84,12 +86,14 @@ def runGit(args, ptv=None):
                 "not recognized as an internal or external command" in output.stdout,
             ]
         ):
-            logger.error("[%s] Unable to find git with command: %s" % (output.stdout, cmd))
+            if not suppress_errors:
+                logger.error("[%s] Unable to find git with command: %s" % (output.stdout, cmd))
             output = None
             gitworked = False
         elif ("fatal:" in output.stdout) or ("fatal:" in output.stderr):
-            logger.error("Error: %s" % output.stderr)
-            logger.error("Git returned bad info. Are you sure this is a git installation? [%s]" % output.stdout)
+            if not suppress_errors:
+                logger.error("Error: %s" % output.stderr)
+                logger.error("Git returned bad info. Are you sure this is a git installation? [%s]" % output.stdout)
             output = None
             gitworked = False
         elif gitworked:
@@ -118,7 +122,7 @@ def getVersion(ptv):
     elif os.path.isdir(os.path.join(comicarr.PROG_DIR, ".git")):
         comicarr.INSTALL_TYPE = "git"
         # Try exact tag match first, then get branch name separately
-        output = runGit("describe --exact-match --tags", ptv)
+        output = runGit("describe --exact-match --tags", ptv, suppress_errors=True)
         if output:
             branch_output = runGit("rev-parse --abbrev-ref HEAD", ptv)
             if branch_output:

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "comicarr"
-version = "0.9.8"
+version = "0.10.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary
- **Git version detection**: Split chained shell commands (`&&`, `||`, `2>`) in `runGit` into separate `subprocess.run()` calls. These shell operators were being passed as literal arguments to git, causing `--abbrev-ref` unknown option errors and failed version detection.
- **Job scheduler SQL TypeError**: `next_run_timestamp` column expects a `Float` but was receiving a `datetime.datetime` object. Now stores the float Unix timestamp (`jtime`) instead.

## Test plan
- [x] `ruff check` and `ruff format --check` pass
- [x] All 458 unit tests pass
- [ ] Start app with `--datadir /tmp/...` and verify git errors and `float() argument` TypeError are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)