### PR TITLE
fix: Resolve library pagination not responding to clicks

### DIFF
--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -90,10 +90,20 @@ export default function SeriesTable({
   );
   const [searchInput, setSearchInput] = useState(search);
 
-  // Sync URL-driven search changes (e.g. browser back/forward) into the input
+  // Local page state for immediate UI response. The nuqs `setParams` update
+  // goes through `startTransition` inside the React Router adapter, which can
+  // silently defer the state commit in React 19 production builds. By keeping
+  // a direct React state we guarantee the table re-renders on page change.
+  const [localPage, setLocalPage] = useState(params.page);
+
+  // Sync URL-driven changes (e.g. browser back/forward) into local state
   useEffect(() => {
     setSearchInput(search);
   }, [search]);
+
+  useEffect(() => {
+    setLocalPage(params.page);
+  }, [params.page]);
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -166,7 +176,7 @@ export default function SeriesTable({
     0,
     Math.ceil(filteredData.length / pageSize) - 1,
   );
-  const effectivePage = Math.min(Math.max(params.page, 0), maxPageEstimate);
+  const effectivePage = Math.min(Math.max(localPage, 0), maxPageEstimate);
 
   const pagination = useMemo(
     () => ({ pageIndex: effectivePage, pageSize }),
@@ -318,6 +328,7 @@ export default function SeriesTable({
         typeof updaterOrValue === "function"
           ? updaterOrValue(sorting)
           : updaterOrValue;
+      setLocalPage(0);
       setParams({
         sort: newSorting.length > 0 ? newSorting[0] : null,
         page: null,
@@ -330,6 +341,7 @@ export default function SeriesTable({
           : updaterOrValue;
       const newPage = newPagination.pageIndex;
       if (newPage !== effectivePage) {
+        setLocalPage(newPage);
         setParams({ page: newPage === 0 ? null : newPage });
       }
     },
@@ -347,19 +359,17 @@ export default function SeriesTable({
 
   const pageCount = table.getPageCount();
 
-  // Sync URL when page is out of bounds (e.g. search filter reduced results).
-  // The table already renders the clamped effectivePage, so this only fixes
-  // the URL — it is not on the critical render path.
+  // Clamp page when out of bounds (e.g. search filter reduced results).
   useEffect(() => {
     const maxPage = Math.max(0, pageCount - 1);
-    const clampedPage = Math.min(Math.max(params.page, 0), maxPage);
+    const clampedPage = Math.min(Math.max(localPage, 0), maxPage);
 
-    if (clampedPage !== params.page) {
+    if (clampedPage !== localPage) {
+      setLocalPage(clampedPage);
       setParams({ page: clampedPage === 0 ? null : clampedPage });
     }
-    // setParams is a stable setter from useQueryStates — safe to omit
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageCount, params.page]);
+  }, [pageCount, localPage]);
 
   if (isLoading) {
     return (
@@ -395,24 +405,27 @@ export default function SeriesTable({
           typeFilter={typeFilter}
           progressFilter={progressFilter}
           statusFilter={statusFilter}
-          onTypeChange={(value) =>
+          onTypeChange={(value) => {
+            setLocalPage(0);
             setParams({
               type: value === "all" ? null : value,
               page: null,
-            })
-          }
-          onProgressChange={(value) =>
+            });
+          }}
+          onProgressChange={(value) => {
+            setLocalPage(0);
             setParams({
               progress: value === "all" ? null : value,
               page: null,
-            })
-          }
-          onStatusChange={(value) =>
+            });
+          }}
+          onStatusChange={(value) => {
+            setLocalPage(0);
             setParams({
               status: value === "all" ? null : value,
               page: null,
-            })
-          }
+            });
+          }}
           counts={filterCounts}
         />
         <div className="flex items-center gap-2">
@@ -437,6 +450,7 @@ export default function SeriesTable({
               variant="ghost"
               size="sm"
               onClick={() => {
+                setLocalPage(0);
                 setParams({ view: "grid", page: null });
                 setRowSelection({});
               }}
@@ -456,6 +470,7 @@ export default function SeriesTable({
             onChange={(e) => {
               setSearchInput(e.target.value);
               setSearch(e.target.value || null);
+              setLocalPage(0);
               setParams({ page: null });
             }}
             className="w-[200px]"


### PR DESCRIPTION
## Summary
- Library page pagination (Next/Previous) was completely unresponsive in production builds
- Root cause: nuqs React Router v7 adapter wraps state updates in `startTransition` via an event emitter — in React 19 production builds these can be silently deferred, so the page index never committed even though the URL updated via `history.replaceState`
- Fix: added a `localPage` React state that updates synchronously alongside `setParams`, so the table always re-renders immediately on page change. URL-driven navigation (back/forward) syncs back via `useEffect`

## Test plan
- [ ] Click Next on the Library page — page advances and "Page X of Y" updates
- [ ] Click Previous — page goes back
- [ ] Verify the URL updates with `?page=N` when paginating
- [ ] Use browser back/forward after paginating — page state stays in sync
- [ ] Change filters/sort/search — page resets to 1
- [ ] Switch between list and grid view — page resets to 1
- [ ] Test in production build (`npm run build` + serve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved pagination state management in the Series table to better handle page resets when filters, sorting, or search criteria change, ensuring users don't encounter out-of-bounds page errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->