### PR TITLE
feat: Elevate manga to first-class citizen with full parity

### DIFF
--- a/comicarr/app/dashboard/service.py
+++ b/comicarr/app/dashboard/service.py
@@ -89,9 +89,7 @@ def get_dashboard_data(ctx):
             result["stats"]["manga_series"] = manga_stats.get("manga_series", 0)
             result["stats"]["manga_have"] = manga_have
             result["stats"]["manga_total"] = manga_total
-            result["stats"]["manga_completion_pct"] = (
-                round(manga_have / manga_total * 100, 1) if manga_total > 0 else 0
-            )
+            result["stats"]["manga_completion_pct"] = round(manga_have / manga_total * 100, 1) if manga_total > 0 else 0
 
         # Comic-specific stats (non-manga)
         comic_stats = db.DBConnection().selectone(

--- a/comicarr/app/dashboard/service.py
+++ b/comicarr/app/dashboard/service.py
@@ -58,7 +58,7 @@ def get_dashboard_data(ctx):
     except Exception as e:
         logger.error("[DASHBOARD] Error fetching upcoming: %s" % e)
 
-    # Stats: aggregate from comics
+    # Stats: aggregate from comics (combined + per content type)
     try:
         stats = db.DBConnection().selectone(
             "SELECT COUNT(*) as total_series, "
@@ -75,6 +75,35 @@ def get_dashboard_data(ctx):
                 "total_expected": total_expected,
                 "completion_pct": round(total_issues / total_expected * 100, 1) if total_expected > 0 else 0,
             }
+
+        # Manga-specific stats
+        manga_stats = db.DBConnection().selectone(
+            "SELECT COUNT(*) as manga_series, "
+            "COALESCE(SUM(Have), 0) as manga_have, "
+            "COALESCE(SUM(Total), 0) as manga_total "
+            "FROM comics WHERE Status != 'Paused' AND ContentType = 'manga'"
+        )
+        if manga_stats:
+            manga_total = manga_stats.get("manga_total", 0) or 0
+            manga_have = manga_stats.get("manga_have", 0) or 0
+            result["stats"]["manga_series"] = manga_stats.get("manga_series", 0)
+            result["stats"]["manga_have"] = manga_have
+            result["stats"]["manga_total"] = manga_total
+            result["stats"]["manga_completion_pct"] = (
+                round(manga_have / manga_total * 100, 1) if manga_total > 0 else 0
+            )
+
+        # Comic-specific stats (non-manga)
+        comic_stats = db.DBConnection().selectone(
+            "SELECT COUNT(*) as comic_series, "
+            "COALESCE(SUM(Have), 0) as comic_have, "
+            "COALESCE(SUM(Total), 0) as comic_total "
+            "FROM comics WHERE Status != 'Paused' AND (ContentType IS NULL OR ContentType = 'comic')"
+        )
+        if comic_stats:
+            result["stats"]["comic_series"] = comic_stats.get("comic_series", 0)
+            result["stats"]["comic_have"] = comic_stats.get("comic_have", 0) or 0
+            result["stats"]["comic_total"] = comic_stats.get("comic_total", 0) or 0
     except Exception as e:
         logger.error("[DASHBOARD] Error fetching stats: %s" % e)
 

--- a/comicarr/app/series/router.py
+++ b/comicarr/app/series/router.py
@@ -221,6 +221,23 @@ def refresh_import(ctx: AppContext = Depends(get_context)):
     return result
 
 
+@router.post("/import/manga/scan", dependencies=[Depends(require_session)])
+def manga_scan(ctx: AppContext = Depends(get_context)):
+    """Trigger a manga library scan."""
+    result = series_service.manga_library_scan(ctx)
+    if not result["success"]:
+        return JSONResponse(status_code=400, content={"detail": result.get("error")})
+    return result
+
+
+@router.get("/import/manga/progress", dependencies=[Depends(require_session)])
+def manga_scan_progress(ctx: AppContext = Depends(get_context)):
+    """Get manga scan progress."""
+    from comicarr import mangasync
+
+    return mangasync.get_scan_progress()
+
+
 # ---------------------------------------------------------------------------
 # REST-compat endpoints (migrated from legacy /rest mount)
 # ---------------------------------------------------------------------------

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -284,6 +284,23 @@ def refresh_import(ctx):
         return {"success": False, "error": "Failed to start import scan: %s" % str(e)}
 
 
+def manga_library_scan(ctx):
+    """Trigger a manga library scan in the background."""
+    from comicarr import mangasync
+
+    manga_dir = getattr(comicarr.CONFIG, "MANGA_DIR", None) if comicarr.CONFIG else None
+    if not manga_dir:
+        return {"success": False, "error": "Manga directory not configured"}
+
+    try:
+        logger.info("[MANGA-SCAN] Starting manga library scan for: %s" % manga_dir)
+        threading.Thread(target=mangasync.mangaScan, name="API-MangaScan").start()
+        return {"success": True, "message": "Manga scan started for: %s" % manga_dir}
+    except Exception as e:
+        logger.error("[MANGA-SCAN] Error: %s" % e)
+        return {"success": False, "error": "Failed to start manga scan: %s" % str(e)}
+
+
 # --- Extracted from helpers.py ---
 
 

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -150,7 +150,9 @@ def get_safe_config(ctx):
 
     safe_keys = [
         "COMIC_DIR",
+        "MANGA_DIR",
         "DESTINATION_DIR",
+        "MANGA_DESTINATION_DIR",
         "CACHE_DIR",
         "LOG_DIR",
         "HTTP_HOST",

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -184,7 +184,7 @@ _CONFIG_DEFINITIONS = OrderedDict(
         "METRON_USERNAME": (str, "Metron", None),
         "METRON_PASSWORD": (str, "Metron", None),
         "USE_METRON_SEARCH": (bool, "Metron", False),
-        "MANGADEX_ENABLED": (bool, "MangaDex", False),
+        "MANGADEX_ENABLED": (bool, "MangaDex", True),
         "MANGADEX_LANGUAGES": (str, "MangaDex", "en"),
         "MANGADEX_CONTENT_RATING": (str, "MangaDex", "safe,suggestive"),
         "LOG_DIR": (str, "Logs", None),
@@ -204,6 +204,8 @@ _CONFIG_DEFINITIONS = OrderedDict(
         "CHGROUP": (str, "Perms", None),
         "ADD_COMICS": (bool, "Import", False),
         "COMIC_DIR": (str, "Import", None),
+        "MANGA_DIR": (str, "Import", None),
+        "MANGA_DESTINATION_DIR": (str, "General", None),
         "IMP_MOVE": (bool, "Import", False),
         "IMP_PATHS": (bool, "Import", False),
         "IMP_RENAME": (bool, "Import", False),
@@ -1516,6 +1518,9 @@ class Config(object):
             if any([self.DESTINATION_DIR is None, self.DESTINATION_DIR == ""]):
                 logger.info("[DOCKER-AWARE] Setting default comic location path to /comics")
                 self.DESTINATION_DIR = "/comics"
+            if any([self.MANGA_DESTINATION_DIR is None, self.MANGA_DESTINATION_DIR == ""]):
+                logger.info("[DOCKER-AWARE] Setting default manga location path to /manga")
+                self.MANGA_DESTINATION_DIR = "/manga"
             if all([self.NZB_DOWNLOADER == 0, self.SAB_DIRECTORY is None, self.SAB_DIRECT_UNPACK is False]):
                 logger.info("[DOCKER-AWARE] Setting default sabnzbd download directory location to /downloads")
                 self.SAB_DIRECT_UNPACK = True
@@ -2326,6 +2331,20 @@ class Config(object):
             if write is True:
                 logger.fdebug("writing: keys - %s: vals - %s" % (vals, ctrls))
                 db.upsert("provider_searches", vals, ctrls)
+
+
+def get_manga_destination():
+    """Return the manga destination directory using the fallback chain.
+
+    Fallback order: MANGA_DESTINATION_DIR -> MANGA_DIR -> DESTINATION_DIR
+    """
+    dest = getattr(comicarr.CONFIG, "MANGA_DESTINATION_DIR", None)
+    if dest:
+        return dest
+    manga_dir = getattr(comicarr.CONFIG, "MANGA_DIR", None)
+    if manga_dir:
+        return manga_dir
+    return getattr(comicarr.CONFIG, "DESTINATION_DIR", None)
 
 
 def ddl_creations():

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -2336,15 +2336,11 @@ class Config(object):
 def get_manga_destination():
     """Return the manga destination directory using the fallback chain.
 
-    Fallback order: MANGA_DESTINATION_DIR -> MANGA_DIR -> DESTINATION_DIR
+    Fallback order: MANGA_DESTINATION_DIR -> MANGA_DIR -> DESTINATION_DIR.
+    MANGA_DIR is included in the fallback because users who only configure a
+    scan source directory expect downloads to land alongside existing files.
     """
-    dest = getattr(comicarr.CONFIG, "MANGA_DESTINATION_DIR", None)
-    if dest:
-        return dest
-    manga_dir = getattr(comicarr.CONFIG, "MANGA_DIR", None)
-    if manga_dir:
-        return manga_dir
-    return getattr(comicarr.CONFIG, "DESTINATION_DIR", None)
+    return comicarr.CONFIG.MANGA_DESTINATION_DIR or comicarr.CONFIG.MANGA_DIR or comicarr.CONFIG.DESTINATION_DIR
 
 
 def ddl_creations():

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -1058,6 +1058,7 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
         dict with status information
     """
     from comicarr import mangadex
+    from comicarr.config import get_manga_destination
 
     logger.info("[MANGADEX] Adding manga with ID: %s" % mangaid)
 
@@ -1114,11 +1115,12 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
     dynamic_name = helpers.filesafe(re.sub(r"[\'\!\@\#\$\%\:\;\/\\]", "", manga_name).lower())
 
     # Build folder path if destination directory is set
-    if comicarr.CONFIG.DESTINATION_DIR:
+    manga_dest = get_manga_destination()
+    if manga_dest:
         folder_format = comicarr.CONFIG.FOLDER_FORMAT or "$Series ($Year)"
         folder_name = folder_format.replace("$Series", manga_name).replace("$Year", str(manga_year))
         folder_name = helpers.filesafe(folder_name)
-        comlocation = os.path.join(comicarr.CONFIG.DESTINATION_DIR, folder_name)
+        comlocation = os.path.join(manga_dest, folder_name)
 
         if comicarr.CONFIG.CREATE_FOLDERS:
             checkdirectory = filechecker.validateAndCreateDirectory(comlocation, True)

--- a/comicarr/manga_parser.py
+++ b/comicarr/manga_parser.py
@@ -1,0 +1,202 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Manga filename parser.
+
+Pure-function module that extracts series name, chapter number, volume number,
+and optional metadata (scanlation group, quality tags) from manga filenames.
+
+Handles common naming conventions found in manga libraries:
+    [Group] Title - c001 (v01) [quality].cbz
+    Title v01 c001.cbz
+    Title - Chapter 001.cbz
+    Title Vol.01 Ch.001.cbz
+    Title 001.cbz              (bare number = chapter)
+    Title v01.cbz              (volume only)
+"""
+
+import os
+import re
+
+VALID_EXTENSIONS = {".cbr", ".cbz", ".cb7", ".pdf"}
+
+# Pre-compiled patterns, ordered from most specific to least specific.
+# Each pattern is a tuple of (compiled_regex, field_mapping) where
+# field_mapping is a dict mapping group names to result keys.
+
+# Pattern 1: [Group] Title - c001 (v01) [quality]
+_PAT_GROUP_FULL = re.compile(
+    r"^\[(?P<group>[^\]]+)\]\s*"
+    r"(?P<series>.+?)\s*"
+    r"-\s*c(?P<chapter>\d+(?:\.\d+)?)"
+    r"(?:\s*-\s*c\d+(?:\.\d+)?)?"  # optional range end (ignored)
+    r"(?:\s*\(v(?P<volume>\d+)\))?"
+    r"(?:\s*\[(?P<quality>[^\]]+)\])?"
+    r"\s*$",
+    re.IGNORECASE,
+)
+
+# Pattern 2: [Group] Title - c001-003 [quality]  (no volume)
+_PAT_GROUP_CHAPTER = re.compile(
+    r"^\[(?P<group>[^\]]+)\]\s*"
+    r"(?P<series>.+?)\s*"
+    r"-\s*c(?P<chapter>\d+(?:\.\d+)?)"
+    r"(?:\s*-\s*c?\d+(?:\.\d+)?)?"  # optional range end
+    r"(?:\s*\[(?P<quality>[^\]]+)\])?"
+    r"\s*$",
+    re.IGNORECASE,
+)
+
+# Pattern 3: Title Vol.01 Ch.001  or  Title Vol 01 Ch 001
+_PAT_VOL_CH_ABBR = re.compile(
+    r"^(?P<series>.+?)\s+"
+    r"[Vv]ol\.?\s*(?P<volume>\d+)\s+"
+    r"[Cc]h\.?\s*(?P<chapter>\d+(?:\.\d+)?)"
+    r"\s*$",
+)
+
+# Pattern 4: Title v01 c001
+_PAT_V_C = re.compile(
+    r"^(?P<series>.+?)\s+"
+    r"[Vv](?P<volume>\d+)\s+"
+    r"[Cc](?P<chapter>\d+(?:\.\d+)?)"
+    r"\s*$",
+)
+
+# Pattern 5: Title - Chapter 001
+_PAT_CHAPTER_LABEL = re.compile(
+    r"^(?P<series>.+?)\s*"
+    r"-\s*[Cc]hapter\s+(?P<chapter>\d+(?:\.\d+)?)"
+    r"\s*$",
+)
+
+# Pattern 6: Title c001-003  (chapter with optional range, no group brackets)
+_PAT_CHAPTER_PREFIX = re.compile(
+    r"^(?P<series>.+?)\s+"
+    r"[Cc](?P<chapter>\d+(?:\.\d+)?)"
+    r"(?:\s*-\s*c?\d+(?:\.\d+)?)?"
+    r"\s*$",
+)
+
+# Pattern 7: Title v01  (volume only, e.g. "Bleach v1")
+_PAT_VOLUME_ONLY = re.compile(
+    r"^(?P<series>.+?)\s+"
+    r"[Vv](?P<volume>\d+)"
+    r"\s*$",
+)
+
+# Pattern 8: Title 001  (bare number = chapter, e.g. "Chainsaw Man 165")
+_PAT_BARE_NUMBER = re.compile(
+    r"^(?P<series>.+?)\s+"
+    r"(?P<chapter>\d+(?:\.\d+)?)"
+    r"\s*$",
+)
+
+# Ordered list — first match wins.
+_PATTERNS = [
+    _PAT_GROUP_FULL,
+    _PAT_GROUP_CHAPTER,
+    _PAT_VOL_CH_ABBR,
+    _PAT_V_C,
+    _PAT_CHAPTER_LABEL,
+    _PAT_CHAPTER_PREFIX,
+    _PAT_VOLUME_ONLY,
+    _PAT_BARE_NUMBER,
+]
+
+
+def parse_manga_filename(filename):
+    """Parse a manga filename and return extracted metadata.
+
+    Args:
+        filename: The filename (with or without directory path) to parse.
+
+    Returns:
+        A dict with keys ``series_name``, ``chapter_number`` (float or None),
+        ``volume_number`` (int or None), ``group`` (str or None), and
+        ``quality`` (str or None).  Returns ``None`` when the filename
+        cannot be parsed or has an invalid extension.
+    """
+    # Strip directory components if present.
+    basename = os.path.basename(filename)
+
+    # Split extension and validate.
+    stem, ext = os.path.splitext(basename)
+    if ext.lower() not in VALID_EXTENSIONS:
+        return None
+
+    stem = stem.strip()
+    if not stem:
+        return None
+
+    for pattern in _PATTERNS:
+        m = pattern.match(stem)
+        if m:
+            return _build_result(m)
+
+    # No pattern matched — unparseable.
+    return None
+
+
+def _build_result(match):
+    """Build a result dict from a regex match object."""
+    groups = match.groupdict()
+
+    series = groups.get("series")
+    if series:
+        series = series.strip().rstrip("-").strip()
+    if not series:
+        return None
+
+    chapter_raw = groups.get("chapter")
+    chapter = _to_chapter_number(chapter_raw)
+
+    volume_raw = groups.get("volume")
+    volume = int(volume_raw) if volume_raw is not None else None
+
+    group = groups.get("group")
+    if group:
+        group = group.strip() or None
+
+    quality = groups.get("quality")
+    if quality:
+        quality = quality.strip() or None
+
+    # If we got neither a chapter nor a volume, it's not useful.
+    if chapter is None and volume is None:
+        return None
+
+    return {
+        "series_name": series,
+        "chapter_number": chapter,
+        "volume_number": volume,
+        "group": group,
+        "quality": quality,
+    }
+
+
+def _to_chapter_number(raw):
+    """Convert a raw chapter string to a float, or None if absent."""
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+        # Return int-like floats as float to keep the contract consistent.
+        return value
+    except (ValueError, TypeError):
+        return None

--- a/comicarr/manga_parser.py
+++ b/comicarr/manga_parser.py
@@ -44,23 +44,13 @@ _PAT_GROUP_FULL = re.compile(
     r"^\[(?P<group>[^\]]+)\]\s*"
     r"(?P<series>.+?)\s*"
     r"-\s*c(?P<chapter>\d+(?:\.\d+)?)"
-    r"(?:\s*-\s*c\d+(?:\.\d+)?)?"  # optional range end (ignored)
+    r"(?:\s*-\s*c?\d+(?:\.\d+)?)?"  # optional range end (ignored)
     r"(?:\s*\(v(?P<volume>\d+)\))?"
     r"(?:\s*\[(?P<quality>[^\]]+)\])?"
     r"\s*$",
     re.IGNORECASE,
 )
 
-# Pattern 2: [Group] Title - c001-003 [quality]  (no volume)
-_PAT_GROUP_CHAPTER = re.compile(
-    r"^\[(?P<group>[^\]]+)\]\s*"
-    r"(?P<series>.+?)\s*"
-    r"-\s*c(?P<chapter>\d+(?:\.\d+)?)"
-    r"(?:\s*-\s*c?\d+(?:\.\d+)?)?"  # optional range end
-    r"(?:\s*\[(?P<quality>[^\]]+)\])?"
-    r"\s*$",
-    re.IGNORECASE,
-)
 
 # Pattern 3: Title Vol.01 Ch.001  or  Title Vol 01 Ch 001
 _PAT_VOL_CH_ABBR = re.compile(
@@ -110,7 +100,6 @@ _PAT_BARE_NUMBER = re.compile(
 # Ordered list — first match wins.
 _PATTERNS = [
     _PAT_GROUP_FULL,
-    _PAT_GROUP_CHAPTER,
     _PAT_VOL_CH_ABBR,
     _PAT_V_C,
     _PAT_CHAPTER_LABEL,
@@ -141,7 +130,7 @@ def parse_manga_filename(filename):
         return None
 
     stem = stem.strip()
-    if not stem:
+    if not stem or len(stem) > 512:
         return None
 
     for pattern in _PATTERNS:

--- a/comicarr/mangasync.py
+++ b/comicarr/mangasync.py
@@ -24,6 +24,7 @@ Mirrors librarysync.py but for manga content.
 
 import os
 import re
+import threading
 
 from sqlalchemy import select
 
@@ -44,10 +45,12 @@ MANGA_SCAN_PROGRESS = {
     "errors": [],
 }
 
+_SCAN_LOCK = threading.Lock()
+
 MANGA_EXTENSIONS = (".cbr", ".cbz", ".cb7", ".pdf")
 
 
-def mangaScan(dir=None, queue=None):
+def mangaScan(scan_dir=None, queue=None):
     """Scan a manga directory for existing manga files.
 
     Walks the directory tree, groups files by series (using parent directory
@@ -58,13 +61,19 @@ def mangaScan(dir=None, queue=None):
     """
     global MANGA_SCAN_STATUS, MANGA_SCAN_PROGRESS
 
-    manga_dir = dir or getattr(comicarr.CONFIG, "MANGA_DIR", None)
+    if not _SCAN_LOCK.acquire(blocking=False):
+        logger.warning("[MANGA-SCAN] Scan already in progress, skipping")
+        return {"status": "already_running"}
+
+    manga_dir = scan_dir or comicarr.CONFIG.MANGA_DIR
     if not manga_dir:
-        logger.warn("[MANGA-SCAN] No MANGA_DIR configured, skipping manga scan")
+        _SCAN_LOCK.release()
+        logger.warning("[MANGA-SCAN] No MANGA_DIR configured, skipping manga scan")
         return {"status": "skipped", "reason": "no_manga_dir"}
 
     if not os.path.isdir(manga_dir):
-        logger.warn("[MANGA-SCAN] Cannot find manga directory: %s" % manga_dir)
+        _SCAN_LOCK.release()
+        logger.warning("[MANGA-SCAN] Cannot find manga directory: %s" % manga_dir)
         return {"status": "error", "reason": "directory_not_found", "path": manga_dir}
 
     MANGA_SCAN_STATUS = "scanning"
@@ -80,16 +89,9 @@ def mangaScan(dir=None, queue=None):
 
     logger.info("[MANGA-SCAN] Starting manga library scan: %s" % manga_dir)
 
-    # Step 1: Walk directory and group files by series folder
-    series_map = _collect_series_files(manga_dir)
-
-    MANGA_SCAN_PROGRESS["series_found"] = len(series_map)
-    logger.info("[MANGA-SCAN] Found %d series directories" % len(series_map))
-
-    # Step 2: For each series, try to match against MangaDex and import
     results = {
         "status": "completed",
-        "series_found": len(series_map),
+        "series_found": 0,
         "series_matched": 0,
         "series_imported": 0,
         "chapters_marked_downloaded": 0,
@@ -97,33 +99,48 @@ def mangaScan(dir=None, queue=None):
         "errors": [],
     }
 
-    for series_name, files in series_map.items():
-        MANGA_SCAN_PROGRESS["current_series"] = series_name
+    try:
+        # Step 1: Walk directory and group files by series folder
+        series_map = _collect_series_files(manga_dir)
 
-        try:
-            match_result = _match_and_import_series(series_name, files)
-            if match_result["matched"]:
-                results["series_matched"] += 1
-                results["series_imported"] += 1
-                results["chapters_marked_downloaded"] += match_result.get("chapters_downloaded", 0)
-                MANGA_SCAN_PROGRESS["series_matched"] += 1
-                MANGA_SCAN_PROGRESS["series_imported"] += 1
-            else:
-                results["unmatched_series"].append(series_name)
-        except Exception as e:
-            logger.error("[MANGA-SCAN] Error processing series '%s': %s" % (series_name, e))
-            results["errors"].append({"series": series_name, "error": str(e)})
-            MANGA_SCAN_PROGRESS["errors"].append(str(e))
+        MANGA_SCAN_PROGRESS["series_found"] = len(series_map)
+        results["series_found"] = len(series_map)
+        logger.info("[MANGA-SCAN] Found %d series directories" % len(series_map))
 
-        MANGA_SCAN_PROGRESS["processed_files"] += len(files)
+        # Step 2: For each series, try to match against MangaDex and import
+        for series_name, files in series_map.items():
+            MANGA_SCAN_PROGRESS["current_series"] = series_name
 
-    MANGA_SCAN_STATUS = "completed"
-    MANGA_SCAN_PROGRESS["current_series"] = None
+            try:
+                match_result = _match_and_import_series(series_name, files)
+                if match_result["matched"]:
+                    results["series_matched"] += 1
+                    results["series_imported"] += 1
+                    results["chapters_marked_downloaded"] += match_result.get("chapters_downloaded", 0)
+                    MANGA_SCAN_PROGRESS["series_matched"] += 1
+                    MANGA_SCAN_PROGRESS["series_imported"] += 1
+                else:
+                    results["unmatched_series"].append(series_name)
+            except Exception as e:
+                logger.error("[MANGA-SCAN] Error processing series '%s': %s" % (series_name, e))
+                results["errors"].append({"series": series_name, "error": str(e)})
+                MANGA_SCAN_PROGRESS["errors"].append(str(e))
 
-    logger.info(
-        "[MANGA-SCAN] Scan complete. Matched: %d/%d series, %d chapters marked downloaded"
-        % (results["series_matched"], results["series_found"], results["chapters_marked_downloaded"])
-    )
+            MANGA_SCAN_PROGRESS["processed_files"] += len(files)
+
+        logger.info(
+            "[MANGA-SCAN] Scan complete. Matched: %d/%d series, %d chapters marked downloaded"
+            % (results["series_matched"], results["series_found"], results["chapters_marked_downloaded"])
+        )
+    except Exception as e:
+        logger.error("[MANGA-SCAN] Fatal error during scan: %s" % e)
+        results["status"] = "error"
+        results["errors"].append({"series": "scan", "error": str(e)})
+        MANGA_SCAN_PROGRESS["errors"].append(str(e))
+    finally:
+        MANGA_SCAN_STATUS = "completed" if results["status"] != "error" else "error"
+        MANGA_SCAN_PROGRESS["current_series"] = None
+        _SCAN_LOCK.release()
 
     return results
 
@@ -268,6 +285,7 @@ def _mark_chapters_downloaded(comic_id, files):
         return 0
 
     # Build lookup by chapter number and volume number
+    # Volume lookup maps to a list since multiple chapters share a volume
     chapter_lookup = {}
     volume_lookup = {}
     for issue in all_issues:
@@ -280,7 +298,10 @@ def _mark_chapters_downloaded(comic_id, files):
                 pass
         if vol:
             try:
-                volume_lookup[int(float(vol))] = issue
+                vol_key = int(float(vol))
+                if vol_key not in volume_lookup:
+                    volume_lookup[vol_key] = []
+                volume_lookup[vol_key].append(issue)
             except (ValueError, TypeError):
                 pass
 
@@ -289,25 +310,28 @@ def _mark_chapters_downloaded(comic_id, files):
             continue
 
         filename = os.path.basename(filepath)
-        matched_issue = None
+        matched_issues = []
 
         # Try chapter match first
         if parsed.get("chapter_number") is not None:
-            matched_issue = chapter_lookup.get(parsed["chapter_number"])
+            match = chapter_lookup.get(parsed["chapter_number"])
+            if match:
+                matched_issues = [match]
 
-        # Fall back to volume match
-        if not matched_issue and parsed.get("volume_number") is not None:
-            matched_issue = volume_lookup.get(parsed["volume_number"])
+        # Fall back to volume match — mark all chapters in the volume
+        if not matched_issues and parsed.get("volume_number") is not None:
+            matched_issues = volume_lookup.get(parsed["volume_number"], [])
 
-        if matched_issue and matched_issue.get("Status") != "Downloaded":
-            issue_id = matched_issue["IssueID"]
-            db.upsert(
-                "issues",
-                {"Status": "Downloaded", "Location": filename},
-                {"IssueID": issue_id},
-            )
-            count += 1
-            logger.fdebug("[MANGA-SCAN] Marked as downloaded: %s -> %s" % (filename, issue_id))
+        for matched_issue in matched_issues:
+            if matched_issue.get("Status") != "Downloaded":
+                issue_id = matched_issue["IssueID"]
+                db.upsert(
+                    "issues",
+                    {"Status": "Downloaded", "Location": filename},
+                    {"IssueID": issue_id},
+                )
+                count += 1
+                logger.fdebug("[MANGA-SCAN] Marked as downloaded: %s -> %s" % (filename, issue_id))
 
     # Update the Have count for the comic
     if count > 0:

--- a/comicarr/mangasync.py
+++ b/comicarr/mangasync.py
@@ -1,0 +1,330 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Manga library scanner — walks MANGA_DIR, groups files by series,
+matches against MangaDex metadata, and populates the library.
+
+Mirrors librarysync.py but for manga content.
+"""
+
+import os
+import re
+
+from sqlalchemy import select
+
+import comicarr
+from comicarr import db, logger
+from comicarr.manga_parser import parse_manga_filename
+from comicarr.tables import comics, issues
+
+# Scan status globals (for UI polling)
+MANGA_SCAN_STATUS = None
+MANGA_SCAN_PROGRESS = {
+    "total_files": 0,
+    "processed_files": 0,
+    "series_found": 0,
+    "series_matched": 0,
+    "series_imported": 0,
+    "current_series": None,
+    "errors": [],
+}
+
+MANGA_EXTENSIONS = (".cbr", ".cbz", ".cb7", ".pdf")
+
+
+def mangaScan(dir=None, queue=None):
+    """Scan a manga directory for existing manga files.
+
+    Walks the directory tree, groups files by series (using parent directory
+    name), parses filenames for chapter/volume info, matches series against
+    MangaDex, and populates the library.
+
+    Returns dict with scan results.
+    """
+    global MANGA_SCAN_STATUS, MANGA_SCAN_PROGRESS
+
+    manga_dir = dir or getattr(comicarr.CONFIG, "MANGA_DIR", None)
+    if not manga_dir:
+        logger.warn("[MANGA-SCAN] No MANGA_DIR configured, skipping manga scan")
+        return {"status": "skipped", "reason": "no_manga_dir"}
+
+    if not os.path.isdir(manga_dir):
+        logger.warn("[MANGA-SCAN] Cannot find manga directory: %s" % manga_dir)
+        return {"status": "error", "reason": "directory_not_found", "path": manga_dir}
+
+    MANGA_SCAN_STATUS = "scanning"
+    MANGA_SCAN_PROGRESS = {
+        "total_files": 0,
+        "processed_files": 0,
+        "series_found": 0,
+        "series_matched": 0,
+        "series_imported": 0,
+        "current_series": None,
+        "errors": [],
+    }
+
+    logger.info("[MANGA-SCAN] Starting manga library scan: %s" % manga_dir)
+
+    # Step 1: Walk directory and group files by series folder
+    series_map = _collect_series_files(manga_dir)
+
+    MANGA_SCAN_PROGRESS["series_found"] = len(series_map)
+    logger.info("[MANGA-SCAN] Found %d series directories" % len(series_map))
+
+    # Step 2: For each series, try to match against MangaDex and import
+    results = {
+        "status": "completed",
+        "series_found": len(series_map),
+        "series_matched": 0,
+        "series_imported": 0,
+        "chapters_marked_downloaded": 0,
+        "unmatched_series": [],
+        "errors": [],
+    }
+
+    for series_name, files in series_map.items():
+        MANGA_SCAN_PROGRESS["current_series"] = series_name
+
+        try:
+            match_result = _match_and_import_series(series_name, files)
+            if match_result["matched"]:
+                results["series_matched"] += 1
+                results["series_imported"] += 1
+                results["chapters_marked_downloaded"] += match_result.get("chapters_downloaded", 0)
+                MANGA_SCAN_PROGRESS["series_matched"] += 1
+                MANGA_SCAN_PROGRESS["series_imported"] += 1
+            else:
+                results["unmatched_series"].append(series_name)
+        except Exception as e:
+            logger.error("[MANGA-SCAN] Error processing series '%s': %s" % (series_name, e))
+            results["errors"].append({"series": series_name, "error": str(e)})
+            MANGA_SCAN_PROGRESS["errors"].append(str(e))
+
+        MANGA_SCAN_PROGRESS["processed_files"] += len(files)
+
+    MANGA_SCAN_STATUS = "completed"
+    MANGA_SCAN_PROGRESS["current_series"] = None
+
+    logger.info(
+        "[MANGA-SCAN] Scan complete. Matched: %d/%d series, %d chapters marked downloaded"
+        % (results["series_matched"], results["series_found"], results["chapters_marked_downloaded"])
+    )
+
+    return results
+
+
+def _collect_series_files(manga_dir):
+    """Walk manga_dir and group files by series directory.
+
+    Expects structure: manga_dir/Series Name/files.cbz
+    Returns dict: {series_name: [(filepath, parsed_info), ...]}
+    """
+    series_map = {}
+
+    for root, _dirs, files in os.walk(manga_dir):
+        for filename in files:
+            if not any(filename.lower().endswith(ext) for ext in MANGA_EXTENSIONS):
+                continue
+
+            filepath = os.path.join(root, filename)
+            parsed = parse_manga_filename(filename)
+
+            # Use the immediate parent directory as the series name
+            # e.g., /manga/Bleach/Bleach v1.cbz -> series = "Bleach"
+            rel_path = os.path.relpath(root, manga_dir)
+            if rel_path == ".":
+                # Files directly in manga_dir — use parsed series name
+                series_name = parsed["series_name"] if parsed else _guess_series_from_filename(filename)
+            else:
+                # Use top-level directory name as series name
+                series_name = rel_path.split(os.sep)[0]
+
+            if not series_name:
+                logger.fdebug("[MANGA-SCAN] Could not determine series for: %s" % filepath)
+                continue
+
+            MANGA_SCAN_PROGRESS["total_files"] += 1
+
+            if series_name not in series_map:
+                series_map[series_name] = []
+            series_map[series_name].append((filepath, parsed))
+
+    return series_map
+
+
+def _guess_series_from_filename(filename):
+    """Extract a series name from a filename when no directory context is available."""
+    # Strip extension
+    name = os.path.splitext(filename)[0]
+    # Remove trailing numbers (likely chapter/volume)
+    name = re.sub(r"\s+(v?\d+[\.\d]*)$", "", name).strip()
+    return name if name else None
+
+
+def _match_and_import_series(series_name, files):
+    """Match a series against MangaDex and import it.
+
+    Returns dict with 'matched' bool and details.
+    """
+    from comicarr import importer, mangadex
+
+    # Check if series already exists in library by name
+    with db.get_engine().connect() as conn:
+        stmt = select(comics).where(
+            comics.c.ComicName == series_name,
+            comics.c.ContentType == "manga",
+        )
+        existing = next((dict(row._mapping) for row in conn.execute(stmt)), None)
+
+    if existing:
+        logger.info("[MANGA-SCAN] Series '%s' already in library, updating chapter statuses" % series_name)
+        chapters_downloaded = _mark_chapters_downloaded(existing["ComicID"], files)
+        return {"matched": True, "chapters_downloaded": chapters_downloaded, "already_existed": True}
+
+    # Search MangaDex for the series
+    logger.info("[MANGA-SCAN] Searching MangaDex for: %s" % series_name)
+    search_results = mangadex.search_manga(series_name, limit=5)
+
+    if not search_results or not search_results.get("results"):
+        logger.info("[MANGA-SCAN] No MangaDex match found for: %s" % series_name)
+        return {"matched": False}
+
+    # Auto-match on high confidence: exact name match (case-insensitive)
+    best_match = None
+    for result in search_results["results"]:
+        result_name = result.get("name", "")
+        if result_name.lower() == series_name.lower():
+            best_match = result
+            break
+
+    # Fall back to first result if no exact match
+    if not best_match:
+        best_match = search_results["results"][0]
+        confidence = _name_similarity(series_name, best_match.get("name", ""))
+        if confidence < 0.7:
+            logger.info(
+                "[MANGA-SCAN] Low confidence match for '%s' -> '%s' (%.1f%%), skipping"
+                % (series_name, best_match.get("name", ""), confidence * 100)
+            )
+            return {"matched": False}
+
+    manga_id = best_match.get("comicid", "")
+    if not manga_id:
+        return {"matched": False}
+
+    logger.info("[MANGA-SCAN] Matched '%s' to MangaDex: %s (%s)" % (series_name, best_match.get("name", ""), manga_id))
+
+    # Import the manga using existing addMangaToDB
+    importer.addMangaToDB(manga_id)
+
+    # After import, mark chapters as Downloaded for files found on disk
+    chapters_downloaded = _mark_chapters_downloaded(manga_id, files)
+
+    return {"matched": True, "chapters_downloaded": chapters_downloaded, "mangadex_name": best_match.get("name", "")}
+
+
+def _name_similarity(name1, name2):
+    """Simple similarity score between two names (0.0 to 1.0)."""
+    s1 = set(name1.lower().split())
+    s2 = set(name2.lower().split())
+    if not s1 or not s2:
+        return 0.0
+    intersection = s1 & s2
+    union = s1 | s2
+    return len(intersection) / len(union)
+
+
+def _mark_chapters_downloaded(comic_id, files):
+    """Mark chapters as Downloaded based on files found on disk.
+
+    Matches parsed chapter/volume numbers from filenames to existing
+    issue records in the database.
+
+    Returns count of chapters marked.
+    """
+    count = 0
+
+    # Get all issues for this comic
+    with db.get_engine().connect() as conn:
+        stmt = select(issues).where(issues.c.ComicID == comic_id)
+        all_issues = [dict(row._mapping) for row in conn.execute(stmt)]
+
+    if not all_issues:
+        return 0
+
+    # Build lookup by chapter number and volume number
+    chapter_lookup = {}
+    volume_lookup = {}
+    for issue in all_issues:
+        ch = issue.get("ChapterNumber")
+        vol = issue.get("VolumeNumber")
+        if ch:
+            try:
+                chapter_lookup[float(ch)] = issue
+            except (ValueError, TypeError):
+                pass
+        if vol:
+            try:
+                volume_lookup[int(float(vol))] = issue
+            except (ValueError, TypeError):
+                pass
+
+    for filepath, parsed in files:
+        if not parsed:
+            continue
+
+        filename = os.path.basename(filepath)
+        matched_issue = None
+
+        # Try chapter match first
+        if parsed.get("chapter_number") is not None:
+            matched_issue = chapter_lookup.get(parsed["chapter_number"])
+
+        # Fall back to volume match
+        if not matched_issue and parsed.get("volume_number") is not None:
+            matched_issue = volume_lookup.get(parsed["volume_number"])
+
+        if matched_issue and matched_issue.get("Status") != "Downloaded":
+            issue_id = matched_issue["IssueID"]
+            db.upsert(
+                "issues",
+                {"Status": "Downloaded", "Location": filename},
+                {"IssueID": issue_id},
+            )
+            count += 1
+            logger.fdebug("[MANGA-SCAN] Marked as downloaded: %s -> %s" % (filename, issue_id))
+
+    # Update the Have count for the comic
+    if count > 0:
+        with db.get_engine().connect() as conn:
+            stmt = select(issues).where(
+                issues.c.ComicID == comic_id,
+                issues.c.Status == "Downloaded",
+            )
+            have_count = len([dict(row._mapping) for row in conn.execute(stmt)])
+        db.upsert("comics", {"Have": have_count}, {"ComicID": comic_id})
+
+    return count
+
+
+def get_scan_progress():
+    """Return current scan progress for UI polling."""
+    return {
+        "status": MANGA_SCAN_STATUS,
+        "progress": MANGA_SCAN_PROGRESS.copy(),
+    }

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -32,6 +32,8 @@ from sqlalchemy import Integer, and_, delete, func, inspect, or_, select
 
 import comicarr
 from comicarr import db, filechecker, getimage, helpers, logger, notifiers, updater, weeklypull
+from comicarr.config import get_manga_destination
+from comicarr.manga_parser import parse_manga_filename
 from comicarr.tables import (
     annuals,
     comics,
@@ -561,6 +563,12 @@ class PostProcessor(object):
             logger.fdebug("%s Now performing post-processing of %s sent from DDL" % (module, self.nzb_name))
 
         self.oneoffinlist = False
+
+        # --- Manga branch: if the comicid is a MangaDex ID, use manga-specific processing ---
+        if self.comicid is not None and str(self.comicid).startswith("md-"):
+            logger.fdebug("%s Manga series detected (ComicID: %s) - branching to manga post-processing" % (module, self.comicid))
+            self._log("Manga series detected - using manga post-processing path")
+            return self._process_manga()
 
         if any(
             [self.nzb_name == "Manual Run", self.issueid is not None, self.comicid is not None, self.apicall is True]
@@ -4134,6 +4142,202 @@ class PostProcessor(object):
             else:
                 self.valreturn.append({"self.log": self.log, "mode": "stop", "issueid": issueid, "comicid": comicid})
                 return self.queue.put(self.valreturn)
+
+    def _process_manga(self):
+        """Post-process a downloaded manga file.
+
+        Routes manga downloads to the manga destination directory,
+        matches files to chapters using the manga filename parser,
+        and updates chapter status to Downloaded.
+        """
+        module = self.module
+
+        # --- Look up the comic (manga series) record ---
+        comicnzb = db.select_one(select(comics).where(comics.c.ComicID == self.comicid))
+        if not comicnzb:
+            self._log("Cannot find manga series in database: %s" % self.comicid)
+            logger.error("%s Cannot find manga series: %s" % (module, self.comicid))
+            self.valreturn.append({"self.log": self.log, "mode": "stop"})
+            return self.queue.put(self.valreturn)
+
+        series_name = comicnzb["ComicName"]
+        logger.info("%s Processing manga download for: %s" % (module, series_name))
+
+        # --- Find files in the download directory ---
+        nzb_dir = self.nzb_folder
+        if not nzb_dir or not os.path.isdir(nzb_dir):
+            if self.nzb_name and os.path.isdir(self.nzb_name):
+                nzb_dir = self.nzb_name
+            else:
+                self._log("Download directory not found")
+                logger.error("%s Download directory not found: %s" % (module, nzb_dir))
+                self.valreturn.append({"self.log": self.log, "mode": "stop"})
+                return self.queue.put(self.valreturn)
+
+        manga_files = []
+        for root, _dirs, files in os.walk(nzb_dir):
+            for f in files:
+                if any(f.lower().endswith(ext) for ext in self.extensions):
+                    manga_files.append(os.path.join(root, f))
+
+        if not manga_files:
+            self._log("No manga files found in download directory")
+            logger.warn("%s No manga files in: %s" % (module, nzb_dir))
+            self.valreturn.append({"self.log": self.log, "mode": "stop"})
+            return self.queue.put(self.valreturn)
+
+        # --- Determine destination directory ---
+        manga_dest = get_manga_destination()
+        if not manga_dest:
+            self._log("No manga destination directory configured")
+            logger.error("%s No manga destination configured" % module)
+            self.valreturn.append({"self.log": self.log, "mode": "stop"})
+            return self.queue.put(self.valreturn)
+
+        series_folder = comicnzb.get("ComicLocation") or os.path.join(
+            manga_dest, helpers.filesafe(series_name) if hasattr(helpers, "filesafe") else re.sub(r'[<>:"/\\|?*]', "_", series_name)
+        )
+
+        # Ensure the series folder exists
+        if not os.path.isdir(series_folder):
+            try:
+                os.makedirs(series_folder, exist_ok=True)
+                logger.fdebug("%s Created manga series directory: %s" % (module, series_folder))
+            except OSError as e:
+                logger.warn("%s Failed to create directory %s: %s" % (module, series_folder, e))
+                self._log("Failed to create manga series directory")
+                self.valreturn.append({"self.log": self.log, "mode": "stop"})
+                return self.queue.put(self.valreturn)
+
+        # --- Process each manga file ---
+        processed = 0
+        last_matched_issueid = None
+        for filepath in manga_files:
+            filename = os.path.basename(filepath)
+            parsed = parse_manga_filename(filename)
+            self._log("Found manga file: %s" % filename)
+
+            # Move/copy file to series folder
+            dst = os.path.join(series_folder, filename)
+            try:
+                self.fileop(filepath, dst)
+                logger.info("%s Moved manga file: %s -> %s" % (module, filename, series_folder))
+            except Exception as e:
+                logger.error("%s Failed to move %s: %s" % (module, filename, e))
+                self._log("Failed to move/copy manga file: %s" % filename)
+                continue
+
+            # --- Match to a chapter/issue in the database ---
+            matching = None
+
+            # Try ChapterNumber column first
+            if parsed and parsed.get("chapter_number") is not None:
+                ch_num = parsed["chapter_number"]
+                ch_str = str(int(ch_num) if ch_num == int(ch_num) else ch_num)
+                matching = db.select_one(
+                    select(issues).where(
+                        and_(
+                            issues.c.ComicID == self.comicid,
+                            issues.c.ChapterNumber == ch_str,
+                        )
+                    )
+                )
+                # Fall back to Issue_Number
+                if matching is None:
+                    matching = db.select_one(
+                        select(issues).where(
+                            and_(
+                                issues.c.ComicID == self.comicid,
+                                issues.c.Issue_Number == ch_str,
+                            )
+                        )
+                    )
+                    # Also try the float string form (e.g. "165.0")
+                    if matching is None and ch_str != str(ch_num):
+                        matching = db.select_one(
+                            select(issues).where(
+                                and_(
+                                    issues.c.ComicID == self.comicid,
+                                    issues.c.Issue_Number == str(ch_num),
+                                )
+                            )
+                        )
+
+            # Try VolumeNumber column
+            if matching is None and parsed and parsed.get("volume_number") is not None:
+                vol_str = str(parsed["volume_number"])
+                matching = db.select_one(
+                    select(issues).where(
+                        and_(
+                            issues.c.ComicID == self.comicid,
+                            issues.c.VolumeNumber == vol_str,
+                        )
+                    )
+                )
+
+            if matching:
+                issueid = matching["IssueID"]
+                db.upsert(
+                    "issues",
+                    {"Status": "Downloaded", "Location": filename},
+                    {"IssueID": issueid},
+                )
+                logger.info(
+                    "%s Matched and marked downloaded: %s (IssueID: %s)"
+                    % (module, filename, issueid)
+                )
+                self._log("Matched to chapter IssueID: %s" % issueid)
+
+                # Clean up nzblog entry
+                with db.get_engine().begin() as conn:
+                    conn.execute(delete(nzblog).where(nzblog.c.IssueID == issueid))
+
+                # Update snatched table
+                db.upsert(
+                    "snatched",
+                    {"Status": "Post-Processed"},
+                    {"IssueID": issueid, "Status": "Snatched"},
+                )
+
+                last_matched_issueid = issueid
+                processed += 1
+            else:
+                logger.warn(
+                    "%s Unable to match %s to any chapter for %s"
+                    % (module, filename, series_name)
+                )
+
+        # Update Have count for the series
+        if processed > 0:
+            have_count = db.select_one(
+                select(func.count()).select_from(issues).where(
+                    and_(
+                        issues.c.ComicID == self.comicid,
+                        issues.c.Status == "Downloaded",
+                    )
+                )
+            )
+            if have_count is not None:
+                count_val = list(have_count.values())[0] if hasattr(have_count, "values") else have_count[0]
+                db.upsert("comics", {"Have": count_val}, {"ComicID": self.comicid})
+
+        if processed > 0:
+            self._log("Post Processing SUCCESSFUL! %d file(s) processed" % processed)
+        else:
+            self._log("Manga post-processing complete: 0 files matched to chapters")
+        logger.info("%s Manga post-processing complete for %s: %d files" % (module, series_name, processed))
+
+        if self.apicall is True:
+            try:
+                comicarr.APILOCK.release()
+            except Exception:
+                pass
+
+        result = {"self.log": self.log, "mode": "stop", "comicid": self.comicid}
+        if last_matched_issueid:
+            result["issueid"] = last_matched_issueid
+        self.valreturn.append(result)
+        return self.queue.put(self.valreturn)
 
     def Process_next(self, comicid, issueid, issuenumOG, ml=None, stat=None):
         if stat is None:

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -566,7 +566,9 @@ class PostProcessor(object):
 
         # --- Manga branch: if the comicid is a MangaDex ID, use manga-specific processing ---
         if self.comicid is not None and str(self.comicid).startswith("md-"):
-            logger.fdebug("%s Manga series detected (ComicID: %s) - branching to manga post-processing" % (module, self.comicid))
+            logger.fdebug(
+                "%s Manga series detected (ComicID: %s) - branching to manga post-processing" % (module, self.comicid)
+            )
             self._log("Manga series detected - using manga post-processing path")
             return self._process_manga()
 
@@ -4292,10 +4294,7 @@ class PostProcessor(object):
                     {"Status": "Downloaded", "Location": filename},
                     {"IssueID": issueid},
                 )
-                logger.info(
-                    "%s Matched and marked downloaded: %s (IssueID: %s)"
-                    % (module, filename, issueid)
-                )
+                logger.info("%s Matched and marked downloaded: %s (IssueID: %s)" % (module, filename, issueid))
                 self._log("Matched to chapter IssueID: %s" % issueid)
 
                 # Clean up nzblog entry
@@ -4312,15 +4311,14 @@ class PostProcessor(object):
                 last_matched_issueid = issueid
                 processed += 1
             else:
-                logger.warn(
-                    "%s Unable to match %s to any chapter for %s"
-                    % (module, filename, series_name)
-                )
+                logger.warn("%s Unable to match %s to any chapter for %s" % (module, filename, series_name))
 
         # Update Have count for the series
         if processed > 0:
             have_count = db.select_one(
-                select(func.count()).select_from(issues).where(
+                select(func.count())
+                .select_from(issues)
+                .where(
                     and_(
                         issues.c.ComicID == self.comicid,
                         issues.c.Status == "Downloaded",

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -4194,9 +4194,14 @@ class PostProcessor(object):
             self.valreturn.append({"self.log": self.log, "mode": "stop"})
             return self.queue.put(self.valreturn)
 
-        series_folder = comicnzb.get("ComicLocation") or os.path.join(
-            manga_dest, helpers.filesafe(series_name) if hasattr(helpers, "filesafe") else re.sub(r'[<>:"/\\|?*]', "_", series_name)
-        )
+        series_folder = comicnzb.get("ComicLocation") or os.path.join(manga_dest, helpers.filesafe(series_name))
+
+        # Validate series_folder is within manga destination
+        if not os.path.realpath(series_folder).startswith(os.path.realpath(manga_dest)):
+            self._log("Series folder is outside manga destination — refusing to write")
+            logger.error("%s Series folder %s is outside manga destination %s" % (module, series_folder, manga_dest))
+            self.valreturn.append({"self.log": self.log, "mode": "stop"})
+            return self.queue.put(self.valreturn)
 
         # Ensure the series folder exists
         if not os.path.isdir(series_folder):
@@ -4217,6 +4222,11 @@ class PostProcessor(object):
             parsed = parse_manga_filename(filename)
             self._log("Found manga file: %s" % filename)
 
+            # Validate source path is within download directory
+            if not os.path.realpath(filepath).startswith(os.path.realpath(nzb_dir)):
+                logger.warning("%s Skipping file outside download directory: %s" % (module, filepath))
+                continue
+
             # Move/copy file to series folder
             dst = os.path.join(series_folder, filename)
             try:
@@ -4233,7 +4243,7 @@ class PostProcessor(object):
             # Try ChapterNumber column first
             if parsed and parsed.get("chapter_number") is not None:
                 ch_num = parsed["chapter_number"]
-                ch_str = str(int(ch_num) if ch_num == int(ch_num) else ch_num)
+                ch_str = "%g" % ch_num
                 matching = db.select_one(
                     select(issues).where(
                         and_(

--- a/comicarr/rsscheck.py
+++ b/comicarr/rsscheck.py
@@ -1859,3 +1859,237 @@ def ddlrss_pack_detect(title, link):
         return {"title": title, "issues": issues, "pack": pack, "link": link}
     else:
         return
+
+
+# ---------------------------------------------------------------------------
+# Manga RSS / Chapter monitoring
+# ---------------------------------------------------------------------------
+
+
+def mangaCheck():
+    """Search for wanted manga chapters using the existing search infrastructure.
+
+    Queries the database for manga series (ContentType='manga') that have
+    chapters in 'Wanted' status, then triggers a search for each one via
+    the search pipeline.  Paused series are skipped.
+
+    Callable from the scheduler or manually.
+    """
+    from comicarr import search
+    from comicarr.tables import comics as t_comics
+    from comicarr.tables import issues as t_issues
+
+    logger.info("[MANGA-RSS] Starting manga wanted-chapter search")
+
+    # Get all active manga series
+    manga_series = db.select_all(
+        select(t_comics).where(
+            t_comics.c.ContentType == "manga",
+            t_comics.c.Status != "Paused",
+        )
+    )
+
+    if not manga_series:
+        logger.info("[MANGA-RSS] No active manga series found")
+        return
+
+    logger.info("[MANGA-RSS] Found %d active manga series to check" % len(manga_series))
+
+    total_searched = 0
+
+    for series in manga_series:
+        comic_id = series["ComicID"]
+        comic_name = series["ComicName"]
+        series_year = series.get("ComicYear") or str(datetime.now().year)
+
+        # Get wanted chapters for this series
+        wanted_statuses = ["Wanted"]
+        if comicarr.CONFIG.FAILED_DOWNLOAD_HANDLING and comicarr.CONFIG.FAILED_AUTO:
+            wanted_statuses.append("Failed")
+
+        wanted_chapters = db.select_all(
+            select(t_issues).where(
+                t_issues.c.ComicID == comic_id,
+                t_issues.c.Status.in_(wanted_statuses),
+            )
+        )
+
+        if not wanted_chapters:
+            continue
+
+        logger.info(
+            "[MANGA-RSS] %s has %d wanted chapter(s)" % (comic_name, len(wanted_chapters))
+        )
+
+        for chapter in wanted_chapters:
+            issue_id = chapter["IssueID"]
+            chapter_number = chapter.get("ChapterNumber") or chapter.get("Issue_Number", "1")
+            issue_date = chapter.get("IssueDate") or "0000-00-00"
+            store_date = chapter.get("ReleaseDate") or "0000-00-00"
+            digital_date = chapter.get("DigitalDate") or "0000-00-00"
+
+            # Skip chapters that are already downloaded/snatched (race condition guard)
+            isscheck = helpers.issue_status(issue_id)
+            if isscheck is True:
+                continue
+
+            try:
+                search.search_init(
+                    comic_name,
+                    str(chapter_number),
+                    str(series_year)[:4],
+                    str(series_year)[:4],
+                    series.get("ComicPublisher", ""),
+                    issue_date,
+                    store_date,
+                    issue_id,
+                    AlternateSearch=series.get("AlternateSearch"),
+                    UseFuzzy=series.get("UseFuzzy"),
+                    ComicVersion=series.get("ComicVersion"),
+                    smode="want",
+                    rsschecker="yes",
+                    ComicID=comic_id,
+                    filesafe=series.get("ComicName_Filesafe"),
+                    booktype="manga",
+                    digitaldate=digital_date,
+                )
+                total_searched += 1
+            except Exception as e:
+                logger.error(
+                    "[MANGA-RSS] Error searching for %s chapter %s: %s"
+                    % (comic_name, chapter_number, e)
+                )
+
+    logger.info("[MANGA-RSS] Manga search complete — searched %d chapter(s)" % total_searched)
+
+
+def mangadexNewChapterCheck():
+    """Poll MangaDex for new chapters not yet tracked in the database.
+
+    For each active manga series whose ComicID starts with 'md-', calls
+    the MangaDex API to retrieve the full chapter list and compares it
+    against existing issues in the database.  Any new chapters are inserted
+    as 'Wanted' issues.
+
+    Uses the built-in rate limiter in mangadex._rate_limit() to stay within
+    the MangaDex 5 req/s limit.
+
+    Callable from the scheduler or manually.
+    """
+    from comicarr import mangadex
+    from comicarr.tables import comics as t_comics
+    from comicarr.tables import issues as t_issues
+
+    logger.info("[MANGA-RSS] Starting MangaDex new-chapter check")
+
+    # Get all active manga series with MangaDex IDs
+    manga_series = db.select_all(
+        select(t_comics).where(
+            t_comics.c.ContentType == "manga",
+            t_comics.c.Status != "Paused",
+            t_comics.c.ComicID.like("md-%"),
+        )
+    )
+
+    if not manga_series:
+        logger.info("[MANGA-RSS] No active MangaDex manga series found")
+        return
+
+    logger.info(
+        "[MANGA-RSS] Checking MangaDex for new chapters across %d series" % len(manga_series)
+    )
+
+    total_new = 0
+
+    for series in manga_series:
+        comic_id = series["ComicID"]
+        comic_name = series["ComicName"]
+
+        # Get existing chapter numbers from the database for this series
+        existing_issues = db.select_all(
+            select(t_issues.c.IssueID, t_issues.c.ChapterNumber).where(
+                t_issues.c.ComicID == comic_id,
+            )
+        )
+
+        existing_chapter_nums = set()
+        existing_issue_ids = set()
+        for iss in existing_issues:
+            existing_issue_ids.add(iss["IssueID"])
+            ch = iss.get("ChapterNumber")
+            if ch is not None:
+                existing_chapter_nums.add(str(ch))
+
+        # Fetch chapters from MangaDex (rate-limited internally)
+        try:
+            mdx_chapters = mangadex.get_all_chapters(comic_id)
+        except Exception as e:
+            logger.error(
+                "[MANGA-RSS] Error fetching MangaDex chapters for %s: %s" % (comic_name, e)
+            )
+            continue
+
+        if not mdx_chapters:
+            logger.fdebug("[MANGA-RSS] No chapters returned from MangaDex for %s" % comic_name)
+            continue
+
+        new_count = 0
+        for ch in mdx_chapters:
+            ch_num = ch.get("chapter")
+
+            if ch_num is None:
+                continue
+
+            # Skip if we already track this chapter
+            if str(ch_num) in existing_chapter_nums:
+                continue
+
+            # Build an IssueID for the new chapter
+            issue_id = "md-%s-ch-%s" % (comic_id[3:], ch_num)
+            if issue_id in existing_issue_ids:
+                continue
+
+            # Determine chapter title
+            ch_title = ch.get("title") or ("Chapter %s" % ch_num)
+
+            # Determine dates
+            publish_at = ch.get("publish_at") or ch.get("created_at") or ""
+            issue_date = publish_at[:10] if len(publish_at) >= 10 else "0000-00-00"
+
+            # Insert the new chapter as Wanted
+            try:
+                db.upsert(
+                    "issues",
+                    {
+                        "ComicName": comic_name,
+                        "IssueName": ch_title,
+                        "Issue_Number": str(ch_num),
+                        "DateAdded": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                        "Status": "Wanted",
+                        "ComicID": comic_id,
+                        "IssueDate": issue_date,
+                        "ReleaseDate": issue_date,
+                        "ChapterNumber": str(ch_num),
+                        "VolumeNumber": str(ch.get("volume")) if ch.get("volume") else None,
+                    },
+                    {"IssueID": issue_id},
+                )
+                new_count += 1
+                logger.fdebug(
+                    "[MANGA-RSS] Added wanted chapter %s for %s" % (ch_num, comic_name)
+                )
+            except Exception as e:
+                logger.error(
+                    "[MANGA-RSS] Error inserting chapter %s for %s: %s"
+                    % (ch_num, comic_name, e)
+                )
+
+        if new_count > 0:
+            logger.info(
+                "[MANGA-RSS] Added %d new wanted chapter(s) for %s" % (new_count, comic_name)
+            )
+            total_new += new_count
+
+    logger.info(
+        "[MANGA-RSS] MangaDex check complete — added %d new wanted chapter(s) total" % total_new
+    )

--- a/comicarr/rsscheck.py
+++ b/comicarr/rsscheck.py
@@ -1916,9 +1916,7 @@ def mangaCheck():
         if not wanted_chapters:
             continue
 
-        logger.info(
-            "[MANGA-RSS] %s has %d wanted chapter(s)" % (comic_name, len(wanted_chapters))
-        )
+        logger.info("[MANGA-RSS] %s has %d wanted chapter(s)" % (comic_name, len(wanted_chapters)))
 
         for chapter in wanted_chapters:
             issue_id = chapter["IssueID"]
@@ -1957,10 +1955,7 @@ def mangaCheck():
                 )
                 total_searched += 1
             except Exception as e:
-                logger.error(
-                    "[MANGA-RSS] Error searching for %s chapter %s: %s"
-                    % (comic_name, chapter_number, e)
-                )
+                logger.error("[MANGA-RSS] Error searching for %s chapter %s: %s" % (comic_name, chapter_number, e))
 
     logger.info("[MANGA-RSS] Manga search complete — searched %d chapter(s)" % total_searched)
 
@@ -1997,9 +1992,7 @@ def mangadexNewChapterCheck():
         logger.info("[MANGA-RSS] No active MangaDex manga series found")
         return
 
-    logger.info(
-        "[MANGA-RSS] Checking MangaDex for new chapters across %d series" % len(manga_series)
-    )
+    logger.info("[MANGA-RSS] Checking MangaDex for new chapters across %d series" % len(manga_series))
 
     total_new = 0
 
@@ -2026,9 +2019,7 @@ def mangadexNewChapterCheck():
         try:
             mdx_chapters = mangadex.get_all_chapters(comic_id)
         except Exception as e:
-            logger.error(
-                "[MANGA-RSS] Error fetching MangaDex chapters for %s: %s" % (comic_name, e)
-            )
+            logger.error("[MANGA-RSS] Error fetching MangaDex chapters for %s: %s" % (comic_name, e))
             continue
 
         if not mdx_chapters:
@@ -2077,21 +2068,12 @@ def mangadexNewChapterCheck():
                     {"IssueID": issue_id},
                 )
                 new_count += 1
-                logger.fdebug(
-                    "[MANGA-RSS] Added wanted chapter %s for %s" % (ch_num, comic_name)
-                )
+                logger.fdebug("[MANGA-RSS] Added wanted chapter %s for %s" % (ch_num, comic_name))
             except Exception as e:
-                logger.error(
-                    "[MANGA-RSS] Error inserting chapter %s for %s: %s"
-                    % (ch_num, comic_name, e)
-                )
+                logger.error("[MANGA-RSS] Error inserting chapter %s for %s: %s" % (ch_num, comic_name, e))
 
         if new_count > 0:
-            logger.info(
-                "[MANGA-RSS] Added %d new wanted chapter(s) for %s" % (new_count, comic_name)
-            )
+            logger.info("[MANGA-RSS] Added %d new wanted chapter(s) for %s" % (new_count, comic_name))
             total_new += new_count
 
-    logger.info(
-        "[MANGA-RSS] MangaDex check complete — added %d new wanted chapter(s) total" % total_new
-    )
+    logger.info("[MANGA-RSS] MangaDex check complete — added %d new wanted chapter(s) total" % total_new)

--- a/comicarr/rsscheck.py
+++ b/comicarr/rsscheck.py
@@ -1897,15 +1897,14 @@ def mangaCheck():
 
     total_searched = 0
 
+    wanted_statuses = ["Wanted"]
+    if comicarr.CONFIG.FAILED_DOWNLOAD_HANDLING and comicarr.CONFIG.FAILED_AUTO:
+        wanted_statuses.append("Failed")
+
     for series in manga_series:
         comic_id = series["ComicID"]
         comic_name = series["ComicName"]
         series_year = series.get("ComicYear") or str(datetime.now().year)
-
-        # Get wanted chapters for this series
-        wanted_statuses = ["Wanted"]
-        if comicarr.CONFIG.FAILED_DOWNLOAD_HANDLING and comicarr.CONFIG.FAILED_AUTO:
-            wanted_statuses.append("Failed")
 
         wanted_chapters = db.select_all(
             select(t_issues).where(
@@ -1952,6 +1951,9 @@ def mangaCheck():
                     filesafe=series.get("ComicName_Filesafe"),
                     booktype="manga",
                     digitaldate=digital_date,
+                    content_type="manga",
+                    chapter_number=str(chapter_number),
+                    volume_number=chapter.get("VolumeNumber"),
                 )
                 total_searched += 1
             except Exception as e:
@@ -2045,7 +2047,7 @@ def mangadexNewChapterCheck():
                 continue
 
             # Build an IssueID for the new chapter
-            issue_id = "md-%s-ch-%s" % (comic_id[3:], ch_num)
+            issue_id = "%s-ch%s" % (comic_id, ch_num)
             if issue_id in existing_issue_ids:
                 continue
 

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -4415,8 +4415,8 @@ def _build_manga_search_terms(series_name, chapter_num, volume_num):
             if ch_float == int(ch_float):
                 ch_padded = "%03d" % int(ch_float)
             else:
-                # Decimal chapters like 10.5
-                ch_padded = "%06.1f" % ch_float
+                # Decimal chapters like 10.5 — pad integer part only
+                ch_padded = "%03d.%s" % (int(ch_float), str(round(ch_float % 1, 1))[2:])
         except (ValueError, TypeError):
             logger.fdebug("[SEARCH-MANGA] Could not parse chapter number: %s" % chapter_num)
             ch_padded = str(chapter_num)

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -200,6 +200,9 @@ def search_init(
     booktype=None,
     ignore_booktype=False,
     _ai_expanded=False,
+    content_type=None,
+    chapter_number=None,
+    volume_number=None,
 ):
 
     comicarr.COMICINFO = []
@@ -247,6 +250,21 @@ def search_init(
         logger.fdebug("Story-ARC Search parameters:")
         logger.fdebug("Story-ARC: %s" % SARC)
         logger.fdebug("IssueArcID: %s" % IssueArcID)
+
+    # --- Manga content-type branch ---
+    # When searching for manga chapters, construct manga-specific query terms
+    # and inject them as AlternateSearch patterns. The rest of the search pipeline
+    # (providers, matching, snatching) works unchanged.
+    if content_type == "manga":
+        logger.fdebug("[SEARCH-MANGA] Manga content detected for %s" % ComicName)
+        manga_terms = _build_manga_search_terms(ComicName, chapter_number, volume_number)
+        if manga_terms:
+            manga_alt_str = "##".join(manga_terms)
+            logger.fdebug("[SEARCH-MANGA] Generated %d search variations: %s" % (len(manga_terms), manga_terms))
+            if AlternateSearch and AlternateSearch != "None":
+                AlternateSearch = manga_alt_str + "##" + AlternateSearch
+            else:
+                AlternateSearch = manga_alt_str
 
     provider_list = provider_order(initial_run=True)
     findit = {}
@@ -753,6 +771,9 @@ def search_init(
                         booktype=booktype,
                         ignore_booktype=ignore_booktype,
                         _ai_expanded=True,
+                        content_type=content_type,
+                        chapter_number=chapter_number,
+                        volume_number=volume_number,
                     )
                     if ai_findit.get("status") is True:
                         # Determine which alternate worked by checking the result
@@ -4359,6 +4380,76 @@ def searchforissue_checker(issueid, storedate, issuedate, digitaldate, info):
         return {"status": True, "reason": None}
     else:
         return {"status": False, "reason": "invalid issueid"}
+
+
+def _build_manga_search_terms(series_name, chapter_num, volume_num):
+    """Build manga-specific search query variations.
+
+    Returns a list of search term strings suitable for NZB/torrent providers.
+    Each variation covers a common manga release naming convention:
+      - chapter-only:   "Series Name" c001 / "Series Name" chapter 001
+      - volume-only:    "Series Name" v01
+      - combined:       "Series Name" v01c001
+
+    Args:
+        series_name: The manga series title (e.g. "One Piece").
+        chapter_num: Chapter number as string or None.
+        volume_num:  Volume number as string or None.
+
+    Returns:
+        List of search term strings (may be empty if both chapter and volume
+        are None).
+    """
+    terms = []
+    if not series_name:
+        return terms
+
+    # Normalize the series name — strip leading/trailing whitespace
+    name = series_name.strip()
+
+    # Zero-pad chapter and volume for consistent matching
+    ch_padded = None
+    if chapter_num is not None:
+        try:
+            ch_float = float(chapter_num)
+            if ch_float == int(ch_float):
+                ch_padded = "%03d" % int(ch_float)
+            else:
+                # Decimal chapters like 10.5
+                ch_padded = "%06.1f" % ch_float
+        except (ValueError, TypeError):
+            logger.fdebug("[SEARCH-MANGA] Could not parse chapter number: %s" % chapter_num)
+            ch_padded = str(chapter_num)
+
+    vol_padded = None
+    if volume_num is not None:
+        try:
+            vol_int = int(volume_num)
+            vol_padded = "%02d" % vol_int
+        except (ValueError, TypeError):
+            logger.fdebug("[SEARCH-MANGA] Could not parse volume number: %s" % volume_num)
+            vol_padded = str(volume_num)
+
+    # Build variations in priority order (most specific first)
+    if ch_padded and vol_padded:
+        # Combined: "Series Name" v01c001
+        terms.append("%s v%sc%s" % (name, vol_padded, ch_padded))
+
+    if ch_padded:
+        # Short chapter: "Series Name" c001
+        terms.append("%s c%s" % (name, ch_padded))
+        # Long chapter: "Series Name" chapter 001
+        terms.append("%s chapter %s" % (name, ch_padded))
+
+    if vol_padded:
+        # Volume only: "Series Name" v01
+        terms.append("%s v%s" % (name, vol_padded))
+
+    logger.fdebug(
+        "[SEARCH-MANGA] Built %d search terms for %s (ch=%s, vol=%s)" % (len(terms), name, chapter_num, volume_num)
+    )
+
+    return terms
 
 
 def get_findcomiciss(IssueNumber):

--- a/frontend/src/components/dashboard/CollectionStats.tsx
+++ b/frontend/src/components/dashboard/CollectionStats.tsx
@@ -8,6 +8,13 @@ interface CollectionStatsProps {
     total_issues: number;
     total_expected: number;
     completion_pct: number;
+    comic_series?: number;
+    comic_have?: number;
+    comic_total?: number;
+    manga_series?: number;
+    manga_have?: number;
+    manga_total?: number;
+    manga_completion_pct?: number;
   };
   isLoading: boolean;
 }
@@ -31,27 +38,38 @@ export default function CollectionStats({
     );
   }
 
+  const hasManga = (stats?.manga_series ?? 0) > 0;
+
   const items = [
     {
       label: "Active Series",
       value: stats?.total_series ?? 0,
+      subtitle: hasManga
+        ? `${stats?.comic_series ?? 0} comics, ${stats?.manga_series ?? 0} manga`
+        : undefined,
       icon: Library,
     },
     {
       label: "Issues Collected",
       value: stats?.total_issues ?? 0,
+      subtitle: hasManga
+        ? `${stats?.comic_have ?? 0} comic, ${stats?.manga_have ?? 0} manga`
+        : undefined,
       icon: BookOpen,
     },
     {
       label: "Completion",
       value: `${stats?.completion_pct ?? 0}%`,
+      subtitle: hasManga
+        ? `Manga: ${stats?.manga_completion_pct ?? 0}%`
+        : undefined,
       icon: TrendingUp,
     },
   ];
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
-      {items.map(({ label, value, icon: Icon }) => (
+      {items.map(({ label, value, subtitle, icon: Icon }) => (
         <Card key={label}>
           <CardContent className="p-5">
             <div className="flex items-center gap-2 text-sm text-muted-foreground mb-1">
@@ -59,6 +77,9 @@ export default function CollectionStats({
               <span>{label}</span>
             </div>
             <p className="text-2xl font-bold tracking-tight">{value}</p>
+            {subtitle && (
+              <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
+            )}
           </CardContent>
         </Card>
       ))}

--- a/frontend/src/components/settings/ApiTab.tsx
+++ b/frontend/src/components/settings/ApiTab.tsx
@@ -63,30 +63,6 @@ export function ApiTab({ config, formData, onChange }: ApiTabProps) {
   return (
     <div className="space-y-6">
       <SettingGroup
-        title="Content Sources"
-        description="Choose which content sources to enable. At least one must be active."
-      >
-        <SettingField
-          label="Comics (Comic Vine)"
-          type="checkbox"
-          checked={comicvineEnabled}
-          onChange={(checked) =>
-            onChange("comicvine_enabled", checked as boolean)
-          }
-          helpText="Enable comic search and metadata from Comic Vine"
-        />
-        <SettingField
-          label="Manga (MangaDex)"
-          type="checkbox"
-          checked={mangadexEnabled}
-          onChange={(checked) =>
-            onChange("mangadex_enabled", checked as boolean)
-          }
-          helpText="Enable manga search and metadata from MangaDex"
-        />
-      </SettingGroup>
-
-      <SettingGroup
         title="Comicarr API Key"
         description="This key is used to authenticate API requests to Comicarr"
       >

--- a/frontend/src/components/settings/GeneralTab.tsx
+++ b/frontend/src/components/settings/GeneralTab.tsx
@@ -3,11 +3,40 @@ import { SettingField } from "./SettingField";
 
 interface GeneralTabProps {
   config: Record<string, unknown>;
+  formData: Record<string, unknown>;
+  onChange: (key: string, value: string | boolean) => void;
 }
 
-export function GeneralTab({ config }: GeneralTabProps) {
+export function GeneralTab({ config, formData, onChange }: GeneralTabProps) {
+  const comicvineEnabled = (formData.comicvine_enabled as boolean) ?? true;
+  const mangadexEnabled = (formData.mangadex_enabled as boolean) ?? false;
+
   return (
     <div className="space-y-6">
+      <SettingGroup
+        title="Content Sources"
+        description="Choose which content sources to enable. At least one must be active."
+      >
+        <SettingField
+          label="Comics (Comic Vine)"
+          type="checkbox"
+          checked={comicvineEnabled}
+          onChange={(checked) =>
+            onChange("comicvine_enabled", checked as boolean)
+          }
+          helpText="Enable comic search and metadata from Comic Vine"
+        />
+        <SettingField
+          label="Manga (MangaDex)"
+          type="checkbox"
+          checked={mangadexEnabled}
+          onChange={(checked) =>
+            onChange("mangadex_enabled", checked as boolean)
+          }
+          helpText="Enable manga search and metadata from MangaDex"
+        />
+      </SettingGroup>
+
       <SettingGroup
         title="Directories"
         description="These paths are configured in your config.ini file and are read-only."
@@ -25,6 +54,20 @@ export function GeneralTab({ config }: GeneralTabProps) {
           type="text"
           readOnly
           helpText="Default destination for downloaded comics"
+        />
+        <SettingField
+          label="Manga Directory"
+          value={config.manga_dir as string | undefined}
+          type="text"
+          readOnly
+          helpText="Location where your manga library is stored"
+        />
+        <SettingField
+          label="Manga Destination Directory"
+          value={config.manga_destination_dir as string | undefined}
+          type="text"
+          readOnly
+          helpText="Default destination for downloaded manga (falls back to Manga Directory, then Destination Directory)"
         />
         <SettingField
           label="Cache Directory"

--- a/frontend/src/hooks/useImport.ts
+++ b/frontend/src/hooks/useImport.ts
@@ -122,3 +122,53 @@ export function useRefreshImport(): UseMutationResult<
     },
   });
 }
+
+// Manga scan hooks
+
+interface MangaScanResponse {
+  success: boolean;
+  message: string;
+}
+
+interface MangaScanProgress {
+  status: string | null;
+  progress: {
+    total_files: number;
+    processed_files: number;
+    series_found: number;
+    series_matched: number;
+    series_imported: number;
+    current_series: string | null;
+    errors: string[];
+  };
+}
+
+export function useMangaScan(): UseMutationResult<
+  MangaScanResponse,
+  Error,
+  void
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      apiRequest<MangaScanResponse>("POST", "/api/import/manga/scan"),
+    onSuccess: () => {
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["mangaScanProgress"] });
+        queryClient.invalidateQueries({ queryKey: ["series"] });
+      }, 2000);
+    },
+  });
+}
+
+export function useMangaScanProgress(
+  enabled = false,
+): UseQueryResult<MangaScanProgress> {
+  return useQuery({
+    queryKey: ["mangaScanProgress"],
+    queryFn: () =>
+      apiRequest<MangaScanProgress>("GET", "/api/import/manga/progress"),
+    enabled,
+    refetchInterval: enabled ? 2000 : false,
+  });
+}

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -1,14 +1,18 @@
 import { useState } from "react";
-import { RefreshCw, EyeOff, Eye } from "lucide-react";
+import { RefreshCw, EyeOff, Eye, BookOpen } from "lucide-react";
 import {
   useImportPending,
   useMatchImport,
   useIgnoreImport,
   useDeleteImport,
   useRefreshImport,
+  useMangaScan,
+  useMangaScanProgress,
 } from "@/hooks/useImport";
+import { useConfig } from "@/hooks/useConfig";
 import { useToast } from "@/components/ui/toast";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
@@ -39,6 +43,11 @@ export default function ImportPage() {
   const ignoreImportMutation = useIgnoreImport();
   const deleteImportMutation = useDeleteImport();
   const refreshImportMutation = useRefreshImport();
+  const mangaScanMutation = useMangaScan();
+  const { data: appConfig } = useConfig();
+  const mangaDirConfigured = !!appConfig?.manga_dir;
+  const [mangaScanning, setMangaScanning] = useState(false);
+  const { data: mangaProgress } = useMangaScanProgress(mangaScanning);
   const { addToast } = useToast();
 
   const handleRefreshImport = async () => {
@@ -55,6 +64,27 @@ export default function ImportPage() {
       });
     }
   };
+
+  const handleMangaScan = async () => {
+    try {
+      await mangaScanMutation.mutateAsync();
+      setMangaScanning(true);
+      addToast({
+        type: "info",
+        message: "Manga library scan started. This may take a few moments.",
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to start manga scan: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+    }
+  };
+
+  // Stop polling when scan completes
+  if (mangaScanning && mangaProgress?.status === "completed") {
+    setMangaScanning(false);
+  }
 
   const handleMatchClick = (group: ImportGroup) => {
     setMatchingGroup(group);
@@ -169,6 +199,49 @@ export default function ImportPage() {
           {(pagination?.total || imports.length) !== 1 ? "s" : ""}
         </p>
       </div>
+
+      <Card className="mb-6">
+        <CardContent className="p-5">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <BookOpen className="w-5 h-5 text-muted-foreground" />
+              <div>
+                <h3 className="font-semibold">Manga Library Scan</h3>
+                <p className="text-sm text-muted-foreground">
+                  {mangaDirConfigured
+                    ? "Scan your manga directory to import existing collections"
+                    : "Configure a Manga Directory in Settings to enable scanning"}
+                </p>
+              </div>
+            </div>
+            <Button
+              onClick={handleMangaScan}
+              disabled={
+                !mangaDirConfigured ||
+                mangaScanMutation.isPending ||
+                mangaScanning
+              }
+            >
+              <RefreshCw
+                className={`w-4 h-4 mr-2 ${mangaScanning ? "animate-spin" : ""}`}
+              />
+              Scan Manga Library
+            </Button>
+          </div>
+          {mangaScanning && mangaProgress?.progress && (
+            <div className="mt-4 text-sm text-muted-foreground space-y-1">
+              <p>
+                Series found: {mangaProgress.progress.series_found} | Matched:{" "}
+                {mangaProgress.progress.series_matched} | Imported:{" "}
+                {mangaProgress.progress.series_imported}
+              </p>
+              {mangaProgress.progress.current_series && (
+                <p>Processing: {mangaProgress.progress.current_series}</p>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-4">

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { RefreshCw, EyeOff, Eye, BookOpen } from "lucide-react";
 import {
   useImportPending,
@@ -81,10 +81,18 @@ export default function ImportPage() {
     }
   };
 
-  // Stop polling when scan completes
-  if (mangaScanning && mangaProgress?.status === "completed") {
+  // Stop polling when scan reaches a terminal state
+  const scanStatus = mangaProgress?.status;
+  const scanTerminal =
+    mangaScanning && (scanStatus === "completed" || scanStatus === "error");
+  useEffect(() => {
+    if (!scanTerminal) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Sync polling state with server-driven terminal status
     setMangaScanning(false);
-  }
+    if (scanStatus === "error") {
+      addToast({ type: "error", message: "Manga scan failed" });
+    }
+  }, [scanTerminal, scanStatus, addToast]);
 
   const handleMatchClick = (group: ImportGroup) => {
     setMatchingGroup(group);

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -177,7 +177,11 @@ export default function SettingsPage() {
         </TabsList>
 
         <TabsContent value="general">
-          <GeneralTab config={formData} />
+          <GeneralTab
+            config={(config ?? {}) as Record<string, unknown>}
+            formData={formData}
+            onChange={handleChange}
+          />
         </TabsContent>
 
         <TabsContent value="interface">

--- a/tests/unit/test_importer_manga_dir.py
+++ b/tests/unit/test_importer_manga_dir.py
@@ -1,0 +1,107 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#  Originally based on Mylar3 (https://github.com/mylar3/mylar3).
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Unit tests for get_manga_destination() fallback chain in comicarr/config.py.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import comicarr
+
+# Ensure LOG_LEVEL is set for tests
+if comicarr.LOG_LEVEL is None:
+    comicarr.LOG_LEVEL = 0
+
+from comicarr.config import get_manga_destination
+
+
+class TestGetMangaDestination:
+    """Tests for the get_manga_destination() fallback chain."""
+
+    def test_returns_manga_destination_dir_when_set(self):
+        """MANGA_DESTINATION_DIR takes highest priority."""
+        mock_config = MagicMock()
+        mock_config.MANGA_DESTINATION_DIR = "/manga/destination"
+        mock_config.MANGA_DIR = "/manga/library"
+        mock_config.DESTINATION_DIR = "/downloads"
+
+        with patch.object(comicarr, "CONFIG", mock_config):
+            result = get_manga_destination()
+
+        assert result == "/manga/destination"
+
+    def test_falls_back_to_manga_dir_when_manga_destination_dir_unset(self):
+        """MANGA_DIR is used when MANGA_DESTINATION_DIR is not set."""
+        mock_config = MagicMock()
+        mock_config.MANGA_DESTINATION_DIR = None
+        mock_config.MANGA_DIR = "/manga/library"
+        mock_config.DESTINATION_DIR = "/downloads"
+
+        with patch.object(comicarr, "CONFIG", mock_config):
+            result = get_manga_destination()
+
+        assert result == "/manga/library"
+
+    def test_falls_back_to_destination_dir_when_both_manga_dirs_unset(self):
+        """DESTINATION_DIR is used when both manga-specific dirs are unset."""
+        mock_config = MagicMock()
+        mock_config.MANGA_DESTINATION_DIR = None
+        mock_config.MANGA_DIR = None
+        mock_config.DESTINATION_DIR = "/downloads"
+
+        with patch.object(comicarr, "CONFIG", mock_config):
+            result = get_manga_destination()
+
+        assert result == "/downloads"
+
+    def test_returns_none_when_all_dirs_unset(self):
+        """Returns None when no directories are configured."""
+        mock_config = MagicMock()
+        mock_config.MANGA_DESTINATION_DIR = None
+        mock_config.MANGA_DIR = None
+        mock_config.DESTINATION_DIR = None
+
+        with patch.object(comicarr, "CONFIG", mock_config):
+            result = get_manga_destination()
+
+        assert result is None
+
+    def test_ignores_empty_string_manga_destination_dir(self):
+        """Empty string MANGA_DESTINATION_DIR is treated as unset."""
+        mock_config = MagicMock()
+        mock_config.MANGA_DESTINATION_DIR = ""
+        mock_config.MANGA_DIR = "/manga/library"
+        mock_config.DESTINATION_DIR = "/downloads"
+
+        with patch.object(comicarr, "CONFIG", mock_config):
+            result = get_manga_destination()
+
+        assert result == "/manga/library"
+
+    def test_ignores_empty_string_manga_dir(self):
+        """Empty string MANGA_DIR is treated as unset, falls through to DESTINATION_DIR."""
+        mock_config = MagicMock()
+        mock_config.MANGA_DESTINATION_DIR = ""
+        mock_config.MANGA_DIR = ""
+        mock_config.DESTINATION_DIR = "/downloads"
+
+        with patch.object(comicarr, "CONFIG", mock_config):
+            result = get_manga_destination()
+
+        assert result == "/downloads"

--- a/tests/unit/test_manga_parser.py
+++ b/tests/unit/test_manga_parser.py
@@ -1,0 +1,369 @@
+"""
+Unit tests for comicarr/manga_parser.py manga filename parser.
+
+Tests cover all common naming conventions, user-specific filenames,
+and edge cases like decimal chapters, chapter ranges, and invalid inputs.
+"""
+
+
+
+class TestUserFilenames:
+    """Tests for the user's actual manga filenames from their NAS."""
+
+    def test_bleach_volume_based(self):
+        """Bleach v1.cbz through Bleach v17.cbz — volume only."""
+        from comicarr.manga_parser import parse_manga_filename
+
+        for vol in range(1, 18):
+            result = parse_manga_filename("Bleach v%d.cbz" % vol)
+            assert result is not None, "Failed to parse Bleach v%d.cbz" % vol
+            assert result["series_name"] == "Bleach"
+            assert result["volume_number"] == vol
+            assert result["chapter_number"] is None
+
+    def test_chainsaw_man_chapter_based(self):
+        """Chainsaw Man 165.cbz through Chainsaw Man 181.cbz — bare number chapter."""
+        from comicarr.manga_parser import parse_manga_filename
+
+        for ch in range(165, 182):
+            result = parse_manga_filename("Chainsaw Man %d.cbz" % ch)
+            assert result is not None, "Failed to parse Chainsaw Man %d.cbz" % ch
+            assert result["series_name"] == "Chainsaw Man"
+            assert result["chapter_number"] == float(ch)
+            assert result["volume_number"] is None
+
+
+class TestScanlatorGroupStyle:
+    """Pattern: [Group] Title - c001 (v01) [quality].cbz"""
+
+    def test_full_group_pattern(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("[Viz] One Piece - c1044 (v103) [HQ].cbz")
+        assert result is not None
+        assert result["series_name"] == "One Piece"
+        assert result["chapter_number"] == 1044.0
+        assert result["volume_number"] == 103
+        assert result["group"] == "Viz"
+        assert result["quality"] == "HQ"
+
+    def test_group_without_volume(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("[Scanlation] Naruto - c700 [Digital].cbz")
+        assert result is not None
+        assert result["series_name"] == "Naruto"
+        assert result["chapter_number"] == 700.0
+        assert result["volume_number"] is None
+        assert result["group"] == "Scanlation"
+        assert result["quality"] == "Digital"
+
+    def test_group_without_quality(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("[Team] Dragon Ball - c100 (v10).cbr")
+        assert result is not None
+        assert result["series_name"] == "Dragon Ball"
+        assert result["chapter_number"] == 100.0
+        assert result["volume_number"] == 10
+        assert result["group"] == "Team"
+        assert result["quality"] is None
+
+    def test_group_minimal(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("[SL] Demon Slayer - c205.cbz")
+        assert result is not None
+        assert result["series_name"] == "Demon Slayer"
+        assert result["chapter_number"] == 205.0
+        assert result["group"] == "SL"
+
+
+class TestVolumeChapterStyle:
+    """Pattern: Title v01 c001.cbz"""
+
+    def test_volume_and_chapter(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Berserk v01 c001.cbz")
+        assert result is not None
+        assert result["series_name"] == "Berserk"
+        assert result["chapter_number"] == 1.0
+        assert result["volume_number"] == 1
+        assert result["group"] is None
+        assert result["quality"] is None
+
+    def test_high_numbers(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("One Piece v103 c1044.cbz")
+        assert result is not None
+        assert result["series_name"] == "One Piece"
+        assert result["chapter_number"] == 1044.0
+        assert result["volume_number"] == 103
+
+
+class TestExplicitChapterLabel:
+    """Pattern: Title - Chapter 001.cbz"""
+
+    def test_chapter_label(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Attack on Titan - Chapter 139.cbz")
+        assert result is not None
+        assert result["series_name"] == "Attack on Titan"
+        assert result["chapter_number"] == 139.0
+        assert result["volume_number"] is None
+
+    def test_chapter_label_lowercase(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("My Hero Academia - chapter 001.cbz")
+        assert result is not None
+        assert result["series_name"] == "My Hero Academia"
+        assert result["chapter_number"] == 1.0
+
+
+class TestAbbreviatedVolChapter:
+    """Pattern: Title Vol.01 Ch.001.cbz"""
+
+    def test_abbreviated_with_dots(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Jujutsu Kaisen Vol.15 Ch.130.cbz")
+        assert result is not None
+        assert result["series_name"] == "Jujutsu Kaisen"
+        assert result["chapter_number"] == 130.0
+        assert result["volume_number"] == 15
+
+    def test_abbreviated_without_dots(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Spy x Family Vol 10 Ch 62.cbz")
+        assert result is not None
+        assert result["series_name"] == "Spy x Family"
+        assert result["chapter_number"] == 62.0
+        assert result["volume_number"] == 10
+
+
+class TestBareNumber:
+    """Pattern: Title 001.cbz — bare number = chapter"""
+
+    def test_bare_number(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Vagabond 327.cbz")
+        assert result is not None
+        assert result["series_name"] == "Vagabond"
+        assert result["chapter_number"] == 327.0
+        assert result["volume_number"] is None
+
+    def test_bare_number_zero_padded(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Slam Dunk 001.cbz")
+        assert result is not None
+        assert result["series_name"] == "Slam Dunk"
+        assert result["chapter_number"] == 1.0
+
+
+class TestVolumeOnly:
+    """Pattern: Title v01.cbz — volume only"""
+
+    def test_volume_only(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Death Note v12.cbz")
+        assert result is not None
+        assert result["series_name"] == "Death Note"
+        assert result["chapter_number"] is None
+        assert result["volume_number"] == 12
+
+    def test_volume_only_uppercase_v(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Fullmetal Alchemist V27.cbz")
+        assert result is not None
+        assert result["series_name"] == "Fullmetal Alchemist"
+        assert result["volume_number"] == 27
+
+
+class TestDecimalChapters:
+    """Edge case: decimal chapter numbers like 686.5"""
+
+    def test_decimal_chapter_bare(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach 686.5.cbz")
+        assert result is not None
+        assert result["series_name"] == "Bleach"
+        assert result["chapter_number"] == 686.5
+
+    def test_decimal_chapter_with_c_prefix(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach c686.5.cbz")
+        assert result is not None
+        assert result["series_name"] == "Bleach"
+        assert result["chapter_number"] == 686.5
+
+    def test_decimal_chapter_in_group_pattern(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("[Viz] Bleach - c686.5 (v74) [HQ].cbz")
+        assert result is not None
+        assert result["chapter_number"] == 686.5
+
+
+class TestChapterRanges:
+    """Edge case: chapter ranges like c001-003 take the first chapter."""
+
+    def test_range_with_group(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("[Group] Title - c001-c003 [HQ].cbz")
+        assert result is not None
+        assert result["chapter_number"] == 1.0
+
+    def test_range_without_c_prefix_on_end(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("[Group] Title - c001-003 [HQ].cbz")
+        assert result is not None
+        assert result["chapter_number"] == 1.0
+
+
+class TestValidExtensions:
+    """Only .cbr, .cbz, .cb7, .pdf should be accepted."""
+
+    def test_cbr_accepted(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach v1.cbr")
+        assert result is not None
+
+    def test_cbz_accepted(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach v1.cbz")
+        assert result is not None
+
+    def test_cb7_accepted(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach v1.cb7")
+        assert result is not None
+
+    def test_pdf_accepted(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach v1.pdf")
+        assert result is not None
+
+    def test_jpg_rejected(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("cover.jpg")
+        assert result is None
+
+    def test_txt_rejected(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("readme.txt")
+        assert result is None
+
+    def test_no_extension_rejected(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach v1")
+        assert result is None
+
+    def test_case_insensitive_extension(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach v1.CBZ")
+        assert result is not None
+
+
+class TestUnparseableInput:
+    """Filenames with no parseable numbers should return None."""
+
+    def test_no_numbers(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Just a Title.cbz")
+        assert result is None
+
+    def test_empty_string(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("")
+        assert result is None
+
+    def test_only_extension(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename(".cbz")
+        assert result is None
+
+
+class TestDirectoryStripping:
+    """Parser should handle full paths by stripping directory components."""
+
+    def test_full_path(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("/manga/Bleach/Bleach v1.cbz")
+        assert result is not None
+        assert result["series_name"] == "Bleach"
+        assert result["volume_number"] == 1
+
+    def test_relative_path(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("manga/Chainsaw Man/Chainsaw Man 165.cbz")
+        assert result is not None
+        assert result["series_name"] == "Chainsaw Man"
+        assert result["chapter_number"] == 165.0
+
+
+class TestResultStructure:
+    """Verify the result dict always has the expected keys."""
+
+    def test_all_keys_present(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("[Viz] One Piece - c1044 (v103) [HQ].cbz")
+        assert result is not None
+        expected_keys = {"series_name", "chapter_number", "volume_number", "group", "quality"}
+        assert set(result.keys()) == expected_keys
+
+    def test_minimal_result_keys(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach v1.cbz")
+        assert result is not None
+        expected_keys = {"series_name", "chapter_number", "volume_number", "group", "quality"}
+        assert set(result.keys()) == expected_keys
+
+    def test_chapter_number_is_float_or_none(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        # When present, chapter_number should be a float
+        result = parse_manga_filename("Bleach 100.cbz")
+        assert isinstance(result["chapter_number"], float)
+
+        # When absent, chapter_number should be None
+        result = parse_manga_filename("Bleach v1.cbz")
+        assert result["chapter_number"] is None
+
+    def test_volume_number_is_int_or_none(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        # When present, volume_number should be an int
+        result = parse_manga_filename("Bleach v1.cbz")
+        assert isinstance(result["volume_number"], int)
+
+        # When absent, volume_number should be None
+        result = parse_manga_filename("Bleach 100.cbz")
+        assert result["volume_number"] is None

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -1,0 +1,315 @@
+#  Copyright (C) 2025-2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Unit tests for manga post-processing in comicarr/postprocessor.py.
+
+Tests cover the _process_manga() method and the manga branch in Process().
+"""
+
+import queue
+from unittest.mock import MagicMock, patch
+
+import comicarr
+
+# Ensure LOG_LEVEL is set for tests
+if comicarr.LOG_LEVEL is None:
+    comicarr.LOG_LEVEL = 0
+
+from comicarr.postprocessor import PostProcessor
+
+
+def _make_pp(nzb_name, nzb_folder, comicid=None, issueid=None, apicall=False):
+    """Create a PostProcessor instance with mocks for queue and APILOCK."""
+    mock_queue = MagicMock(spec=queue.Queue)
+    mock_apilock = MagicMock()
+    mock_apilock.locked.return_value = False
+
+    mock_config = MagicMock()
+    mock_config.FILE_OPTS = "move"
+    mock_config.IGNORE_SEARCH_WORDS = []
+    mock_config.PRE_SCRIPTS = None
+
+    with patch.object(comicarr, "APILOCK", mock_apilock), \
+         patch.object(comicarr, "CONFIG", mock_config):
+        pp = PostProcessor(
+            nzb_name=nzb_name,
+            nzb_folder=nzb_folder,
+            comicid=comicid,
+            issueid=issueid,
+            queue=mock_queue,
+            apicall=apicall,
+        )
+    return pp, mock_queue
+
+
+class TestMangaBranchDetection:
+    """Tests for the manga branch guard in Process()."""
+
+    def test_md_prefix_triggers_manga_branch(self):
+        """ComicID starting with 'md-' should trigger _process_manga."""
+        pp, mock_queue = _make_pp(
+            nzb_name="Chainsaw Man 165.cbz",
+            nzb_folder="/tmp/downloads",
+            comicid="md-abc123",
+            apicall=True,
+        )
+        with patch.object(pp, "_process_manga", return_value=None) as mock_pm:
+            pp.Process()
+            mock_pm.assert_called_once()
+
+    def test_regular_comicid_skips_manga_branch(self):
+        """A non-md ComicID should NOT call _process_manga."""
+        pp, mock_queue = _make_pp(
+            nzb_name="Batman 001.cbz",
+            nzb_folder="/tmp/downloads",
+            comicid="12345",
+            issueid="67890",
+            apicall=True,
+        )
+        with patch.object(pp, "_process_manga") as mock_pm, \
+             patch("comicarr.postprocessor.filechecker") as mock_fc, \
+             patch("comicarr.postprocessor.db") as mock_db:
+            mock_db.select_one.return_value = {"ComicID": "12345"}
+            mock_fc.FileChecker.return_value.listFiles.return_value = {
+                "comiccount": 0, "comiclist": []
+            }
+            try:
+                pp.Process()
+            except Exception:
+                pass
+            mock_pm.assert_not_called()
+
+    def test_none_comicid_skips_manga_branch(self):
+        """When comicid is None, manga branch should be skipped."""
+        pp, mock_queue = _make_pp(
+            nzb_name="Manual Run",
+            nzb_folder="/tmp/downloads",
+            comicid=None,
+            apicall=True,
+        )
+        with patch.object(pp, "_process_manga") as mock_pm:
+            try:
+                pp.Process()
+            except Exception:
+                pass
+            mock_pm.assert_not_called()
+
+
+class TestProcessMangaSeriesLookup:
+    """Tests for the comic/series lookup in _process_manga."""
+
+    def test_comic_not_found_returns_stop(self, tmp_path):
+        """When series is not in the database, should return stop."""
+        pp, mock_queue = _make_pp(
+            nzb_name="Bleach v1.cbz",
+            nzb_folder=str(tmp_path),
+            comicid="md-bleach",
+        )
+
+        with patch("comicarr.postprocessor.db") as mock_db:
+            mock_db.select_one.return_value = None
+            pp._process_manga()
+
+        mock_queue.put.assert_called_once()
+        result = mock_queue.put.call_args[0][0]
+        assert result[0]["mode"] == "stop"
+        assert "Cannot find manga series" in result[0]["self.log"]
+
+
+class TestProcessMangaNoFiles:
+    """Tests for when no manga files are in the download directory."""
+
+    def test_no_files_returns_stop(self, tmp_path):
+        """When no manga files exist in download dir, should return stop."""
+        (tmp_path / "readme.txt").write_text("not a manga")
+
+        pp, mock_queue = _make_pp(
+            nzb_name="something",
+            nzb_folder=str(tmp_path),
+            comicid="md-bleach",
+        )
+
+        comic_row = {"ComicName": "Bleach", "ComicLocation": "/manga/Bleach"}
+
+        with patch("comicarr.postprocessor.db") as mock_db:
+            mock_db.select_one.return_value = comic_row
+            pp._process_manga()
+
+        mock_queue.put.assert_called_once()
+        result = mock_queue.put.call_args[0][0]
+        assert result[0]["mode"] == "stop"
+        assert "No manga files" in result[0]["self.log"]
+
+
+class TestProcessMangaNoDestination:
+    """Tests for when manga destination is not configured."""
+
+    def test_no_manga_destination_returns_stop(self, tmp_path):
+        """When get_manga_destination() returns None, should return stop."""
+        cbz = tmp_path / "Bleach v1.cbz"
+        cbz.write_bytes(b"fake cbz")
+
+        pp, mock_queue = _make_pp(
+            nzb_name="Bleach v1.cbz",
+            nzb_folder=str(tmp_path),
+            comicid="md-bleach",
+        )
+
+        comic_row = {"ComicName": "Bleach", "ComicLocation": None}
+
+        with patch("comicarr.postprocessor.db") as mock_db, \
+             patch("comicarr.postprocessor.get_manga_destination", return_value=None):
+            mock_db.select_one.return_value = comic_row
+            pp._process_manga()
+
+        mock_queue.put.assert_called_once()
+        result = mock_queue.put.call_args[0][0]
+        assert result[0]["mode"] == "stop"
+        assert "No manga destination" in result[0]["self.log"]
+
+
+class TestProcessMangaFileMove:
+    """Tests for file moving in _process_manga."""
+
+    def test_moves_files_to_series_folder(self, tmp_path):
+        """Should move manga files to the series folder."""
+        cbz = tmp_path / "Bleach v1.cbz"
+        cbz.write_bytes(b"fake cbz")
+
+        dest_dir = tmp_path / "manga" / "Bleach"
+        dest_dir.mkdir(parents=True)
+
+        pp, mock_queue = _make_pp(
+            nzb_name="Bleach v1.cbz",
+            nzb_folder=str(tmp_path),
+            comicid="md-bleach",
+        )
+
+        comic_row = {"ComicName": "Bleach", "ComicLocation": str(dest_dir)}
+
+        with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")), \
+             patch("comicarr.postprocessor.db") as mock_db:
+            # First call: comic lookup. Remaining: chapter/issue lookups return None
+            mock_db.select_one.side_effect = [comic_row, None, None, None]
+            pp.fileop = MagicMock()
+
+            pp._process_manga()
+
+        # fileop should have been called to move the file
+        pp.fileop.assert_called_once()
+        args = pp.fileop.call_args[0]
+        assert args[0] == str(cbz)
+        assert "Bleach v1.cbz" in args[1]
+
+    def test_move_failure_continues(self, tmp_path):
+        """When file move fails, should log error and continue."""
+        cbz = tmp_path / "Bleach v1.cbz"
+        cbz.write_bytes(b"fake cbz")
+
+        dest_dir = tmp_path / "manga" / "Bleach"
+        dest_dir.mkdir(parents=True)
+
+        pp, mock_queue = _make_pp(
+            nzb_name="Bleach v1.cbz",
+            nzb_folder=str(tmp_path),
+            comicid="md-bleach",
+        )
+
+        comic_row = {"ComicName": "Bleach", "ComicLocation": str(dest_dir)}
+
+        with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")), \
+             patch("comicarr.postprocessor.db") as mock_db:
+            mock_db.select_one.return_value = comic_row
+            pp.fileop = MagicMock(side_effect=OSError("Permission denied"))
+
+            pp._process_manga()
+
+        mock_queue.put.assert_called_once()
+        result = mock_queue.put.call_args[0][0]
+        assert "0 files matched" in result[0]["self.log"]
+
+
+class TestProcessMangaChapterMatch:
+    """Tests for chapter matching and DB updates."""
+
+    def test_matches_chapter_and_updates_status(self, tmp_path):
+        """Should match file to chapter via db.select_one and update status."""
+        cbz = tmp_path / "Chainsaw Man 165.cbz"
+        cbz.write_bytes(b"fake cbz")
+
+        dest_dir = tmp_path / "manga" / "Chainsaw Man"
+        dest_dir.mkdir(parents=True)
+
+        pp, mock_queue = _make_pp(
+            nzb_name="Chainsaw Man 165.cbz",
+            nzb_folder=str(tmp_path),
+            comicid="md-csm",
+        )
+
+        comic_row = {"ComicName": "Chainsaw Man", "ComicLocation": str(dest_dir)}
+        issue_row = {"IssueID": "md-csm-ch165", "ChapterNumber": "165", "ComicID": "md-csm"}
+        have_count = {"count_1": 5}
+
+        mock_conn = MagicMock()
+
+        with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")), \
+             patch("comicarr.postprocessor.db") as mock_db:
+            # select_one calls: 1) comic lookup, 2) chapter match, 3) have count
+            mock_db.select_one.side_effect = [comic_row, issue_row, have_count]
+            mock_db.get_engine.return_value.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+            mock_db.get_engine.return_value.begin.return_value.__exit__ = MagicMock(return_value=False)
+            pp.fileop = MagicMock()
+
+            pp._process_manga()
+
+        # Should have updated issue status
+        mock_db.upsert.assert_any_call(
+            "issues",
+            {"Status": "Downloaded", "Location": "Chainsaw Man 165.cbz"},
+            {"IssueID": "md-csm-ch165"},
+        )
+
+        result = mock_queue.put.call_args[0][0]
+        assert "Post Processing SUCCESSFUL" in result[0]["self.log"]
+
+    def test_unmatched_file_logs_warning(self, tmp_path):
+        """When no chapter matches, should log warning but not crash."""
+        cbz = tmp_path / "Chainsaw Man 999.cbz"
+        cbz.write_bytes(b"fake cbz")
+
+        dest_dir = tmp_path / "manga" / "Chainsaw Man"
+        dest_dir.mkdir(parents=True)
+
+        pp, mock_queue = _make_pp(
+            nzb_name="Chainsaw Man 999.cbz",
+            nzb_folder=str(tmp_path),
+            comicid="md-csm",
+        )
+
+        comic_row = {"ComicName": "Chainsaw Man", "ComicLocation": str(dest_dir)}
+
+        with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")), \
+             patch("comicarr.postprocessor.db") as mock_db:
+            # comic lookup succeeds, all chapter/issue lookups return None
+            mock_db.select_one.side_effect = [comic_row, None, None, None]
+            pp.fileop = MagicMock()
+
+            pp._process_manga()
+
+        result = mock_queue.put.call_args[0][0]
+        assert "0 files matched" in result[0]["self.log"]

--- a/tests/unit/test_manga_rss.py
+++ b/tests/unit/test_manga_rss.py
@@ -38,7 +38,7 @@ def _make_series(comic_id="md-abc123", name="One Piece", year="1999", status="Ac
     }
 
 
-def _make_chapter(comic_id="md-abc123", issue_id="md-abc123-ch-100", ch_num="100", status="Wanted"):
+def _make_chapter(comic_id="md-abc123", issue_id="md-abc123-ch100", ch_num="100", status="Wanted"):
     return {
         "IssueID": issue_id,
         "ComicID": comic_id,
@@ -136,8 +136,8 @@ class TestMangaCheck:
     @patch("comicarr.search.search_init")
     def test_handles_search_error_gracefully(self, mock_search_init, mock_db, mock_helpers):
         series = _make_series()
-        ch1 = _make_chapter(ch_num="100", issue_id="md-abc123-ch-100")
-        ch2 = _make_chapter(ch_num="101", issue_id="md-abc123-ch-101")
+        ch1 = _make_chapter(ch_num="100", issue_id="md-abc123-ch100")
+        ch2 = _make_chapter(ch_num="101", issue_id="md-abc123-ch101")
 
         mock_db.select_all.side_effect = [
             [series],
@@ -233,7 +233,7 @@ class TestMangadexNewChapterCheck:
         assert value_dict["Status"] == "Wanted"
         assert value_dict["VolumeNumber"] == "1"
         key_dict = first_call[0][2]
-        assert key_dict["IssueID"] == "md-abc123-ch-1"
+        assert key_dict["IssueID"] == "md-abc123-ch1"
 
     @patch("comicarr.rsscheck.db")
     @patch("comicarr.mangadex.get_all_chapters")
@@ -242,7 +242,7 @@ class TestMangadexNewChapterCheck:
 
         mock_db.select_all.side_effect = [
             [series],
-            [{"IssueID": "md-abc123-ch-1", "ChapterNumber": "1"}],  # ch 1 exists
+            [{"IssueID": "md-abc123-ch1", "ChapterNumber": "1"}],  # ch 1 exists
         ]
         mock_get_chapters.return_value = [
             {"id": "ch-uuid-1", "chapter": "1", "volume": None, "title": "Ch 1"},

--- a/tests/unit/test_manga_rss.py
+++ b/tests/unit/test_manga_rss.py
@@ -1,0 +1,334 @@
+#  Copyright (C) 2025-2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""
+Unit tests for manga RSS / chapter monitoring in comicarr/rsscheck.py.
+
+Tests cover mangaCheck() and mangadexNewChapterCheck() — the two additive
+functions for manga series monitoring.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_series(comic_id="md-abc123", name="One Piece", year="1999", status="Active"):
+    return {
+        "ComicID": comic_id,
+        "ComicName": name,
+        "ComicYear": year,
+        "Status": status,
+        "ComicPublisher": "Shueisha",
+        "AlternateSearch": None,
+        "UseFuzzy": None,
+        "ComicVersion": None,
+        "ComicName_Filesafe": name,
+    }
+
+
+def _make_chapter(comic_id="md-abc123", issue_id="md-abc123-ch-100", ch_num="100", status="Wanted"):
+    return {
+        "IssueID": issue_id,
+        "ComicID": comic_id,
+        "ComicName": "One Piece",
+        "Issue_Number": ch_num,
+        "ChapterNumber": ch_num,
+        "Status": status,
+        "IssueDate": "2026-01-01",
+        "ReleaseDate": "2026-01-01",
+        "DigitalDate": "0000-00-00",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module():
+    """Remove rsscheck from the module cache so each test gets a fresh import
+    with its own patches applied."""
+    mods_to_remove = [k for k in sys.modules if k.startswith("comicarr.rsscheck")]
+    for m in mods_to_remove:
+        del sys.modules[m]
+    yield
+    mods_to_remove = [k for k in sys.modules if k.startswith("comicarr.rsscheck")]
+    for m in mods_to_remove:
+        del sys.modules[m]
+
+
+# ---------------------------------------------------------------------------
+# mangaCheck tests
+# ---------------------------------------------------------------------------
+
+
+class TestMangaCheck:
+    """Tests for mangaCheck() — wanted chapter search triggering."""
+
+    @patch("comicarr.rsscheck.helpers")
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.search.search_init")
+    def test_skips_when_no_manga_series(self, mock_search_init, mock_db, mock_helpers):
+        mock_db.select_all.return_value = []
+
+        from comicarr.rsscheck import mangaCheck
+
+        mangaCheck()
+
+        mock_search_init.assert_not_called()
+
+    @patch("comicarr.CONFIG", MagicMock(FAILED_DOWNLOAD_HANDLING=False, FAILED_AUTO=False))
+    @patch("comicarr.rsscheck.helpers")
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.search.search_init")
+    def test_triggers_search_for_wanted_chapters(self, mock_search_init, mock_db, mock_helpers):
+        series = _make_series()
+        chapter = _make_chapter()
+
+        mock_db.select_all.side_effect = [
+            [series],   # first call: manga series query
+            [chapter],  # second call: wanted chapters query
+        ]
+        mock_helpers.issue_status.return_value = False  # not already downloaded
+
+        from comicarr.rsscheck import mangaCheck
+
+        mangaCheck()
+
+        assert mock_search_init.call_count == 1
+        call_kwargs = mock_search_init.call_args
+        # First positional arg is comic name
+        assert call_kwargs[0][0] == "One Piece"
+        # Check booktype kwarg
+        assert call_kwargs[1]["booktype"] == "manga"
+
+    @patch("comicarr.CONFIG", MagicMock(FAILED_DOWNLOAD_HANDLING=False, FAILED_AUTO=False))
+    @patch("comicarr.rsscheck.helpers")
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.search.search_init")
+    def test_skips_already_downloaded_chapters(self, mock_search_init, mock_db, mock_helpers):
+        series = _make_series()
+        chapter = _make_chapter()
+
+        mock_db.select_all.side_effect = [
+            [series],
+            [chapter],
+        ]
+        mock_helpers.issue_status.return_value = True  # already downloaded
+
+        from comicarr.rsscheck import mangaCheck
+
+        mangaCheck()
+
+        mock_search_init.assert_not_called()
+
+    @patch("comicarr.CONFIG", MagicMock(FAILED_DOWNLOAD_HANDLING=False, FAILED_AUTO=False))
+    @patch("comicarr.rsscheck.helpers")
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.search.search_init")
+    def test_handles_search_error_gracefully(self, mock_search_init, mock_db, mock_helpers):
+        series = _make_series()
+        ch1 = _make_chapter(ch_num="100", issue_id="md-abc123-ch-100")
+        ch2 = _make_chapter(ch_num="101", issue_id="md-abc123-ch-101")
+
+        mock_db.select_all.side_effect = [
+            [series],
+            [ch1, ch2],
+        ]
+        mock_helpers.issue_status.return_value = False
+        mock_search_init.side_effect = [Exception("provider down"), None]
+
+        from comicarr.rsscheck import mangaCheck
+
+        # Should not raise even though first search fails
+        mangaCheck()
+
+        assert mock_search_init.call_count == 2
+
+    @patch("comicarr.CONFIG", MagicMock(FAILED_DOWNLOAD_HANDLING=False, FAILED_AUTO=False))
+    @patch("comicarr.rsscheck.helpers")
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.search.search_init")
+    def test_skips_series_with_no_wanted_chapters(self, mock_search_init, mock_db, mock_helpers):
+        series = _make_series()
+
+        mock_db.select_all.side_effect = [
+            [series],
+            [],  # no wanted chapters
+        ]
+
+        from comicarr.rsscheck import mangaCheck
+
+        mangaCheck()
+
+        mock_search_init.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# mangadexNewChapterCheck tests
+# ---------------------------------------------------------------------------
+
+
+class TestMangadexNewChapterCheck:
+    """Tests for mangadexNewChapterCheck() — MangaDex polling for new chapters."""
+
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.mangadex.get_all_chapters")
+    def test_skips_when_no_manga_series(self, mock_get_chapters, mock_db):
+        mock_db.select_all.return_value = []
+
+        from comicarr.rsscheck import mangadexNewChapterCheck
+
+        mangadexNewChapterCheck()
+
+        mock_get_chapters.assert_not_called()
+
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.mangadex.get_all_chapters")
+    def test_adds_new_chapters_as_wanted(self, mock_get_chapters, mock_db):
+        series = _make_series()
+
+        # First call: manga series; second call: existing issues
+        mock_db.select_all.side_effect = [
+            [series],
+            [],  # no existing issues
+        ]
+        mock_get_chapters.return_value = [
+            {
+                "id": "ch-uuid-1",
+                "chapter": "1",
+                "volume": "1",
+                "title": "Romance Dawn",
+                "publish_at": "1999-07-22T00:00:00+00:00",
+            },
+            {
+                "id": "ch-uuid-2",
+                "chapter": "2",
+                "volume": "1",
+                "title": "They Call Him Straw Hat Luffy",
+                "publish_at": "1999-07-29T00:00:00+00:00",
+            },
+        ]
+
+        from comicarr.rsscheck import mangadexNewChapterCheck
+
+        mangadexNewChapterCheck()
+
+        assert mock_db.upsert.call_count == 2
+
+        # Verify first upsert call
+        first_call = mock_db.upsert.call_args_list[0]
+        assert first_call[0][0] == "issues"  # table name
+        value_dict = first_call[0][1]
+        assert value_dict["ComicName"] == "One Piece"
+        assert value_dict["ChapterNumber"] == "1"
+        assert value_dict["Status"] == "Wanted"
+        assert value_dict["VolumeNumber"] == "1"
+        key_dict = first_call[0][2]
+        assert key_dict["IssueID"] == "md-abc123-ch-1"
+
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.mangadex.get_all_chapters")
+    def test_skips_existing_chapters(self, mock_get_chapters, mock_db):
+        series = _make_series()
+
+        mock_db.select_all.side_effect = [
+            [series],
+            [{"IssueID": "md-abc123-ch-1", "ChapterNumber": "1"}],  # ch 1 exists
+        ]
+        mock_get_chapters.return_value = [
+            {"id": "ch-uuid-1", "chapter": "1", "volume": None, "title": "Ch 1"},
+            {"id": "ch-uuid-2", "chapter": "2", "volume": None, "title": "Ch 2"},
+        ]
+
+        from comicarr.rsscheck import mangadexNewChapterCheck
+
+        mangadexNewChapterCheck()
+
+        # Only chapter 2 should be inserted (chapter 1 already exists)
+        assert mock_db.upsert.call_count == 1
+        value_dict = mock_db.upsert.call_args_list[0][0][1]
+        assert value_dict["ChapterNumber"] == "2"
+
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.mangadex.get_all_chapters")
+    def test_handles_api_error_gracefully(self, mock_get_chapters, mock_db):
+        series = _make_series()
+
+        mock_db.select_all.side_effect = [
+            [series],
+            [],
+        ]
+        mock_get_chapters.side_effect = Exception("API timeout")
+
+        from comicarr.rsscheck import mangadexNewChapterCheck
+
+        # Should not raise
+        mangadexNewChapterCheck()
+
+        mock_db.upsert.assert_not_called()
+
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.mangadex.get_all_chapters")
+    def test_skips_chapters_with_no_number(self, mock_get_chapters, mock_db):
+        series = _make_series()
+
+        mock_db.select_all.side_effect = [
+            [series],
+            [],
+        ]
+        mock_get_chapters.return_value = [
+            {"id": "ch-uuid-1", "chapter": None, "volume": "1", "title": "Oneshot"},
+        ]
+
+        from comicarr.rsscheck import mangadexNewChapterCheck
+
+        mangadexNewChapterCheck()
+
+        mock_db.upsert.assert_not_called()
+
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.mangadex.get_all_chapters")
+    def test_handles_none_from_api(self, mock_get_chapters, mock_db):
+        series = _make_series()
+
+        mock_db.select_all.side_effect = [
+            [series],
+            [],
+        ]
+        mock_get_chapters.return_value = None
+
+        from comicarr.rsscheck import mangadexNewChapterCheck
+
+        # Should not raise
+        mangadexNewChapterCheck()
+
+        mock_db.upsert.assert_not_called()
+
+    @patch("comicarr.rsscheck.db")
+    @patch("comicarr.mangadex.get_all_chapters")
+    def test_volume_number_none_when_not_provided(self, mock_get_chapters, mock_db):
+        series = _make_series()
+
+        mock_db.select_all.side_effect = [
+            [series],
+            [],
+        ]
+        mock_get_chapters.return_value = [
+            {"id": "ch-uuid-1", "chapter": "5", "volume": None, "title": "Ch 5"},
+        ]
+
+        from comicarr.rsscheck import mangadexNewChapterCheck
+
+        mangadexNewChapterCheck()
+
+        value_dict = mock_db.upsert.call_args_list[0][0][1]
+        assert value_dict["VolumeNumber"] is None

--- a/tests/unit/test_manga_rss.py
+++ b/tests/unit/test_manga_rss.py
@@ -73,6 +73,7 @@ def _isolate_module():
 class TestMangaCheck:
     """Tests for mangaCheck() — wanted chapter search triggering."""
 
+    @patch("comicarr.CONFIG", MagicMock(FAILED_DOWNLOAD_HANDLING=False, FAILED_AUTO=False))
     @patch("comicarr.rsscheck.helpers")
     @patch("comicarr.rsscheck.db")
     @patch("comicarr.search.search_init")
@@ -177,6 +178,7 @@ class TestMangaCheck:
 # ---------------------------------------------------------------------------
 
 
+@patch("comicarr.CONFIG", MagicMock())
 class TestMangadexNewChapterCheck:
     """Tests for mangadexNewChapterCheck() — MangaDex polling for new chapters."""
 

--- a/tests/unit/test_manga_rss.py
+++ b/tests/unit/test_manga_rss.py
@@ -14,10 +14,9 @@ Tests cover mangaCheck() and mangadexNewChapterCheck() — the two additive
 functions for manga series monitoring.
 """
 
-import sys
 from unittest.mock import MagicMock, patch
 
-import pytest
+from comicarr.rsscheck import mangaCheck, mangadexNewChapterCheck
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -49,20 +48,8 @@ def _make_chapter(comic_id="md-abc123", issue_id="md-abc123-ch100", ch_num="100"
         "IssueDate": "2026-01-01",
         "ReleaseDate": "2026-01-01",
         "DigitalDate": "0000-00-00",
+        "VolumeNumber": None,
     }
-
-
-@pytest.fixture(autouse=True)
-def _isolate_module():
-    """Remove rsscheck from the module cache so each test gets a fresh import
-    with its own patches applied."""
-    mods_to_remove = [k for k in sys.modules if k.startswith("comicarr.rsscheck")]
-    for m in mods_to_remove:
-        del sys.modules[m]
-    yield
-    mods_to_remove = [k for k in sys.modules if k.startswith("comicarr.rsscheck")]
-    for m in mods_to_remove:
-        del sys.modules[m]
 
 
 # ---------------------------------------------------------------------------
@@ -80,8 +67,6 @@ class TestMangaCheck:
     def test_skips_when_no_manga_series(self, mock_search_init, mock_db, mock_helpers):
         mock_db.select_all.return_value = []
 
-        from comicarr.rsscheck import mangaCheck
-
         mangaCheck()
 
         mock_search_init.assert_not_called()
@@ -95,20 +80,16 @@ class TestMangaCheck:
         chapter = _make_chapter()
 
         mock_db.select_all.side_effect = [
-            [series],   # first call: manga series query
-            [chapter],  # second call: wanted chapters query
+            [series],
+            [chapter],
         ]
-        mock_helpers.issue_status.return_value = False  # not already downloaded
-
-        from comicarr.rsscheck import mangaCheck
+        mock_helpers.issue_status.return_value = False
 
         mangaCheck()
 
         assert mock_search_init.call_count == 1
         call_kwargs = mock_search_init.call_args
-        # First positional arg is comic name
         assert call_kwargs[0][0] == "One Piece"
-        # Check booktype kwarg
         assert call_kwargs[1]["booktype"] == "manga"
 
     @patch("comicarr.CONFIG", MagicMock(FAILED_DOWNLOAD_HANDLING=False, FAILED_AUTO=False))
@@ -123,9 +104,7 @@ class TestMangaCheck:
             [series],
             [chapter],
         ]
-        mock_helpers.issue_status.return_value = True  # already downloaded
-
-        from comicarr.rsscheck import mangaCheck
+        mock_helpers.issue_status.return_value = True
 
         mangaCheck()
 
@@ -147,9 +126,6 @@ class TestMangaCheck:
         mock_helpers.issue_status.return_value = False
         mock_search_init.side_effect = [Exception("provider down"), None]
 
-        from comicarr.rsscheck import mangaCheck
-
-        # Should not raise even though first search fails
         mangaCheck()
 
         assert mock_search_init.call_count == 2
@@ -163,10 +139,8 @@ class TestMangaCheck:
 
         mock_db.select_all.side_effect = [
             [series],
-            [],  # no wanted chapters
+            [],
         ]
-
-        from comicarr.rsscheck import mangaCheck
 
         mangaCheck()
 
@@ -187,8 +161,6 @@ class TestMangadexNewChapterCheck:
     def test_skips_when_no_manga_series(self, mock_get_chapters, mock_db):
         mock_db.select_all.return_value = []
 
-        from comicarr.rsscheck import mangadexNewChapterCheck
-
         mangadexNewChapterCheck()
 
         mock_get_chapters.assert_not_called()
@@ -198,10 +170,9 @@ class TestMangadexNewChapterCheck:
     def test_adds_new_chapters_as_wanted(self, mock_get_chapters, mock_db):
         series = _make_series()
 
-        # First call: manga series; second call: existing issues
         mock_db.select_all.side_effect = [
             [series],
-            [],  # no existing issues
+            [],
         ]
         mock_get_chapters.return_value = [
             {
@@ -220,15 +191,12 @@ class TestMangadexNewChapterCheck:
             },
         ]
 
-        from comicarr.rsscheck import mangadexNewChapterCheck
-
         mangadexNewChapterCheck()
 
         assert mock_db.upsert.call_count == 2
 
-        # Verify first upsert call
         first_call = mock_db.upsert.call_args_list[0]
-        assert first_call[0][0] == "issues"  # table name
+        assert first_call[0][0] == "issues"
         value_dict = first_call[0][1]
         assert value_dict["ComicName"] == "One Piece"
         assert value_dict["ChapterNumber"] == "1"
@@ -244,18 +212,15 @@ class TestMangadexNewChapterCheck:
 
         mock_db.select_all.side_effect = [
             [series],
-            [{"IssueID": "md-abc123-ch1", "ChapterNumber": "1"}],  # ch 1 exists
+            [{"IssueID": "md-abc123-ch1", "ChapterNumber": "1"}],
         ]
         mock_get_chapters.return_value = [
             {"id": "ch-uuid-1", "chapter": "1", "volume": None, "title": "Ch 1"},
             {"id": "ch-uuid-2", "chapter": "2", "volume": None, "title": "Ch 2"},
         ]
 
-        from comicarr.rsscheck import mangadexNewChapterCheck
-
         mangadexNewChapterCheck()
 
-        # Only chapter 2 should be inserted (chapter 1 already exists)
         assert mock_db.upsert.call_count == 1
         value_dict = mock_db.upsert.call_args_list[0][0][1]
         assert value_dict["ChapterNumber"] == "2"
@@ -271,9 +236,6 @@ class TestMangadexNewChapterCheck:
         ]
         mock_get_chapters.side_effect = Exception("API timeout")
 
-        from comicarr.rsscheck import mangadexNewChapterCheck
-
-        # Should not raise
         mangadexNewChapterCheck()
 
         mock_db.upsert.assert_not_called()
@@ -291,8 +253,6 @@ class TestMangadexNewChapterCheck:
             {"id": "ch-uuid-1", "chapter": None, "volume": "1", "title": "Oneshot"},
         ]
 
-        from comicarr.rsscheck import mangadexNewChapterCheck
-
         mangadexNewChapterCheck()
 
         mock_db.upsert.assert_not_called()
@@ -308,9 +268,6 @@ class TestMangadexNewChapterCheck:
         ]
         mock_get_chapters.return_value = None
 
-        from comicarr.rsscheck import mangadexNewChapterCheck
-
-        # Should not raise
         mangadexNewChapterCheck()
 
         mock_db.upsert.assert_not_called()
@@ -327,8 +284,6 @@ class TestMangadexNewChapterCheck:
         mock_get_chapters.return_value = [
             {"id": "ch-uuid-1", "chapter": "5", "volume": None, "title": "Ch 5"},
         ]
-
-        from comicarr.rsscheck import mangadexNewChapterCheck
 
         mangadexNewChapterCheck()
 

--- a/tests/unit/test_manga_search.py
+++ b/tests/unit/test_manga_search.py
@@ -1,0 +1,163 @@
+"""
+Unit tests for manga search query construction in comicarr/search.py.
+
+Tests cover _build_manga_search_terms() which generates NZB/torrent-provider
+query variations for manga chapters and volumes.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+# Patch the logger so _build_manga_search_terms can be imported without
+# initializing the full comicarr application.
+@pytest.fixture(autouse=True)
+def _mock_logger():
+    with patch("comicarr.search.logger") as mock_log:
+        mock_log.fdebug = lambda *a, **kw: None
+        yield mock_log
+
+
+def _build():
+    from comicarr.search import _build_manga_search_terms
+
+    return _build_manga_search_terms
+
+
+class TestBuildMangaSearchTermsChapterOnly:
+    """When only a chapter number is provided (no volume)."""
+
+    def test_integer_chapter(self):
+        build = _build()
+        terms = build("One Piece", "1044", None)
+        assert '"One Piece" c1044' not in terms  # not quoted — raw name
+        assert "One Piece c1044" in terms
+        assert "One Piece chapter 1044" in terms
+
+    def test_single_digit_chapter_is_zero_padded(self):
+        build = _build()
+        terms = build("Naruto", "5", None)
+        assert "Naruto c005" in terms
+        assert "Naruto chapter 005" in terms
+
+    def test_two_digit_chapter_is_zero_padded(self):
+        build = _build()
+        terms = build("Bleach", "42", None)
+        assert "Bleach c042" in terms
+        assert "Bleach chapter 042" in terms
+
+    def test_three_digit_chapter_no_extra_padding(self):
+        build = _build()
+        terms = build("Dragon Ball", "100", None)
+        assert "Dragon Ball c100" in terms
+        assert "Dragon Ball chapter 100" in terms
+
+    def test_decimal_chapter(self):
+        build = _build()
+        terms = build("Chainsaw Man", "10.5", None)
+        # Decimal chapters get formatted as e.g. "0010.5"
+        assert any("c" in t and "10.5" in t for t in terms)
+        assert any("chapter" in t and "10.5" in t for t in terms)
+
+    def test_no_volume_term_when_volume_is_none(self):
+        build = _build()
+        terms = build("Naruto", "700", None)
+        assert not any("v" in t.split()[-1] for t in terms if "c" not in t.split()[-1])
+
+
+class TestBuildMangaSearchTermsVolumeOnly:
+    """When only a volume number is provided (no chapter)."""
+
+    def test_single_digit_volume(self):
+        build = _build()
+        terms = build("Bleach", None, "1")
+        assert "Bleach v01" in terms
+
+    def test_two_digit_volume(self):
+        build = _build()
+        terms = build("One Piece", None, "103")
+        assert "One Piece v103" in terms
+
+    def test_no_chapter_terms_when_chapter_is_none(self):
+        build = _build()
+        terms = build("Bleach", None, "5")
+        assert not any("chapter" in t for t in terms)
+        assert not any(" c0" in t or " c1" in t for t in terms)
+
+
+class TestBuildMangaSearchTermsCombined:
+    """When both chapter and volume are provided."""
+
+    def test_combined_term_is_first(self):
+        build = _build()
+        terms = build("One Piece", "1044", "103")
+        # Combined should be first (most specific)
+        assert terms[0] == "One Piece v103c1044"
+
+    def test_all_variations_present(self):
+        build = _build()
+        terms = build("One Piece", "1044", "103")
+        assert "One Piece v103c1044" in terms
+        assert "One Piece c1044" in terms
+        assert "One Piece chapter 1044" in terms
+        assert "One Piece v103" in terms
+
+    def test_combined_zero_padding(self):
+        build = _build()
+        terms = build("Naruto", "5", "2")
+        assert "Naruto v02c005" in terms
+        assert "Naruto c005" in terms
+        assert "Naruto v02" in terms
+
+
+class TestBuildMangaSearchTermsEdgeCases:
+    """Edge cases and error handling."""
+
+    def test_empty_series_name_returns_empty(self):
+        build = _build()
+        assert build("", "1", "1") == []
+
+    def test_none_series_name_returns_empty(self):
+        build = _build()
+        assert build(None, "1", "1") == []
+
+    def test_both_none_returns_empty(self):
+        build = _build()
+        assert build("Test", None, None) == []
+
+    def test_whitespace_stripped_from_name(self):
+        build = _build()
+        terms = build("  One Piece  ", "1", None)
+        assert "One Piece c001" in terms
+
+    def test_non_numeric_chapter_used_as_string(self):
+        build = _build()
+        terms = build("Test Series", "Special", None)
+        assert any("cSpecial" in t for t in terms)
+
+    def test_non_numeric_volume_used_as_string(self):
+        build = _build()
+        terms = build("Test Series", None, "TBD")
+        assert any("vTBD" in t for t in terms)
+
+    def test_chapter_zero(self):
+        build = _build()
+        terms = build("Test", "0", None)
+        assert "Test c000" in terms
+        assert "Test chapter 000" in terms
+
+    def test_large_chapter_number(self):
+        build = _build()
+        terms = build("Test", "1500", None)
+        assert "Test c1500" in terms
+
+    def test_priority_order(self):
+        """Combined terms should come before individual terms."""
+        build = _build()
+        terms = build("Series", "10", "5")
+        combined_idx = terms.index("Series v05c010")
+        chapter_idx = terms.index("Series c010")
+        volume_idx = terms.index("Series v05")
+        assert combined_idx < chapter_idx
+        assert combined_idx < volume_idx

--- a/uv.lock
+++ b/uv.lock
@@ -353,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "comicarr"
-version = "0.10.2"
+version = "0.10.4"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

- Add complete manga support across config, UI, import, search, download, and dashboard
- Enable MangaDex by default, add dedicated manga directory configuration with Docker defaults
- Create manga filename parser supporting common naming conventions (volume-based, chapter-based, scanlator group)
- Build manga library scanner to import existing collections from disk
- Extend NZB/torrent search and post-processing pipelines with ContentType-aware manga branching
- Add manga RSS monitoring and MangaDex new chapter detection
- Show manga stats breakdown on dashboard alongside comics

## Changes

### Backend (Python)
| File | Change |
|------|--------|
| `config.py` | Add `MANGA_DIR`, `MANGA_DESTINATION_DIR`, `get_manga_destination()`, change `MANGADEX_ENABLED` default to `True`, Docker `/manga` default |
| `manga_parser.py` | **New** — Pure-function filename parser for manga naming conventions |
| `mangasync.py` | **New** — Manga library scanner (walk dir, group by series, match MangaDex, import) |
| `importer.py` | Route `addMangaToDB()` through centralized manga directory resolver |
| `search.py` | Add `content_type`/`chapter_number`/`volume_number` params, manga query construction |
| `postprocessor.py` | Add `_process_manga()` method with ContentType branch at `Process()` entry |
| `rsscheck.py` | Add `mangaCheck()` and `mangadexNewChapterCheck()` functions |
| `app/dashboard/service.py` | Add manga-specific stats (series count, completion %) |
| `app/series/router.py` | Add `/import/manga/scan` and `/import/manga/progress` endpoints |
| `app/series/service.py` | Add `manga_library_scan()` service function |
| `app/system/service.py` | Expose `MANGA_DIR` and `MANGA_DESTINATION_DIR` in `get_safe_config()` |

### Frontend (React/TypeScript)
| File | Change |
|------|--------|
| `GeneralTab.tsx` | Add content source toggles + manga directory fields |
| `ApiTab.tsx` | Remove content source toggles (moved to General) |
| `SettingsPage.tsx` | Pass `formData`/`onChange` to GeneralTab |
| `ImportPage.tsx` | Add "Scan Manga Library" card with progress tracking |
| `useImport.ts` | Add `useMangaScan()` and `useMangaScanProgress()` hooks |
| `CollectionStats.tsx` | Show manga stats breakdown when manga series exist |

### Tests (87 new tests)
| File | Tests |
|------|-------|
| `test_manga_parser.py` | 38 tests — all naming patterns, edge cases, extensions |
| `test_manga_search.py` | 21 tests — query construction, padding, priority order |
| `test_manga_postprocessor.py` | 10 tests — branch detection, file move, chapter matching |
| `test_manga_rss.py` | 12 tests — wanted search, new chapter detection, error handling |
| `test_importer_manga_dir.py` | 6 tests — directory fallback chain |

## Test plan

- [x] All 545 backend tests pass (87 new + 458 existing)
- [x] All 34 frontend tests pass
- [x] `ruff check` passes on all modified Python files
- [x] `tsc --noEmit` passes (zero TypeScript errors)
- [x] `eslint` passes (zero warnings)
- [x] Manga parser verified against real NAS filenames (`Bleach v1.cbz`, `Chainsaw Man 165.cbz`)

## Post-Deploy Monitoring & Validation

- **Log queries**: `[MANGA-SCAN]`, `[MANGADEX]`, `[SEARCH-MANGA]`, `[MANGA-RSS]`, `[DOCKER-AWARE]`
- **Metrics to watch**: MangaDex API rate limit errors, manga scan duration, chapter match rate
- **Expected healthy signals**: Manga series appear in library after scan, chapters marked as Downloaded for files on disk, dashboard shows manga stats
- **Failure signals**: `[MANGA-SCAN] Error processing series` logs, MangaDex API 429 responses, missing manga directory on Docker startup
- **Validation window**: 7 days post-deploy, monitor import scan results on NAS deployment
- **Rollback trigger**: If manga scan corrupts existing comic library data or causes MangaDex rate limiting that impacts metadata fetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)