### PR TITLE
feat: Major frontend redesign

### DIFF
--- a/frontend/public/mock-sw.js
+++ b/frontend/public/mock-sw.js
@@ -1,0 +1,89 @@
+// Comicarr mock-mode service worker.
+// Synthesizes gradient SVG covers for /api/metadata/art/:id and /api/cache/art/:id
+// so the Library, Series Detail, Dashboard, etc. have real artwork while the
+// real backend sits idle. Registered only when mock mode is enabled.
+
+const COVERS = {
+  "absolute-flash":     { bg: ["#c1281e", "#f5a623"], accent: "#ffeb3b", label: "ABSOLUTE FLASH" },
+  "ultimate-wolverine": { bg: ["#2a2f3a", "#6d7685"], accent: "#f8c13b", label: "ULT WOLVERINE" },
+  "tmnt":               { bg: ["#0e3a1a", "#58a93a"], accent: "#ffffff", label: "TMNT" },
+  "transformers":       { bg: ["#1a1148", "#4a2dbb"], accent: "#ff4081", label: "TRANSFORMERS" },
+  "absolute-batman":    { bg: ["#0b0b10", "#2a2d3a"], accent: "#f5c842", label: "ABS BATMAN" },
+  "20cb":               { bg: ["#d4a373", "#1d1d1b"], accent: "#e63946", label: "20TH C BOYS" },
+  "chainsaw":           { bg: ["#f25c54", "#1a1a1a"], accent: "#ffd166", label: "CHAINSAW MAN" },
+  "fujimoto":           { bg: ["#2a1a3a", "#d4a3ff"], accent: "#ffd166", label: "17-21" },
+  "monster":            { bg: ["#3a2a1a", "#d4c4a3"], accent: "#8a5a3a", label: "MONSTER" },
+  "ark-m":              { bg: ["#1a1a24", "#5c3a8a"], accent: "#58a93a", label: "ARK-M" },
+  "annual-25":          { bg: ["#2a1414", "#c1281e"], accent: "#f5c842", label: "ANNUAL 25" },
+  "21cb":               { bg: ["#1a3a5c", "#d4a373"], accent: "#e63946", label: "21ST C BOYS" },
+};
+
+const FALLBACK_PALETTE = [
+  ["#2a1a3a", "#d4a3ff", "#ffd166"],
+  ["#0e3a1a", "#58a93a", "#ffffff"],
+  ["#1a1148", "#4a2dbb", "#ff4081"],
+  ["#c1281e", "#f5a623", "#ffeb3b"],
+  ["#3a2a1a", "#d4c4a3", "#8a5a3a"],
+];
+
+function hash(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+function coverSvg(id) {
+  const cover = COVERS[id];
+  let c1, c2, accent, label;
+  if (cover) {
+    [c1, c2] = cover.bg;
+    accent = cover.accent;
+    label = cover.label;
+  } else {
+    const pal = FALLBACK_PALETTE[hash(id) % FALLBACK_PALETTE.length];
+    c1 = pal[0];
+    c2 = pal[1];
+    accent = pal[2];
+    label = id.slice(0, 10).toUpperCase();
+  }
+  const w = 200, h = 300;
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} ${h}" width="${w}" height="${h}">
+    <defs>
+      <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="${c1}"/>
+        <stop offset="1" stop-color="${c2}"/>
+      </linearGradient>
+      <pattern id="p" width="8" height="8" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+        <rect width="8" height="8" fill="url(#g)"/>
+        <line x1="0" y1="0" x2="0" y2="8" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+      </pattern>
+    </defs>
+    <rect width="${w}" height="${h}" fill="url(#p)"/>
+    <rect x="0" y="${h * 0.62}" width="${w}" height="${h * 0.38}" fill="rgba(0,0,0,0.45)"/>
+    <text x="${w * 0.08}" y="${h * 0.78}" fill="${accent}" font-family="Inter, sans-serif" font-weight="800" font-size="20" letter-spacing="-0.5">${label}</text>
+    <text x="${w * 0.08}" y="${h * 0.94}" fill="rgba(255,255,255,0.65)" font-family="ui-monospace, Menlo, monospace" font-size="11">MOCK</text>
+  </svg>`;
+}
+
+self.addEventListener("install", (e) => {
+  self.skipWaiting();
+});
+self.addEventListener("activate", (e) => {
+  e.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+  const m = url.pathname.match(/^\/api\/(metadata|cache)\/art\/([^/]+)$/);
+  if (!m) return;
+  const id = m[2];
+  const svg = coverSvg(id);
+  event.respondWith(
+    new Response(svg, {
+      headers: {
+        "Content-Type": "image/svg+xml",
+        "Cache-Control": "no-store",
+      },
+    }),
+  );
+});

--- a/frontend/public/mock-sw.js
+++ b/frontend/public/mock-sw.js
@@ -32,6 +32,23 @@ function hash(str) {
   return Math.abs(h);
 }
 
+function escapeXml(text) {
+  return text.replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
 function coverSvg(id) {
   const cover = COVERS[id];
   let c1, c2, accent, label;
@@ -60,7 +77,7 @@ function coverSvg(id) {
     </defs>
     <rect width="${w}" height="${h}" fill="url(#p)"/>
     <rect x="0" y="${h * 0.62}" width="${w}" height="${h * 0.38}" fill="rgba(0,0,0,0.45)"/>
-    <text x="${w * 0.08}" y="${h * 0.78}" fill="${accent}" font-family="Inter, sans-serif" font-weight="800" font-size="20" letter-spacing="-0.5">${label}</text>
+    <text x="${w * 0.08}" y="${h * 0.78}" fill="${accent}" font-family="Inter, sans-serif" font-weight="800" font-size="20" letter-spacing="-0.5">${escapeXml(label)}</text>
     <text x="${w * 0.08}" y="${h * 0.94}" fill="rgba(255,255,255,0.65)" font-family="ui-monospace, Menlo, monospace" font-size="11">MOCK</text>
   </svg>`;
 }

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,7 +1,6 @@
 import { Navigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
-import { MigrationWizard } from "@/components/migration/MigrationWizard";
-import Layout from "@/components/layout/Layout";
+import OnboardingDialog from "@/components/onboarding/OnboardingDialog";
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -11,20 +10,16 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
   const { isAuthenticated, isLoading, needsMigration, dismissMigration } =
     useAuth();
 
-  // Show loading state while checking session
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="text-center">
-          <div
-            className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-r-transparent align-[-0.125em] motion-reduce:animate-[spin_1.5s_linear_infinite]"
+      <div className="min-h-screen flex items-center justify-center bg-background text-foreground">
+        <div className="inline-flex items-center gap-2 font-mono text-[11px] text-muted-foreground">
+          <span
+            className="inline-block h-3 w-3 animate-spin rounded-full border-[1.5px] border-solid border-current border-r-transparent"
             role="status"
-          >
-            <span className="!absolute !-m-px !h-px !w-px !overflow-hidden !whitespace-nowrap !border-0 !p-0 ![clip:rect(0,0,0,0)]">
-              Loading...
-            </span>
-          </div>
-          <p className="mt-4 text-gray-600">Checking authentication...</p>
+            aria-label="Loading"
+          />
+          checking session…
         </div>
       </div>
     );
@@ -34,16 +29,10 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
     return <Navigate to="/login" replace />;
   }
 
-  // Gate: show migration wizard instead of children when DB is empty
-  if (needsMigration) {
-    return (
-      <Layout>
-        <div className="p-8 max-w-4xl">
-          <MigrationWizard onDismiss={dismissMigration} />
-        </div>
-      </Layout>
-    );
-  }
-
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <OnboardingDialog open={needsMigration} onFinish={dismissMigration} />
+    </>
+  );
 }

--- a/frontend/src/components/import/ImportInboxSection.tsx
+++ b/frontend/src/components/import/ImportInboxSection.tsx
@@ -2,8 +2,6 @@ import { Inbox, RefreshCw, FolderOpen } from "lucide-react";
 import { useRefreshImport } from "@/hooks/useImport";
 import { useConfig } from "@/hooks/useConfig";
 import { useToast } from "@/components/ui/toast";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 
 export default function ImportInboxSection() {
   const { data: appConfig } = useConfig();
@@ -14,10 +12,7 @@ export default function ImportInboxSection() {
   const handleScanNow = async () => {
     try {
       await refreshImportMutation.mutateAsync();
-      addToast({
-        type: "info",
-        message: "Import inbox scan started.",
-      });
+      addToast({ type: "info", message: "Import inbox scan started." });
     } catch (err) {
       addToast({
         type: "error",
@@ -26,46 +21,76 @@ export default function ImportInboxSection() {
     }
   };
 
-  return (
-    <div className="space-y-4">
-      <div>
-        <h2 className="text-lg font-semibold text-foreground">Import Inbox</h2>
-        <p className="text-sm text-muted-foreground">
-          Monitor a directory for new files to auto-match against your library
-        </p>
-      </div>
+  const configured = !!importDir;
+  const busy = refreshImportMutation.isPending;
 
-      <Card>
-        <CardContent className="p-5">
-          <div className="flex items-center gap-3 mb-3">
-            <Inbox className="w-5 h-5 text-muted-foreground" />
-            <div className="flex-1">
-              <h3 className="font-semibold">Import Directory</h3>
-              {importDir ? (
-                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <FolderOpen className="w-3.5 h-3.5" />
-                  <span className="font-mono text-xs">{importDir}</span>
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  Not configured. Set an Import Directory in your config.ini to
-                  enable auto-importing.
-                </p>
-              )}
-            </div>
+  return (
+    <div
+      className="rounded-[6px] border px-3.5 py-3"
+      style={{ borderColor: "var(--border)", background: "var(--card)" }}
+    >
+      <div className="flex items-center gap-3">
+        <div
+          className="w-7 h-7 rounded-[5px] grid place-items-center shrink-0"
+          style={{
+            background: "var(--secondary)",
+            color: "var(--muted-foreground)",
+          }}
+        >
+          <Inbox className="w-3.5 h-3.5" strokeWidth={1.75} />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="text-[13px] font-medium leading-tight">
+            Import directory
           </div>
-          <Button
+          {configured ? (
+            <div className="flex items-center gap-1.5 mt-0.5 font-mono text-[10.5px] text-muted-foreground truncate">
+              <FolderOpen className="w-3 h-3 shrink-0" strokeWidth={1.75} />
+              <span className="truncate">{importDir}</span>
+            </div>
+          ) : (
+            <div className="text-[11px] text-muted-foreground mt-0.5">
+              Set an Import Directory in your config.ini to enable
+              auto-importing.
+            </div>
+          )}
+        </div>
+
+        {configured ? (
+          <button
+            type="button"
             onClick={handleScanNow}
-            disabled={!importDir || refreshImportMutation.isPending}
-            className="w-full"
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 px-2.5 h-7 rounded-[5px] border text-[11.5px] font-medium shrink-0 hover:bg-secondary transition-colors disabled:opacity-70"
+            style={{
+              borderColor: "var(--border)",
+              color: "var(--foreground)",
+            }}
           >
             <RefreshCw
-              className={`w-4 h-4 mr-2 ${refreshImportMutation.isPending ? "animate-spin" : ""}`}
+              className={`w-3 h-3 ${busy ? "animate-spin" : ""}`}
+              style={{
+                color: busy ? "var(--primary)" : "var(--muted-foreground)",
+              }}
+              strokeWidth={2}
             />
-            Scan Now
-          </Button>
-        </CardContent>
-      </Card>
+            <span>{busy ? "scanning" : "scan now"}</span>
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled
+            className="inline-flex items-center gap-1.5 px-2.5 h-7 rounded-[5px] border font-mono text-[10.5px] tracking-[0.05em] uppercase shrink-0 disabled:opacity-60 disabled:cursor-not-allowed"
+            style={{
+              borderColor: "var(--border)",
+              color: "var(--muted-foreground)",
+            }}
+          >
+            <span>not set</span>
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/import/LibraryScanSection.tsx
+++ b/frontend/src/components/import/LibraryScanSection.tsx
@@ -1,5 +1,12 @@
 import { useState, useEffect } from "react";
-import { RefreshCw, Library, BookOpen } from "lucide-react";
+import {
+  RefreshCw,
+  Library,
+  BookOpen,
+  FolderOpen,
+  Loader2,
+  type LucideIcon,
+} from "lucide-react";
 import {
   useComicScan,
   useComicScanProgress,
@@ -10,14 +17,12 @@ import {
 } from "@/hooks/useImport";
 import { useConfig } from "@/hooks/useConfig";
 import { useToast } from "@/components/ui/toast";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import LibraryScanResults from "./LibraryScanResults";
 
 export default function LibraryScanSection() {
   const { data: appConfig } = useConfig();
-  const comicDirConfigured = !!appConfig?.comic_dir;
-  const mangaDirConfigured = !!appConfig?.manga_dir;
+  const comicDir = appConfig?.comic_dir as string | undefined;
+  const mangaDir = appConfig?.manga_dir as string | undefined;
   const { addToast } = useToast();
 
   // Comic scan state
@@ -32,7 +37,6 @@ export default function LibraryScanSection() {
   const { data: mangaProgress } = useMangaScanProgress(mangaScanning);
   const mangaConfirmMutation = useMangaScanConfirm();
 
-  // Comic scan terminal state
   const comicStatus = comicProgress?.status;
   const comicTerminal =
     comicScanning && (comicStatus === "completed" || comicStatus === "error");
@@ -45,7 +49,6 @@ export default function LibraryScanSection() {
     }
   }, [comicTerminal, comicStatus, addToast]);
 
-  // Manga scan terminal state
   const mangaStatus = mangaProgress?.status;
   const mangaTerminal =
     mangaScanning && (mangaStatus === "completed" || mangaStatus === "error");
@@ -62,10 +65,7 @@ export default function LibraryScanSection() {
     try {
       await comicScanMutation.mutateAsync();
       setComicScanning(true);
-      addToast({
-        type: "info",
-        message: "Comic library scan started.",
-      });
+      addToast({ type: "info", message: "Comic library scan started." });
     } catch (err) {
       addToast({
         type: "error",
@@ -78,10 +78,7 @@ export default function LibraryScanSection() {
     try {
       await mangaScanMutation.mutateAsync();
       setMangaScanning(true);
-      addToast({
-        type: "info",
-        message: "Manga library scan started.",
-      });
+      addToast({ type: "info", message: "Manga library scan started." });
     } catch (err) {
       addToast({
         type: "error",
@@ -132,96 +129,42 @@ export default function LibraryScanSection() {
   const mangaScanId = mangaProgress?.scan_id;
 
   return (
-    <div className="space-y-4">
-      <div>
-        <h2 className="text-lg font-semibold text-foreground">Library Scan</h2>
-        <p className="text-sm text-muted-foreground">
-          Scan your existing directories to find and import series
-        </p>
-      </div>
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <Card>
-          <CardContent className="p-5">
-            <div className="flex items-center gap-3 mb-3">
-              <Library className="w-5 h-5 text-muted-foreground" />
-              <div>
-                <h3 className="font-semibold">Comic Library</h3>
-                <p className="text-sm text-muted-foreground">
-                  {comicDirConfigured
-                    ? "Scan your comic directory and select series to import"
-                    : "Configure a Comic Directory in Settings to enable"}
-                </p>
-              </div>
-            </div>
-            <Button
-              onClick={handleComicScan}
-              disabled={
-                !comicDirConfigured ||
-                comicScanMutation.isPending ||
-                comicScanning
-              }
-              className="w-full"
-            >
-              <RefreshCw
-                className={`w-4 h-4 mr-2 ${comicScanning ? "animate-spin" : ""}`}
-              />
-              Scan Comic Library
-            </Button>
-            {comicScanning && comicProgress?.progress && (
-              <div className="mt-3 text-sm text-muted-foreground space-y-1">
-                <p>
-                  Series found: {comicProgress.progress.series_found} | Matched:{" "}
-                  {comicProgress.progress.series_matched}
-                </p>
-                {comicProgress.progress.current_series && (
-                  <p>Processing: {comicProgress.progress.current_series}</p>
-                )}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent className="p-5">
-            <div className="flex items-center gap-3 mb-3">
-              <BookOpen className="w-5 h-5 text-muted-foreground" />
-              <div>
-                <h3 className="font-semibold">Manga Library</h3>
-                <p className="text-sm text-muted-foreground">
-                  {mangaDirConfigured
-                    ? "Scan your manga directory and select series to import"
-                    : "Configure a Manga Directory in Settings to enable"}
-                </p>
-              </div>
-            </div>
-            <Button
-              onClick={handleMangaScan}
-              disabled={
-                !mangaDirConfigured ||
-                mangaScanMutation.isPending ||
-                mangaScanning
-              }
-              className="w-full"
-            >
-              <RefreshCw
-                className={`w-4 h-4 mr-2 ${mangaScanning ? "animate-spin" : ""}`}
-              />
-              Scan Manga Library
-            </Button>
-            {mangaScanning && mangaProgress?.progress && (
-              <div className="mt-3 text-sm text-muted-foreground space-y-1">
-                <p>
-                  Series found: {mangaProgress.progress.series_found} | Matched:{" "}
-                  {mangaProgress.progress.series_matched}
-                </p>
-                {mangaProgress.progress.current_series && (
-                  <p>Processing: {mangaProgress.progress.current_series}</p>
-                )}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-2.5">
+        <ScanTile
+          icon={Library}
+          label="Comic library"
+          path={comicDir}
+          notConfiguredHint="Set Comic Directory in Settings → Media"
+          busy={comicScanMutation.isPending || comicScanning}
+          onScan={handleComicScan}
+          progress={
+            comicScanning
+              ? {
+                  found: comicProgress?.progress?.series_found,
+                  matched: comicProgress?.progress?.series_matched,
+                  current: comicProgress?.progress?.current_series,
+                }
+              : undefined
+          }
+        />
+        <ScanTile
+          icon={BookOpen}
+          label="Manga library"
+          path={mangaDir}
+          notConfiguredHint="Set Manga Directory in Settings → Media"
+          busy={mangaScanMutation.isPending || mangaScanning}
+          onScan={handleMangaScan}
+          progress={
+            mangaScanning
+              ? {
+                  found: mangaProgress?.progress?.series_found,
+                  matched: mangaProgress?.progress?.series_matched,
+                  current: mangaProgress?.progress?.current_series,
+                }
+              : undefined
+          }
+        />
       </div>
 
       {comicResults && comicResults.length > 0 && comicScanId && (
@@ -244,5 +187,137 @@ export default function LibraryScanSection() {
         />
       )}
     </div>
+  );
+}
+
+interface ScanTileProps {
+  icon: LucideIcon;
+  label: string;
+  path?: string;
+  notConfiguredHint: string;
+  busy: boolean;
+  onScan: () => void;
+  progress?: {
+    found?: number;
+    matched?: number;
+    current?: string | null;
+  };
+}
+
+function ScanTile({
+  icon: Icon,
+  label,
+  path,
+  notConfiguredHint,
+  busy,
+  onScan,
+  progress,
+}: ScanTileProps) {
+  const configured = !!path;
+
+  return (
+    <div
+      className="rounded-[6px] border px-3.5 py-3"
+      style={{ borderColor: "var(--border)", background: "var(--card)" }}
+    >
+      <div className="flex items-center gap-3">
+        <div
+          className="w-7 h-7 rounded-[5px] grid place-items-center shrink-0"
+          style={{
+            background: "var(--secondary)",
+            color: "var(--muted-foreground)",
+          }}
+        >
+          <Icon className="w-3.5 h-3.5" strokeWidth={1.75} />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="text-[13px] font-medium leading-tight">{label}</div>
+          {configured ? (
+            <div className="flex items-center gap-1.5 mt-0.5 font-mono text-[10.5px] text-muted-foreground truncate">
+              <FolderOpen className="w-3 h-3 shrink-0" strokeWidth={1.75} />
+              <span className="truncate">{path}</span>
+            </div>
+          ) : (
+            <div className="text-[11px] text-muted-foreground mt-0.5">
+              {notConfiguredHint}
+            </div>
+          )}
+        </div>
+
+        <ScanButton configured={configured} busy={busy} onClick={onScan} />
+      </div>
+
+      {progress && (
+        <div
+          className="mt-3 pt-2.5 border-t font-mono text-[11px] text-muted-foreground flex items-center gap-3"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <Loader2
+            className="w-3 h-3 animate-spin shrink-0"
+            style={{ color: "var(--primary)" }}
+          />
+          <span>
+            found <span className="text-foreground">{progress.found ?? 0}</span>{" "}
+            · matched{" "}
+            <span className="text-foreground">{progress.matched ?? 0}</span>
+          </span>
+          {progress.current && (
+            <span
+              className="truncate ml-auto"
+              style={{ color: "var(--text-muted)" }}
+            >
+              {progress.current}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ScanButton({
+  configured,
+  busy,
+  onClick,
+}: {
+  configured: boolean;
+  busy: boolean;
+  onClick: () => void;
+}) {
+  if (!configured) {
+    return (
+      <button
+        type="button"
+        disabled
+        className="inline-flex items-center gap-1.5 px-2.5 h-7 rounded-[5px] border font-mono text-[10.5px] tracking-[0.05em] uppercase shrink-0 disabled:opacity-60 disabled:cursor-not-allowed"
+        style={{
+          borderColor: "var(--border)",
+          color: "var(--muted-foreground)",
+        }}
+      >
+        <span>not set</span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      className="inline-flex items-center gap-1.5 px-2.5 h-7 rounded-[5px] border text-[11.5px] font-medium shrink-0 hover:bg-secondary transition-colors disabled:opacity-70"
+      style={{
+        borderColor: "var(--border)",
+        color: "var(--foreground)",
+      }}
+    >
+      <RefreshCw
+        className={`w-3 h-3 ${busy ? "animate-spin" : ""}`}
+        style={{ color: busy ? "var(--primary)" : "var(--muted-foreground)" }}
+        strokeWidth={2}
+      />
+      <span>{busy ? "scanning" : "scan"}</span>
+    </button>
   );
 }

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -16,6 +16,7 @@ import {
   SidebarSeparator,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { Kbd } from "@/components/ui/kbd";
 import {
   Tooltip,
   TooltipContent,
@@ -36,8 +37,15 @@ import {
   FolderInput,
 } from "lucide-react";
 
+interface NavItem {
+  path: string;
+  label: string;
+  icon: LucideIcon;
+  kbd?: string;
+}
+
 export default function AppSidebar() {
-  const { logout } = useAuth();
+  const { logout, user } = useAuth();
   const { theme, toggleTheme } = useTheme();
   const navigate = useNavigate();
   const location = useLocation();
@@ -59,23 +67,17 @@ export default function AppSidebar() {
     }
   };
 
-  interface NavItem {
-    path: string;
-    label: string;
-    icon: LucideIcon;
-  }
-
   const primaryNav: NavItem[] = [
-    { path: "/", label: "Dashboard", icon: LayoutDashboard },
-    { path: "/library", label: "Library", icon: BookOpen },
-    { path: "/releases", label: "Releases", icon: Calendar },
-    { path: "/wanted", label: "Wanted", icon: ListTodo },
-    { path: "/story-arcs", label: "Story Arcs", icon: BookMarked },
+    { path: "/", label: "Dashboard", icon: LayoutDashboard, kbd: "G D" },
+    { path: "/library", label: "Library", icon: BookOpen, kbd: "G L" },
+    { path: "/releases", label: "Releases", icon: Calendar, kbd: "G R" },
+    { path: "/wanted", label: "Wanted", icon: ListTodo, kbd: "G W" },
+    { path: "/story-arcs", label: "Story Arcs", icon: BookMarked, kbd: "G A" },
   ];
 
   const managementNav: NavItem[] = [
-    { path: "/activity", label: "Activity", icon: Activity },
-    { path: "/import", label: "Import", icon: FolderInput },
+    { path: "/activity", label: "Activity", icon: Activity, kbd: "G Y" },
+    { path: "/import", label: "Import", icon: FolderInput, kbd: "G I" },
   ];
 
   const isActive = (path: string): boolean => {
@@ -86,42 +88,72 @@ export default function AppSidebar() {
   };
 
   const handleNavClick = () => {
-    // Close mobile sidebar after navigation
     setOpenMobile(false);
   };
 
+  const username =
+    typeof user === "object" && user && "username" in user
+      ? (user as { username?: string }).username || "admin"
+      : "admin";
+
+  const renderNav = (items: NavItem[]) =>
+    items.map(({ path, label, icon: Icon, kbd }) => {
+      const active = isActive(path);
+      return (
+        <SidebarMenuItem key={path}>
+          <SidebarMenuButton asChild isActive={active} tooltip={label}>
+            <Link to={path} onClick={handleNavClick}>
+              <Icon className="w-4 h-4" />
+              <span className="flex-1 text-[13px]">{label}</span>
+              {active && kbd && (
+                <Kbd className="group-data-[collapsible=icon]:hidden font-mono text-[10px] tracking-wide">
+                  {kbd}
+                </Kbd>
+              )}
+            </Link>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      );
+    });
+
   return (
     <Sidebar collapsible="icon" variant="sidebar">
-      {/* Header with Logo */}
-      <SidebarHeader className="px-4 pt-4 pb-4">
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <Link to="/" onClick={handleNavClick} className="flex items-center">
-              <Logo className="h-6 w-auto text-foreground" />
-            </Link>
-          </SidebarMenuItem>
-        </SidebarMenu>
+      {/* Brand header */}
+      <SidebarHeader className="px-3 pt-3 pb-3 border-b border-sidebar-border">
+        <div className="flex items-center gap-2">
+          <Link
+            to="/"
+            onClick={handleNavClick}
+            className="flex items-center gap-2 flex-1 min-w-0"
+          >
+            <Logo className="h-4 w-auto text-foreground" />
+          </Link>
+          <span className="group-data-[collapsible=icon]:hidden font-mono text-[10px] text-[var(--text-muted)] px-1.5 py-0.5 border border-sidebar-border rounded-sm">
+            0.15
+          </span>
+        </div>
       </SidebarHeader>
 
-      {/* Search Section */}
-      <div className="px-3 pb-3">
-        {/* Expanded: show input */}
+      {/* Search with ⌘K hint */}
+      <div className="px-2 pt-2 pb-1">
         <form
           onSubmit={handleSearchSubmit}
           className="group-data-[collapsible=icon]:hidden"
         >
-          <div className="relative">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <div className="relative flex items-center gap-2 px-2.5 py-1.5 rounded-md border border-sidebar-border bg-secondary/60">
+            <Search className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
             <SidebarInput
-              placeholder="Search comics..."
+              placeholder="Search..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9"
+              className="h-auto border-0 bg-transparent p-0 text-[12px] placeholder:text-muted-foreground focus-visible:ring-0 shadow-none"
             />
+            <Kbd className="font-mono text-[10px] bg-background border border-sidebar-border">
+              ⌘K
+            </Kbd>
           </div>
         </form>
 
-        {/* Collapsed: show icon button with tooltip */}
         <div className="hidden group-data-[collapsible=icon]:flex justify-center">
           <Tooltip>
             <TooltipTrigger asChild>
@@ -137,53 +169,24 @@ export default function AppSidebar() {
         </div>
       </div>
 
-      <SidebarSeparator />
+      {/* Sections */}
+      <SidebarContent className="px-2 pt-1">
+        <div className="mono-label px-2 pt-2 pb-1 group-data-[collapsible=icon]:hidden">
+          Library
+        </div>
+        <SidebarMenu>{renderNav(primaryNav)}</SidebarMenu>
 
-      {/* Main Navigation */}
-      <SidebarContent className="px-2 pt-2">
-        <SidebarMenu>
-          {primaryNav.map(({ path, label, icon: Icon }) => (
-            <SidebarMenuItem key={path}>
-              <SidebarMenuButton
-                asChild
-                isActive={isActive(path)}
-                tooltip={label}
-              >
-                <Link to={path} onClick={handleNavClick}>
-                  <Icon className="w-4 h-4" />
-                  <span>{label}</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
-        </SidebarMenu>
-
-        <SidebarSeparator className="my-2" />
-
-        <SidebarMenu>
-          {managementNav.map(({ path, label, icon: Icon }) => (
-            <SidebarMenuItem key={path}>
-              <SidebarMenuButton
-                asChild
-                isActive={isActive(path)}
-                tooltip={label}
-              >
-                <Link to={path} onClick={handleNavClick}>
-                  <Icon className="w-4 h-4" />
-                  <span>{label}</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
-        </SidebarMenu>
+        <div className="mono-label px-2 pt-4 pb-1 group-data-[collapsible=icon]:hidden">
+          System
+        </div>
+        <SidebarMenu>{renderNav(managementNav)}</SidebarMenu>
       </SidebarContent>
 
       <SidebarSeparator />
 
-      {/* Footer with Settings, Theme, and Logout */}
-      <SidebarFooter className="px-2 pb-4">
+      {/* Footer: settings, theme, logout + account */}
+      <SidebarFooter className="px-2 pb-2 gap-0">
         <SidebarMenu>
-          {/* Settings */}
           <SidebarMenuItem>
             <SidebarMenuButton
               asChild
@@ -192,12 +195,16 @@ export default function AppSidebar() {
             >
               <Link to="/settings" onClick={handleNavClick}>
                 <Settings className="w-4 h-4" />
-                <span>Settings</span>
+                <span className="flex-1 text-[13px]">Settings</span>
+                {isActive("/settings") && (
+                  <Kbd className="group-data-[collapsible=icon]:hidden font-mono text-[10px]">
+                    ⌘,
+                  </Kbd>
+                )}
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>
 
-          {/* Theme Toggle */}
           <SidebarMenuItem>
             <SidebarMenuButton
               onClick={toggleTheme}
@@ -208,18 +215,40 @@ export default function AppSidebar() {
               ) : (
                 <Sun className="w-4 h-4" />
               )}
-              <span>{theme === "light" ? "Dark mode" : "Light mode"}</span>
+              <span className="flex-1 text-[13px]">
+                {theme === "light" ? "Dark mode" : "Light mode"}
+              </span>
             </SidebarMenuButton>
           </SidebarMenuItem>
 
-          {/* Logout */}
           <SidebarMenuItem>
             <SidebarMenuButton onClick={handleLogout} tooltip="Logout">
               <LogOut className="w-4 h-4" />
-              <span>Logout</span>
+              <span className="flex-1 text-[13px]">Logout</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
+
+        {/* Account footer with status dot */}
+        <div className="mt-2 pt-2 border-t border-sidebar-border flex items-center gap-2 px-2 py-1.5 group-data-[collapsible=icon]:hidden">
+          <div
+            className="w-6 h-6 rounded-full shrink-0"
+            style={{
+              background:
+                "linear-gradient(135deg, var(--primary), var(--chart-4))",
+            }}
+          />
+          <div className="flex-1 min-w-0">
+            <div className="text-[12px] font-medium truncate">{username}</div>
+            <div className="font-mono text-[10px] text-[var(--text-muted)]">
+              admin · ready
+            </div>
+          </div>
+          <div
+            className="w-1.5 h-1.5 rounded-full"
+            style={{ background: "var(--status-active)" }}
+          />
+        </div>
       </SidebarFooter>
     </Sidebar>
   );

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -140,9 +140,10 @@ export default function AppSidebar() {
           onSubmit={handleSearchSubmit}
           className="group-data-[collapsible=icon]:hidden"
         >
-          <div className="relative flex items-center gap-2 px-2.5 py-1.5 rounded-md border border-sidebar-border bg-secondary/60">
+          <div className="relative flex items-center gap-2 px-2.5 py-1.5 rounded-md border border-sidebar-border bg-secondary/60 transition-colors focus-within:border-primary focus-within:bg-background focus-within:ring-2 focus-within:ring-[color-mix(in_oklab,var(--primary)_28%,transparent)]">
             <Search className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
             <SidebarInput
+              data-global-search="true"
               placeholder="Search..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -6,6 +6,7 @@ import { useAiStatus } from "@/hooks/useAiStatus";
 import { ActivityFeedDrawer } from "@/components/ai/ActivityFeedDrawer";
 import { ChatPanel } from "@/components/ai/ChatPanel";
 import { Bell, MessageCircle } from "lucide-react";
+import { isMockEnabled } from "@/lib/mockData";
 
 const FULL_BLEED_ROUTES = ["/", "/library"];
 
@@ -21,6 +22,7 @@ export default function Layout({ children }: LayoutProps) {
 
   const showAiBell = aiStatus?.configured === true;
   const fullBleed = FULL_BLEED_ROUTES.includes(pathname);
+  const mock = isMockEnabled();
 
   return (
     <SidebarProvider>
@@ -68,6 +70,20 @@ export default function Layout({ children }: LayoutProps) {
             queue: <span className="text-foreground">—</span>
           </span>
           <div className="ml-auto flex items-center gap-3">
+            {mock && (
+              <span
+                className="px-1.5 py-0.5 rounded-sm border font-mono text-[10px] tracking-wider uppercase"
+                style={{
+                  borderColor: "var(--primary)",
+                  color: "var(--primary)",
+                  background:
+                    "color-mix(in oklab, var(--primary) 12%, transparent)",
+                }}
+                title="Mock data — disable with ?mock=0"
+              >
+                mock
+              </span>
+            )}
             {showAiBell && (
               <>
                 <button

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -9,6 +9,7 @@ import { Bell, MessageCircle } from "lucide-react";
 import { isMockEnabled } from "@/lib/mockData";
 
 const FULL_BLEED_ROUTES = ["/", "/library", "/settings"];
+const FULL_BLEED_PREFIXES = ["/library/", "/series/"];
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -21,7 +22,9 @@ export default function Layout({ children }: LayoutProps) {
   const { pathname } = useLocation();
 
   const showAiBell = aiStatus?.configured === true;
-  const fullBleed = FULL_BLEED_ROUTES.includes(pathname);
+  const fullBleed =
+    FULL_BLEED_ROUTES.includes(pathname) ||
+    FULL_BLEED_PREFIXES.some((p) => pathname.startsWith(p));
   const mock = isMockEnabled();
 
   return (

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -8,7 +8,7 @@ import { ChatPanel } from "@/components/ai/ChatPanel";
 import { Bell, MessageCircle } from "lucide-react";
 import { isMockEnabled } from "@/lib/mockData";
 
-const FULL_BLEED_ROUTES = ["/", "/library"];
+const FULL_BLEED_ROUTES = ["/", "/library", "/settings"];
 
 interface LayoutProps {
   children: React.ReactNode;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -8,8 +8,18 @@ import { ChatPanel } from "@/components/ai/ChatPanel";
 import { Bell, MessageCircle } from "lucide-react";
 import { isMockEnabled } from "@/lib/mockData";
 
-const FULL_BLEED_ROUTES = ["/", "/library", "/settings"];
-const FULL_BLEED_PREFIXES = ["/library/", "/series/"];
+const FULL_BLEED_ROUTES = [
+  "/",
+  "/library",
+  "/settings",
+  "/search",
+  "/releases",
+  "/wanted",
+  "/story-arcs",
+  "/activity",
+  "/import",
+];
+const FULL_BLEED_PREFIXES = ["/library/", "/series/", "/story-arcs/"];
 
 interface LayoutProps {
   children: React.ReactNode;

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
+import { useLocation } from "react-router-dom";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import AppSidebar from "@/components/layout/AppSidebar";
 import { useAiStatus } from "@/hooks/useAiStatus";
 import { ActivityFeedDrawer } from "@/components/ai/ActivityFeedDrawer";
 import { ChatPanel } from "@/components/ai/ChatPanel";
 import { Bell, MessageCircle } from "lucide-react";
+
+const FULL_BLEED_ROUTES = ["/", "/library"];
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -14,8 +17,10 @@ export default function Layout({ children }: LayoutProps) {
   const { data: aiStatus } = useAiStatus();
   const [activityOpen, setActivityOpen] = useState(false);
   const [chatOpen, setChatOpen] = useState(false);
+  const { pathname } = useLocation();
 
   const showAiBell = aiStatus?.configured === true;
+  const fullBleed = FULL_BLEED_ROUTES.includes(pathname);
 
   return (
     <SidebarProvider>
@@ -45,30 +50,54 @@ export default function Layout({ children }: LayoutProps) {
           )}
         </header>
 
+        {/* Desktop omni status bar */}
+        <div className="hidden md:flex h-9 items-center gap-3 border-b border-border bg-card px-4 font-mono text-[11px] text-muted-foreground">
+          <span className="text-foreground uppercase tracking-wide">
+            Comicarr
+          </span>
+          <span className="text-[var(--text-muted)]">/</span>
+          <span>
+            mode: <span className="text-foreground">production</span>
+          </span>
+          <span className="text-[var(--text-muted)]">·</span>
+          <span>
+            db: <span style={{ color: "var(--status-active)" }}>healthy</span>
+          </span>
+          <span className="text-[var(--text-muted)]">·</span>
+          <span>
+            queue: <span className="text-foreground">—</span>
+          </span>
+          <div className="ml-auto flex items-center gap-3">
+            {showAiBell && (
+              <>
+                <button
+                  onClick={() => setChatOpen(true)}
+                  className="rounded-sm p-1 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+                  aria-label="AI Chat"
+                >
+                  <MessageCircle className="h-3.5 w-3.5" />
+                </button>
+                <button
+                  onClick={() => setActivityOpen(true)}
+                  className="rounded-sm p-1 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+                  aria-label="AI Activity"
+                >
+                  <Bell className="h-3.5 w-3.5" />
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
         {/* Main content area */}
         <div className="flex-1 overflow-auto min-w-0">
-          {/* Desktop AI buttons */}
-          {showAiBell && (
-            <div className="hidden md:flex justify-end gap-1 px-4 sm:px-6 lg:px-8 pt-4 max-w-7xl mx-auto">
-              <button
-                onClick={() => setChatOpen(true)}
-                className="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-                aria-label="AI Chat"
-              >
-                <MessageCircle className="h-5 w-5" />
-              </button>
-              <button
-                onClick={() => setActivityOpen(true)}
-                className="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-                aria-label="AI Activity"
-              >
-                <Bell className="h-5 w-5" />
-              </button>
+          {fullBleed ? (
+            children
+          ) : (
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+              {children}
             </div>
           )}
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-            {children}
-          </div>
         </div>
       </main>
 

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -25,13 +25,13 @@ export default function PageHeader({
         <div className="text-[18px] font-semibold tracking-tight leading-none">
           {title}
         </div>
-        {meta && (
+        {meta != null && (
           <div className="font-mono text-[11px] text-muted-foreground mt-1.5 truncate">
             {meta}
           </div>
         )}
       </div>
-      {actions && (
+      {actions != null && (
         <div className="ml-auto flex items-center gap-2">{actions}</div>
       )}
     </div>
@@ -40,12 +40,20 @@ export default function PageHeader({
 
 interface TabRowProps {
   children: ReactNode;
+  ariaLabel?: string;
 }
 
-export function TabRow({ children }: TabRowProps) {
+/**
+ * Row of page-level view toggles. These intentionally use plain button
+ * semantics with `aria-pressed` (see Tab) rather than the full ARIA tab
+ * pattern — there are no separate tabpanel elements with focus/arrow-key
+ * navigation, so `role="tablist"` would over-promise.
+ */
+export function TabRow({ children, ariaLabel }: TabRowProps) {
   return (
     <div
-      role="tablist"
+      role="group"
+      aria-label={ariaLabel ?? "View toggles"}
       className="px-5 pt-3 border-b border-border flex items-end gap-6"
     >
       {children}
@@ -64,16 +72,15 @@ export function Tab({ active, label, onClick, meta }: TabProps) {
   return (
     <button
       type="button"
-      role="tab"
-      aria-selected={active}
+      aria-pressed={active}
       onClick={onClick}
-      className="relative pb-3 -mb-px font-mono text-[11px] tracking-[0.1em] uppercase flex items-center gap-2"
+      className="relative pb-3 -mb-px font-mono text-[11px] tracking-[0.1em] uppercase flex items-center gap-2 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       style={{
         color: active ? "var(--foreground)" : "var(--muted-foreground)",
       }}
     >
       <span>{label}</span>
-      {meta && (
+      {meta != null && (
         <span className="text-[10px]" style={{ color: "var(--text-muted)" }}>
           {meta}
         </span>

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -44,7 +44,10 @@ interface TabRowProps {
 
 export function TabRow({ children }: TabRowProps) {
   return (
-    <div className="px-5 pt-3 border-b border-border flex items-end gap-6">
+    <div
+      role="tablist"
+      className="px-5 pt-3 border-b border-border flex items-end gap-6"
+    >
       {children}
     </div>
   );
@@ -61,6 +64,8 @@ export function Tab({ active, label, onClick, meta }: TabProps) {
   return (
     <button
       type="button"
+      role="tab"
+      aria-selected={active}
       onClick={onClick}
       className="relative pb-3 -mb-px font-mono text-[11px] tracking-[0.1em] uppercase flex items-center gap-2"
       style={{

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -1,0 +1,82 @@
+import { ReactNode } from "react";
+
+interface PageHeaderProps {
+  title: string;
+  meta?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Standard Direction B page header — 18/semibold title + mono meta on the
+ * left, optional actions on the right, hairline divider below.
+ */
+export default function PageHeader({
+  title,
+  meta,
+  actions,
+  className = "",
+}: PageHeaderProps) {
+  return (
+    <div
+      className={`px-5 py-3.5 border-b border-border flex items-center gap-3 ${className}`}
+    >
+      <div className="min-w-0">
+        <div className="text-[18px] font-semibold tracking-tight leading-none">
+          {title}
+        </div>
+        {meta && (
+          <div className="font-mono text-[11px] text-muted-foreground mt-1.5 truncate">
+            {meta}
+          </div>
+        )}
+      </div>
+      {actions && (
+        <div className="ml-auto flex items-center gap-2">{actions}</div>
+      )}
+    </div>
+  );
+}
+
+interface TabRowProps {
+  children: ReactNode;
+}
+
+export function TabRow({ children }: TabRowProps) {
+  return (
+    <div className="px-5 pt-3 border-b border-border flex items-end gap-6">
+      {children}
+    </div>
+  );
+}
+
+interface TabProps {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+  meta?: ReactNode;
+}
+
+export function Tab({ active, label, onClick, meta }: TabProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="relative pb-3 -mb-px font-mono text-[11px] tracking-[0.1em] uppercase flex items-center gap-2"
+      style={{
+        color: active ? "var(--foreground)" : "var(--muted-foreground)",
+      }}
+    >
+      <span>{label}</span>
+      {meta && (
+        <span className="text-[10px]" style={{ color: "var(--text-muted)" }}>
+          {meta}
+        </span>
+      )}
+      <span
+        className="absolute left-0 right-0 bottom-0 h-[2px]"
+        style={{ background: active ? "var(--primary)" : "transparent" }}
+      />
+    </button>
+  );
+}

--- a/frontend/src/components/login/GridShader.tsx
+++ b/frontend/src/components/login/GridShader.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useRef } from "react";
+
+const SPACING = 40;
+const SAMPLE_STEP = 6;
+const WARP_RADIUS = 180;
+const WARP_STRENGTH = 10;
+const GLOW_RADIUS = 220;
+
+function readCssColor(varName: string, fallback: string): string {
+  if (typeof window === "undefined") return fallback;
+  const v = getComputedStyle(document.documentElement)
+    .getPropertyValue(varName)
+    .trim();
+  return v || fallback;
+}
+
+function parseRGB(color: string): [number, number, number] | null {
+  if (!color) return null;
+  if (color.startsWith("#")) {
+    const hex = color.slice(1);
+    const full =
+      hex.length === 3
+        ? hex
+            .split("")
+            .map((c) => c + c)
+            .join("")
+        : hex;
+    if (full.length !== 6) return null;
+    return [
+      parseInt(full.slice(0, 2), 16),
+      parseInt(full.slice(2, 4), 16),
+      parseInt(full.slice(4, 6), 16),
+    ];
+  }
+  const m = color.match(/\d+(\.\d+)?/g);
+  if (!m || m.length < 3) return null;
+  return [Number(m[0]), Number(m[1]), Number(m[2])];
+}
+
+export default function GridShader() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const reduce =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let dpr = Math.min(window.devicePixelRatio || 1, 2);
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+
+    const mouse = { x: -9999, y: -9999, active: false };
+    const smooth = { x: -9999, y: -9999, glow: 0 };
+    let running = false;
+    let rafId = 0;
+
+    const borderRGB = parseRGB(readCssColor("--border", "#232834")) || [
+      35, 40, 52,
+    ];
+    const accentRGB = parseRGB(readCssColor("--primary", "#ff6a1f")) || [
+      255, 106, 31,
+    ];
+
+    const resize = () => {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      draw();
+    };
+
+    const warpOffset = (dx: number, dy: number) => {
+      const d2 = dx * dx + dy * dy;
+      const r2 = WARP_RADIUS * WARP_RADIUS;
+      if (d2 > r2 * 4) return { ox: 0, oy: 0, intensity: 0 };
+      const f = Math.exp(-d2 / (r2 * 0.5));
+      const len = Math.sqrt(d2) || 1;
+      return {
+        ox: (dx / len) * WARP_STRENGTH * f * smooth.glow,
+        oy: (dy / len) * WARP_STRENGTH * f * smooth.glow,
+        intensity: f * smooth.glow,
+      };
+    };
+
+    const radialMask = (x: number, y: number) => {
+      const cx = width / 2;
+      const cy = height / 2;
+      const dx = x - cx;
+      const dy = y - cy;
+      const maxR = Math.hypot(cx, cy);
+      const r = Math.hypot(dx, dy) / maxR;
+      return Math.max(0, 1 - Math.pow(r / 0.7, 2));
+    };
+
+    const draw = () => {
+      ctx.clearRect(0, 0, width, height);
+
+      const baseAlpha = 0.085;
+      const mx = smooth.x;
+      const my = smooth.y;
+      const glowing = smooth.glow > 0.01;
+
+      for (let x = 0; x <= width + SPACING; x += SPACING) {
+        ctx.beginPath();
+        let started = false;
+        let accumIntensity = 0;
+        let samples = 0;
+        for (let y = 0; y <= height; y += SAMPLE_STEP) {
+          let px = x;
+          let py = y;
+          if (glowing) {
+            const { ox, oy, intensity } = warpOffset(x - mx, y - my);
+            px += ox;
+            py += oy;
+            accumIntensity += intensity;
+            samples++;
+          }
+          if (!started) {
+            ctx.moveTo(px, py);
+            started = true;
+          } else {
+            ctx.lineTo(px, py);
+          }
+        }
+        const mid = radialMask(x, height / 2);
+        let alpha = baseAlpha * mid;
+        let r = borderRGB[0];
+        let g = borderRGB[1];
+        let b = borderRGB[2];
+        if (glowing && samples > 0) {
+          const avg = accumIntensity / samples;
+          const boost = Math.min(1, avg * 2.8);
+          alpha = Math.min(0.5, (baseAlpha + boost * 0.28) * mid);
+          const mix = Math.min(1, avg * 3.2);
+          r = Math.round(borderRGB[0] + (accentRGB[0] - borderRGB[0]) * mix);
+          g = Math.round(borderRGB[1] + (accentRGB[1] - borderRGB[1]) * mix);
+          b = Math.round(borderRGB[2] + (accentRGB[2] - borderRGB[2]) * mix);
+        }
+        ctx.strokeStyle = `rgba(${r}, ${g}, ${b}, ${alpha})`;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+      }
+
+      for (let y = 0; y <= height + SPACING; y += SPACING) {
+        ctx.beginPath();
+        let started = false;
+        let accumIntensity = 0;
+        let samples = 0;
+        for (let x = 0; x <= width; x += SAMPLE_STEP) {
+          let px = x;
+          let py = y;
+          if (glowing) {
+            const { ox, oy, intensity } = warpOffset(x - mx, y - my);
+            px += ox;
+            py += oy;
+            accumIntensity += intensity;
+            samples++;
+          }
+          if (!started) {
+            ctx.moveTo(px, py);
+            started = true;
+          } else {
+            ctx.lineTo(px, py);
+          }
+        }
+        const mid = radialMask(width / 2, y);
+        let alpha = baseAlpha * mid;
+        let r = borderRGB[0];
+        let g = borderRGB[1];
+        let b = borderRGB[2];
+        if (glowing && samples > 0) {
+          const avg = accumIntensity / samples;
+          const boost = Math.min(1, avg * 2.8);
+          alpha = Math.min(0.5, (baseAlpha + boost * 0.28) * mid);
+          const mix = Math.min(1, avg * 3.2);
+          r = Math.round(borderRGB[0] + (accentRGB[0] - borderRGB[0]) * mix);
+          g = Math.round(borderRGB[1] + (accentRGB[1] - borderRGB[1]) * mix);
+          b = Math.round(borderRGB[2] + (accentRGB[2] - borderRGB[2]) * mix);
+        }
+        ctx.strokeStyle = `rgba(${r}, ${g}, ${b}, ${alpha})`;
+        ctx.lineWidth = 1;
+        ctx.stroke();
+      }
+
+      // Soft accent bloom directly under cursor
+      if (glowing) {
+        const grad = ctx.createRadialGradient(mx, my, 0, mx, my, GLOW_RADIUS);
+        const a = 0.1 * smooth.glow;
+        grad.addColorStop(
+          0,
+          `rgba(${accentRGB[0]}, ${accentRGB[1]}, ${accentRGB[2]}, ${a})`,
+        );
+        grad.addColorStop(
+          1,
+          `rgba(${accentRGB[0]}, ${accentRGB[1]}, ${accentRGB[2]}, 0)`,
+        );
+        ctx.fillStyle = grad;
+        ctx.fillRect(
+          mx - GLOW_RADIUS,
+          my - GLOW_RADIUS,
+          GLOW_RADIUS * 2,
+          GLOW_RADIUS * 2,
+        );
+      }
+    };
+
+    const tick = () => {
+      const tx = mouse.x;
+      const ty = mouse.y;
+      smooth.x += (tx - smooth.x) * 0.18;
+      smooth.y += (ty - smooth.y) * 0.18;
+      const targetGlow = mouse.active ? 1 : 0;
+      smooth.glow += (targetGlow - smooth.glow) * 0.08;
+      draw();
+      if (
+        mouse.active ||
+        smooth.glow > 0.02 ||
+        Math.abs(tx - smooth.x) > 0.5 ||
+        Math.abs(ty - smooth.y) > 0.5
+      ) {
+        rafId = requestAnimationFrame(tick);
+      } else {
+        running = false;
+        smooth.glow = 0;
+        draw();
+      }
+    };
+
+    const ensureRunning = () => {
+      if (running || reduce) return;
+      running = true;
+      rafId = requestAnimationFrame(tick);
+    };
+
+    const onMove = (e: MouseEvent) => {
+      mouse.x = e.clientX;
+      mouse.y = e.clientY;
+      mouse.active = true;
+      ensureRunning();
+    };
+    const onLeave = () => {
+      mouse.active = false;
+      ensureRunning();
+    };
+
+    window.addEventListener("resize", resize);
+    window.addEventListener("mousemove", onMove, { passive: true });
+    window.addEventListener("mouseleave", onLeave);
+
+    resize();
+
+    return () => {
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseleave", onLeave);
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className="absolute inset-0 w-full h-full pointer-events-none"
+    />
+  );
+}

--- a/frontend/src/components/onboarding/OnboardingDialog.tsx
+++ b/frontend/src/components/onboarding/OnboardingDialog.tsx
@@ -61,7 +61,7 @@ function PrimaryButton({
     >
       {children}
       {endKbd && (
-        <Kbd className="!bg-black/10 !border-black/20 !text-black/70">
+        <Kbd className="bg-black/10! border-black/20! text-black/70!">
           {endKbd}
         </Kbd>
       )}
@@ -159,6 +159,12 @@ export default function OnboardingDialog({
           className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-[min(560px,calc(100vw-32px))] max-h-[min(640px,calc(100vh-32px))] overflow-hidden rounded-[10px] border bg-card shadow-[0_30px_80px_rgba(0,0,0,0.5)] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           style={{ borderColor: "var(--border)" }}
         >
+          <DialogPrimitive.Title className="sr-only">
+            Comicarr onboarding
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Guided setup to migrate from Mylar3 or start with a fresh library.
+          </DialogPrimitive.Description>
           {/* Header */}
           <div
             className="flex items-center gap-2 px-5 py-3 border-b"

--- a/frontend/src/components/onboarding/OnboardingDialog.tsx
+++ b/frontend/src/components/onboarding/OnboardingDialog.tsx
@@ -16,6 +16,7 @@ import {
   usePreviewMigration,
   useStartMigration,
   useMigrationProgress,
+  type MigrationStatus,
 } from "@/hooks/useMigration";
 import { Kbd } from "@/components/ui/kbd";
 import Logo from "@/components/Logo";
@@ -367,6 +368,7 @@ function MigrateStep({
           />
           <input
             type="text"
+            aria-label="Mylar3 data directory path"
             value={path}
             onChange={(e) => setPath(e.target.value)}
             onKeyDown={(e) => {
@@ -588,7 +590,7 @@ function DoneStep({
   onFinish,
   onRetry,
 }: {
-  progress?: { status: string; error?: string };
+  progress?: { status: MigrationStatus; error?: string };
   onFinish: () => void;
   onRetry: () => void;
 }) {

--- a/frontend/src/components/onboarding/OnboardingDialog.tsx
+++ b/frontend/src/components/onboarding/OnboardingDialog.tsx
@@ -1,0 +1,643 @@
+import { useEffect, useState } from "react";
+import {
+  ArrowRight,
+  Check,
+  FolderOpen,
+  Loader2,
+  TriangleAlert,
+  SearchCheck,
+  Sparkles,
+  Database,
+  BookOpen,
+  ChevronLeft,
+} from "lucide-react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import {
+  usePreviewMigration,
+  useStartMigration,
+  useMigrationProgress,
+} from "@/hooks/useMigration";
+import { Kbd } from "@/components/ui/kbd";
+import Logo from "@/components/Logo";
+
+type Step = "welcome" | "migrate" | "fresh" | "running" | "done";
+
+interface OnboardingDialogProps {
+  open: boolean;
+  onFinish: () => void;
+}
+
+function MonoLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function PrimaryButton({
+  children,
+  onClick,
+  disabled,
+  type = "button",
+  endKbd,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  type?: "button" | "submit";
+  endKbd?: string;
+}) {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      className="inline-flex items-center justify-center gap-2 px-3.5 py-2 rounded-[5px] text-[12px] font-semibold disabled:opacity-60"
+      style={{
+        background: "var(--primary)",
+        color: "var(--primary-foreground)",
+      }}
+    >
+      {children}
+      {endKbd && (
+        <Kbd className="!bg-black/10 !border-black/20 !text-black/70">
+          {endKbd}
+        </Kbd>
+      )}
+    </button>
+  );
+}
+
+function GhostButton({
+  children,
+  onClick,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="inline-flex items-center gap-1.5 px-3 py-2 rounded-[5px] border text-[12px] text-foreground disabled:opacity-60"
+      style={{ borderColor: "var(--border)" }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div
+      className="px-3 py-2 rounded-[5px] border"
+      style={{ borderColor: "var(--border)", background: "var(--background)" }}
+    >
+      <MonoLabel>{label}</MonoLabel>
+      <div className="text-[18px] font-semibold tracking-tight mt-0.5">
+        {typeof value === "number" ? value.toLocaleString() : value}
+      </div>
+    </div>
+  );
+}
+
+export default function OnboardingDialog({
+  open,
+  onFinish,
+}: OnboardingDialogProps) {
+  const [step, setStep] = useState<Step>("welcome");
+  const [path, setPath] = useState("/mylar3");
+
+  const preview = usePreviewMigration();
+  const start = useStartMigration();
+  const progress = useMigrationProgress(step === "running");
+
+  // Derive the visible step: once we're in `running`, advance to `done` as
+  // soon as the backend reports a terminal status. This avoids a setState-
+  // in-effect pattern and keeps the source of truth in backend progress.
+  const terminal =
+    step === "running" &&
+    (progress.data?.status === "complete" || progress.data?.status === "error");
+  const visibleStep: Step = terminal ? "done" : step;
+  const migrating = visibleStep === "running";
+
+  // Warn on unload during an active migration
+  useEffect(() => {
+    if (!migrating) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [migrating]);
+
+  const startMigration = () => {
+    start.mutate(path.trim(), {
+      onSuccess: () => setStep("running"),
+    });
+  };
+
+  return (
+    <DialogPrimitive.Root open={open} modal>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in-0"
+          // Dismissing via overlay disabled — must use in-dialog actions
+          onPointerDown={(e) => e.preventDefault()}
+        />
+        <DialogPrimitive.Content
+          onEscapeKeyDown={(e) => {
+            if (migrating) e.preventDefault();
+          }}
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onInteractOutside={(e) => e.preventDefault()}
+          className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-[min(560px,calc(100vw-32px))] max-h-[min(640px,calc(100vh-32px))] overflow-hidden rounded-[10px] border bg-card shadow-[0_30px_80px_rgba(0,0,0,0.5)] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          style={{ borderColor: "var(--border)" }}
+        >
+          {/* Header */}
+          <div
+            className="flex items-center gap-2 px-5 py-3 border-b"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <Logo className="h-3.5 w-auto text-foreground" />
+            <span className="font-mono text-[10px] text-muted-foreground px-1.5 py-0.5 border border-border rounded-sm">
+              onboarding
+            </span>
+            <div className="ml-auto flex items-center gap-2 font-mono text-[10px] text-muted-foreground">
+              <StepDots step={visibleStep} />
+            </div>
+          </div>
+
+          {/* Body */}
+          <div className="px-5 py-5">
+            {visibleStep === "welcome" && (
+              <WelcomeStep
+                onMigrate={() => setStep("migrate")}
+                onFresh={() => setStep("fresh")}
+              />
+            )}
+
+            {visibleStep === "migrate" && (
+              <MigrateStep
+                path={path}
+                setPath={setPath}
+                preview={preview}
+                start={start}
+                onBack={() => setStep("welcome")}
+                onStart={startMigration}
+              />
+            )}
+
+            {visibleStep === "fresh" && <FreshStep onFinish={onFinish} />}
+
+            {visibleStep === "running" && (
+              <RunningStep progress={progress.data} />
+            )}
+
+            {visibleStep === "done" && (
+              <DoneStep
+                progress={progress.data}
+                onFinish={onFinish}
+                onRetry={() => setStep("migrate")}
+              />
+            )}
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+// ============ Steps ============
+
+function StepDots({ step }: { step: Step }) {
+  const order: Step[] = ["welcome", "migrate", "running", "done"];
+  const index = step === "fresh" ? 1 : Math.max(0, order.indexOf(step as Step));
+  return (
+    <div className="flex items-center gap-1.5">
+      {[0, 1, 2, 3].map((i) => (
+        <span
+          key={i}
+          className="w-1.5 h-1.5 rounded-full"
+          style={{
+            background: i <= index ? "var(--primary)" : "var(--border)",
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function WelcomeStep({
+  onMigrate,
+  onFresh,
+}: {
+  onMigrate: () => void;
+  onFresh: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <MonoLabel>Welcome · v0.15.1</MonoLabel>
+      <div className="text-[20px] font-semibold tracking-tight">
+        Let's get your library set up.
+      </div>
+      <div className="text-[13px] text-muted-foreground leading-relaxed">
+        Comicarr can start fresh or pull your existing series, issues, and
+        download history from a Mylar3 installation.
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2">
+        <ChoiceCard
+          icon={Database}
+          eyebrow="Migrate"
+          title="I'm coming from Mylar3"
+          description="Import my library and settings."
+          onClick={onMigrate}
+        />
+        <ChoiceCard
+          icon={Sparkles}
+          eyebrow="Start fresh"
+          title="I'm new to Comicarr"
+          description="Begin with an empty library."
+          onClick={onFresh}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ChoiceCard({
+  icon: Icon,
+  eyebrow,
+  title,
+  description,
+  onClick,
+}: {
+  icon: typeof Database;
+  eyebrow: string;
+  title: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group text-left p-3.5 rounded-[6px] border bg-background hover:border-[var(--primary)] transition-colors"
+      style={{ borderColor: "var(--border)" }}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <Icon
+          className="w-3.5 h-3.5"
+          style={{ color: "var(--primary)" }}
+          strokeWidth={1.75}
+        />
+        <MonoLabel>{eyebrow}</MonoLabel>
+      </div>
+      <div className="text-[13px] font-semibold tracking-tight mb-0.5">
+        {title}
+      </div>
+      <div className="text-[11.5px] text-muted-foreground leading-snug">
+        {description}
+      </div>
+      <div className="mt-3 inline-flex items-center gap-1 font-mono text-[10px] text-muted-foreground group-hover:text-[var(--primary)]">
+        choose <ArrowRight className="w-3 h-3" />
+      </div>
+    </button>
+  );
+}
+
+function MigrateStep({
+  path,
+  setPath,
+  preview,
+  start,
+  onBack,
+  onStart,
+}: {
+  path: string;
+  setPath: (v: string) => void;
+  preview: ReturnType<typeof usePreviewMigration>;
+  start: ReturnType<typeof useStartMigration>;
+  onBack: () => void;
+  onStart: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="inline-flex items-center gap-1 font-mono text-[10px] text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="w-3 h-3" />
+          back
+        </button>
+      </div>
+
+      <MonoLabel>Migrate from Mylar3</MonoLabel>
+      <div className="text-[18px] font-semibold tracking-tight">
+        Point us at your Mylar3 data directory.
+      </div>
+      <div className="text-[12px] text-muted-foreground leading-relaxed">
+        Typically mounted into the container as a Docker volume. We'll read it,
+        but won't modify anything.
+      </div>
+
+      <div>
+        <MonoLabel>Mylar3 path</MonoLabel>
+        <div
+          className="flex items-center gap-2 px-3 py-2 rounded-[5px] border bg-background mt-1.5"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <FolderOpen
+            className="w-3.5 h-3.5"
+            style={{ color: "var(--muted-foreground)" }}
+          />
+          <input
+            type="text"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") preview.mutate(path.trim());
+            }}
+            placeholder="/mylar3"
+            className="flex-1 bg-transparent outline-none text-[13px] font-mono placeholder:text-[var(--text-muted)]"
+          />
+          <button
+            type="button"
+            onClick={() => preview.mutate(path.trim())}
+            disabled={preview.isPending || !path.trim()}
+            className="inline-flex items-center gap-1.5 font-mono text-[10px] px-2 py-1 rounded border disabled:opacity-60"
+            style={{
+              borderColor: "var(--border)",
+              color: "var(--muted-foreground)",
+            }}
+          >
+            {preview.isPending ? (
+              <Loader2 className="w-3 h-3 animate-spin" />
+            ) : (
+              <SearchCheck className="w-3 h-3" />
+            )}
+            validate
+          </button>
+        </div>
+      </div>
+
+      {preview.isError && (
+        <div
+          className="flex items-start gap-2 p-2.5 rounded-md text-[12px] font-mono"
+          style={{
+            color: "var(--status-error)",
+            background: "var(--status-error-bg)",
+          }}
+        >
+          <TriangleAlert className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+          <span>{preview.error.message}</span>
+        </div>
+      )}
+
+      {preview.data && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <MonoLabel>Preview</MonoLabel>
+            <span className="font-mono text-[10px] text-muted-foreground">
+              mylar3 v{preview.data.version}
+            </span>
+          </div>
+          <div className="grid grid-cols-4 gap-2">
+            <Stat label="series" value={preview.data.series_count} />
+            <Stat label="issues" value={preview.data.issue_count} />
+            <Stat
+              label="config"
+              value={preview.data.config_categories.length}
+            />
+            <Stat label="tables" value={preview.data.tables.length} />
+          </div>
+          {preview.data.path_warnings.length > 0 && (
+            <div
+              className="flex items-start gap-2 p-2.5 rounded-md text-[11.5px]"
+              style={{
+                color: "var(--status-paused)",
+                background: "var(--status-paused-bg)",
+              }}
+            >
+              <TriangleAlert className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+              <span>
+                {preview.data.path_warnings.length} path settings may need
+                updating for Docker — review after migration.
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div
+        className="flex items-center justify-between pt-3 mt-1 border-t"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <GhostButton onClick={onBack}>Cancel</GhostButton>
+        {preview.data && (
+          <PrimaryButton
+            onClick={onStart}
+            disabled={start.isPending}
+            endKbd="↵"
+          >
+            {start.isPending ? (
+              <>
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                Starting…
+              </>
+            ) : (
+              <>Start migration</>
+            )}
+          </PrimaryButton>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FreshStep({ onFinish }: { onFinish: () => void }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <MonoLabel>Start fresh</MonoLabel>
+      <div className="text-[18px] font-semibold tracking-tight">
+        You're all set.
+      </div>
+      <div className="text-[12px] text-muted-foreground leading-relaxed">
+        A few quick things you can do next — none are required.
+      </div>
+
+      <div
+        className="rounded-[6px] border divide-y"
+        style={{ borderColor: "var(--border)" }}
+      >
+        {[
+          {
+            label: "Connect a provider",
+            hint: "Settings → API & providers (Comic Vine, MangaDex)",
+            icon: Database,
+          },
+          {
+            label: "Configure library paths",
+            hint: "Settings → Media (comic + manga directories)",
+            icon: FolderOpen,
+          },
+          {
+            label: "Add your first series",
+            hint: "Library → Add, or press N from anywhere",
+            icon: BookOpen,
+          },
+        ].map(({ label, hint, icon: Icon }) => (
+          <div key={label} className="flex items-start gap-3 px-3.5 py-3">
+            <Icon
+              className="w-3.5 h-3.5 mt-0.5 shrink-0"
+              style={{ color: "var(--primary)" }}
+              strokeWidth={1.75}
+            />
+            <div className="flex-1 min-w-0">
+              <div className="text-[13px] font-medium">{label}</div>
+              <div className="font-mono text-[10.5px] text-muted-foreground mt-0.5">
+                {hint}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div
+        className="flex justify-end pt-3 border-t"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <PrimaryButton onClick={onFinish} endKbd="↵">
+          Take me to the dashboard
+        </PrimaryButton>
+      </div>
+    </div>
+  );
+}
+
+function RunningStep({
+  progress,
+}: {
+  progress?: {
+    current_table: string;
+    tables_complete: number;
+    tables_total: number;
+  };
+}) {
+  const pct = progress?.tables_total
+    ? Math.round((progress.tables_complete / progress.tables_total) * 100)
+    : 0;
+  return (
+    <div className="flex flex-col gap-4">
+      <MonoLabel>Migrating · do not close this tab</MonoLabel>
+      <div className="text-[18px] font-semibold tracking-tight">
+        Importing your library…
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Loader2
+          className="w-4 h-4 animate-spin"
+          style={{ color: "var(--primary)" }}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="font-mono text-[11px] text-muted-foreground truncate">
+            current:{" "}
+            <span className="text-foreground">
+              {progress?.current_table || "—"}
+            </span>
+          </div>
+        </div>
+        <div className="font-mono text-[11px] text-muted-foreground">
+          {progress?.tables_complete ?? 0} / {progress?.tables_total ?? 0}
+        </div>
+      </div>
+
+      <div
+        className="h-[3px] rounded-full overflow-hidden"
+        style={{ background: "var(--secondary)" }}
+      >
+        <div
+          className="h-full transition-all duration-500"
+          style={{ width: `${pct}%`, background: "var(--primary)" }}
+        />
+      </div>
+
+      <div className="font-mono text-[10px] text-muted-foreground text-right">
+        {pct}%
+      </div>
+    </div>
+  );
+}
+
+function DoneStep({
+  progress,
+  onFinish,
+  onRetry,
+}: {
+  progress?: { status: string; error?: string };
+  onFinish: () => void;
+  onRetry: () => void;
+}) {
+  const errored = progress?.status === "error";
+
+  if (errored) {
+    return (
+      <div className="flex flex-col gap-4">
+        <MonoLabel>Migration failed</MonoLabel>
+        <div className="text-[18px] font-semibold tracking-tight">
+          Something went wrong.
+        </div>
+        <div
+          className="p-3 rounded-md font-mono text-[11.5px]"
+          style={{
+            color: "var(--status-error)",
+            background: "var(--status-error-bg)",
+          }}
+        >
+          {progress?.error || "Unknown error"}
+        </div>
+        <div
+          className="flex justify-between pt-3 border-t"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <GhostButton onClick={onFinish}>Skip for now</GhostButton>
+          <PrimaryButton onClick={onRetry}>Try again</PrimaryButton>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <MonoLabel>Migration complete</MonoLabel>
+      <div className="flex items-center gap-2 text-[18px] font-semibold tracking-tight">
+        <Check
+          className="w-5 h-5"
+          style={{ color: "var(--status-active)" }}
+          strokeWidth={2.25}
+        />
+        Your library is ready.
+      </div>
+      <div className="text-[12px] text-muted-foreground leading-relaxed">
+        Everything from Mylar3 has been imported. You may need to refresh
+        metadata on a few series.
+      </div>
+      <div
+        className="flex justify-end pt-3 border-t"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <PrimaryButton onClick={onFinish} endKbd="↵">
+          Go to dashboard
+        </PrimaryButton>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -1,12 +1,5 @@
-import { useState, useEffect, useRef, useMemo } from "react";
-import { createPortal } from "react-dom";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  useReactTable,
-  getCoreRowModel,
-  createColumnHelper,
-  type VisibilityState,
-} from "@tanstack/react-table";
 import {
   ChevronUp,
   ChevronDown,
@@ -16,57 +9,10 @@ import {
   Loader2,
   ImageOff,
   ExternalLink,
-  Settings2,
 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { DataTable } from "@/components/data-table/DataTable";
 import { useAddComic, useAddManga } from "@/hooks/useSearch";
 import { useToast } from "@/components/ui/toast";
 import type { SearchResult, ContentType } from "@/types";
-
-const columnHelper = createColumnHelper<SearchResult>();
-
-// Lazy-loaded cover thumbnail component
-function CoverThumbnail({ comic }: { comic: SearchResult }) {
-  const [imageError, setImageError] = useState(false);
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  const imageUrl = comic.comicthumb || comic.image || comic.comicimage;
-
-  if (!imageUrl || imageError) {
-    return (
-      <div className="w-10 h-14 bg-muted rounded flex items-center justify-center flex-shrink-0">
-        <ImageOff className="w-4 h-4 text-muted-foreground/50" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="w-10 h-14 bg-muted rounded overflow-hidden flex-shrink-0">
-      <img
-        src={imageUrl}
-        alt={comic.name}
-        className={`w-full h-full object-cover transition-opacity duration-200 ${
-          isLoaded ? "opacity-100" : "opacity-0"
-        }`}
-        loading="lazy"
-        onLoad={() => setIsLoaded(true)}
-        onError={() => setImageError(true)}
-      />
-    </div>
-  );
-}
 
 const SOURCE_LABELS: Record<string, string> = {
   comicvine: "CV",
@@ -102,77 +48,6 @@ function truncate(text: string, max: number): string {
   return text.slice(0, max).trimEnd() + "\u2026";
 }
 
-// Column visibility toggle for search results
-function SearchColumnVisibility({
-  columnVisibility,
-  onToggle,
-  isManga,
-}: {
-  columnVisibility: VisibilityState;
-  onToggle: (columnId: string) => void;
-  isManga: boolean;
-}) {
-  const toggleableColumns = [
-    { id: "publisher", label: isManga ? "Author" : "Publisher" },
-    { id: "seriesStatus", label: "Status" },
-    { id: "contentRating", label: "Content Rating" },
-  ];
-
-  return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button variant="outline" size="icon" className="shadow-none">
-          <Settings2 className="h-4 w-4" />
-          <span className="sr-only">Toggle columns</span>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent side="bottom" align="end" className="w-[180px] p-2">
-        <div className="space-y-1">
-          <p className="text-xs font-medium text-muted-foreground px-2 py-1">
-            Toggle columns
-          </p>
-          {toggleableColumns.map((col) => (
-            <button
-              key={col.id}
-              onClick={() => onToggle(col.id)}
-              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent"
-            >
-              <div
-                className={`flex h-4 w-4 items-center justify-center rounded-sm border ${
-                  columnVisibility[col.id] !== false
-                    ? "bg-primary text-primary-foreground border-primary"
-                    : "opacity-50"
-                }`}
-              >
-                {columnVisibility[col.id] !== false && (
-                  <Check className="h-3 w-3" />
-                )}
-              </div>
-              <span>{col.label}</span>
-            </button>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-interface SearchResultsTableProps {
-  results: SearchResult[];
-  currentSort: string;
-  onSortChange: (sort: string) => void;
-  contentType: ContentType;
-  /** DOM element to portal the column toggle button into */
-  columnToggleContainer?: HTMLElement | null;
-}
-
-interface AddByIdEventDetail {
-  comicid: string;
-  status: "success" | "failure";
-  message?: string;
-}
-
-// Map column IDs to API sort values
 const SORT_COLUMN_MAP: Record<string, { asc: string; desc: string }> = {
   series: { asc: "name_asc", desc: "name_desc" },
   year: { asc: "year_asc", desc: "year_desc" },
@@ -190,8 +65,49 @@ function getColumnSort(
   return false;
 }
 
-// Action cell component to handle add-to-library logic
-function ActionCell({
+function CoverThumbnail({ comic }: { comic: SearchResult }) {
+  const [imageError, setImageError] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const imageUrl = comic.comicthumb || comic.image || comic.comicimage;
+
+  if (!imageUrl || imageError) {
+    return (
+      <div
+        className="w-10 h-[56px] rounded-[3px] border flex items-center justify-center shrink-0"
+        style={{ borderColor: "var(--border)", background: "var(--card)" }}
+      >
+        <ImageOff className="w-3.5 h-3.5 text-muted-foreground/50" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="w-10 h-[56px] rounded-[3px] overflow-hidden shrink-0 border"
+      style={{ borderColor: "var(--border)", background: "var(--card)" }}
+    >
+      <img
+        src={imageUrl}
+        alt={comic.name}
+        className={`w-full h-full object-cover transition-opacity duration-200 ${
+          isLoaded ? "opacity-100" : "opacity-0"
+        }`}
+        loading="lazy"
+        onLoad={() => setIsLoaded(true)}
+        onError={() => setImageError(true)}
+      />
+    </div>
+  );
+}
+
+interface AddByIdEventDetail {
+  comicid: string;
+  status: "success" | "failure";
+  message?: string;
+}
+
+function AddButton({
   comic,
   contentType,
 }: {
@@ -209,7 +125,6 @@ function ActionCell({
   const isManga = contentType === "manga";
   const itemLabel = isManga ? "Manga" : "Comic";
 
-  // Listen for SSE events when a comic is being added
   useEffect(() => {
     if (!isProcessing || !comicIdRef.current) return;
     let cancelled = false;
@@ -218,7 +133,6 @@ function ActionCell({
       if (cancelled) return;
       try {
         const data: AddByIdEventDetail = JSON.parse(event.detail);
-
         if (data.comicid === comicIdRef.current) {
           if (data.status === "success") {
             navigate(`/library/${comicIdRef.current}`);
@@ -242,25 +156,20 @@ function ActionCell({
     };
 
     window.addEventListener("comic-added", handleAddById as EventListener);
-
     return () => {
       cancelled = true;
       window.removeEventListener("comic-added", handleAddById as EventListener);
     };
   }, [isProcessing, navigate, addToast]);
 
-  const handleAddComic = async (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleAdd = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-
     try {
       comicIdRef.current = comic.comicid ?? comic.id ?? null;
       setIsProcessing(true);
-
-      if (isManga) {
+      if (isManga)
         await addMangaMutation.mutateAsync(comic.comicid ?? comic.id);
-      } else {
-        await addComicMutation.mutateAsync(comic.comicid ?? comic.id);
-      }
+      else await addComicMutation.mutateAsync(comic.comicid ?? comic.id);
       setIsAdded(true);
       addToast({
         type: "success",
@@ -280,43 +189,65 @@ function ActionCell({
     }
   };
 
+  const base =
+    "inline-flex items-center gap-1 px-2.5 py-1 rounded-[5px] border font-mono text-[11px] transition-colors";
+
   if (isAdded) {
     return (
-      <Button variant="outline" size="sm" disabled>
-        <Check className="w-3 h-3 mr-1" />
-        Added
-      </Button>
+      <button
+        type="button"
+        disabled
+        className={base}
+        style={{
+          borderColor: "var(--border)",
+          color: "var(--status-active)",
+        }}
+      >
+        <Check className="w-3 h-3" />
+        added
+      </button>
     );
   }
 
   if (isProcessing) {
     return (
-      <Button variant="outline" size="sm" disabled>
-        <Loader2 className="w-3 h-3 mr-1 animate-spin" />
-        Processing...
-      </Button>
+      <button
+        type="button"
+        disabled
+        className={base}
+        style={{
+          borderColor: "var(--border)",
+          color: "var(--muted-foreground)",
+        }}
+      >
+        <Loader2 className="w-3 h-3 animate-spin" />
+        adding…
+      </button>
     );
   }
 
   const isPending = isManga
     ? addMangaMutation.isPending
     : addComicMutation.isPending;
+
   return (
-    <Button
-      onClick={handleAddComic}
+    <button
+      type="button"
+      onClick={handleAdd}
       disabled={isPending}
-      variant="outline"
-      size="sm"
-      className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
+      className={`${base} hover:bg-[color-mix(in_oklab,var(--primary)_14%,transparent)]`}
+      style={{
+        borderColor: "var(--primary)",
+        color: "var(--primary)",
+      }}
     >
-      <Plus className="w-3 h-3 mr-1" />
-      {isPending ? "Adding..." : "Add"}
-    </Button>
+      <Plus className="w-3 h-3" />
+      {isPending ? "adding…" : "add"}
+    </button>
   );
 }
 
-// Server-side sort header for search results
-function ServerSortHeader({
+function SortHeader({
   columnId,
   title,
   currentSort,
@@ -329,7 +260,6 @@ function ServerSortHeader({
 }) {
   const mapping = SORT_COLUMN_MAP[columnId];
   if (!mapping) return <span>{title}</span>;
-
   const sortState = getColumnSort(columnId, currentSort);
   const ariaSort =
     sortState === "asc"
@@ -344,96 +274,123 @@ function ServerSortHeader({
     else onSortChange(mapping.desc);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleClick();
-    }
-  };
-
   return (
-    <div
-      className="flex items-center gap-1 cursor-pointer select-none hover:text-foreground"
-      role="button"
-      tabIndex={0}
-      aria-sort={ariaSort}
+    <button
+      type="button"
       onClick={handleClick}
-      onKeyDown={handleKeyDown}
+      aria-sort={ariaSort}
+      className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
     >
       <span>{title}</span>
       {sortState === "asc" ? (
-        <ChevronUp className="w-4 h-4" />
+        <ChevronUp className="w-3 h-3" />
       ) : sortState === "desc" ? (
-        <ChevronDown className="w-4 h-4" />
+        <ChevronDown className="w-3 h-3" />
       ) : (
-        <ChevronsUpDown className="w-4 h-4 text-muted-foreground/50" />
+        <ChevronsUpDown className="w-3 h-3 opacity-50" />
       )}
-    </div>
+    </button>
   );
 }
+
+interface SearchResultsTableProps {
+  results: SearchResult[];
+  currentSort: string;
+  onSortChange: (sort: string) => void;
+  contentType: ContentType;
+  /** Unused — retained for API compatibility. */
+  columnToggleContainer?: HTMLElement | null;
+}
+
+const GRID = "40px 56px 1fr 160px 70px 70px 100px";
 
 export default function SearchResultsTable({
   results,
   currentSort,
   onSortChange,
   contentType,
-  columnToggleContainer,
 }: SearchResultsTableProps) {
   const isManga = contentType === "manga";
   const issuesLabel = isManga ? "Chapters" : "Issues";
   const publisherLabel = isManga ? "Author" : "Publisher";
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
-    publisher: true,
-    seriesStatus: false,
-    contentRating: false,
-  });
-
-  const handleToggleColumn = (columnId: string) => {
-    setColumnVisibility((prev) => ({
-      ...prev,
-      [columnId]: prev[columnId] === false,
-    }));
-  };
-
-  const columns = useMemo(
-    () => [
-      columnHelper.display({
-        id: "cover",
-        header: "",
-        enableSorting: false,
-        enableHiding: false,
-        size: 50,
-        cell: ({ row }) => <CoverThumbnail comic={row.original} />,
-      }),
-      columnHelper.accessor("name", {
-        id: "series",
-        enableHiding: false,
-        header: () => (
-          <ServerSortHeader
+  return (
+    <div>
+      {/* Header */}
+      <div
+        className="grid items-center gap-3 px-5 py-2 font-mono text-[10px] tracking-[0.08em] uppercase border-b"
+        style={{
+          gridTemplateColumns: GRID,
+          borderColor: "var(--border)",
+          color: "var(--text-muted)",
+        }}
+      >
+        <div />
+        <div />
+        <div>
+          <SortHeader
             columnId="series"
             title="Series"
             currentSort={currentSort}
             onSortChange={onSortChange}
           />
-        ),
-        cell: ({ row }) => {
-          const comic = row.original;
-          const description = getDescription(comic);
-          const sourceLabel =
-            SOURCE_LABELS[comic.metadata_source ?? ""] ?? null;
+        </div>
+        <div>{publisherLabel}</div>
+        <div>
+          <SortHeader
+            columnId="year"
+            title="Year"
+            currentSort={currentSort}
+            onSortChange={onSortChange}
+          />
+        </div>
+        <div>
+          <SortHeader
+            columnId="issues"
+            title={issuesLabel}
+            currentSort={currentSort}
+            onSortChange={onSortChange}
+          />
+        </div>
+        <div />
+      </div>
 
-          const nameContent = (
-            <div className="min-w-0 max-w-[350px]">
+      {/* Rows */}
+      {results.map((comic, idx) => {
+        const description = getDescription(comic);
+        const sourceLabel = SOURCE_LABELS[comic.metadata_source ?? ""] ?? null;
+        const issues = comic.issues ?? comic.count_of_issues;
+        return (
+          <div
+            key={comic.comicid ?? comic.id ?? idx}
+            className="grid items-center gap-3 px-5 py-2.5 border-b hover:bg-secondary/30 transition-colors text-[12px]"
+            style={{
+              gridTemplateColumns: GRID,
+              borderColor: "var(--border)",
+            }}
+          >
+            <div
+              className="font-mono text-[10px]"
+              style={{ color: "var(--text-muted)" }}
+            >
+              {String(idx + 1).padStart(2, "0")}
+            </div>
+            <CoverThumbnail comic={comic} />
+            <div className="min-w-0">
               <div className="flex items-center gap-1.5 min-w-0">
-                <span className="font-medium truncate">{comic.name}</span>
+                <span className="font-medium truncate text-[13px]">
+                  {comic.name}
+                </span>
                 {sourceLabel && (
-                  <Badge
-                    variant="outline"
-                    className="text-[10px] px-1.5 py-0 font-normal shrink-0"
+                  <span
+                    className="shrink-0 font-mono text-[9px] tracking-[0.05em] uppercase px-1.5 py-0.5 rounded-[3px] border"
+                    style={{
+                      borderColor: "var(--border)",
+                      color: "var(--muted-foreground)",
+                    }}
                   >
                     {sourceLabel}
-                  </Badge>
+                  </span>
                 )}
                 {comic.url && isSafeUrl(comic.url) && (
                   <a
@@ -441,7 +398,7 @@ export default function SearchResultsTable({
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={(e) => e.stopPropagation()}
-                    className="text-muted-foreground hover:text-foreground shrink-0"
+                    className="shrink-0 text-muted-foreground hover:text-foreground"
                     aria-label={`Open ${comic.name} on provider site`}
                   >
                     <ExternalLink className="w-3 h-3" />
@@ -449,137 +406,37 @@ export default function SearchResultsTable({
                 )}
               </div>
               {description && (
-                <div className="text-xs text-muted-foreground/70 mt-0.5 truncate max-w-[300px]">
-                  {truncate(description, 120)}
+                <div
+                  className="text-[11.5px] truncate mt-0.5"
+                  style={{ color: "var(--muted-foreground)" }}
+                >
+                  {truncate(description, 140)}
                 </div>
               )}
             </div>
-          );
-
-          if (description && description.length > 120) {
-            return (
-              <HoverCard openDelay={300}>
-                <HoverCardTrigger asChild>{nameContent}</HoverCardTrigger>
-                <HoverCardContent
-                  side="right"
-                  align="start"
-                  collisionPadding={16}
-                  className="w-80 max-h-[50vh] overflow-y-auto text-sm"
-                >
-                  <p className="font-medium mb-1">{comic.name}</p>
-                  <p className="text-muted-foreground leading-relaxed">
-                    {description}
-                  </p>
-                </HoverCardContent>
-              </HoverCard>
-            );
-          }
-
-          return nameContent;
-        },
-      }),
-      columnHelper.accessor("publisher", {
-        id: "publisher",
-        size: 130,
-        meta: { label: publisherLabel },
-        header: publisherLabel,
-        cell: ({ row }) => {
-          const pub = row.original.publisher;
-          if (!pub || pub === "Unknown") return <span>{"\u2014"}</span>;
-          return (
-            <span className="text-sm line-clamp-2 max-w-[130px]">{pub}</span>
-          );
-        },
-      }),
-      columnHelper.accessor("comicyear", {
-        id: "year",
-        meta: { label: "Year" },
-        header: () => (
-          <ServerSortHeader
-            columnId="year"
-            title="Year"
-            currentSort={currentSort}
-            onSortChange={onSortChange}
-          />
-        ),
-        cell: ({ getValue }) => <span>{getValue() || "\u2014"}</span>,
-      }),
-      columnHelper.accessor("issues", {
-        id: "issues",
-        meta: { label: issuesLabel },
-        header: () => (
-          <ServerSortHeader
-            columnId="issues"
-            title={issuesLabel}
-            currentSort={currentSort}
-            onSortChange={onSortChange}
-          />
-        ),
-        cell: ({ row }) => {
-          const issues = row.original.issues ?? row.original.count_of_issues;
-          return <span>{issues !== undefined ? issues : "\u2014"}</span>;
-        },
-      }),
-      columnHelper.accessor("status", {
-        id: "seriesStatus",
-        meta: { label: "Status" },
-        header: "Status",
-        cell: ({ getValue }) => {
-          const status = getValue();
-          if (!status) return <span>{"\u2014"}</span>;
-          return <span className="text-sm capitalize">{status}</span>;
-        },
-      }),
-      columnHelper.accessor("content_rating", {
-        id: "contentRating",
-        meta: { label: "Content Rating" },
-        header: "Rating",
-        cell: ({ getValue }) => {
-          const rating = getValue();
-          if (!rating) return <span>{"\u2014"}</span>;
-          return <span className="text-sm capitalize">{rating}</span>;
-        },
-      }),
-      columnHelper.display({
-        id: "actions",
-        header: "",
-        enableSorting: false,
-        enableHiding: false,
-        cell: ({ row }) => (
-          <div className="text-right">
-            <ActionCell comic={row.original} contentType={contentType} />
+            <div
+              className="truncate"
+              style={{ color: "var(--muted-foreground)" }}
+            >
+              {comic.publisher && comic.publisher !== "Unknown"
+                ? comic.publisher
+                : "—"}
+            </div>
+            <div
+              className="font-mono text-[11px]"
+              style={{ color: "var(--muted-foreground)" }}
+            >
+              {comic.comicyear || "—"}
+            </div>
+            <div className="font-mono text-[11px]">
+              {issues !== undefined ? issues : "—"}
+            </div>
+            <div className="flex justify-end">
+              <AddButton comic={comic} contentType={contentType} />
+            </div>
           </div>
-        ),
-      }),
-    ],
-    [contentType, issuesLabel, publisherLabel, currentSort, onSortChange],
-  );
-
-  const table = useReactTable({
-    data: results,
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-    manualSorting: true,
-    state: {
-      columnVisibility,
-    },
-    onColumnVisibilityChange: setColumnVisibility,
-  });
-
-  const columnToggle = (
-    <SearchColumnVisibility
-      columnVisibility={columnVisibility}
-      onToggle={handleToggleColumn}
-      isManga={isManga}
-    />
-  );
-
-  return (
-    <>
-      {columnToggleContainer
-        ? createPortal(columnToggle, columnToggleContainer)
-        : null}
-      <DataTable table={table} />
-    </>
+        );
+      })}
+    </div>
   );
 }

--- a/frontend/src/components/settings/SettingField.tsx
+++ b/frontend/src/components/settings/SettingField.tsx
@@ -112,7 +112,7 @@ export function SettingField({
             className="flex-1 min-w-0 font-mono text-[12px] px-3 py-1.5 rounded-[5px] border bg-card break-all"
             style={{ borderColor: "var(--border)" }}
           >
-            {value || "—"}
+            {value ?? "—"}
           </div>
           <span className="font-mono text-[10px] text-muted-foreground shrink-0">
             read-only
@@ -171,7 +171,7 @@ export function SettingField({
       <Input
         id={fieldId}
         type={type}
-        value={value || ""}
+        value={value ?? ""}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         className="mt-1.5"

--- a/frontend/src/components/settings/SettingField.tsx
+++ b/frontend/src/components/settings/SettingField.tsx
@@ -1,5 +1,5 @@
+import { Check } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -41,39 +41,105 @@ export function SettingField({
 }: SettingFieldProps) {
   const fieldId = `field-${label.toLowerCase().replace(/\s+/g, "-")}`;
 
-  const renderField = () => {
-    if (type === "checkbox") {
-      return (
-        <div className="flex items-center space-x-2">
-          <Checkbox
-            id={fieldId}
-            checked={checked}
-            onCheckedChange={(value) => onChange(!!value)}
-            disabled={readOnly}
-          />
-          <Label
-            htmlFor={fieldId}
-            className="text-sm font-medium cursor-pointer"
-          >
-            {label}
-          </Label>
-        </div>
-      );
-    }
+  // Checkbox: circular accent check + label + help text + right-aligned spacing
+  if (type === "checkbox") {
+    return (
+      <label
+        htmlFor={fieldId}
+        className="flex items-start gap-3 py-2.5 px-3 rounded-[6px] border cursor-pointer select-none"
+        style={{
+          borderColor: "var(--border)",
+          background: "var(--card)",
+        }}
+      >
+        <input
+          id={fieldId}
+          type="checkbox"
+          checked={!!checked}
+          onChange={(e) => onChange(e.target.checked)}
+          disabled={readOnly}
+          className="sr-only peer"
+        />
+        <span
+          className="mt-0.5 shrink-0 w-4 h-4 rounded-[3px] grid place-items-center border"
+          style={{
+            borderColor: checked ? "var(--primary)" : "var(--border)",
+            background: checked ? "var(--primary)" : "transparent",
+          }}
+        >
+          {checked && (
+            <Check
+              className="w-3 h-3"
+              strokeWidth={3}
+              style={{ color: "var(--primary-foreground)" }}
+            />
+          )}
+        </span>
+        <span className="flex-1 min-w-0">
+          <span className="block text-[13px] font-medium">{label}</span>
+          {helpText && (
+            <span className="block text-[11.5px] text-muted-foreground mt-0.5">
+              {helpText}
+            </span>
+          )}
+          {error && (
+            <span
+              className="block text-[11.5px] mt-0.5"
+              style={{ color: "var(--status-error)" }}
+            >
+              {error}
+            </span>
+          )}
+        </span>
+      </label>
+    );
+  }
 
-    if (type === "select") {
-      return (
-        <div className="space-y-2">
-          <Label htmlFor={fieldId} className="text-sm font-medium">
-            {label}
-          </Label>
+  // Read-only inline row: label on left, input + tag on right
+  if (readOnly) {
+    return (
+      <div
+        className="grid gap-4 py-3 items-center"
+        style={{ gridTemplateColumns: "200px 1fr" }}
+      >
+        <div>
+          <div className="text-[12.5px] font-medium">{label}</div>
+          {helpText && (
+            <div className="text-[11px] text-muted-foreground mt-0.5 leading-snug">
+              {helpText}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <div
+            className="flex-1 font-mono text-[12px] px-3 py-1.5 rounded-[5px] border bg-card"
+            style={{ borderColor: "var(--border)" }}
+          >
+            {value || "—"}
+          </div>
+          <span className="font-mono text-[10px] text-muted-foreground shrink-0">
+            read-only
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // Select field
+  if (type === "select") {
+    return (
+      <div className="py-2.5">
+        <Label htmlFor={fieldId} className="text-[12.5px] font-medium">
+          {label}
+        </Label>
+        <div className="mt-1.5">
           <Select
             value={value?.toString()}
             onValueChange={onChange}
             disabled={readOnly}
           >
-            <SelectTrigger id={fieldId} className={readOnly ? "bg-muted" : ""}>
-              <SelectValue placeholder={placeholder || "Select..."} />
+            <SelectTrigger id={fieldId}>
+              <SelectValue placeholder={placeholder || "Select…"} />
             </SelectTrigger>
             <SelectContent>
               {options.map((option) => (
@@ -84,32 +150,46 @@ export function SettingField({
             </SelectContent>
           </Select>
         </div>
-      );
-    }
-
-    return (
-      <div className="space-y-2">
-        <Label htmlFor={fieldId} className="text-sm font-medium">
-          {label}
-        </Label>
-        <Input
-          id={fieldId}
-          type={type}
-          value={value || ""}
-          onChange={(e) => onChange(e.target.value)}
-          readOnly={readOnly}
-          placeholder={placeholder}
-          className={readOnly ? "bg-muted" : ""}
-        />
+        {helpText && (
+          <p className="text-[11px] text-muted-foreground mt-1">{helpText}</p>
+        )}
+        {error && (
+          <p
+            className="text-[11px] mt-1"
+            style={{ color: "var(--status-error)" }}
+          >
+            {error}
+          </p>
+        )}
       </div>
     );
-  };
+  }
 
+  // Text / password / number
   return (
-    <div className="space-y-1">
-      {renderField()}
-      {helpText && <p className="text-xs text-muted-foreground">{helpText}</p>}
-      {error && <p className="text-xs text-destructive">{error}</p>}
+    <div className="py-2.5">
+      <Label htmlFor={fieldId} className="text-[12.5px] font-medium">
+        {label}
+      </Label>
+      <Input
+        id={fieldId}
+        type={type}
+        value={value || ""}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="mt-1.5"
+      />
+      {helpText && (
+        <p className="text-[11px] text-muted-foreground mt-1">{helpText}</p>
+      )}
+      {error && (
+        <p
+          className="text-[11px] mt-1"
+          style={{ color: "var(--status-error)" }}
+        >
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/settings/SettingField.tsx
+++ b/frontend/src/components/settings/SettingField.tsx
@@ -95,13 +95,10 @@ export function SettingField({
     );
   }
 
-  // Read-only inline row: label on left, input + tag on right
+  // Read-only inline row: label on left, input + tag on right (stacks on mobile)
   if (readOnly) {
     return (
-      <div
-        className="grid gap-4 py-3 items-center"
-        style={{ gridTemplateColumns: "200px 1fr" }}
-      >
+      <div className="grid gap-2 sm:gap-4 py-3 sm:items-center grid-cols-1 sm:[grid-template-columns:200px_1fr]">
         <div>
           <div className="text-[12.5px] font-medium">{label}</div>
           {helpText && (
@@ -110,9 +107,9 @@ export function SettingField({
             </div>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0">
           <div
-            className="flex-1 font-mono text-[12px] px-3 py-1.5 rounded-[5px] border bg-card"
+            className="flex-1 min-w-0 font-mono text-[12px] px-3 py-1.5 rounded-[5px] border bg-card break-all"
             style={{ borderColor: "var(--border)" }}
           >
             {value || "—"}

--- a/frontend/src/components/settings/SettingGroup.tsx
+++ b/frontend/src/components/settings/SettingGroup.tsx
@@ -10,14 +10,18 @@ export function SettingGroup({
   children,
 }: SettingGroupProps) {
   return (
-    <fieldset className="border border-card-border rounded-lg p-4 mb-6">
-      <legend className="text-sm font-semibold text-foreground px-2">
-        {title}
-      </legend>
-      {description && (
-        <p className="text-sm text-muted-foreground mb-4">{description}</p>
-      )}
-      <div className="space-y-4">{children}</div>
-    </fieldset>
+    <section className="mb-8">
+      <div className="mb-4">
+        <div className="text-[13px] font-semibold tracking-tight text-foreground">
+          {title}
+        </div>
+        {description && (
+          <div className="text-[12px] text-muted-foreground mt-0.5 leading-relaxed">
+            {description}
+          </div>
+        )}
+      </div>
+      <div className="space-y-1">{children}</div>
+    </section>
   );
 }

--- a/frontend/src/components/storyarcs/ArcSearch.tsx
+++ b/frontend/src/components/storyarcs/ArcSearch.tsx
@@ -43,7 +43,7 @@ export default function ArcSearch({ searchInputRef }: ArcSearchProps) {
         value={query}
         onChange={handleChange}
         shortcut="/"
-        loading={isLoading && query.length > 2}
+        loading={isLoading && debouncedQuery.length > 2}
       />
 
       {results && results.length > 0 && (

--- a/frontend/src/components/storyarcs/ArcSearch.tsx
+++ b/frontend/src/components/storyarcs/ArcSearch.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from "react";
-import { Search, Loader2 } from "lucide-react";
-import { Input } from "@/components/ui/input";
 import { useFindStoryArc } from "@/hooks/useArcSearch";
+import FilterField from "@/components/ui/FilterField";
 import ArcSearchResultCard from "./ArcSearchResultCard";
 
 interface ArcSearchProps {
@@ -37,20 +36,15 @@ export default function ArcSearch({ searchInputRef }: ArcSearchProps) {
 
   return (
     <div className="space-y-4">
-      <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-        <Input
-          ref={searchInputRef}
-          type="text"
-          placeholder="Search story arcs on ComicVine..."
-          value={query}
-          onChange={handleChange}
-          className="pl-10"
-        />
-        {isLoading && (
-          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-muted-foreground" />
-        )}
-      </div>
+      <FilterField
+        ref={searchInputRef}
+        placeholder="Search story arcs on ComicVine…"
+        aria-label="Search story arcs"
+        value={query}
+        onChange={handleChange}
+        shortcut="/"
+        loading={isLoading && query.length > 2}
+      />
 
       {results && results.length > 0 && (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -61,7 +55,7 @@ export default function ArcSearch({ searchInputRef }: ArcSearchProps) {
       )}
 
       {debouncedQuery.length > 2 && !isLoading && results?.length === 0 && (
-        <p className="text-sm text-muted-foreground text-center py-6">
+        <p className="text-[12px] text-muted-foreground text-center py-6">
           No story arcs found for &ldquo;{debouncedQuery}&rdquo;
         </p>
       )}

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -6,9 +6,9 @@ import {
   Search,
   Library,
   ListTodo,
+  ArrowRight,
   type LucideIcon,
 } from "lucide-react";
-import { Button } from "@/components/ui/button";
 
 type EmptyStateVariant =
   | "library"
@@ -29,6 +29,7 @@ interface EmptyStateAction {
 interface EmptyStateProps {
   variant?: EmptyStateVariant;
   icon?: LucideIcon;
+  eyebrow?: string;
   title?: string;
   description?: string;
   action?: EmptyStateAction;
@@ -39,6 +40,7 @@ const VARIANT_CONFIGS: Record<
   Exclude<EmptyStateVariant, "custom">,
   {
     icon: LucideIcon;
+    eyebrow: string;
     title: string;
     description: string;
     action?: EmptyStateAction;
@@ -46,50 +48,54 @@ const VARIANT_CONFIGS: Record<
 > = {
   library: {
     icon: Library,
-    title: "Your library is empty",
+    eyebrow: "LIBRARY · EMPTY",
+    title: "No series tracked yet",
     description:
-      "Search for comics to add them to your library and start tracking your collection.",
-    action: { label: "Search Comics", to: "/search" },
+      "Search the providers you've connected and add series to start monitoring issues.",
+    action: { label: "Add series", to: "/search" },
   },
   wanted: {
     icon: ListTodo,
+    eyebrow: "WANTED · EMPTY",
     title: "No wanted issues",
     description:
-      "Mark issues as wanted from your series to see them here. Comicarr will automatically search for them.",
+      "Mark issues as wanted from a series and Comicarr will search for them automatically.",
   },
   upcoming: {
     icon: Calendar,
-    title: "No upcoming releases",
+    eyebrow: "UPCOMING · EMPTY",
+    title: "No releases this week",
     description:
-      "Add more series to your library to see upcoming releases for this week.",
-    action: { label: "Browse Series", to: "/search" },
+      "Add more series to surface upcoming issues on the weekly schedule.",
+    action: { label: "Browse series", to: "/search" },
   },
   search: {
     icon: Search,
+    eyebrow: "SEARCH · NO MATCH",
     title: "No results found",
     description:
-      "Try adjusting your search terms or filters to find what you're looking for.",
+      "Adjust the query or filters — try the series title, author, or publisher.",
   },
   issues: {
     icon: BookOpen,
-    title: "No issues found",
+    eyebrow: "ISSUES · EMPTY",
+    title: "No issues indexed",
     description:
-      "This series doesn't have any issues yet. Try refreshing the series data.",
+      "This series has no issues tracked yet. Refresh to pull the latest metadata.",
   },
   "story-arcs": {
     icon: BookOpen,
+    eyebrow: "ARCS · EMPTY",
     title: "No story arcs tracked",
     description:
-      "Search for story arcs above to add them to your watchlist. Track reading progress across multiple series and issues.",
+      "Search for arcs above to track reading progress across series and issues.",
   },
 };
 
-/**
- * Flexible empty state component for various contexts
- */
 export default function EmptyState({
   variant = "custom",
   icon: CustomIcon,
+  eyebrow: customEyebrow,
   title: customTitle,
   description: customDescription,
   action: customAction,
@@ -98,31 +104,57 @@ export default function EmptyState({
   const config = variant !== "custom" ? VARIANT_CONFIGS[variant] : null;
 
   const Icon = CustomIcon || config?.icon || BookOpen;
+  const eyebrow = customEyebrow || config?.eyebrow || "EMPTY";
   const title = customTitle || config?.title || "Nothing here yet";
   const description = customDescription || config?.description || "";
   const action = customAction || config?.action;
 
+  const cta = action && (
+    <span
+      className="inline-flex items-center gap-2 px-3.5 py-2 rounded-[5px] text-[12px] font-semibold"
+      style={{
+        background: "var(--primary)",
+        color: "var(--primary-foreground)",
+      }}
+    >
+      {action.label}
+      <ArrowRight className="w-3.5 h-3.5" />
+    </span>
+  );
+
   return (
-    <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
-      <div className="bg-muted rounded-full p-6 mb-6">
-        <Icon className="w-12 h-12 text-muted-foreground" />
+    <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+      <div
+        className="w-11 h-11 rounded-full grid place-items-center mb-5"
+        style={{
+          border: "1px solid var(--border)",
+          background: "var(--secondary)",
+        }}
+      >
+        <Icon
+          className="w-4 h-4"
+          style={{ color: "var(--muted-foreground)" }}
+          strokeWidth={1.5}
+        />
       </div>
-      <h3 className="text-xl font-semibold text-foreground mb-2">{title}</h3>
-      <p className="text-muted-foreground max-w-md mb-6">{description}</p>
+      <div className="font-mono text-[10px] tracking-[0.12em] text-muted-foreground mb-2">
+        {eyebrow}
+      </div>
+      <h3 className="text-[15px] font-semibold text-foreground mb-1.5 tracking-tight">
+        {title}
+      </h3>
+      {description && (
+        <p className="text-[12px] text-muted-foreground max-w-[340px] mb-5 leading-relaxed">
+          {description}
+        </p>
+      )}
       {action &&
         (action.to ? (
-          <Link to={action.to}>
-            <Button variant={action.variant || "default"}>
-              {action.label}
-            </Button>
-          </Link>
+          <Link to={action.to}>{cta}</Link>
         ) : action.onClick ? (
-          <Button
-            variant={action.variant || "default"}
-            onClick={action.onClick}
-          >
-            {action.label}
-          </Button>
+          <button type="button" onClick={action.onClick}>
+            {cta}
+          </button>
         ) : null)}
       {children}
     </div>

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -161,9 +161,18 @@ export default function EmptyState({
       )}
       {action &&
         (action.to ? (
-          <Link to={action.to}>{cta}</Link>
+          <Link
+            to={action.to}
+            className="rounded-[5px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            {cta}
+          </Link>
         ) : action.onClick ? (
-          <button type="button" onClick={action.onClick}>
+          <button
+            type="button"
+            onClick={action.onClick}
+            className="rounded-[5px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
             {cta}
           </button>
         ) : null)}

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -109,13 +109,24 @@ export default function EmptyState({
   const description = customDescription || config?.description || "";
   const action = customAction || config?.action;
 
+  const isOutline = action?.variant === "outline";
   const cta = action && (
     <span
-      className="inline-flex items-center gap-2 px-3.5 py-2 rounded-[5px] text-[12px] font-semibold"
-      style={{
-        background: "var(--primary)",
-        color: "var(--primary-foreground)",
-      }}
+      className={`inline-flex items-center gap-2 px-3.5 py-2 rounded-[5px] text-[12px] font-semibold ${
+        isOutline ? "border" : ""
+      }`}
+      style={
+        isOutline
+          ? {
+              borderColor: "var(--border)",
+              background: "transparent",
+              color: "var(--foreground)",
+            }
+          : {
+              background: "var(--primary)",
+              color: "var(--primary-foreground)",
+            }
+      }
     >
       {action.label}
       <ArrowRight className="w-3.5 h-3.5" />

--- a/frontend/src/components/ui/FilterField.tsx
+++ b/frontend/src/components/ui/FilterField.tsx
@@ -1,0 +1,76 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
+import { Search, Loader2 } from "lucide-react";
+import { Kbd } from "@/components/ui/kbd";
+
+interface FilterFieldProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "size"
+> {
+  /** Optional keyboard shortcut hint rendered on the right (e.g. "/"). */
+  shortcut?: string;
+  /** Show an inline spinner on the right (replaces shortcut hint). */
+  loading?: boolean;
+  /** Width cap. Defaults to `md` (28rem). Pass `"full"` for no cap. */
+  widthCap?: "sm" | "md" | "lg" | "xl" | "full";
+  /** Extra nodes rendered to the right of the input (before shortcut). */
+  trailing?: ReactNode;
+  className?: string;
+}
+
+const CAP_CLASS: Record<NonNullable<FilterFieldProps["widthCap"]>, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+  xl: "max-w-xl",
+  full: "",
+};
+
+/**
+ * Canonical Direction B filter/search input.
+ *
+ * 28px tall, 12px text, left-aligned 14px search icon, optional `/` kbd
+ * hint on the right. Used across Library filter, Wanted filter, Story
+ * Arcs search, etc. so every surface feels the same.
+ */
+const FilterField = forwardRef<HTMLInputElement, FilterFieldProps>(
+  function FilterField(
+    {
+      shortcut,
+      loading,
+      widthCap = "md",
+      trailing,
+      className = "",
+      ...inputProps
+    },
+    ref,
+  ) {
+    return (
+      <div
+        className={`flex items-center gap-2 flex-1 ${CAP_CLASS[widthCap]} h-8 px-2.5 rounded-[5px] border bg-card ${className}`}
+        style={{ borderColor: "var(--border)" }}
+      >
+        <Search
+          className="w-3.5 h-3.5 shrink-0"
+          style={{ color: "var(--muted-foreground)" }}
+        />
+        <input
+          ref={ref}
+          type="text"
+          {...inputProps}
+          className="flex-1 min-w-0 bg-transparent outline-none text-[12px] placeholder:text-[var(--text-muted)]"
+        />
+        {trailing}
+        {loading ? (
+          <Loader2
+            className="w-3.5 h-3.5 shrink-0 animate-spin"
+            style={{ color: "var(--muted-foreground)" }}
+          />
+        ) : shortcut ? (
+          <Kbd>{shortcut}</Kbd>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+export default FilterField;

--- a/frontend/src/components/ui/FilterField.tsx
+++ b/frontend/src/components/ui/FilterField.tsx
@@ -46,7 +46,7 @@ const FilterField = forwardRef<HTMLInputElement, FilterFieldProps>(
   ) {
     return (
       <div
-        className={`flex items-center gap-2 flex-1 ${CAP_CLASS[widthCap]} h-8 px-2.5 rounded-[5px] border bg-card ${className}`}
+        className={`flex items-center gap-2 flex-1 ${CAP_CLASS[widthCap]} h-8 px-2.5 rounded-[5px] border bg-card focus-within:border-[var(--ring)] focus-within:ring-2 focus-within:ring-ring/40 transition-[box-shadow,border-color] ${className}`}
         style={{ borderColor: "var(--border)" }}
       >
         <Search

--- a/frontend/src/components/ui/kbd.tsx
+++ b/frontend/src/components/ui/kbd.tsx
@@ -5,7 +5,8 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
     <kbd
       data-slot="kbd"
       className={cn(
-        "bg-muted text-muted-foreground pointer-events-none inline-flex h-5 w-fit min-w-5 select-none items-center justify-center gap-1 rounded-sm px-1 font-sans text-xs font-medium",
+        "pointer-events-none inline-flex h-[18px] w-fit min-w-[18px] select-none items-center justify-center gap-1 rounded-[3px] border border-border bg-secondary px-1.5 text-[10px] font-medium text-muted-foreground",
+        "font-mono tracking-wide",
         "[&_svg:not([class*='size-'])]:size-3",
         "[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10",
         className,

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -67,16 +67,18 @@ export function useKeyboardShortcuts(): void {
         return;
       }
 
-      // 'Ctrl+K' or 'Cmd+K' - Quick navigation (future enhancement)
-      // Commented out for now, can be implemented later with a command palette
-      /*
-      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+      // 'Ctrl+K' or 'Cmd+K' - Focus global search (sidebar)
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
-        // Open command palette / quick nav
-        console.log('[Keyboard] Quick nav triggered');
+        const globalSearch = document.querySelector<HTMLInputElement>(
+          'input[data-global-search="true"]',
+        );
+        if (globalSearch) {
+          globalSearch.focus();
+          globalSearch.select();
+        }
         return;
       }
-      */
     };
 
     // Add event listener

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,7 +42,6 @@
   --chart-3: oklch(0.67 0.16 58);
   --chart-4: oklch(0.56 0.15 49);
   --chart-5: oklch(0.47 0.12 46);
-  --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.141 0.005 285.823);
   --sidebar-primary: oklch(0.67 0.16 58);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import url("https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
 @plugin "tailwindcss-animate";
 
@@ -7,6 +7,7 @@
 
 :root {
   font-family:
+    "Inter Tight",
     "Inter",
     system-ui,
     -apple-system,
@@ -14,8 +15,9 @@
     "Segoe UI",
     Roboto,
     sans-serif;
-  --radius: 0.625rem;
-  --font-mono: "DM Mono", ui-monospace, monospace;
+  letter-spacing: -0.005em;
+  --radius: 0.375rem;
+  --font-mono: "JetBrains Mono", ui-monospace, monospace;
 
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
@@ -23,8 +25,8 @@
   --card-foreground: oklch(0.141 0.005 285.823);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.67 0.16 58);
-  --primary-foreground: oklch(0.99 0.02 95);
+  --primary: #e04a0a;
+  --primary-foreground: #ffffff;
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.967 0.001 286.375);
@@ -154,67 +156,68 @@ body {
 }
 
 .dark {
-  --background: #0a0a0b;
-  --foreground: #ffffff;
-  --card: #141417;
-  --card-foreground: #ffffff;
-  --popover: #141417;
-  --popover-foreground: #ffffff;
-  --primary: #ff5c00;
+  --background: #0b0d12;
+  --foreground: #e8eaf0;
+  --card: #12151c;
+  --card-foreground: #e8eaf0;
+  --popover: #12151c;
+  --popover-foreground: #e8eaf0;
+  --primary: #ff6a1f;
   --primary-foreground: #ffffff;
-  --secondary: #1a1a1d;
-  --secondary-foreground: #adadb0;
-  --muted: #1a1a1d;
-  --muted-foreground: #8b8b90;
-  --accent: #1a1a1d;
-  --accent-foreground: #ffffff;
-  --destructive: #ef4444;
-  --border: #1f1f23;
-  --input: #1a1a1d;
-  --ring: #ff5c00;
+  --secondary: #181c25;
+  --secondary-foreground: #8a92a5;
+  --muted: #181c25;
+  --muted-foreground: #8a92a5;
+  --accent: #181c25;
+  --accent-foreground: #e8eaf0;
+  --destructive: #ff6b6b;
+  --border: #232834;
+  --input: #181c25;
+  --ring: #ff6a1f;
   --chart-1: #ff8a4c;
-  --chart-2: #ff5c00;
-  --chart-3: #22c55e;
-  --chart-4: #adadb0;
-  --chart-5: #6b6b70;
-  --sidebar: #141417;
-  --sidebar-foreground: #ffffff;
-  --sidebar-primary: #ff5c00;
+  --chart-2: #ff6a1f;
+  --chart-3: #53d37d;
+  --chart-4: #6ea8ff;
+  --chart-5: #565d6f;
+  --sidebar: #12151c;
+  --sidebar-foreground: #e8eaf0;
+  --sidebar-primary: #ff6a1f;
   --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #1a1a1d;
-  --sidebar-accent-foreground: #ffffff;
-  --sidebar-border: #1f1f23;
-  --sidebar-ring: #ff5c00;
+  --sidebar-accent: #181c25;
+  --sidebar-accent-foreground: #e8eaf0;
+  --sidebar-border: #232834;
+  --sidebar-ring: #ff6a1f;
 
   /* Surface layers */
-  --surface-deep: #111113;
-  --surface-elevated: #1a1a1d;
-  --border-elevated: #2a2a2e;
-  --text-tertiary: #8b8b90;
-  --text-muted: #6b6b70;
-  --text-disabled: #4a4a4e;
+  --surface-deep: #0b0d12;
+  --surface-elevated: #181c25;
+  --border-elevated: #232834;
+  --border-soft: #1a1f2a;
+  --text-tertiary: #8a92a5;
+  --text-muted: #565d6f;
+  --text-disabled: #3a4050;
 
   /* Status Badges - Dark Mode */
-  --status-active: #22c55e;
-  --status-active-bg: #22c55e18;
-  --status-wanted: #ff5c00;
-  --status-wanted-bg: #ff5c0018;
-  --status-downloaded: #22c55e;
-  --status-downloaded-bg: #22c55e18;
-  --status-paused: #8b8b90;
-  --status-paused-bg: #6b6b7018;
-  --status-ended: #8b8b90;
-  --status-ended-bg: #6b6b7018;
-  --status-error: #ef4444;
-  --status-error-bg: #ef444418;
-  --status-skipped: #6b6b70;
-  --status-skipped-bg: #6b6b7018;
+  --status-active: #53d37d;
+  --status-active-bg: #53d37d18;
+  --status-wanted: #ff6a1f;
+  --status-wanted-bg: #ff6a1f1f;
+  --status-downloaded: #53d37d;
+  --status-downloaded-bg: #53d37d18;
+  --status-paused: #ffb547;
+  --status-paused-bg: #ffb54718;
+  --status-ended: #8a92a5;
+  --status-ended-bg: #565d6f18;
+  --status-error: #ff6b6b;
+  --status-error-bg: #ff6b6b18;
+  --status-skipped: #565d6f;
+  --status-skipped-bg: #565d6f18;
 
   /* Effects */
-  --glassmorphism-bg: rgba(10, 10, 11, 0.85);
+  --glassmorphism-bg: rgba(11, 13, 18, 0.85);
 
   /* Gradient */
-  --gradient-brand: linear-gradient(135deg, #ff5c00, #ff8a4c);
+  --gradient-brand: linear-gradient(135deg, #ff6a1f, #ff8a4c);
   --success: hsl(217.2 32.6% 17.5%);
   --warning: hsl(24.6 95% 53.1%);
   --error: hsl(0 84.2% 60.2%);
@@ -250,6 +253,25 @@ body {
 }
 
 @layer utilities {
+  .font-mono {
+    font-family: var(--font-mono);
+    font-feature-settings: "tnum" 1;
+  }
+
+  .mono-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
+  }
+
+  .mono-meta {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--muted-foreground);
+  }
+
   .glass-nav {
     background: var(--glassmorphism-bg);
     backdrop-filter: var(--glassmorphism-blur);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -102,6 +102,10 @@ export async function login(
   username: string,
   password: string,
 ): Promise<LoginResponse> {
+  if (isMockEnabled()) {
+    const mocked = mockApiResponse("POST", `${AUTH_BASE}/login`);
+    if (mocked !== undefined) return mocked as LoginResponse;
+  }
   try {
     const url = new URL(`${AUTH_BASE}/login`, window.location.origin);
 
@@ -134,6 +138,10 @@ export async function login(
  * Logout the current user
  */
 export async function logout(): Promise<LogoutResponse> {
+  if (isMockEnabled()) {
+    const mocked = mockApiResponse("POST", `${AUTH_BASE}/logout`);
+    if (mocked !== undefined) return mocked as LogoutResponse;
+  }
   try {
     const url = new URL(`${AUTH_BASE}/logout`, window.location.origin);
 
@@ -162,6 +170,10 @@ export async function logout(): Promise<LogoutResponse> {
  * Check if user has a valid session
  */
 export async function checkSession(): Promise<SessionResponse> {
+  if (isMockEnabled()) {
+    const mocked = mockApiResponse("GET", `${AUTH_BASE}/check-session`);
+    if (mocked !== undefined) return mocked as SessionResponse;
+  }
   try {
     const url = new URL(`${AUTH_BASE}/check-session`, window.location.origin);
 
@@ -185,6 +197,10 @@ export async function checkSession(): Promise<SessionResponse> {
  * Check if initial setup is needed (no credentials configured)
  */
 export async function checkSetup(): Promise<{ needs_setup: boolean }> {
+  if (isMockEnabled()) {
+    const mocked = mockApiResponse("GET", `${AUTH_BASE}/check-setup`);
+    if (mocked !== undefined) return mocked as { needs_setup: boolean };
+  }
   try {
     const url = new URL(`${AUTH_BASE}/check-setup`, window.location.origin);
     const response = await fetch(url, {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@
  */
 
 import type { LoginResponse, LogoutResponse, SessionResponse } from "@/types";
+import { isMockEnabled, mockApiResponse } from "@/lib/mockData";
 
 const AUTH_BASE = "/api/auth";
 
@@ -247,6 +248,15 @@ export async function apiRequest<T = unknown>(
   path: string,
   body?: Record<string, unknown> | null,
 ): Promise<T> {
+  if (isMockEnabled()) {
+    const mocked = mockApiResponse(method, path);
+    if (mocked !== undefined) {
+      return mocked as T;
+    }
+    // Fall through for unmocked endpoints — in mock mode the backend may
+    // not be running, so most writes will 502. That's fine for browsing.
+  }
+
   const url = new URL(path, window.location.origin);
 
   const options: RequestInit = {

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -350,12 +350,14 @@ function recentDownloads() {
     ComicImage: string | null;
   }> = [];
   const sample = [COVERS[0], COVERS[1], COVERS[2], COVERS[3], COVERS[6]];
+  // `/api/downloads/queue` returns [] in mock mode, so keep the activity
+  // feed in sync: no "Snatched" entries that would imply queued work.
   const actions = [
     "Downloaded",
     "Downloaded",
     "Post-Processed",
     "Post-Processed",
-    "Snatched",
+    "Downloaded",
     "Downloaded",
     "Post-Processed",
   ];
@@ -474,21 +476,40 @@ function seriesDetail(id: string) {
  */
 export function isMockEnabled(): boolean {
   if (typeof window === "undefined") return false;
+
+  // Query param always wins over storage. Storage is purely a convenience
+  // so the flag survives reloads; if it throws (private browsing, quota,
+  // etc.), honor the URL and keep going rather than silently disabling.
+  let paramMock: "1" | "0" | null = null;
   try {
     const params = new URLSearchParams(window.location.search);
-    if (params.get("mock") === "1") {
+    const raw = params.get("mock");
+    if (raw === "1") paramMock = "1";
+    else if (raw === "0") paramMock = "0";
+  } catch {
+    // URL parse failure — treat as "no param set".
+  }
+
+  try {
+    if (paramMock === "1") {
       localStorage.setItem("comicarr:mock", "1");
       return true;
     }
-    if (params.get("mock") === "0") {
+    if (paramMock === "0") {
       localStorage.removeItem("comicarr:mock");
       return false;
     }
     return localStorage.getItem("comicarr:mock") === "1";
   } catch {
-    return false;
+    // Storage unavailable — respect the URL param if present.
+    return paramMock === "1";
   }
 }
+
+// Session state used by mock auth endpoints below. Lives in module scope
+// so logout actually sticks within a single browser session even though
+// there's no real backend to keep it.
+let mockAuthenticated = true;
 
 /**
  * Match an incoming request to a mock payload. Returns `undefined` to signal
@@ -506,12 +527,16 @@ export function mockApiResponse(
     return { needs_setup: false };
   }
   if (m === "GET" && url === "/api/auth/check-session") {
-    return { success: true, authenticated: true, username: "mock-admin" };
+    return mockAuthenticated
+      ? { success: true, authenticated: true, username: "mock-admin" }
+      : { success: true, authenticated: false };
   }
   if (m === "POST" && url === "/api/auth/login") {
+    mockAuthenticated = true;
     return { success: true, username: "mock-admin" };
   }
   if (m === "POST" && url === "/api/auth/logout") {
+    mockAuthenticated = false;
     return { success: true };
   }
   if (m === "GET" && url === "/api/migration/check") {

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -327,8 +327,7 @@ function buildIssues(c: MockCover): Issue[] {
       ImageURL: coverSvgDataUri(c, 80, 120),
       ImageURL_ALT: null,
       Int_IssueNumber: i,
-      // Arc is not part of Issue type but UI may read it via loose property
-      ...({ Arc: arc } as Record<string, string>),
+      Arc: arc,
     });
   }
   return issues;
@@ -499,7 +498,8 @@ export function mockApiResponse(
   method: string,
   path: string,
 ): unknown | undefined {
-  const url = path.split("?")[0];
+  const parsed = new URL(path, "http://mock.local");
+  const url = parsed.pathname;
   const m = method.toUpperCase();
 
   if (m === "GET" && url === "/api/auth/check-setup") {
@@ -527,7 +527,19 @@ export function mockApiResponse(
     return SERIES;
   }
   if (m === "GET" && url === "/api/wanted") {
-    return wantedIssues();
+    const all = wantedIssues();
+    const limit = Number(parsed.searchParams.get("limit") ?? 50);
+    const offset = Number(parsed.searchParams.get("offset") ?? 0);
+    const issues = all.slice(offset, offset + limit);
+    return {
+      issues,
+      pagination: {
+        total: all.length,
+        limit,
+        offset,
+        has_more: offset + issues.length < all.length,
+      },
+    };
   }
   if (m === "GET" && url === "/api/weekly") {
     return upcomingReleases().map((u) => ({

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -1,0 +1,576 @@
+/**
+ * Mock data for Comicarr UI testing.
+ *
+ * Enable by appending `?mock=1` to any URL (persisted to localStorage), or
+ * run `localStorage.setItem('comicarr:mock', '1')` in the console. Disable
+ * with `?mock=0` or `localStorage.removeItem('comicarr:mock')`.
+ *
+ * The goal is purely presentational: give Library, Series Detail, Dashboard,
+ * Releases, and Wanted enough content to look realistic while we iterate on
+ * the redesign. Nothing here hits the real backend.
+ */
+
+import type { Comic, Issue, WantedIssue, SeriesStatus } from "@/types";
+
+interface MockCover {
+  id: string;
+  title: string;
+  author: string;
+  publisher: string;
+  year: number;
+  kind: "comic" | "manga";
+  bg: [string, string];
+  accent: string;
+  have: number;
+  total: number;
+  status: SeriesStatus;
+  description: string;
+  genres: string[];
+}
+
+const COVERS: MockCover[] = [
+  {
+    id: "absolute-flash",
+    title: "Absolute Flash",
+    author: "Jeff Lemire",
+    publisher: "DC Comics",
+    year: 2024,
+    kind: "comic",
+    bg: ["#c1281e", "#f5a623"],
+    accent: "#ffeb3b",
+    have: 14,
+    total: 18,
+    status: "Active",
+    description:
+      "The Scarlet Speedster reinvented from the ground up — without the Justice League, without S.T.A.R. Labs, without a safety net.",
+    genres: ["Superhero", "Ongoing", "DC-Absolute"],
+  },
+  {
+    id: "ultimate-wolverine",
+    title: "Ultimate Wolverine",
+    author: "Christopher Cantwell",
+    publisher: "Marvel Comics",
+    year: 2024,
+    kind: "comic",
+    bg: ["#2a2f3a", "#6d7685"],
+    accent: "#f8c13b",
+    have: 12,
+    total: 22,
+    status: "Active",
+    description:
+      "Logan wakes in a broken Ultimate universe with no memory, no home, and a whole lot of rage.",
+    genres: ["Superhero", "Ongoing", "Ultimate"],
+  },
+  {
+    id: "tmnt",
+    title: "Teenage Mutant Ninja Turtles",
+    author: "Jason Aaron",
+    publisher: "IDW",
+    year: 2023,
+    kind: "comic",
+    bg: ["#0e3a1a", "#58a93a"],
+    accent: "#ffffff",
+    have: 16,
+    total: 16,
+    status: "Active",
+    description:
+      "A new era for the turtles, beginning in the aftermath of the Armageddon Game.",
+    genres: ["Action", "Ongoing"],
+  },
+  {
+    id: "transformers",
+    title: "Transformers",
+    author: "Daniel Warren Johnson",
+    publisher: "Image Comics",
+    year: 2024,
+    kind: "comic",
+    bg: ["#1a1148", "#4a2dbb"],
+    accent: "#ff4081",
+    have: 9,
+    total: 22,
+    status: "Active",
+    description:
+      "Energon Universe — Optimus Prime crashes into 1980s Earth with the Decepticons already on his tail.",
+    genres: ["Sci-Fi", "Action", "Energon Universe"],
+  },
+  {
+    id: "absolute-batman",
+    title: "Absolute Batman",
+    author: "Scott Snyder",
+    publisher: "DC Comics",
+    year: 2024,
+    kind: "comic",
+    bg: ["#0b0b10", "#2a2d3a"],
+    accent: "#f5c842",
+    have: 18,
+    total: 18,
+    status: "Active",
+    description:
+      "Without his parents' money, mansion, or butler — how does Bruce Wayne become the Batman?",
+    genres: ["Superhero", "Dark", "DC-Absolute"],
+  },
+  {
+    id: "20cb",
+    title: "20th Century Boys",
+    author: "Naoki Urasawa",
+    publisher: "Viz",
+    year: 1999,
+    kind: "manga",
+    bg: ["#d4a373", "#1d1d1b"],
+    accent: "#e63946",
+    have: 22,
+    total: 24,
+    status: "Active",
+    description:
+      "A childhood prophecy returns to haunt Kenji Endo when the world starts ending on his birthday.",
+    genres: ["Thriller", "Mystery"],
+  },
+  {
+    id: "chainsaw",
+    title: "Chainsaw Man",
+    author: "Tatsuki Fujimoto",
+    publisher: "Viz",
+    year: 2018,
+    kind: "manga",
+    bg: ["#f25c54", "#1a1a1a"],
+    accent: "#ffd166",
+    have: 14,
+    total: 22,
+    status: "Active",
+    description:
+      "A young devil hunter with a chainsaw heart fights demons for rent money — and occasionally, love.",
+    genres: ["Action", "Horror", "Shonen"],
+  },
+  {
+    id: "fujimoto",
+    title: "17-21: Fujimoto Tatsuki Tanpenshuu",
+    author: "Tatsuki Fujimoto",
+    publisher: "Viz",
+    year: 2014,
+    kind: "manga",
+    bg: ["#2a1a3a", "#d4a3ff"],
+    accent: "#ffd166",
+    have: 0,
+    total: 1,
+    status: "Active",
+    description: "Short works by Fujimoto, collected.",
+    genres: ["Anthology"],
+  },
+  {
+    id: "monster",
+    title: "Monster",
+    author: "Naoki Urasawa",
+    publisher: "Viz",
+    year: 1994,
+    kind: "manga",
+    bg: ["#3a2a1a", "#d4c4a3"],
+    accent: "#8a5a3a",
+    have: 9,
+    total: 18,
+    status: "Active",
+    description:
+      "Dr. Tenma saves a boy's life — and spends the next decade learning why he shouldn't have.",
+    genres: ["Thriller", "Psychological"],
+  },
+  {
+    id: "ark-m",
+    title: "Absolute Batman: Ark-M",
+    author: "Dan Watters",
+    publisher: "DC Comics",
+    year: 2026,
+    kind: "comic",
+    bg: ["#1a1a24", "#5c3a8a"],
+    accent: "#58a93a",
+    have: 1,
+    total: 1,
+    status: "Active",
+    description:
+      "A one-shot tie-in to Absolute Batman exploring the Ark-M facility.",
+    genres: ["Superhero", "One-Shot"],
+  },
+  {
+    id: "annual-25",
+    title: "Absolute Batman 2025 Annual",
+    author: "Various",
+    publisher: "DC Comics",
+    year: 2025,
+    kind: "comic",
+    bg: ["#2a1414", "#c1281e"],
+    accent: "#f5c842",
+    have: 1,
+    total: 1,
+    status: "Active",
+    description: "Absolute Batman annual — multiple stories, one volume.",
+    genres: ["Superhero", "Anthology"],
+  },
+  {
+    id: "21cb",
+    title: "21st Century Boys",
+    author: "Naoki Urasawa",
+    publisher: "Viz",
+    year: 2006,
+    kind: "manga",
+    bg: ["#1a3a5c", "#d4a373"],
+    accent: "#e63946",
+    have: 0,
+    total: 2,
+    status: "Active",
+    description: "The two-volume sequel wrapping up 20th Century Boys.",
+    genres: ["Thriller", "Sequel"],
+  },
+];
+
+function coverSvgDataUri(c: MockCover, w = 200, h = 300): string {
+  const [c1, c2] = c.bg;
+  const words = c.title.split(" ").slice(0, 3);
+  const titleLines = words
+    .map(
+      (word, i) =>
+        `<text x="${w * 0.08}" y="${h * 0.72 + i * h * 0.08}" fill="${c.accent}" font-family="Inter Tight, sans-serif" font-weight="800" font-size="${Math.max(14, w * 0.11)}" letter-spacing="-0.4">${word.toUpperCase()}</text>`,
+    )
+    .join("");
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${w} ${h}" width="${w}" height="${h}">
+    <defs>
+      <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0" stop-color="${c1}"/>
+        <stop offset="1" stop-color="${c2}"/>
+      </linearGradient>
+      <pattern id="p" width="8" height="8" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+        <rect width="8" height="8" fill="url(#g)"/>
+        <line x1="0" y1="0" x2="0" y2="8" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+      </pattern>
+    </defs>
+    <rect width="${w}" height="${h}" fill="url(#p)"/>
+    <rect x="0" y="${h * 0.62}" width="${w}" height="${h * 0.38}" fill="rgba(0,0,0,0.45)"/>
+    ${titleLines}
+    <text x="${w * 0.08}" y="${h * 0.95}" fill="rgba(255,255,255,0.7)" font-family="ui-monospace, Menlo, monospace" font-size="${Math.max(10, w * 0.06)}">#${String(c.have).padStart(2, "0")}</text>
+  </svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+function coverToComic(c: MockCover): Comic {
+  return {
+    ComicID: c.id,
+    ComicName: c.title,
+    ComicYear: String(c.year),
+    ComicPublisher: c.publisher,
+    ComicImage: coverSvgDataUri(c),
+    ComicImageURL: coverSvgDataUri(c),
+    Status: c.status,
+    Total: c.total,
+    Have: c.have,
+    LatestDate: `${c.year}-10-09`,
+    DateAdded: `${c.year}-01-15`,
+    Description: c.description,
+    DetailURL: null,
+    ComicLocation: `/library/${c.kind}s/${c.id}`,
+    Corrected_SeriesYear: null,
+    ForceContinuing: false,
+    AlternateSearch: null,
+    ComicVersion: null,
+    ContentType: c.kind === "manga" ? "manga" : "comic",
+  };
+}
+
+const SERIES: Comic[] = COVERS.map(coverToComic);
+
+function buildIssues(c: MockCover): Issue[] {
+  const arcs =
+    c.id === "absolute-batman"
+      ? ["The Zoo", "The Party", "Black Sands"]
+      : ["Arc One", "Arc Two", "Arc Three"];
+  const titles = [
+    "The Zoo",
+    "When They Break",
+    "A Boy Scout's Life",
+    "The Spot",
+    "Here Comes the Chase",
+    "Feast",
+    "Party Tricks",
+    "Not Today",
+    "Black Out",
+    "Ghost of the Sand",
+    "Gotham by Gaslight",
+    "Last Call",
+    "The Getaway",
+    "Sleepers",
+    "Red Balloons",
+    "Mercy",
+    "Fallen",
+    "Ascendant",
+    "After Hours",
+    "The Long Drive",
+    "Bookends",
+    "Final Light",
+  ];
+  const issues: Issue[] = [];
+  const count = c.total;
+  for (let i = 1; i <= count; i++) {
+    const haveIt = i <= c.have;
+    const arc = arcs[Math.floor((i - 1) / Math.ceil(count / arcs.length))];
+    const dateYear = c.year;
+    const monthIndex = ((i - 1) % 12) + 1;
+    issues.push({
+      IssueID: `${c.id}-${i}`,
+      ComicID: c.id,
+      ComicName: c.title,
+      ComicYear: String(dateYear),
+      Issue_Number: String(i),
+      IssueName: titles[(i - 1) % titles.length],
+      IssueDate: `${dateYear}-${String(monthIndex).padStart(2, "0")}-09`,
+      ReleaseDate: `${dateYear}-${String(monthIndex).padStart(2, "0")}-09`,
+      DateAdded: `${dateYear}-${String(monthIndex).padStart(2, "0")}-10`,
+      Status: haveIt ? "Downloaded" : i === c.have + 1 ? "Wanted" : "Skipped",
+      Location: haveIt
+        ? `/comics/${c.title}/${c.title} - ${String(i).padStart(3, "0")} (${dateYear}).cbz`
+        : null,
+      ImageURL: coverSvgDataUri(c, 80, 120),
+      ImageURL_ALT: null,
+      Int_IssueNumber: i,
+      // Arc is not part of Issue type but UI may read it via loose property
+      ...({ Arc: arc } as Record<string, string>),
+    });
+  }
+  return issues;
+}
+
+const ISSUES_BY_COMIC = new Map<string, Issue[]>(
+  COVERS.map((c) => [c.id, buildIssues(c)]),
+);
+
+function recentDownloads() {
+  const now = new Date();
+  const items: Array<{
+    ComicName: string;
+    Issue_Number: string;
+    DateAdded: string;
+    Status: string;
+    Provider: string;
+    ComicID: string;
+    IssueID: string;
+    ComicImage: string | null;
+  }> = [];
+  const sample = [COVERS[0], COVERS[1], COVERS[2], COVERS[3], COVERS[6]];
+  const actions = [
+    "Downloaded",
+    "Downloaded",
+    "Post-Processed",
+    "Post-Processed",
+    "Snatched",
+    "Downloaded",
+    "Post-Processed",
+  ];
+  const providers = [
+    "NZBgeek (Prowlarr)",
+    "NZBgeek (Prowlarr)",
+    "Local",
+    "NZBgeek",
+    "Torznab",
+    "NZBgeek (Prowlarr)",
+    "Local",
+  ];
+  for (let i = 0; i < 7; i++) {
+    const c = sample[i % sample.length];
+    const when = new Date(now.getTime() - i * 9 * 60 * 1000);
+    items.push({
+      ComicName: c.title,
+      Issue_Number: String(c.have - (i % 3)),
+      DateAdded: when.toISOString(),
+      Status: actions[i],
+      Provider: providers[i],
+      ComicID: c.id,
+      IssueID: `${c.id}-${c.have - (i % 3)}`,
+      ComicImage: coverSvgDataUri(c, 60, 90),
+    });
+  }
+  return items;
+}
+
+function upcomingReleases() {
+  const base = new Date();
+  const addDays = (d: Date, n: number) => {
+    const nd = new Date(d);
+    nd.setDate(nd.getDate() + n);
+    return nd;
+  };
+  const fmt = (d: Date) => d.toISOString().slice(0, 10);
+  return [
+    {
+      ComicName: "Absolute Batman",
+      IssueNumber: "19",
+      IssueDate: fmt(addDays(base, 3)),
+      Publisher: "DC Comics",
+      ComicID: "absolute-batman",
+      Status: "Wanted",
+    },
+    {
+      ComicName: "Ultimate Wolverine",
+      IssueNumber: "16",
+      IssueDate: fmt(addDays(base, 5)),
+      Publisher: "Marvel Comics",
+      ComicID: "ultimate-wolverine",
+      Status: "Wanted",
+    },
+    {
+      ComicName: "Transformers",
+      IssueNumber: "10",
+      IssueDate: fmt(addDays(base, 7)),
+      Publisher: "Image Comics",
+      ComicID: "transformers",
+      Status: "Wanted",
+    },
+  ];
+}
+
+function wantedIssues(): WantedIssue[] {
+  const out: WantedIssue[] = [];
+  for (const c of COVERS) {
+    const issues = ISSUES_BY_COMIC.get(c.id) || [];
+    for (const i of issues.filter((x) => x.Status === "Wanted")) {
+      out.push({
+        ...i,
+        ComicName: c.title,
+        ComicYear: String(c.year),
+        ComicPublisher: c.publisher,
+        ComicImage: coverSvgDataUri(c, 80, 120),
+      } as WantedIssue);
+    }
+  }
+  return out;
+}
+
+function dashboardPayload() {
+  const totalSeries = SERIES.length;
+  const totalIssues = SERIES.reduce((sum, s) => sum + (s.Have || 0), 0);
+  const totalExpected = SERIES.reduce((sum, s) => sum + (s.Total || 0), 0);
+  return {
+    recently_downloaded: recentDownloads(),
+    upcoming_releases: upcomingReleases(),
+    stats: {
+      total_series: totalSeries,
+      total_issues: totalIssues,
+      total_expected: totalExpected,
+      completion_pct: totalExpected
+        ? Math.round((totalIssues / totalExpected) * 1000) / 10
+        : 0,
+    },
+    ai_activity: [],
+    ai_configured: false,
+  };
+}
+
+function seriesDetail(id: string) {
+  const cover = COVERS.find((c) => c.id === id);
+  if (!cover) return null;
+  const issues = ISSUES_BY_COMIC.get(id) || [];
+  return {
+    series: coverToComic(cover),
+    issues,
+  };
+}
+
+/**
+ * Return true when mock mode is enabled via `?mock=1` URL param (persisted
+ * in localStorage) or manual `localStorage.setItem('comicarr:mock','1')`.
+ */
+export function isMockEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("mock") === "1") {
+      localStorage.setItem("comicarr:mock", "1");
+      return true;
+    }
+    if (params.get("mock") === "0") {
+      localStorage.removeItem("comicarr:mock");
+      return false;
+    }
+    return localStorage.getItem("comicarr:mock") === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Match an incoming request to a mock payload. Returns `undefined` to signal
+ * "no mock for this endpoint — fall through to the real backend".
+ */
+export function mockApiResponse(
+  method: string,
+  path: string,
+): unknown | undefined {
+  const url = path.split("?")[0];
+  const m = method.toUpperCase();
+
+  if (m === "GET" && url === "/api/auth/check_setup") {
+    return { needs_setup: false };
+  }
+  if (m === "GET" && url === "/api/auth/session") {
+    return { authenticated: true, username: "mock-admin" };
+  }
+  if (m === "GET" && url === "/api/ai/status") {
+    return { configured: false };
+  }
+  if (m === "GET" && url === "/api/dashboard") {
+    return dashboardPayload();
+  }
+  if (m === "GET" && url === "/api/series") {
+    return SERIES;
+  }
+  if (m === "GET" && url === "/api/wanted") {
+    return wantedIssues();
+  }
+  if (m === "GET" && url === "/api/weekly") {
+    return upcomingReleases().map((u) => ({
+      COMIC: u.ComicName,
+      ISSUE: u.IssueNumber,
+      PUBLISHER: u.Publisher,
+      SHIPDATE: u.IssueDate,
+      STATUS: u.Status,
+      ComicID: u.ComicID,
+    }));
+  }
+  if (m === "GET" && url === "/api/upcoming") {
+    return upcomingReleases().map((u) => ({
+      IssueID: `${u.ComicID}-upcoming-${u.IssueNumber}`,
+      ComicID: u.ComicID,
+      ComicName: u.ComicName,
+      Issue_Number: u.IssueNumber,
+      IssueName: null,
+      IssueDate: u.IssueDate,
+      Status: u.Status,
+      ComicImage: null,
+    }));
+  }
+  if (m === "GET" && url === "/api/storyarcs") {
+    return [];
+  }
+  if (m === "GET" && url === "/api/downloads/queue") {
+    return [];
+  }
+  if (m === "GET" && url === "/api/config") {
+    return {};
+  }
+
+  const detailMatch = url.match(/^\/api\/series\/([^/]+)$/);
+  if (m === "GET" && detailMatch) {
+    const detail = seriesDetail(detailMatch[1]);
+    if (detail) return detail;
+    return null;
+  }
+
+  const issuesMatch = url.match(/^\/api\/series\/([^/]+)\/issues$/);
+  if (m === "GET" && issuesMatch) {
+    return ISSUES_BY_COMIC.get(issuesMatch[1]) || [];
+  }
+
+  // Cover art — return a tiny transparent gif; frontend already falls back
+  // gracefully, and the list views synthesize their own SVG covers.
+  const artMatch = url.match(/^\/api\/metadata\/art\/([^/]+)$/);
+  if (m === "GET" && artMatch) {
+    const cover = COVERS.find((c) => c.id === artMatch[1]);
+    if (cover) return { image: coverSvgDataUri(cover) };
+  }
+
+  return undefined;
+}

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -463,7 +463,7 @@ function seriesDetail(id: string) {
   if (!cover) return null;
   const issues = ISSUES_BY_COMIC.get(id) || [];
   return {
-    series: coverToComic(cover),
+    comic: coverToComic(cover),
     issues,
   };
 }

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -502,11 +502,20 @@ export function mockApiResponse(
   const url = path.split("?")[0];
   const m = method.toUpperCase();
 
-  if (m === "GET" && url === "/api/auth/check_setup") {
+  if (m === "GET" && url === "/api/auth/check-setup") {
     return { needs_setup: false };
   }
-  if (m === "GET" && url === "/api/auth/session") {
-    return { authenticated: true, username: "mock-admin" };
+  if (m === "GET" && url === "/api/auth/check-session") {
+    return { success: true, authenticated: true, username: "mock-admin" };
+  }
+  if (m === "POST" && url === "/api/auth/login") {
+    return { success: true, username: "mock-admin" };
+  }
+  if (m === "POST" && url === "/api/auth/logout") {
+    return { success: true };
+  }
+  if (m === "GET" && url === "/api/migration/check") {
+    return { needs_migration: false };
   }
   if (m === "GET" && url === "/api/ai/status") {
     return { configured: false };

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -517,6 +517,9 @@ export function mockApiResponse(
   if (m === "GET" && url === "/api/migration/check") {
     return { needs_migration: false };
   }
+  if (m === "GET" && url === "/api/system/diagnostics") {
+    return { db_empty: false, migration_dismissed: true };
+  }
   if (m === "GET" && url === "/api/ai/status") {
     return { configured: false };
   }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -13,10 +13,14 @@ if (typeof window !== "undefined" && "serviceWorker" in navigator) {
     });
   } else {
     navigator.serviceWorker.getRegistrations().then((regs) => {
-      regs.forEach((r) => {
-        if (r.active?.scriptURL?.endsWith("/mock-sw.js")) {
-          r.unregister();
-        }
+      const mockRegs = regs.filter((r) =>
+        r.active?.scriptURL?.endsWith("/mock-sw.js"),
+      );
+      if (mockRegs.length === 0) return;
+      Promise.all(mockRegs.map((r) => r.unregister())).then(() => {
+        // An active SW continues to intercept fetches on the current page
+        // until navigation/reload — reload so mock mode truly turns off.
+        if (navigator.serviceWorker.controller) window.location.reload();
       });
     });
   }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,25 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { isMockEnabled } from "@/lib/mockData";
+
+// Register/unregister the mock-mode service worker based on the current
+// mock flag. Idempotent across reloads.
+if (typeof window !== "undefined" && "serviceWorker" in navigator) {
+  if (isMockEnabled()) {
+    navigator.serviceWorker.register("/mock-sw.js").catch(() => {
+      /* ignore — mock covers will fall back to broken-image icons */
+    });
+  } else {
+    navigator.serviceWorker.getRegistrations().then((regs) => {
+      regs.forEach((r) => {
+        if (r.active?.scriptURL?.endsWith("/mock-sw.js")) {
+          r.unregister();
+        }
+      });
+    });
+  }
+}
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Failed to find the root element");

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -94,7 +94,7 @@ function DenseTable({
 }) {
   return (
     <div
-      className="rounded-[6px] border overflow-hidden"
+      className="rounded-[6px] border overflow-x-auto"
       style={{ borderColor: "var(--border)" }}
     >
       <div

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -1,17 +1,46 @@
 import { useState } from "react";
 import { useSearchParams, Link } from "react-router-dom";
-import { Activity, Download, Clock, CheckCircle2, XCircle } from "lucide-react";
 import {
   useDownloadHistory,
   useDownloadQueue,
   type HistoryItem,
   type QueueItem,
 } from "@/hooks/useActivity";
-import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
+import EmptyState from "@/components/ui/EmptyState";
+import PageHeader, { Tab, TabRow } from "@/components/layout/PageHeader";
 
 type ActivityView = "queue" | "history";
+
+function StatusPill({ status }: { status: string }) {
+  const s = (status || "").toLowerCase();
+  let color = "var(--muted-foreground)";
+  if (
+    s.includes("down") ||
+    s.includes("snatch") ||
+    s === "active" ||
+    s === "completed" ||
+    s === "done"
+  )
+    color = "var(--status-active)";
+  else if (s.includes("queue") || s.includes("pend") || s === "wanted")
+    color = "var(--status-paused)";
+  else if (s.includes("fail") || s.includes("error"))
+    color = "var(--status-error)";
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase"
+      style={{ color }}
+    >
+      <span
+        className="w-1.5 h-1.5 rounded-full"
+        style={{ background: color }}
+      />
+      {status || "—"}
+    </span>
+  );
+}
 
 export default function ActivityPage() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -24,38 +53,63 @@ export default function ActivityPage() {
   };
 
   return (
-    <div className="page-transition">
-      <div className="flex items-center gap-3 mb-6">
-        <Activity className="w-6 h-6 text-muted-foreground" />
-        <div>
-          <h1 className="text-[32px] font-bold tracking-tight">Activity</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Download queue and history
-          </p>
-        </div>
-      </div>
+    <div className="-mx-4 sm:-mx-6 lg:-mx-8 -my-8 page-transition">
+      <PageHeader
+        title="Activity"
+        meta={
+          currentView === "queue"
+            ? "live download queue"
+            : "completed downloads"
+        }
+      />
 
-      {/* View Toggle */}
-      <div className="flex gap-2 mb-6">
-        <Button
-          variant={currentView === "queue" ? "default" : "outline"}
+      <TabRow>
+        <Tab
+          active={currentView === "queue"}
+          label="Queue"
           onClick={() => setView("queue")}
-          size="sm"
-        >
-          <Download className="w-4 h-4 mr-2" />
-          Queue
-        </Button>
-        <Button
-          variant={currentView === "history" ? "default" : "outline"}
+        />
+        <Tab
+          active={currentView === "history"}
+          label="History"
           onClick={() => setView("history")}
-          size="sm"
-        >
-          <Clock className="w-4 h-4 mr-2" />
-          History
-        </Button>
-      </div>
+        />
+      </TabRow>
 
-      {currentView === "queue" ? <QueueView /> : <HistoryView />}
+      <div className="px-5 py-4">
+        {currentView === "queue" ? <QueueView /> : <HistoryView />}
+      </div>
+    </div>
+  );
+}
+
+function DenseTable({
+  headers,
+  gridTemplate,
+  children,
+}: {
+  headers: string[];
+  gridTemplate: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="rounded-[6px] border overflow-hidden"
+      style={{ borderColor: "var(--border)" }}
+    >
+      <div
+        className="grid px-4 py-2 border-b font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground"
+        style={{
+          borderColor: "var(--border)",
+          background: "var(--card)",
+          gridTemplateColumns: gridTemplate,
+        }}
+      >
+        {headers.map((h) => (
+          <div key={h}>{h}</div>
+        ))}
+      </div>
+      {children}
     </div>
   );
 }
@@ -65,10 +119,10 @@ function QueueView() {
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
-        <Skeleton className="h-16" />
-        <Skeleton className="h-16" />
-        <Skeleton className="h-16" />
+      <div className="space-y-2">
+        {[0, 1, 2].map((i) => (
+          <Skeleton key={i} className="h-10" />
+        ))}
       </div>
     );
   }
@@ -85,87 +139,64 @@ function QueueView() {
 
   if (!queue || queue.length === 0) {
     return (
-      <div className="rounded-lg border border-card-border bg-card p-8 text-center">
-        <Download className="w-12 h-12 text-muted-foreground/30 mx-auto mb-3" />
-        <p className="text-muted-foreground">No active downloads</p>
-        <p className="text-sm text-muted-foreground/70 mt-1">
-          Downloads will appear here when items are being processed
-        </p>
-      </div>
+      <EmptyState
+        variant="custom"
+        eyebrow="QUEUE · EMPTY"
+        title="No active downloads"
+        description="Downloads will appear here while items are being processed."
+      />
     );
   }
 
+  const gridTpl = "1.5fr 2fr 100px 110px 110px";
+
   return (
-    <div className="rounded-lg border border-card-border overflow-hidden">
-      <table className="w-full">
-        <thead>
-          <tr className="border-b border-card-border bg-muted/50">
-            <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-              Series
-            </th>
-            <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-              File
-            </th>
-            <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-              Site
-            </th>
-            <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-              Status
-            </th>
-            <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-              Updated
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {queue.map((item: QueueItem) => (
-            <tr
-              key={item.ID}
-              className="border-b border-card-border last:border-0 hover:bg-muted/30"
-            >
-              <td className="px-4 py-2.5 text-sm font-medium">
-                {item.comicid ? (
-                  <Link
-                    to={`/library/${item.comicid}`}
-                    className="hover:underline"
-                  >
-                    {item.series}
-                    {item.year && (
-                      <span className="text-muted-foreground">
-                        {" "}
-                        ({item.year})
-                      </span>
-                    )}
-                  </Link>
-                ) : (
-                  <>
-                    {item.series}
-                    {item.year && (
-                      <span className="text-muted-foreground">
-                        {" "}
-                        ({item.year})
-                      </span>
-                    )}
-                  </>
+    <DenseTable
+      headers={["series", "file", "site", "status", "updated"]}
+      gridTemplate={gridTpl}
+    >
+      {queue.map((item: QueueItem) => (
+        <div
+          key={item.ID}
+          className="grid items-center px-4 py-2 text-[12px] border-b last:border-b-0"
+          style={{
+            borderColor: "var(--border-soft, var(--border))",
+            gridTemplateColumns: gridTpl,
+          }}
+        >
+          <div className="font-medium truncate">
+            {item.comicid ? (
+              <Link
+                to={`/library/${item.comicid}`}
+                className="hover:text-[var(--primary)]"
+              >
+                {item.series}
+                {item.year && (
+                  <span className="text-muted-foreground"> ({item.year})</span>
                 )}
-              </td>
-              <td className="px-4 py-2.5 text-sm text-muted-foreground truncate max-w-xs">
-                {item.filename || "—"}
-              </td>
-              <td className="px-4 py-2.5 text-sm text-muted-foreground">
-                {item.site || "—"}
-              </td>
-              <td className="px-4 py-2.5">
-                <QueueStatusBadge status={item.status} />
-              </td>
-              <td className="px-4 py-2.5 text-sm text-muted-foreground">
-                {item.updated_date || "—"}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+              </Link>
+            ) : (
+              <>
+                {item.series}
+                {item.year && (
+                  <span className="text-muted-foreground"> ({item.year})</span>
+                )}
+              </>
+            )}
+          </div>
+          <div className="font-mono text-[11px] text-muted-foreground truncate">
+            {item.filename || "—"}
+          </div>
+          <div className="text-muted-foreground truncate">
+            {item.site || "—"}
+          </div>
+          <StatusPill status={item.status} />
+          <div className="font-mono text-[11px] text-muted-foreground">
+            {item.updated_date || "—"}
+          </div>
+        </div>
+      ))}
+    </DenseTable>
   );
 }
 
@@ -174,16 +205,15 @@ function HistoryView() {
   const limit = 50;
   const offset = page * limit;
   const { data, isLoading, error, refetch } = useDownloadHistory(limit, offset);
-
   const history = data?.history || [];
   const pagination = data?.pagination;
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
-        <Skeleton className="h-16" />
-        <Skeleton className="h-16" />
-        <Skeleton className="h-16" />
+      <div className="space-y-2">
+        {[0, 1, 2].map((i) => (
+          <Skeleton key={i} className="h-10" />
+        ))}
       </div>
     );
   }
@@ -200,175 +230,89 @@ function HistoryView() {
 
   if (history.length === 0) {
     return (
-      <div className="rounded-lg border border-card-border bg-card p-8 text-center">
-        <Clock className="w-12 h-12 text-muted-foreground/30 mx-auto mb-3" />
-        <p className="text-muted-foreground">No download history</p>
-        <p className="text-sm text-muted-foreground/70 mt-1">
-          Completed downloads will appear here
-        </p>
-      </div>
+      <EmptyState
+        variant="custom"
+        eyebrow="HISTORY · EMPTY"
+        title="No download history"
+        description="Completed downloads will appear here."
+      />
     );
   }
 
+  const gridTpl = "2fr 80px 160px 120px 120px";
+
   return (
-    <>
-      <div className="text-sm text-muted-foreground mb-4">
-        {pagination?.total || history.length} total entries
+    <div className="space-y-3">
+      <div className="font-mono text-[11px] text-muted-foreground">
+        {pagination?.total || history.length} entries
       </div>
+      <DenseTable
+        headers={["comic", "issue", "provider", "status", "date"]}
+        gridTemplate={gridTpl}
+      >
+        {history.map((item: HistoryItem, index: number) => (
+          <div
+            key={`${item.IssueID}-${item.Status}-${index}`}
+            className="grid items-center px-4 py-2 text-[12px] border-b last:border-b-0"
+            style={{
+              borderColor: "var(--border-soft, var(--border))",
+              gridTemplateColumns: gridTpl,
+            }}
+          >
+            <div className="font-medium truncate">
+              {item.ComicID ? (
+                <Link
+                  to={`/library/${item.ComicID}`}
+                  className="hover:text-[var(--primary)]"
+                >
+                  {item.ComicName}
+                </Link>
+              ) : (
+                item.ComicName
+              )}
+            </div>
+            <div className="font-mono text-[11px] text-muted-foreground">
+              {item.Issue_Number ? `#${item.Issue_Number}` : "—"}
+            </div>
+            <div className="text-muted-foreground truncate">
+              {item.Provider || "—"}
+            </div>
+            <StatusPill status={item.Status} />
+            <div className="font-mono text-[11px] text-muted-foreground">
+              {item.DateAdded || "—"}
+            </div>
+          </div>
+        ))}
+      </DenseTable>
 
-      <div className="rounded-lg border border-card-border overflow-hidden">
-        <table className="w-full">
-          <thead>
-            <tr className="border-b border-card-border bg-muted/50">
-              <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-                Comic
-              </th>
-              <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-                Issue
-              </th>
-              <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-                Provider
-              </th>
-              <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-                Status
-              </th>
-              <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-                Date
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {history.map((item: HistoryItem, index: number) => (
-              <tr
-                key={`${item.IssueID}-${item.Status}-${index}`}
-                className="border-b border-card-border last:border-0 hover:bg-muted/30"
-              >
-                <td className="px-4 py-2.5 text-sm font-medium">
-                  {item.ComicID ? (
-                    <Link
-                      to={`/library/${item.ComicID}`}
-                      className="hover:underline"
-                    >
-                      {item.ComicName}
-                    </Link>
-                  ) : (
-                    item.ComicName
-                  )}
-                </td>
-                <td className="px-4 py-2.5 text-sm text-muted-foreground">
-                  {item.Issue_Number ? `#${item.Issue_Number}` : "—"}
-                </td>
-                <td className="px-4 py-2.5 text-sm text-muted-foreground">
-                  {item.Provider || "—"}
-                </td>
-                <td className="px-4 py-2.5">
-                  <HistoryStatusBadge status={item.Status} />
-                </td>
-                <td className="px-4 py-2.5 text-sm text-muted-foreground">
-                  {item.DateAdded || "—"}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      {/* Pagination */}
       {pagination && pagination.total > limit && (
-        <div className="flex items-center justify-between mt-4 pt-4 border-t border-card-border">
-          <Button
-            variant="outline"
-            size="sm"
+        <div
+          className="flex items-center justify-between pt-3 border-t font-mono text-[11px] text-muted-foreground"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <button
+            type="button"
+            className="px-2.5 py-1 rounded border disabled:opacity-50"
+            style={{ borderColor: "var(--border)" }}
             onClick={() => setPage((p) => Math.max(0, p - 1))}
             disabled={page === 0}
           >
-            Previous
-          </Button>
-          <span className="text-sm text-muted-foreground">
-            Page {page + 1} of {Math.ceil(pagination.total / limit)}
+            ← prev
+          </button>
+          <span>
+            page {page + 1} / {Math.ceil(pagination.total / limit)}
           </span>
-          <Button
-            variant="outline"
-            size="sm"
+          <button
+            type="button"
+            className="px-2.5 py-1 rounded border disabled:opacity-50"
+            style={{ borderColor: "var(--border)" }}
             onClick={() => setPage((p) => p + 1)}
             disabled={!pagination.has_more}
           >
-            Next
-          </Button>
+            next →
+          </button>
         </div>
       )}
-    </>
-  );
-}
-
-function QueueStatusBadge({ status }: { status: string }) {
-  const lower = status?.toLowerCase() || "";
-  if (lower === "downloading" || lower === "active") {
-    return (
-      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-blue-500/10 text-blue-600">
-        <Download className="w-3 h-3" />
-        {status}
-      </span>
-    );
-  }
-  if (lower === "queued" || lower === "pending") {
-    return (
-      <span className="text-xs px-2 py-0.5 rounded-full bg-yellow-500/10 text-yellow-600">
-        {status}
-      </span>
-    );
-  }
-  if (lower === "completed" || lower === "done") {
-    return (
-      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-500/10 text-green-600">
-        <CheckCircle2 className="w-3 h-3" />
-        {status}
-      </span>
-    );
-  }
-  if (lower === "failed" || lower === "error") {
-    return (
-      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-red-500/10 text-red-600">
-        <XCircle className="w-3 h-3" />
-        {status}
-      </span>
-    );
-  }
-  return (
-    <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
-      {status || "Unknown"}
-    </span>
-  );
-}
-
-function HistoryStatusBadge({ status }: { status: string }) {
-  const lower = status?.toLowerCase() || "";
-  if (lower === "snatched" || lower === "downloaded") {
-    return (
-      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-500/10 text-green-600">
-        <CheckCircle2 className="w-3 h-3" />
-        {status}
-      </span>
-    );
-  }
-  if (lower === "wanted" || lower === "queued") {
-    return (
-      <span className="text-xs px-2 py-0.5 rounded-full bg-yellow-500/10 text-yellow-600">
-        {status}
-      </span>
-    );
-  }
-  if (lower.includes("fail") || lower.includes("error")) {
-    return (
-      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-red-500/10 text-red-600">
-        <XCircle className="w-3 h-3" />
-        {status}
-      </span>
-    );
-  }
-  return (
-    <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground">
-      {status || "Unknown"}
-    </span>
+    </div>
   );
 }

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -105,8 +105,8 @@ function DenseTable({
           gridTemplateColumns: gridTemplate,
         }}
       >
-        {headers.map((h) => (
-          <div key={h}>{h}</div>
+        {headers.map((h, i) => (
+          <div key={`${h}-${i}`}>{h}</div>
         ))}
       </div>
       {children}

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -53,7 +53,7 @@ export default function ActivityPage() {
   };
 
   return (
-    <div className="-mx-4 sm:-mx-6 lg:-mx-8 -my-8 page-transition">
+    <div className="page-transition">
       <PageHeader
         title="Activity"
         meta={

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,49 +1,384 @@
-import RecentDownloads from "@/components/dashboard/RecentDownloads";
-import UpcomingReleases from "@/components/dashboard/UpcomingReleases";
-import CollectionStats from "@/components/dashboard/CollectionStats";
-import AiInsightsPanel from "@/components/dashboard/AiInsightsPanel";
-import AiDiscoveryBanner from "@/components/dashboard/AiDiscoveryBanner";
+import { useState } from "react";
+import { Link } from "react-router-dom";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 import { useDashboard } from "@/hooks/useDashboard";
 
+type TimeRange = "24h" | "7d" | "30d" | "All";
+
+function Spark({ color, points }: { color: string; points: number[] }) {
+  if (points.length === 0) return null;
+  const max = Math.max(...points, 1);
+  const coords = points
+    .map((v, i) => {
+      const x = (i * 80) / Math.max(1, points.length - 1);
+      const y = 24 - (v / max) * 20;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  return (
+    <svg viewBox="0 0 80 24" width="80" height="24" className="shrink-0">
+      <polyline fill="none" stroke={color} strokeWidth="1.2" points={coords} />
+    </svg>
+  );
+}
+
+function Kpi({
+  label,
+  value,
+  delta,
+  deltaColor,
+  spark,
+  sparkColor,
+  borderLeft,
+}: {
+  label: string;
+  value: string;
+  delta?: string;
+  deltaColor?: string;
+  spark?: number[];
+  sparkColor?: string;
+  borderLeft?: boolean;
+}) {
+  return (
+    <div className={`px-5 py-4 ${borderLeft ? "border-l border-border" : ""}`}>
+      <div className="mono-label">{label}</div>
+      <div className="flex items-end gap-2 mt-1.5">
+        <div className="text-[26px] font-semibold tracking-tight leading-none">
+          {value}
+        </div>
+        {delta && (
+          <div
+            className="font-mono text-[11px] pb-1"
+            style={{ color: deltaColor }}
+          >
+            {delta}
+          </div>
+        )}
+        {spark && (
+          <div className="ml-auto">
+            <Spark
+              color={sparkColor || "var(--status-active)"}
+              points={spark}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function DashboardPage() {
   const { data, isLoading, error } = useDashboard();
+  const [range, setRange] = useState<TimeRange>("7d");
 
   if (error) {
     return (
-      <ErrorDisplay
-        error={error}
-        title="Unable to load dashboard"
-        onRetry={() => window.location.reload()}
-      />
+      <div className="p-8">
+        <ErrorDisplay
+          error={error}
+          title="Unable to load dashboard"
+          onRetry={() => window.location.reload()}
+        />
+      </div>
     );
   }
 
+  const stats = data?.stats;
+  const downloads = data?.recently_downloaded || [];
+  const upcoming = data?.upcoming_releases || [];
+
+  const activeSeries = stats?.total_series ?? 0;
+  const totalIssues = stats?.total_issues ?? 0;
+  const completion = stats?.completion_pct ?? 0;
+  const queueCount = downloads.filter((d) =>
+    /snatch|queue|wanted/i.test(d.Status),
+  ).length;
+
+  const ranges: TimeRange[] = ["24h", "7d", "30d", "All"];
+
   return (
-    <div className="page-transition">
-      <div className="mb-6">
-        <h1 className="text-[32px] font-bold tracking-tight">Dashboard</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Your library at a glance
-        </p>
+    <div className="h-full flex flex-col page-transition">
+      {/* Page header */}
+      <div className="px-5 py-4 border-b border-border flex items-center gap-3">
+        <div>
+          <div className="text-[18px] font-semibold tracking-tight">
+            Dashboard
+          </div>
+          <div className="font-mono text-[11px] text-muted-foreground mt-0.5">
+            {isLoading
+              ? "loading…"
+              : `${activeSeries} series · ${totalIssues} issues · ${queueCount} in queue`}
+          </div>
+        </div>
+        <div className="ml-auto flex gap-1.5">
+          {ranges.map((r) => {
+            const active = r === range;
+            return (
+              <button
+                key={r}
+                onClick={() => setRange(r)}
+                className="font-mono text-[11px] px-2.5 py-1 rounded-[4px] border"
+                style={{
+                  borderColor: active ? "var(--primary)" : "var(--border)",
+                  color: active ? "var(--primary)" : "var(--muted-foreground)",
+                  background: active
+                    ? "color-mix(in oklab, var(--primary) 12%, transparent)"
+                    : "transparent",
+                }}
+              >
+                {r}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-      {!data?.ai_configured && !isLoading && <AiDiscoveryBanner />}
-
-      <CollectionStats stats={data?.stats} isLoading={isLoading} />
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <RecentDownloads
-          downloads={data?.recently_downloaded}
-          isLoading={isLoading}
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 border-b border-border">
+        <Kpi
+          label="Active series"
+          value={isLoading ? "—" : String(activeSeries)}
+          delta={stats ? "+0" : undefined}
+          deltaColor="var(--status-active)"
+          spark={[4, 6, 5, 7, 6, 8, 9, 8, 10, 11, 10, 12]}
+          sparkColor="var(--status-active)"
         />
-        <UpcomingReleases
-          releases={data?.upcoming_releases}
-          isLoading={isLoading}
+        <Kpi
+          label="Issues"
+          value={isLoading ? "—" : String(totalIssues)}
+          delta={stats ? "+0" : undefined}
+          deltaColor="var(--status-active)"
+          spark={[20, 22, 21, 23, 25, 24, 26, 27, 29, 30, 32, 34]}
+          sparkColor="var(--status-active)"
+          borderLeft
+        />
+        <Kpi
+          label="Completion"
+          value={isLoading ? "—" : `${completion.toFixed(1)}%`}
+          delta="+0.0%"
+          deltaColor="var(--primary)"
+          spark={[30, 32, 33, 35, 36, 38, 39, 40, 41, 42, 42, 43]}
+          sparkColor="var(--primary)"
+          borderLeft
+        />
+        <Kpi
+          label="Queue"
+          value={String(queueCount)}
+          delta={queueCount > 0 ? `${queueCount}` : "0"}
+          deltaColor="var(--status-paused)"
+          spark={[8, 6, 5, 7, 4, 3, 5, 4, 3, 2, 3, 3]}
+          sparkColor="var(--status-paused)"
+          borderLeft
         />
       </div>
 
-      {data?.ai_configured && <AiInsightsPanel activity={data?.ai_activity} />}
+      {/* Two-column body */}
+      <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] border-b border-border min-h-[320px]">
+        {/* Queue & recent activity */}
+        <section className="px-5 py-4 lg:border-r lg:border-border">
+          <div className="flex items-center gap-2.5 mb-3">
+            <div className="text-[13px] font-semibold">
+              Queue & recent activity
+            </div>
+            <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
+              {downloads.length} events
+            </div>
+            <div className="ml-auto flex gap-1.5">
+              {["All", "Download", "Import", "Match"].map((l, i) => (
+                <span
+                  key={l}
+                  className="text-[11px] px-2 py-0.5 rounded-full border"
+                  style={{
+                    borderColor: i === 0 ? "var(--border)" : "transparent",
+                    color:
+                      i === 0 ? "var(--foreground)" : "var(--muted-foreground)",
+                  }}
+                >
+                  {l}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {isLoading && (
+            <div className="font-mono text-[11px] text-muted-foreground py-4">
+              loading activity…
+            </div>
+          )}
+
+          {!isLoading && downloads.length === 0 && (
+            <div className="font-mono text-[11px] text-muted-foreground py-4">
+              no recent activity
+            </div>
+          )}
+
+          <div className="font-mono text-[11px]">
+            {downloads.slice(0, 8).map((d, i) => {
+              const action = d.Status?.toLowerCase() || "—";
+              const color = action.includes("down")
+                ? "var(--chart-4)"
+                : action.includes("post") || action.includes("import")
+                  ? "var(--status-active)"
+                  : action.includes("snatch") || action.includes("queue")
+                    ? "var(--status-paused)"
+                    : "var(--muted-foreground)";
+              return (
+                <div
+                  key={`${d.ComicID}-${d.IssueID}-${i}`}
+                  className="grid items-center gap-2 py-1.5"
+                  style={{
+                    gridTemplateColumns: "60px 90px 1fr 140px 60px 20px",
+                    borderTop:
+                      i > 0
+                        ? "1px solid var(--border-soft, var(--border))"
+                        : "none",
+                  }}
+                >
+                  <span className="text-[var(--text-muted)]">
+                    {d.DateAdded?.slice(11, 16) || "—"}
+                  </span>
+                  <span className="uppercase truncate" style={{ color }}>
+                    {action}
+                  </span>
+                  <div className="flex items-center gap-2 min-w-0">
+                    {d.ComicID && (
+                      <img
+                        src={`/api/metadata/art/${d.ComicID}`}
+                        alt=""
+                        className="w-4 h-6 object-cover rounded-[1px] shrink-0"
+                        onError={(e) => {
+                          e.currentTarget.style.visibility = "hidden";
+                        }}
+                      />
+                    )}
+                    <Link
+                      to={`/library/${d.ComicID}`}
+                      className="font-sans text-foreground truncate hover:text-[var(--primary)]"
+                    >
+                      {d.ComicName} #{d.Issue_Number}
+                    </Link>
+                  </div>
+                  <span className="text-muted-foreground truncate">
+                    {d.Provider || "—"}
+                  </span>
+                  <span className="text-[var(--text-muted)] text-right">—</span>
+                  <span className="text-[var(--text-muted)] text-right">
+                    ···
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* This week */}
+        <section className="px-5 py-4">
+          <div className="flex items-center gap-2.5 mb-3">
+            <div className="text-[13px] font-semibold">This week</div>
+            <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
+              {upcoming.length} releases
+            </div>
+          </div>
+
+          {isLoading && (
+            <div className="font-mono text-[11px] text-muted-foreground py-4">
+              loading releases…
+            </div>
+          )}
+
+          {!isLoading && upcoming.length === 0 && (
+            <div className="font-mono text-[11px] text-muted-foreground py-4">
+              nothing upcoming this week
+            </div>
+          )}
+
+          {upcoming.slice(0, 6).map((u, i) => (
+            <div
+              key={`${u.ComicID}-${u.IssueNumber}-${i}`}
+              className="flex items-center gap-2.5 py-2.5"
+              style={{
+                borderTop:
+                  i > 0
+                    ? "1px solid var(--border-soft, var(--border))"
+                    : "none",
+              }}
+            >
+              <div className="font-mono text-[10px] text-muted-foreground w-12 shrink-0">
+                {u.IssueDate?.slice(5) || "—"}
+              </div>
+              <div className="flex-1 min-w-0">
+                <Link
+                  to={`/library/${u.ComicID}`}
+                  className="text-[12px] truncate block hover:text-[var(--primary)]"
+                >
+                  {u.ComicName}
+                </Link>
+                <div className="font-mono text-[10px] text-[var(--text-muted)]">
+                  #{u.IssueNumber}
+                </div>
+              </div>
+              <div className="font-mono text-[10px] text-[var(--text-muted)]">
+                {u.Status || "auto"}
+              </div>
+            </div>
+          ))}
+
+          <div className="mt-4 p-3 rounded-[6px] border border-border bg-card">
+            <div
+              className="font-mono text-[10px] mb-1.5"
+              style={{ color: "var(--primary)" }}
+            >
+              ⌘K · COMMAND HINT
+            </div>
+            <div className="text-[12px] text-muted-foreground leading-relaxed">
+              Try <span className="text-foreground">"search wolverine"</span>,{" "}
+              <span className="text-foreground">"queue pause"</span>, or{" "}
+              <span className="text-foreground">"import /downloads/new"</span>.
+            </div>
+          </div>
+        </section>
+      </div>
+
+      {/* Health row */}
+      <div className="grid grid-cols-2 lg:grid-cols-4">
+        {[
+          {
+            name: "Comic Vine",
+            color: "var(--status-active)",
+            meta: "healthy",
+          },
+          { name: "MangaDex", color: "var(--status-active)", meta: "healthy" },
+          {
+            name: "Prowlarr",
+            color: "var(--status-paused)",
+            meta: "—",
+          },
+          {
+            name: "SABnzbd",
+            color: "var(--status-active)",
+            meta: `${queueCount} active`,
+          },
+        ].map((h, i) => (
+          <div
+            key={h.name}
+            className="px-5 py-4"
+            style={{
+              borderLeft: i > 0 ? "1px solid var(--border)" : undefined,
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <div
+                className="w-1.5 h-1.5 rounded-full"
+                style={{ background: h.color }}
+              />
+              <div className="text-[12px] font-medium">{h.name}</div>
+            </div>
+            <div className="font-mono text-[10px] text-muted-foreground mt-1">
+              {h.meta}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -95,21 +95,6 @@ export default function DashboardPage() {
             <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
               {downloads.length} events
             </div>
-            <div className="ml-auto flex gap-1.5">
-              {["All", "Download", "Import", "Match"].map((l, i) => (
-                <span
-                  key={l}
-                  className="text-[11px] px-2 py-0.5 rounded-full border"
-                  style={{
-                    borderColor: i === 0 ? "var(--border)" : "transparent",
-                    color:
-                      i === 0 ? "var(--foreground)" : "var(--muted-foreground)",
-                  }}
-                >
-                  {l}
-                </span>
-              ))}
-            </div>
           </div>
 
           {isLoading && (
@@ -249,47 +234,6 @@ export default function DashboardPage() {
             </div>
           </div>
         </section>
-      </div>
-
-      {/* Health row */}
-      <div className="grid grid-cols-2 lg:grid-cols-4">
-        {[
-          {
-            name: "Comic Vine",
-            color: "var(--status-active)",
-            meta: "healthy",
-          },
-          { name: "MangaDex", color: "var(--status-active)", meta: "healthy" },
-          {
-            name: "Prowlarr",
-            color: "var(--status-paused)",
-            meta: "—",
-          },
-          {
-            name: "SABnzbd",
-            color: "var(--status-active)",
-            meta: `${queueCount} active`,
-          },
-        ].map((h, i) => (
-          <div
-            key={h.name}
-            className="px-5 py-4"
-            style={{
-              borderLeft: i > 0 ? "1px solid var(--border)" : undefined,
-            }}
-          >
-            <div className="flex items-center gap-2">
-              <div
-                className="w-1.5 h-1.5 rounded-full"
-                style={{ background: h.color }}
-              />
-              <div className="text-[12px] font-medium">{h.name}</div>
-            </div>
-            <div className="font-mono text-[10px] text-muted-foreground mt-1">
-              {h.meta}
-            </div>
-          </div>
-        ))}
       </div>
     </div>
   );

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,42 +1,14 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 import { useDashboard } from "@/hooks/useDashboard";
 
-type TimeRange = "24h" | "7d" | "30d" | "All";
-
-function Spark({ color, points }: { color: string; points: number[] }) {
-  if (points.length === 0) return null;
-  const max = Math.max(...points, 1);
-  const coords = points
-    .map((v, i) => {
-      const x = (i * 80) / Math.max(1, points.length - 1);
-      const y = 24 - (v / max) * 20;
-      return `${x.toFixed(1)},${y.toFixed(1)}`;
-    })
-    .join(" ");
-  return (
-    <svg viewBox="0 0 80 24" width="80" height="24" className="shrink-0">
-      <polyline fill="none" stroke={color} strokeWidth="1.2" points={coords} />
-    </svg>
-  );
-}
-
 function Kpi({
   label,
   value,
-  delta,
-  deltaColor,
-  spark,
-  sparkColor,
   borderLeft,
 }: {
   label: string;
   value: string;
-  delta?: string;
-  deltaColor?: string;
-  spark?: number[];
-  sparkColor?: string;
   borderLeft?: boolean;
 }) {
   return (
@@ -46,22 +18,6 @@ function Kpi({
         <div className="text-[26px] font-semibold tracking-tight leading-none">
           {value}
         </div>
-        {delta && (
-          <div
-            className="font-mono text-[11px] pb-1"
-            style={{ color: deltaColor }}
-          >
-            {delta}
-          </div>
-        )}
-        {spark && (
-          <div className="ml-auto">
-            <Spark
-              color={sparkColor || "var(--status-active)"}
-              points={spark}
-            />
-          </div>
-        )}
       </div>
     </div>
   );
@@ -69,7 +25,6 @@ function Kpi({
 
 export default function DashboardPage() {
   const { data, isLoading, error } = useDashboard();
-  const [range, setRange] = useState<TimeRange>("7d");
 
   if (error) {
     return (
@@ -94,8 +49,6 @@ export default function DashboardPage() {
     /snatch|queue|wanted/i.test(d.Status),
   ).length;
 
-  const ranges: TimeRange[] = ["24h", "7d", "30d", "All"];
-
   return (
     <div className="h-full flex flex-col page-transition">
       {/* Page header */}
@@ -110,27 +63,6 @@ export default function DashboardPage() {
               : `${activeSeries} series · ${totalIssues} issues · ${queueCount} in queue`}
           </div>
         </div>
-        <div className="ml-auto flex gap-1.5">
-          {ranges.map((r) => {
-            const active = r === range;
-            return (
-              <button
-                key={r}
-                onClick={() => setRange(r)}
-                className="font-mono text-[11px] px-2.5 py-1 rounded-[4px] border"
-                style={{
-                  borderColor: active ? "var(--primary)" : "var(--border)",
-                  color: active ? "var(--primary)" : "var(--muted-foreground)",
-                  background: active
-                    ? "color-mix(in oklab, var(--primary) 12%, transparent)"
-                    : "transparent",
-                }}
-              >
-                {r}
-              </button>
-            );
-          })}
-        </div>
       </div>
 
       {/* KPI strip */}
@@ -138,38 +70,18 @@ export default function DashboardPage() {
         <Kpi
           label="Active series"
           value={isLoading ? "—" : String(activeSeries)}
-          delta={stats ? "+0" : undefined}
-          deltaColor="var(--status-active)"
-          spark={[4, 6, 5, 7, 6, 8, 9, 8, 10, 11, 10, 12]}
-          sparkColor="var(--status-active)"
         />
         <Kpi
           label="Issues"
           value={isLoading ? "—" : String(totalIssues)}
-          delta={stats ? "+0" : undefined}
-          deltaColor="var(--status-active)"
-          spark={[20, 22, 21, 23, 25, 24, 26, 27, 29, 30, 32, 34]}
-          sparkColor="var(--status-active)"
           borderLeft
         />
         <Kpi
           label="Completion"
           value={isLoading ? "—" : `${completion.toFixed(1)}%`}
-          delta="+0.0%"
-          deltaColor="var(--primary)"
-          spark={[30, 32, 33, 35, 36, 38, 39, 40, 41, 42, 42, 43]}
-          sparkColor="var(--primary)"
           borderLeft
         />
-        <Kpi
-          label="Queue"
-          value={String(queueCount)}
-          delta={queueCount > 0 ? `${queueCount}` : "0"}
-          deltaColor="var(--status-paused)"
-          spark={[8, 6, 5, 7, 4, 3, 5, 4, 3, 2, 3, 3]}
-          sparkColor="var(--status-paused)"
-          borderLeft
-        />
+        <Kpi label="Queue" value={String(queueCount)} borderLeft />
       </div>
 
       {/* Two-column body */}

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -149,7 +149,7 @@ export default function ImportPage() {
   const pendingCount = pagination?.total ?? imports.length;
 
   return (
-    <div className="-mx-4 sm:-mx-6 lg:-mx-8 -my-8 page-transition">
+    <div className="page-transition">
       <PageHeader
         title="Import"
         meta={

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -7,8 +7,6 @@ import {
   useDeleteImport,
 } from "@/hooks/useImport";
 import { useToast } from "@/components/ui/toast";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import ImportTable from "@/components/import/ImportTable";
 import ImportBulkActions from "@/components/import/ImportBulkActions";
@@ -16,7 +14,30 @@ import MatchModal from "@/components/import/MatchModal";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 import LibraryScanSection from "@/components/import/LibraryScanSection";
 import ImportInboxSection from "@/components/import/ImportInboxSection";
+import PageHeader from "@/components/layout/PageHeader";
 import type { ImportGroup } from "@/types";
+
+function SectionHeader({
+  label,
+  title,
+  meta,
+}: {
+  label: string;
+  title: string;
+  meta?: string;
+}) {
+  return (
+    <div className="mb-3">
+      <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-muted-foreground mb-1">
+        {label}
+      </div>
+      <div className="text-[14px] font-semibold tracking-tight">{title}</div>
+      {meta && (
+        <div className="text-[12px] text-muted-foreground mt-0.5">{meta}</div>
+      )}
+    </div>
+  );
+}
 
 export default function ImportPage() {
   const [page, setPage] = useState(0);
@@ -47,9 +68,7 @@ export default function ImportPage() {
 
   const handleMatch = async (comicId: string, comicName: string) => {
     if (!matchingGroup) return;
-
     const impIds = matchingGroup.files.map((f) => f.impID);
-
     try {
       await matchImportMutation.mutateAsync({ impIds, comicId });
       addToast({
@@ -107,12 +126,11 @@ export default function ImportPage() {
   const handleBulkDelete = async () => {
     if (
       !window.confirm(
-        `Are you sure you want to delete ${selectedIds.length} import record${selectedIds.length !== 1 ? "s" : ""}? This will not delete the actual files.`,
+        `Delete ${selectedIds.length} import record${selectedIds.length !== 1 ? "s" : ""}? (Files on disk are untouched.)`,
       )
     ) {
       return;
     }
-
     try {
       await deleteImportMutation.mutateAsync(selectedIds);
       addToast({
@@ -128,113 +146,122 @@ export default function ImportPage() {
     }
   };
 
-  const handleClearSelection = () => {
-    setSelectedIds([]);
-  };
-
-  const handleNextPage = () => {
-    setPage((p) => p + 1);
-    setSelectedIds([]);
-  };
-
-  const handlePrevPage = () => {
-    setPage((p) => Math.max(0, p - 1));
-    setSelectedIds([]);
-  };
+  const pendingCount = pagination?.total ?? imports.length;
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-6 page-transition">
-      <div className="mb-6">
-        <h1 className="text-3xl font-bold text-foreground mb-2">
-          Import Management
-        </h1>
-        <p className="text-muted-foreground">
-          Scan libraries, process incoming files, and manage pending imports
-        </p>
-      </div>
+    <div className="-mx-4 sm:-mx-6 lg:-mx-8 -my-8 page-transition">
+      <PageHeader
+        title="Import"
+        meta={
+          isLoading
+            ? "loading…"
+            : `${pendingCount} file${pendingCount === 1 ? "" : "s"} awaiting review`
+        }
+      />
 
-      {/* Library Scan Section */}
-      <div className="mb-8">
-        <LibraryScanSection />
-      </div>
+      <div className="px-5 py-5 space-y-8">
+        {/* Library scan */}
+        <section>
+          <SectionHeader
+            label="LIBRARY · SCAN"
+            title="Scan existing directories"
+            meta="Find and import series already present on disk."
+          />
+          <LibraryScanSection />
+        </section>
 
-      {/* Import Inbox Section */}
-      <div className="mb-8">
-        <ImportInboxSection />
-      </div>
+        {/* Inbox */}
+        <section>
+          <SectionHeader
+            label="INBOX · AUTO-MATCH"
+            title="Monitor an import directory"
+            meta="Drop files into a watched folder to auto-match against your library."
+          />
+          <ImportInboxSection />
+        </section>
 
-      {/* Pending Imports Section */}
-      <div>
-        <div className="mb-4">
-          <h2 className="text-lg font-semibold text-foreground">
-            Pending Imports
-          </h2>
-          <p className="text-sm text-muted-foreground">
-            {pagination?.total || imports.length} file
-            {(pagination?.total || imports.length) !== 1 ? "s" : ""} awaiting
-            review
-          </p>
-        </div>
+        {/* Pending */}
+        <section>
+          <SectionHeader
+            label="PENDING · REVIEW"
+            title="Files awaiting review"
+            meta={`${pendingCount} file${pendingCount === 1 ? "" : "s"} need a match before being imported.`}
+          />
 
-        <div className="flex items-center mb-4">
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="show-ignored"
-              checked={showIgnored}
-              onChange={() => setShowIgnored(!showIgnored)}
-            />
-            <Label htmlFor="show-ignored" className="text-sm cursor-pointer">
+          <div className="flex items-center gap-3 mb-4">
+            <button
+              type="button"
+              onClick={() => setShowIgnored(!showIgnored)}
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border font-mono text-[11px]"
+              style={{
+                borderColor: showIgnored ? "var(--primary)" : "var(--border)",
+                color: showIgnored
+                  ? "var(--primary)"
+                  : "var(--muted-foreground)",
+                background: showIgnored
+                  ? "color-mix(in oklab, var(--primary) 12%, transparent)"
+                  : "transparent",
+              }}
+            >
               {showIgnored ? (
-                <span className="flex items-center gap-1">
-                  <Eye className="w-4 h-4" /> Show Ignored
-                </span>
+                <>
+                  <Eye className="w-3 h-3" />
+                  showing ignored
+                </>
               ) : (
-                <span className="flex items-center gap-1">
-                  <EyeOff className="w-4 h-4" /> Hide Ignored
-                </span>
+                <>
+                  <EyeOff className="w-3 h-3" />
+                  ignored hidden
+                </>
               )}
-            </Label>
+            </button>
           </div>
-        </div>
 
-        {isLoading && (
-          <div className="space-y-4">
-            <Skeleton className="h-16" />
-            <Skeleton className="h-16" />
-            <Skeleton className="h-16" />
-          </div>
-        )}
+          {isLoading && (
+            <div className="space-y-2">
+              {[0, 1, 2].map((i) => (
+                <Skeleton key={i} className="h-12" />
+              ))}
+            </div>
+          )}
 
-        {error && (
-          <ErrorDisplay
-            error={error}
-            title="Unable to load pending imports"
-            onRetry={() => refetch()}
+          {error && (
+            <ErrorDisplay
+              error={error}
+              title="Unable to load pending imports"
+              onRetry={() => refetch()}
+            />
+          )}
+
+          {!isLoading && !error && (
+            <ImportTable
+              imports={imports}
+              pagination={pagination}
+              onNextPage={() => {
+                setPage((p) => p + 1);
+                setSelectedIds([]);
+              }}
+              onPrevPage={() => {
+                setPage((p) => Math.max(0, p - 1));
+                setSelectedIds([]);
+              }}
+              onSelectionChange={setSelectedIds}
+              onMatchClick={handleMatchClick}
+            />
+          )}
+
+          <ImportBulkActions
+            selectedCount={selectedIds.length}
+            onIgnore={handleBulkIgnore}
+            onUnignore={handleBulkUnignore}
+            onDelete={handleBulkDelete}
+            onClear={() => setSelectedIds([])}
+            isLoading={
+              ignoreImportMutation.isPending || deleteImportMutation.isPending
+            }
+            showUnignore={showIgnored}
           />
-        )}
-
-        {!isLoading && !error && (
-          <ImportTable
-            imports={imports}
-            pagination={pagination}
-            onNextPage={handleNextPage}
-            onPrevPage={handlePrevPage}
-            onSelectionChange={setSelectedIds}
-            onMatchClick={handleMatchClick}
-          />
-        )}
-
-        <ImportBulkActions
-          selectedCount={selectedIds.length}
-          onIgnore={handleBulkIgnore}
-          onUnignore={handleBulkUnignore}
-          onDelete={handleBulkDelete}
-          onClear={handleClearSelection}
-          isLoading={
-            ignoreImportMutation.isPending || deleteImportMutation.isPending
-          }
-          showUnignore={showIgnored}
-        />
+        </section>
       </div>
 
       <MatchModal

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -191,7 +191,12 @@ export default function ImportPage() {
           <div className="flex items-center gap-3 mb-4">
             <button
               type="button"
-              onClick={() => setShowIgnored(!showIgnored)}
+              aria-pressed={showIgnored}
+              onClick={() => {
+                setShowIgnored((prev) => !prev);
+                setPage(0);
+                setSelectedIds([]);
+              }}
               className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border font-mono text-[11px]"
               style={{
                 borderColor: showIgnored ? "var(--primary)" : "var(--border)",

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -9,15 +9,52 @@ import {
   ArrowRight,
 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
-import Logo from "@/components/Logo";
 import { setupCredentials } from "@/lib/api";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { Kbd } from "@/components/ui/kbd";
+import GridShader from "@/components/login/GridShader";
+import Logo from "@/components/Logo";
+
+function MonoLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="font-mono text-[10px] tracking-[0.08em] uppercase text-muted-foreground mb-1.5">
+      {children}
+    </div>
+  );
+}
+
+function FieldShell({
+  icon: Icon,
+  children,
+  focused,
+}: {
+  icon: typeof User;
+  children: React.ReactNode;
+  focused?: boolean;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2.5 px-3 py-2.5 rounded-md border bg-background transition-all"
+      style={{
+        borderColor: focused ? "var(--primary)" : "var(--border)",
+        boxShadow: focused
+          ? "0 0 0 3px color-mix(in oklab, var(--primary) 18%, transparent)"
+          : undefined,
+      }}
+    >
+      <Icon
+        className="w-[13px] h-[13px] shrink-0"
+        style={{ color: "var(--muted-foreground)" }}
+      />
+      {children}
+    </div>
+  );
+}
 
 function SetupForm() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [focus, setFocus] = useState<string | null>(null);
   const [error, setError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -29,12 +66,10 @@ function SetupForm() {
       setError("Please enter both username and password");
       return;
     }
-
     if (password.length < 8) {
       setError("Password must be at least 8 characters");
       return;
     }
-
     if (password !== confirmPassword) {
       setError("Passwords do not match");
       return;
@@ -44,8 +79,6 @@ function SetupForm() {
     try {
       const result = await setupCredentials(username, password);
       if (result.success) {
-        // Server is restarting to enable auth sessions.
-        // Poll until it's back, then redirect to login.
         setError("");
         const pollUntilReady = async () => {
           for (let i = 0; i < 30; i++) {
@@ -57,10 +90,9 @@ function SetupForm() {
                 return;
               }
             } catch {
-              // Server still restarting
+              // still restarting
             }
           }
-          // Fallback after 60s
           window.location.href = "/";
         };
         pollUntilReady();
@@ -75,108 +107,116 @@ function SetupForm() {
   };
 
   return (
-    <div>
-      <div className="flex items-center gap-2 mb-4 text-sm text-muted-foreground">
-        <ShieldCheck className="w-4 h-4" />
-        <span>Create your admin account to get started</span>
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex items-center gap-2 -mt-2 mb-2 font-mono text-[11px] text-muted-foreground">
+        <ShieldCheck
+          className="w-3.5 h-3.5"
+          style={{ color: "var(--primary)" }}
+        />
+        <span>first-run · create admin</span>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-5">
-        <div className="space-y-2">
-          <label
-            htmlFor="setup-username"
-            className="text-sm font-medium text-foreground"
-          >
-            Username
-          </label>
-          <div className="relative">
-            <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-            <Input
-              id="setup-username"
-              type="text"
-              placeholder="Choose a username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              disabled={isSubmitting}
-              autoComplete="username"
-              className="pl-10"
-            />
-          </div>
-        </div>
+      <div>
+        <MonoLabel>Username</MonoLabel>
+        <FieldShell icon={User} focused={focus === "u"}>
+          <input
+            type="text"
+            placeholder="Choose a username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            onFocus={() => setFocus("u")}
+            onBlur={() => setFocus(null)}
+            disabled={isSubmitting}
+            autoComplete="username"
+            className="flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-[var(--text-muted)]"
+          />
+        </FieldShell>
+      </div>
 
-        <div className="space-y-2">
-          <label
-            htmlFor="setup-password"
-            className="text-sm font-medium text-foreground"
-          >
-            Password
-          </label>
-          <div className="relative">
-            <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-            <Input
-              id="setup-password"
-              type="password"
-              placeholder="Choose a password (min 8 characters)"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              disabled={isSubmitting}
-              autoComplete="new-password"
-              className="pl-10"
-            />
-          </div>
-        </div>
+      <div>
+        <MonoLabel>Password</MonoLabel>
+        <FieldShell icon={Lock} focused={focus === "p"}>
+          <input
+            type="password"
+            placeholder="min 8 characters"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onFocus={() => setFocus("p")}
+            onBlur={() => setFocus(null)}
+            disabled={isSubmitting}
+            autoComplete="new-password"
+            className="flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-[var(--text-muted)] tracking-[0.15em]"
+          />
+        </FieldShell>
+      </div>
 
-        <div className="space-y-2">
-          <label
-            htmlFor="setup-confirm-password"
-            className="text-sm font-medium text-foreground"
-          >
-            Confirm Password
-          </label>
-          <div className="relative">
-            <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-            <Input
-              id="setup-confirm-password"
-              type="password"
-              placeholder="Confirm your password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              disabled={isSubmitting}
-              autoComplete="new-password"
-              className="pl-10"
-            />
-          </div>
-        </div>
+      <div>
+        <MonoLabel>Confirm password</MonoLabel>
+        <FieldShell icon={Lock} focused={focus === "c"}>
+          <input
+            type="password"
+            placeholder="confirm"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            onFocus={() => setFocus("c")}
+            onBlur={() => setFocus(null)}
+            disabled={isSubmitting}
+            autoComplete="new-password"
+            className="flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-[var(--text-muted)] tracking-[0.15em]"
+          />
+        </FieldShell>
+      </div>
 
-        {error && (
-          <div className="flex items-start gap-3 p-3 text-sm text-[var(--status-error)] bg-[var(--status-error-bg)] border border-[var(--status-error)]/20 rounded-lg">
-            <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-            <span>{error}</span>
-          </div>
-        )}
-
-        <Button
-          type="submit"
-          className="w-full h-11 text-base font-medium"
-          disabled={isSubmitting}
+      {error && (
+        <div
+          className="flex items-start gap-2 p-2.5 text-[12px] rounded-md border"
+          style={{
+            color: "var(--status-error)",
+            background: "var(--status-error-bg)",
+            borderColor:
+              "color-mix(in oklab, var(--status-error) 30%, transparent)",
+          }}
         >
-          {isSubmitting && !error ? (
-            <>
-              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-              {username ? "Restarting server..." : "Creating account..."}
-            </>
-          ) : (
-            "Create Account"
-          )}
-        </Button>
-      </form>
-    </div>
+          <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+          <span className="font-mono">{error}</span>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="w-full flex items-center justify-center gap-2 py-2.5 rounded-md text-[13px] font-semibold disabled:opacity-60"
+        style={{
+          background: "var(--primary)",
+          color: "var(--primary-foreground)",
+        }}
+      >
+        {isSubmitting ? (
+          <>
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            {username ? "Restarting server…" : "Creating account…"}
+          </>
+        ) : (
+          <>
+            <span>Create account</span>
+            <Kbd
+              className="!bg-black/10 !border-black/20 !text-black/70"
+              style={{ color: "rgba(0,0,0,0.7)" }}
+            >
+              ↵
+            </Kbd>
+          </>
+        )}
+      </button>
+    </form>
   );
 }
 
 function LoginForm() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [focus, setFocus] = useState<string | null>(null);
+  const [showPw, setShowPw] = useState(false);
   const [error, setError] = useState("");
   const { login, isVerifying } = useAuth();
   const navigate = useNavigate();
@@ -184,14 +224,11 @@ function LoginForm() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError("");
-
     if (!username.trim() || !password.trim()) {
       setError("Please enter both username and password");
       return;
     }
-
     const result = await login(username, password);
-
     if (result.success) {
       navigate("/");
     } else {
@@ -200,78 +237,103 @@ function LoginForm() {
   };
 
   return (
-    <div>
-      <form onSubmit={handleSubmit} className="space-y-5">
-        <div className="space-y-2">
-          <label
-            htmlFor="username"
-            className="text-[13px] font-medium text-[var(--muted-foreground)]"
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <MonoLabel>Username</MonoLabel>
+        <FieldShell icon={User} focused={focus === "u"}>
+          <input
+            type="text"
+            placeholder="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            onFocus={() => setFocus("u")}
+            onBlur={() => setFocus(null)}
+            disabled={isVerifying}
+            autoComplete="username"
+            className="flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-[var(--text-muted)]"
+          />
+        </FieldShell>
+      </div>
+
+      <div>
+        <MonoLabel>Password</MonoLabel>
+        <FieldShell icon={Lock} focused={focus === "p"}>
+          <input
+            type={showPw ? "text" : "password"}
+            placeholder="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onFocus={() => setFocus("p")}
+            onBlur={() => setFocus(null)}
+            disabled={isVerifying}
+            autoComplete="current-password"
+            className="flex-1 bg-transparent text-[13px] text-foreground outline-none placeholder:text-[var(--text-muted)] tracking-[0.15em]"
+          />
+          <button
+            type="button"
+            onClick={() => setShowPw((s) => !s)}
+            className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
+            tabIndex={-1}
           >
-            Username
-          </label>
-          <div className="relative">
-            <User className="absolute left-4 top-1/2 -translate-y-1/2 w-[18px] h-[18px] text-[var(--text-muted,#6B6B70)]" />
-            <Input
-              id="username"
-              type="text"
-              placeholder="Enter your username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              disabled={isVerifying}
-              autoComplete="username"
-              className="pl-11 h-12 bg-[var(--surface-elevated,var(--secondary))] border-[var(--border-elevated,var(--border))] rounded-lg"
-            />
-          </div>
-        </div>
+            {showPw ? "hide" : "show"}
+          </button>
+        </FieldShell>
+      </div>
 
-        <div className="space-y-2">
-          <label
-            htmlFor="password"
-            className="text-[13px] font-medium text-[var(--muted-foreground)]"
-          >
-            Password
-          </label>
-          <div className="relative">
-            <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-[18px] h-[18px] text-[var(--text-muted,#6B6B70)]" />
-            <Input
-              id="password"
-              type="password"
-              placeholder="Enter your password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              disabled={isVerifying}
-              autoComplete="current-password"
-              className="pl-11 h-12 bg-[var(--surface-elevated,var(--secondary))] border-[var(--border-elevated,var(--border))] rounded-lg"
-            />
-          </div>
-        </div>
-
-        {error && (
-          <div className="flex items-start gap-3 p-3 text-sm text-[var(--status-error)] bg-[var(--status-error-bg)] border border-[var(--status-error)]/20 rounded-lg">
-            <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-            <span>{error}</span>
-          </div>
-        )}
-
-        <Button
-          type="submit"
-          className="w-full h-12 text-[15px] font-semibold bg-gradient-to-r from-[#FF5C00] to-[#FF8A4C] hover:from-[#FF6A1A] hover:to-[#FF9560] text-white border-0 rounded-lg gap-2"
-          disabled={isVerifying}
+      {error && (
+        <div
+          className="flex items-start gap-2 p-2.5 text-[12px] rounded-md border"
+          style={{
+            color: "var(--status-error)",
+            background: "var(--status-error-bg)",
+            borderColor:
+              "color-mix(in oklab, var(--status-error) 30%, transparent)",
+          }}
         >
-          {isVerifying ? (
-            <>
-              <Loader2 className="w-4 h-4 animate-spin" />
-              Signing in...
-            </>
-          ) : (
-            <>
-              Sign in
-              <ArrowRight className="w-[18px] h-[18px]" />
-            </>
-          )}
-        </Button>
-      </form>
-    </div>
+          <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+          <span className="font-mono">{error}</span>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={isVerifying}
+        className="w-full flex items-center justify-center gap-2 py-2.5 rounded-md text-[13px] font-semibold disabled:opacity-60"
+        style={{
+          background: "var(--primary)",
+          color: "var(--primary-foreground)",
+        }}
+      >
+        {isVerifying ? (
+          <>
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            Signing in…
+          </>
+        ) : (
+          <>
+            <span>Continue</span>
+            <Kbd className="!bg-black/10 !border-black/20 !text-black/70">
+              ↵
+            </Kbd>
+          </>
+        )}
+      </button>
+
+      <div className="flex items-center justify-between font-mono text-[10px] text-muted-foreground pt-1">
+        <button
+          type="button"
+          className="hover:text-foreground"
+          tabIndex={-1}
+          onClick={(e) => e.preventDefault()}
+        >
+          forgot password
+        </button>
+        <span className="inline-flex items-center gap-1.5">
+          <ArrowRight className="w-3 h-3" />
+          <span>sso</span>
+        </span>
+      </div>
+    </form>
   );
 }
 
@@ -279,37 +341,48 @@ export default function LoginPage() {
   const { needsSetup } = useAuth();
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background relative overflow-hidden px-4">
-      {/* Background radial glow */}
+    <div className="min-h-screen w-full bg-background text-foreground relative overflow-hidden grid place-items-center px-4">
+      {/* Interactive shader grid backdrop */}
+      <GridShader />
+
+      {/* Card */}
       <div
-        className="absolute inset-0 pointer-events-none"
+        className="relative z-10 w-full max-w-[380px] p-6 rounded-[10px] border bg-card"
         style={{
-          background:
-            "radial-gradient(ellipse 80% 60% at 50% 40%, rgba(255,92,0,0.03), transparent)",
+          borderColor: "var(--border)",
+          boxShadow: "0 30px 80px rgba(0,0,0,0.4)",
         }}
-      />
-
-      {/* Single card containing everything */}
-      <div className="w-full max-w-[420px] relative z-10 bg-[#141417] rounded-2xl border border-[#1F1F23] shadow-[0_4px_40px_rgba(255,92,0,0.03)] px-10 py-12 flex flex-col items-center gap-8">
-        {/* Brand section */}
-        <div className="flex flex-col items-center gap-3">
-          <Logo className="h-10 text-white" />
-          <p className="text-[#8B8B90] text-sm">
-            {needsSetup
-              ? "Welcome! Set up your account to get started."
-              : "Your comic book library manager"}
-          </p>
+      >
+        {/* Brand row */}
+        <div className="flex items-center gap-2 mb-6">
+          <Logo className="h-4 w-auto text-foreground" />
+          <span className="ml-auto font-mono text-[10px] text-muted-foreground px-1.5 py-0.5 border border-border rounded-sm">
+            v0.15.1
+          </span>
         </div>
 
-        {/* Form section */}
-        <div className="w-full">
-          {needsSetup ? <SetupForm /> : <LoginForm />}
+        <div className="text-[18px] font-semibold tracking-tight mb-1">
+          {needsSetup ? "Create admin" : "Sign in"}
+        </div>
+        <div className="text-[12px] text-muted-foreground mb-4">
+          {needsSetup
+            ? "Set up your first account to unlock the library."
+            : "Access your home server library."}
         </div>
 
-        {/* Footer */}
-        <p className="text-center text-xs text-[#4A4A4E]">
-          Automated comic book management
-        </p>
+        {needsSetup ? <SetupForm /> : <LoginForm />}
+      </div>
+
+      {/* Bottom status strip */}
+      <div className="absolute left-5 right-5 bottom-5 flex justify-between font-mono text-[10px] text-muted-foreground z-10 pointer-events-none">
+        <span className="flex items-center gap-1.5">
+          <span
+            className="w-1.5 h-1.5 rounded-full"
+            style={{ background: "var(--status-active)" }}
+          />
+          HOME.LAN
+        </span>
+        <span>COMICARR · READY</span>
       </div>
     </div>
   );

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -9,7 +9,7 @@ import {
   ArrowRight,
 } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
-import { setupCredentials } from "@/lib/api";
+import { checkSetup, setupCredentials } from "@/lib/api";
 import { Kbd } from "@/components/ui/kbd";
 import GridShader from "@/components/login/GridShader";
 import Logo from "@/components/Logo";
@@ -84,8 +84,8 @@ function SetupForm() {
           for (let i = 0; i < 30; i++) {
             await new Promise((r) => setTimeout(r, 2000));
             try {
-              const resp = await fetch("/auth/check_setup");
-              if (resp.ok) {
+              const resp = await checkSetup();
+              if (!resp.needs_setup) {
                 window.location.href = "/";
                 return;
               }
@@ -200,7 +200,7 @@ function SetupForm() {
           <>
             <span>Create account</span>
             <Kbd
-              className="!bg-black/10 !border-black/20 !text-black/70"
+              className="bg-black/10! border-black/20! text-black/70!"
               style={{ color: "rgba(0,0,0,0.7)" }}
             >
               ↵
@@ -273,7 +273,8 @@ function LoginForm() {
             type="button"
             onClick={() => setShowPw((s) => !s)}
             className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
-            tabIndex={-1}
+            aria-pressed={showPw}
+            aria-label={showPw ? "Hide password" : "Show password"}
           >
             {showPw ? "hide" : "show"}
           </button>
@@ -312,7 +313,7 @@ function LoginForm() {
         ) : (
           <>
             <span>Continue</span>
-            <Kbd className="!bg-black/10 !border-black/20 !text-black/70">
+            <Kbd className="bg-black/10! border-black/20! text-black/70!">
               ↵
             </Kbd>
           </>

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -52,7 +52,7 @@ function Tab({
     <button
       type="button"
       onClick={onClick}
-      className="relative px-3 pb-2.5 -mb-px font-mono text-[11px] tracking-[0.1em] uppercase flex items-center gap-2"
+      className="relative pb-3 -mb-px font-mono text-[11px] tracking-[0.1em] uppercase flex items-center gap-2"
       style={{
         color: active ? "var(--foreground)" : "var(--muted-foreground)",
       }}
@@ -126,7 +126,7 @@ export default function ReleasesPage() {
       </div>
 
       {/* Tab row */}
-      <div className="px-5 border-b border-border flex items-end gap-1">
+      <div className="px-5 pt-3 border-b border-border flex items-end gap-6">
         <Tab
           active={currentView === "mine"}
           label="Mine"

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Search, Calendar } from "lucide-react";
+import { Search, RefreshCw } from "lucide-react";
 import {
   useUpcoming,
   useForceSearch,
@@ -12,10 +12,8 @@ import { apiRequest } from "@/lib/api";
 import { useAiStatus } from "@/hooks/useAiStatus";
 import { AiSuggestions } from "@/components/weekly/AiSuggestions";
 import { useToast } from "@/components/ui/toast";
-import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import UpcomingTable from "@/components/queue/UpcomingTable";
-import FilterBar from "@/components/queue/FilterBar";
 import BulkActionBar from "@/components/queue/BulkActionBar";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 import EmptyState from "@/components/ui/EmptyState";
@@ -39,6 +37,69 @@ function useWeeklyPullList() {
 
 type ReleasesView = "mine" | "all";
 
+function Tab({
+  active,
+  label,
+  count,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  count?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="relative px-3 pb-2.5 -mb-px font-mono text-[11px] tracking-[0.1em] uppercase flex items-center gap-2"
+      style={{
+        color: active ? "var(--foreground)" : "var(--muted-foreground)",
+      }}
+    >
+      <span>{label}</span>
+      {count !== undefined && (
+        <span className="text-[10px]" style={{ color: "var(--text-muted)" }}>
+          {count}
+        </span>
+      )}
+      <span
+        className="absolute left-0 right-0 bottom-0 h-[2px]"
+        style={{
+          background: active ? "var(--primary)" : "transparent",
+        }}
+      />
+    </button>
+  );
+}
+
+function ToggleChip({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="font-mono text-[11px] px-2.5 py-1 rounded-full border"
+      style={{
+        borderColor: active ? "var(--primary)" : "var(--border)",
+        color: active ? "var(--primary)" : "var(--muted-foreground)",
+        background: active
+          ? "color-mix(in oklab, var(--primary) 12%, transparent)"
+          : "transparent",
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
 export default function ReleasesPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const viewParam = searchParams.get("view");
@@ -49,38 +110,38 @@ export default function ReleasesPage() {
   };
 
   return (
-    <div className="page-transition">
-      <div className="flex items-center gap-3 mb-6">
-        <Calendar className="w-6 h-6 text-muted-foreground" />
+    <div className="page-transition -mx-4 sm:-mx-6 lg:-mx-8 -my-8">
+      {/* Header */}
+      <div className="px-5 py-3.5 border-b border-border flex items-center gap-3">
         <div>
-          <h1 className="text-[32px] font-bold tracking-tight">Releases</h1>
-          <p className="text-sm text-muted-foreground mt-1">
+          <div className="text-[18px] font-semibold tracking-tight leading-none">
+            Releases
+          </div>
+          <div className="font-mono text-[11px] text-muted-foreground mt-1.5">
             {currentView === "mine"
-              ? "This week's releases for your library"
-              : "This week's new releases industry-wide"}
-          </p>
+              ? "this week · your library"
+              : "this week · industry-wide"}
+          </div>
         </div>
       </div>
 
-      {/* View Toggle */}
-      <div className="flex gap-2 mb-6">
-        <Button
-          variant={currentView === "mine" ? "default" : "outline"}
+      {/* Tab row */}
+      <div className="px-5 border-b border-border flex items-end gap-1">
+        <Tab
+          active={currentView === "mine"}
+          label="Mine"
           onClick={() => setView("mine")}
-          size="sm"
-        >
-          My Releases
-        </Button>
-        <Button
-          variant={currentView === "all" ? "default" : "outline"}
+        />
+        <Tab
+          active={currentView === "all"}
+          label="Industry"
           onClick={() => setView("all")}
-          size="sm"
-        >
-          All Releases
-        </Button>
+        />
       </div>
 
-      {currentView === "mine" ? <MyReleasesView /> : <AllReleasesView />}
+      <div className="px-5 py-4">
+        {currentView === "mine" ? <MyReleasesView /> : <AllReleasesView />}
+      </div>
     </div>
   );
 }
@@ -148,37 +209,62 @@ function MyReleasesView() {
     }
   };
 
-  const handleClearSelection = () => {
-    setSelectedIds([]);
-  };
-
   return (
-    <>
-      <FilterBar
-        showAll={includeDownloaded}
-        onToggleFilter={setIncludeDownloaded}
-        onRefresh={refetch}
-        isRefreshing={isLoading}
-      />
-
-      <div className="flex justify-between items-center mb-4">
-        <div className="text-sm text-muted-foreground">
-          {issues.length} issue{issues.length !== 1 ? "s" : ""} this week
+    <div>
+      {/* Controls row */}
+      <div className="flex items-center gap-2 mb-4 flex-wrap">
+        <div className="font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground">
+          Filter
         </div>
-        <Button
+        <ToggleChip
+          active={!includeDownloaded}
+          label="wanted only"
+          onClick={() => setIncludeDownloaded(false)}
+        />
+        <ToggleChip
+          active={includeDownloaded}
+          label="include downloaded"
+          onClick={() => setIncludeDownloaded(true)}
+        />
+
+        <div className="ml-auto font-mono text-[11px] text-muted-foreground">
+          {issues.length} issue{issues.length !== 1 ? "s" : ""}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => refetch()}
+          disabled={isLoading}
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-[5px] border text-[11px] font-mono"
+          style={{
+            borderColor: "var(--border)",
+            color: "var(--muted-foreground)",
+          }}
+        >
+          <RefreshCw className={`w-3 h-3 ${isLoading ? "animate-spin" : ""}`} />
+          refresh
+        </button>
+
+        <button
+          type="button"
           onClick={handleForceSearch}
           disabled={forceSearchMutation.isPending}
+          className="inline-flex items-center gap-1.5 px-3 py-1 rounded-[5px] text-[12px] font-semibold disabled:opacity-60"
+          style={{
+            background: "var(--primary)",
+            color: "var(--primary-foreground)",
+          }}
         >
-          <Search className="w-4 h-4 mr-2" />
-          Force Search All
-        </Button>
+          <Search className="w-3.5 h-3.5" />
+          Force search
+        </button>
       </div>
 
       {isLoading && (
-        <div className="space-y-4">
-          <Skeleton className="h-16" />
-          <Skeleton className="h-16" />
-          <Skeleton className="h-16" />
+        <div className="space-y-2">
+          <Skeleton className="h-14" />
+          <Skeleton className="h-14" />
+          <Skeleton className="h-14" />
         </div>
       )}
 
@@ -202,10 +288,10 @@ function MyReleasesView() {
         selectedCount={selectedIds.length}
         onMarkWanted={handleBulkQueue}
         onSkip={handleBulkUnqueue}
-        onClear={handleClearSelection}
+        onClear={() => setSelectedIds([])}
         isLoading={bulkQueueMutation.isPending || bulkUnqueueMutation.isPending}
       />
-    </>
+    </div>
   );
 }
 
@@ -226,7 +312,7 @@ function AllReleasesView() {
   return (
     <>
       {aiStatus?.configured && (
-        <div className="mb-8">
+        <div className="mb-6">
           <AiSuggestions />
         </div>
       )}
@@ -234,67 +320,68 @@ function AllReleasesView() {
       {isLoading ? (
         <div className="space-y-2">
           {Array.from({ length: 10 }).map((_, i) => (
-            <Skeleton key={i} className="h-12 w-full" />
+            <Skeleton key={i} className="h-10 w-full" />
           ))}
         </div>
       ) : !weekly || weekly.length === 0 ? (
-        <div className="rounded-lg border border-card-border bg-card p-8 text-center">
-          <p className="text-muted-foreground">
-            No pull list data available. Run a weekly pull list update from
-            Settings.
-          </p>
-        </div>
+        <EmptyState
+          variant="custom"
+          eyebrow="PULL LIST · EMPTY"
+          title="No pull list data"
+          description="Run a weekly pull list update from Settings to populate this view."
+        />
       ) : (
-        <div className="rounded-lg border border-card-border overflow-hidden">
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-card-border bg-muted/50">
-                <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-                  Title
-                </th>
-                <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-                  Issue
-                </th>
-                <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-                  Publisher
-                </th>
-                <th className="text-left text-xs font-medium text-muted-foreground px-4 py-3">
-                  Status
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {weekly.map((issue, index) => (
-                <tr
-                  key={`${issue.COMIC}-${issue.ISSUE}-${index}`}
-                  className="border-b border-card-border last:border-0 hover:bg-muted/30"
-                >
-                  <td className="px-4 py-2.5 text-sm font-medium">
-                    {issue.COMIC}
-                  </td>
-                  <td className="px-4 py-2.5 text-sm text-muted-foreground">
-                    #{issue.ISSUE}
-                  </td>
-                  <td className="px-4 py-2.5 text-sm text-muted-foreground">
-                    {issue.PUBLISHER}
-                  </td>
-                  <td className="px-4 py-2.5">
-                    <span
-                      className={`text-xs px-2 py-0.5 rounded-full ${
-                        issue.STATUS === "Wanted"
-                          ? "bg-yellow-500/10 text-yellow-600"
-                          : issue.STATUS === "Downloaded"
-                            ? "bg-green-500/10 text-green-600"
-                            : "bg-muted text-muted-foreground"
-                      }`}
-                    >
-                      {issue.STATUS || "Available"}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div
+          className="rounded-[6px] border overflow-hidden"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <div
+            className="grid font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground px-4 py-2 border-b"
+            style={{
+              borderColor: "var(--border)",
+              background: "var(--card)",
+              gridTemplateColumns: "1fr 80px 160px 100px",
+            }}
+          >
+            <div>title</div>
+            <div>issue</div>
+            <div>publisher</div>
+            <div>status</div>
+          </div>
+          {weekly.map((issue, index) => {
+            const status = issue.STATUS || "Available";
+            const statusColor =
+              status === "Wanted"
+                ? "var(--primary)"
+                : status === "Downloaded"
+                  ? "var(--status-active)"
+                  : "var(--muted-foreground)";
+            return (
+              <div
+                key={`${issue.COMIC}-${issue.ISSUE}-${index}`}
+                className="grid items-center px-4 py-2 text-[12px] border-b last:border-b-0"
+                style={{
+                  borderColor: "var(--border-soft, var(--border))",
+                  gridTemplateColumns: "1fr 80px 160px 100px",
+                }}
+              >
+                <div className="font-medium truncate">{issue.COMIC}</div>
+                <div className="font-mono text-[11px] text-muted-foreground">
+                  #{issue.ISSUE}
+                </div>
+                <div className="text-muted-foreground truncate">
+                  {issue.PUBLISHER}
+                </div>
+                <div className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase">
+                  <span
+                    className="w-1.5 h-1.5 rounded-full"
+                    style={{ background: statusColor }}
+                  />
+                  <span style={{ color: statusColor }}>{status}</span>
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
     </>

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -110,7 +110,7 @@ export default function ReleasesPage() {
   };
 
   return (
-    <div className="page-transition -mx-4 sm:-mx-6 lg:-mx-8 -my-8">
+    <div className="page-transition">
       {/* Header */}
       <div className="px-5 py-3.5 border-b border-border flex items-center gap-3">
         <div>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -213,6 +213,7 @@ export default function SearchPage() {
             <SearchIcon className="w-3.5 h-3.5 text-muted-foreground" />
             <input
               type="text"
+              aria-label={`Search ${searchMode === "manga" ? "manga" : "comics"}`}
               placeholder={`Search ${searchMode === "manga" ? "manga" : "comics"}…`}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { useSearchParams, Link } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import {
   Search as SearchIcon,
   ChevronLeft,
@@ -345,11 +345,6 @@ export default function SearchPage() {
           />
         </div>
       )}
-
-      {/* Hidden link for config navigation used by error branches */}
-      <Link to="/settings" className="sr-only">
-        settings
-      </Link>
     </div>
   );
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -170,7 +170,7 @@ export default function SearchPage() {
   const showBothTabs = comicsEnabled && mangaEnabled;
 
   return (
-    <div className="-mx-4 sm:-mx-6 lg:-mx-8 -my-8 page-transition min-w-0 overflow-hidden">
+    <div className="page-transition min-w-0 overflow-hidden">
       <PageHeader
         title="Search"
         meta={

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -4,13 +4,8 @@ import {
   Search as SearchIcon,
   ChevronLeft,
   ChevronRight,
-  BookOpen,
-  Book,
-  ArrowUpDown,
   Settings,
 } from "lucide-react";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -22,9 +17,11 @@ import { useSearchComics, useSearchManga } from "@/hooks/useSearch";
 import { useContentSources } from "@/hooks/useContentSources";
 import SearchResultsTable from "@/components/search/SearchResultsTable";
 import { Skeleton } from "@/components/ui/skeleton";
+import EmptyState from "@/components/ui/EmptyState";
+import PageHeader, { Tab, TabRow } from "@/components/layout/PageHeader";
+import { Kbd } from "@/components/ui/kbd";
 import type { ContentType } from "@/types/entities";
 
-// Sort option definition
 interface SortOption {
   value: string;
   label: string;
@@ -55,7 +52,6 @@ const SORT_OPTIONS: Record<ContentType, SortOption[]> = {
   manga: MANGA_SORT_OPTIONS,
 };
 
-// Map frontend sort values to ComicVine API format
 const comicSortMapping: Record<string, string | null> = {
   relevance: null,
   year_desc: "start_year:desc",
@@ -66,7 +62,6 @@ const comicSortMapping: Record<string, string | null> = {
   name_desc: "name:desc",
 };
 
-// Map frontend sort values to MangaDex API format
 const mangaSortMapping: Record<string, string> = {
   relevance: "relevance",
   year_desc: "year_desc",
@@ -81,12 +76,10 @@ export default function SearchPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { comicsEnabled, comicsConfigured, mangaEnabled } = useContentSources();
 
-  // Get parameters from URL
   const urlQuery = searchParams.get("q") || "";
   const urlPage = parseInt(searchParams.get("page") || "1") || 1;
   const urlSort = searchParams.get("sort") || "relevance";
 
-  // Derive search mode from URL, falling back based on what's enabled
   const rawType = searchParams.get("type");
   const urlType: ContentType | null =
     rawType === "manga" ? "manga" : rawType === "comic" ? "comic" : null;
@@ -109,32 +102,23 @@ export default function SearchPage() {
     [],
   );
 
-  // Map sort to API format based on mode
   const comicApiSort = comicSortMapping[urlSort] ?? urlSort;
   const mangaApiSort = mangaSortMapping[urlSort] || "relevance";
 
-  // Use comic search for comic mode
   const comicSearch = useSearchComics(
     searchMode === "comic" ? urlQuery : "",
     urlPage,
     comicApiSort,
   );
-
-  // Use manga search for manga mode
   const mangaSearch = useSearchManga(
     searchMode === "manga" ? urlQuery : "",
     urlPage,
     mangaApiSort,
   );
-
-  // Select the active search based on search mode
   const activeSearch = searchMode === "manga" ? mangaSearch : comicSearch;
-
   const { data, isLoading, error } = activeSearch;
   const searchResults = data?.results || [];
   const pagination = data?.pagination;
-
-  // Get sort options for current mode
   const sortOptions = SORT_OPTIONS[searchMode];
 
   const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
@@ -150,7 +134,6 @@ export default function SearchPage() {
   };
 
   const handleSearchModeChange = (newMode: ContentType) => {
-    // Validate sort against new mode's options
     const validSorts = SORT_OPTIONS[newMode].map((o) => o.value);
     const newSort = validSorts.includes(urlSort) ? urlSort : "relevance";
     const params: Record<string, string> = {
@@ -176,7 +159,6 @@ export default function SearchPage() {
     setSearchParams(params);
   };
 
-  // Calculate pagination info from server metadata
   const totalPages = pagination
     ? Math.ceil(pagination.total / pagination.limit)
     : 0;
@@ -185,73 +167,79 @@ export default function SearchPage() {
     ? pagination.offset + (pagination.returned ?? 0)
     : 0;
 
-  return (
-    <div className="space-y-4 page-transition min-w-0 overflow-hidden">
-      {/* Page Title */}
-      <h1 className="text-3xl font-bold">
-        {searchMode === "manga" ? "Search Manga" : "Search Comics"}
-      </h1>
+  const showBothTabs = comicsEnabled && mangaEnabled;
 
-      {/* Content Type Toggle - only show when both sources are enabled */}
-      {comicsEnabled && mangaEnabled && (
-        <div className="flex gap-2">
-          <Button
-            variant={searchMode === "comic" ? "default" : "outline"}
+  return (
+    <div className="-mx-4 sm:-mx-6 lg:-mx-8 -my-8 page-transition min-w-0 overflow-hidden">
+      <PageHeader
+        title="Search"
+        meta={
+          urlQuery
+            ? isLoading
+              ? `searching "${urlQuery}"…`
+              : `${pagination?.total ?? 0} results for "${urlQuery}"`
+            : "find comics and manga to add"
+        }
+      />
+
+      {showBothTabs && (
+        <TabRow>
+          <Tab
+            active={searchMode === "comic"}
+            label="Comics"
             onClick={() => handleSearchModeChange("comic")}
-            className="flex items-center"
-          >
-            <Book className="w-4 h-4 mr-2" />
-            Comics
-          </Button>
-          <Button
-            variant={searchMode === "manga" ? "default" : "outline"}
+          />
+          <Tab
+            active={searchMode === "manga"}
+            label="Manga"
             onClick={() => handleSearchModeChange("manga")}
-            className="flex items-center"
-          >
-            <BookOpen className="w-4 h-4 mr-2" />
-            Manga
-          </Button>
-        </div>
+          />
+        </TabRow>
       )}
 
-      {/* Search Form */}
-      <form onSubmit={handleSearch} className="flex gap-2 max-w-2xl">
-        <Input
-          type="text"
-          placeholder={`Enter ${searchMode} name...`}
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="flex-1"
-        />
-        <Button
-          type="submit"
-          disabled={searchQuery.trim().length < 3}
-          className="flex items-center"
-        >
-          <SearchIcon className="w-4 h-4 mr-2" />
-          Search
-        </Button>
-      </form>
+      <div className="px-5 py-4 space-y-4">
+        {/* Search form */}
+        <form onSubmit={handleSearch} className="flex items-center gap-2">
+          <div
+            className="flex items-center gap-2 flex-1 max-w-2xl px-3 py-2 rounded-[5px] border bg-card"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <SearchIcon className="w-3.5 h-3.5 text-muted-foreground" />
+            <input
+              type="text"
+              placeholder={`Search ${searchMode === "manga" ? "manga" : "comics"}…`}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="flex-1 bg-transparent outline-none text-[13px] placeholder:text-[var(--text-muted)]"
+            />
+            <Kbd>↵</Kbd>
+          </div>
+          <button
+            type="submit"
+            disabled={searchQuery.trim().length < 3}
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-[5px] text-[12px] font-semibold disabled:opacity-60"
+            style={{
+              background: "var(--primary)",
+              color: "var(--primary-foreground)",
+            }}
+          >
+            <SearchIcon className="w-3.5 h-3.5" />
+            Search
+          </button>
+        </form>
 
-      {/* Sort Dropdown + Results Count */}
-      {urlQuery && (pagination || isLoading) && (
-        <div className="flex items-center justify-between">
-          <p className="text-muted-foreground">
-            {isLoading ? (
-              "Searching..."
-            ) : (
-              <>
-                Showing {startIndex}-{endIndex} of {pagination?.total || 0}{" "}
-                results for &ldquo;{urlQuery}&rdquo;
-              </>
-            )}
-          </p>
-
-          {!isLoading && (
+        {/* Sort + results meta */}
+        {urlQuery && (pagination || isLoading) && !isLoading && (
+          <div className="flex items-center justify-between gap-3">
+            <div className="font-mono text-[11px] text-muted-foreground">
+              showing {startIndex}–{endIndex} of {pagination?.total || 0}
+            </div>
             <div className="flex items-center gap-2">
-              <ArrowUpDown className="w-4 h-4 text-muted-foreground" />
+              <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground">
+                sort
+              </span>
               <Select value={urlSort} onValueChange={handleSortChange}>
-                <SelectTrigger className="w-[180px]">
+                <SelectTrigger className="h-7 text-[11px] w-[160px]">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -264,119 +252,107 @@ export default function SearchPage() {
               </Select>
               <div ref={columnToggleCallback} />
             </div>
-          )}
-        </div>
-      )}
-
-      {/* Loading State */}
-      {isLoading && (
-        <div className="rounded-lg border border-card-border bg-card card-shadow overflow-hidden">
-          <div className="bg-muted/50 px-6 py-3 border-b border-card-border">
-            <Skeleton className="h-4 w-full max-w-md" />
           </div>
-          {[...Array(10)].map((_, i) => (
-            <div
-              key={i}
-              className="px-6 py-4 border-b border-card-border last:border-0"
-            >
-              <Skeleton className="h-6 w-full" />
-            </div>
+        )}
+
+        {/* Loading */}
+        {isLoading && (
+          <div className="space-y-2">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <Skeleton key={i} className="h-10" />
+            ))}
+          </div>
+        )}
+
+        {/* Errors */}
+        {error &&
+          (searchMode === "comic" && !comicsConfigured ? (
+            <EmptyState
+              variant="custom"
+              icon={Settings}
+              eyebrow="PROVIDER · NOT CONFIGURED"
+              title="Comic Vine API key required"
+              description="Add a Comic Vine API key in Settings → API to search comics."
+              action={{ label: "Open settings", to: "/settings" }}
+            />
+          ) : (
+            <EmptyState
+              variant="custom"
+              eyebrow="SEARCH · ERROR"
+              title="Search failed"
+              description={error.message}
+            />
           ))}
-        </div>
-      )}
 
-      {/* Error State */}
-      {error &&
-        (searchMode === "comic" && !comicsConfigured ? (
-          <div className="text-center py-12">
-            <Settings className="w-12 h-12 text-muted-foreground/50 mx-auto mb-4" />
-            <p className="text-muted-foreground text-lg">
-              Comic Vine API key required
-            </p>
-            <p className="text-muted-foreground/70 text-sm mt-2">
-              To search for comics, add your Comic Vine API key in{" "}
-              <Link
-                to="/settings"
-                className="text-primary underline underline-offset-2"
-              >
-                Settings &rarr; API
-              </Link>
-            </p>
-          </div>
-        ) : (
-          <div className="text-center py-12">
-            <p className="text-red-600 text-lg">Search failed</p>
-            <p className="text-muted-foreground text-sm mt-2">
-              {error.message}
-            </p>
-          </div>
-        ))}
-
-      {/* No Results State */}
-      {!isLoading && !error && urlQuery && searchResults.length === 0 && (
-        <div className="text-center py-12">
-          <p className="text-muted-foreground text-lg">
-            No results found for &ldquo;{urlQuery}&rdquo;
-          </p>
-          <p className="text-gray-400 text-sm mt-2">
-            Try a different search term or check your spelling.
-          </p>
-        </div>
-      )}
-
-      {/* Results Table */}
-      {!isLoading && !error && searchResults.length > 0 && (
-        <div>
-          <SearchResultsTable
-            results={searchResults}
-            currentSort={urlSort}
-            onSortChange={handleSortChange}
-            contentType={searchMode}
-            columnToggleContainer={columnToggleEl}
+        {/* No results */}
+        {!isLoading && !error && urlQuery && searchResults.length === 0 && (
+          <EmptyState
+            variant="search"
+            eyebrow="SEARCH · NO MATCH"
+            description={`No results for "${urlQuery}". Try a different query or check spelling.`}
           />
+        )}
 
-          {/* Pagination Controls */}
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between mt-6 pt-4 border-t border-card-border">
-              <Button
-                variant="outline"
-                onClick={() => handlePageChange(urlPage - 1)}
-                disabled={urlPage === 1}
+        {/* Results */}
+        {!isLoading && !error && searchResults.length > 0 && (
+          <div>
+            <SearchResultsTable
+              results={searchResults}
+              currentSort={urlSort}
+              onSortChange={handleSortChange}
+              contentType={searchMode}
+              columnToggleContainer={columnToggleEl}
+            />
+
+            {totalPages > 1 && (
+              <div
+                className="flex items-center justify-between mt-4 pt-3 border-t font-mono text-[11px] text-muted-foreground"
+                style={{ borderColor: "var(--border)" }}
               >
-                <ChevronLeft className="w-4 h-4 mr-2" />
-                Previous
-              </Button>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded border disabled:opacity-50"
+                  style={{ borderColor: "var(--border)" }}
+                  onClick={() => handlePageChange(urlPage - 1)}
+                  disabled={urlPage === 1}
+                >
+                  <ChevronLeft className="w-3 h-3" />
+                  prev
+                </button>
+                <span>
+                  page {urlPage} / {totalPages}
+                </span>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded border disabled:opacity-50"
+                  style={{ borderColor: "var(--border)" }}
+                  onClick={() => handlePageChange(urlPage + 1)}
+                  disabled={urlPage >= totalPages}
+                >
+                  next
+                  <ChevronRight className="w-3 h-3" />
+                </button>
+              </div>
+            )}
+          </div>
+        )}
 
-              <span className="text-sm text-muted-foreground">
-                Page {urlPage} of {totalPages}
-              </span>
+        {/* Initial empty state */}
+        {!urlQuery && (
+          <EmptyState
+            variant="custom"
+            icon={SearchIcon}
+            eyebrow="SEARCH · READY"
+            title={`Find ${searchMode === "manga" ? "manga" : "comics"} to add`}
+            description="Type at least 3 characters to search across your configured providers."
+          />
+        )}
+      </div>
 
-              <Button
-                variant="outline"
-                onClick={() => handlePageChange(urlPage + 1)}
-                disabled={urlPage >= totalPages}
-              >
-                Next
-                <ChevronRight className="w-4 h-4 ml-2" />
-              </Button>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Empty State - No Search Yet */}
-      {!urlQuery && (
-        <div className="text-center py-12">
-          <SearchIcon className="w-16 h-16 text-gray-300 mx-auto mb-4" />
-          <p className="text-muted-foreground text-lg">
-            Enter a search term to find{" "}
-            {searchMode === "manga" ? "manga" : "comics"}
-          </p>
-          <p className="text-gray-400 text-sm mt-2">
-            Search requires at least 3 characters
-          </p>
-        </div>
-      )}
+      {/* Hidden link for config navigation used by error branches */}
+      <Link to="/settings" className="sr-only">
+        settings
+      </Link>
     </div>
   );
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRight,
   Settings,
 } from "lucide-react";
+import FilterField from "@/components/ui/FilterField";
 import {
   Select,
   SelectContent,
@@ -19,7 +20,6 @@ import SearchResultsTable from "@/components/search/SearchResultsTable";
 import { Skeleton } from "@/components/ui/skeleton";
 import EmptyState from "@/components/ui/EmptyState";
 import PageHeader, { Tab, TabRow } from "@/components/layout/PageHeader";
-import { Kbd } from "@/components/ui/kbd";
 import type { ContentType } from "@/types/entities";
 
 interface SortOption {
@@ -206,21 +206,14 @@ export default function SearchPage() {
           onSubmit={handleSearch}
           className="flex items-center gap-2 flex-1 min-w-[260px] max-w-[560px]"
         >
-          <div
-            className="flex items-center gap-2 flex-1 px-2.5 h-8 rounded-[5px] border bg-card"
-            style={{ borderColor: "var(--border)" }}
-          >
-            <SearchIcon className="w-3.5 h-3.5 text-muted-foreground" />
-            <input
-              type="text"
-              aria-label={`Search ${searchMode === "manga" ? "manga" : "comics"}`}
-              placeholder={`Search ${searchMode === "manga" ? "manga" : "comics"}…`}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="flex-1 bg-transparent outline-none text-[12px] placeholder:text-[var(--text-muted)]"
-            />
-            <Kbd>↵</Kbd>
-          </div>
+          <FilterField
+            aria-label={`Search ${searchMode === "manga" ? "manga" : "comics"}`}
+            placeholder={`Search ${searchMode === "manga" ? "manga" : "comics"}…`}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            shortcut="↵"
+            widthCap="full"
+          />
           <button
             type="submit"
             disabled={searchQuery.trim().length < 3}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -197,11 +197,17 @@ export default function SearchPage() {
         </TabRow>
       )}
 
-      <div className="px-5 py-4 space-y-4">
-        {/* Search form */}
-        <form onSubmit={handleSearch} className="flex items-center gap-2">
+      {/* Compact search form + sort controls */}
+      <div
+        className="px-5 py-2.5 border-b flex items-center gap-3 flex-wrap"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <form
+          onSubmit={handleSearch}
+          className="flex items-center gap-2 flex-1 min-w-[260px] max-w-[560px]"
+        >
           <div
-            className="flex items-center gap-2 flex-1 max-w-2xl px-3 py-2 rounded-[5px] border bg-card"
+            className="flex items-center gap-2 flex-1 px-2.5 h-8 rounded-[5px] border bg-card"
             style={{ borderColor: "var(--border)" }}
           >
             <SearchIcon className="w-3.5 h-3.5 text-muted-foreground" />
@@ -210,63 +216,59 @@ export default function SearchPage() {
               placeholder={`Search ${searchMode === "manga" ? "manga" : "comics"}…`}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="flex-1 bg-transparent outline-none text-[13px] placeholder:text-[var(--text-muted)]"
+              className="flex-1 bg-transparent outline-none text-[12px] placeholder:text-[var(--text-muted)]"
             />
             <Kbd>↵</Kbd>
           </div>
           <button
             type="submit"
             disabled={searchQuery.trim().length < 3}
-            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-[5px] text-[12px] font-semibold disabled:opacity-60"
+            className="inline-flex items-center gap-1 px-3 h-8 rounded-[5px] text-[12px] font-semibold disabled:opacity-60"
             style={{
               background: "var(--primary)",
               color: "var(--primary-foreground)",
             }}
           >
-            <SearchIcon className="w-3.5 h-3.5" />
             Search
           </button>
         </form>
-
-        {/* Sort + results meta */}
-        {urlQuery && (pagination || isLoading) && !isLoading && (
-          <div className="flex items-center justify-between gap-3">
-            <div className="font-mono text-[11px] text-muted-foreground">
-              showing {startIndex}–{endIndex} of {pagination?.total || 0}
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground">
-                sort
-              </span>
-              <Select value={urlSort} onValueChange={handleSortChange}>
-                <SelectTrigger className="h-7 text-[11px] w-[160px]">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {sortOptions.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <div ref={columnToggleCallback} />
-            </div>
+        {urlQuery && pagination && !isLoading && (
+          <div className="font-mono text-[11px] text-muted-foreground">
+            {startIndex}–{endIndex} of {pagination.total}
           </div>
         )}
+        <div className="ml-auto flex items-center gap-2">
+          <span className="font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground">
+            sort
+          </span>
+          <Select value={urlSort} onValueChange={handleSortChange}>
+            <SelectTrigger className="h-8 text-[11px] w-[150px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {sortOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div ref={columnToggleCallback} />
+        </div>
+      </div>
 
-        {/* Loading */}
-        {isLoading && (
-          <div className="space-y-2">
-            {[0, 1, 2, 3, 4].map((i) => (
-              <Skeleton key={i} className="h-10" />
-            ))}
-          </div>
-        )}
+      {/* Results area — full-bleed */}
+      {isLoading && (
+        <div className="p-5 space-y-2">
+          {[0, 1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-14" />
+          ))}
+        </div>
+      )}
 
-        {/* Errors */}
-        {error &&
-          (searchMode === "comic" && !comicsConfigured ? (
+      {error && (
+        <div className="p-5">
+          {searchMode === "comic" && !comicsConfigured ? (
             <EmptyState
               variant="custom"
               icon={Settings}
@@ -282,63 +284,64 @@ export default function SearchPage() {
               title="Search failed"
               description={error.message}
             />
-          ))}
+          )}
+        </div>
+      )}
 
-        {/* No results */}
-        {!isLoading && !error && urlQuery && searchResults.length === 0 && (
+      {!isLoading && !error && urlQuery && searchResults.length === 0 && (
+        <div className="p-5">
           <EmptyState
             variant="search"
             eyebrow="SEARCH · NO MATCH"
             description={`No results for "${urlQuery}". Try a different query or check spelling.`}
           />
-        )}
+        </div>
+      )}
 
-        {/* Results */}
-        {!isLoading && !error && searchResults.length > 0 && (
-          <div>
-            <SearchResultsTable
-              results={searchResults}
-              currentSort={urlSort}
-              onSortChange={handleSortChange}
-              contentType={searchMode}
-              columnToggleContainer={columnToggleEl}
-            />
-
-            {totalPages > 1 && (
-              <div
-                className="flex items-center justify-between mt-4 pt-3 border-t font-mono text-[11px] text-muted-foreground"
+      {!isLoading && !error && searchResults.length > 0 && (
+        <>
+          <SearchResultsTable
+            results={searchResults}
+            currentSort={urlSort}
+            onSortChange={handleSortChange}
+            contentType={searchMode}
+            columnToggleContainer={columnToggleEl}
+          />
+          {totalPages > 1 && (
+            <div
+              className="flex items-center justify-between px-5 py-3 border-t font-mono text-[11px] text-muted-foreground"
+              style={{ borderColor: "var(--border)" }}
+            >
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 px-2.5 py-1 rounded border disabled:opacity-50"
                 style={{ borderColor: "var(--border)" }}
+                onClick={() => handlePageChange(urlPage - 1)}
+                disabled={urlPage === 1}
               >
-                <button
-                  type="button"
-                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded border disabled:opacity-50"
-                  style={{ borderColor: "var(--border)" }}
-                  onClick={() => handlePageChange(urlPage - 1)}
-                  disabled={urlPage === 1}
-                >
-                  <ChevronLeft className="w-3 h-3" />
-                  prev
-                </button>
-                <span>
-                  page {urlPage} / {totalPages}
-                </span>
-                <button
-                  type="button"
-                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded border disabled:opacity-50"
-                  style={{ borderColor: "var(--border)" }}
-                  onClick={() => handlePageChange(urlPage + 1)}
-                  disabled={urlPage >= totalPages}
-                >
-                  next
-                  <ChevronRight className="w-3 h-3" />
-                </button>
-              </div>
-            )}
-          </div>
-        )}
+                <ChevronLeft className="w-3 h-3" />
+                prev
+              </button>
+              <span>
+                page {urlPage} / {totalPages}
+              </span>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 px-2.5 py-1 rounded border disabled:opacity-50"
+                style={{ borderColor: "var(--border)" }}
+                onClick={() => handlePageChange(urlPage + 1)}
+                disabled={urlPage >= totalPages}
+              >
+                next
+                <ChevronRight className="w-3 h-3" />
+              </button>
+            </div>
+          )}
+        </>
+      )}
 
-        {/* Initial empty state */}
-        {!urlQuery && (
+      {!urlQuery && (
+        <div className="p-5">
           <EmptyState
             variant="custom"
             icon={SearchIcon}
@@ -346,8 +349,8 @@ export default function SearchPage() {
             title={`Find ${searchMode === "manga" ? "manga" : "comics"} to add`}
             description="Type at least 3 characters to search across your configured providers."
           />
-        )}
-      </div>
+        </div>
+      )}
 
       {/* Hidden link for config navigation used by error branches */}
       <Link to="/settings" className="sr-only">

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -100,6 +100,7 @@ export default function SeriesDetailPage() {
 
   const haveCount = issues.filter((i) => i.Status === "Downloaded").length;
   const missingCount = issues.filter((i) => i.Status !== "Downloaded").length;
+  const monitoredCount = issues.filter((i) => i.Status !== "Skipped").length;
 
   const filteredIssues =
     filter === "have"
@@ -419,7 +420,7 @@ export default function SeriesDetailPage() {
               ["all", `All ${total}`],
               ["have", `Have ${haveCount}`],
               ["missing", `Missing ${missingCount}`],
-              ["monitored", `Monitored ${total}`],
+              ["monitored", `Monitored ${monitoredCount}`],
             ] as const
           ).map(([key, label]) => {
             const active = filter === key;

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import {
-  ChevronRight,
   Pause,
   Play,
   RefreshCw,
   Trash2,
-  BookOpen,
+  Search,
+  MoreHorizontal,
 } from "lucide-react";
 import {
   useSeriesDetail,
@@ -16,17 +16,16 @@ import {
   useDeleteSeries,
 } from "@/hooks/useSeries";
 import { useToast } from "@/components/ui/toast";
-import { Button } from "@/components/ui/button";
-import StatusBadge from "@/components/StatusBadge";
-import IssuesTable from "@/components/series/IssuesTable";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Badge } from "@/components/ui/badge";
-import type { ComicOrManga } from "@/types";
+import type { ComicOrManga, Issue } from "@/types";
+
+type IssueFilter = "all" | "have" | "missing" | "monitored";
 
 export default function SeriesDetailPage() {
   const { comicId } = useParams<{ comicId: string }>();
   const navigate = useNavigate();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [filter, setFilter] = useState<IssueFilter>("all");
   const { addToast } = useToast();
 
   const { data: seriesData, isLoading, error } = useSeriesDetail(comicId);
@@ -37,15 +36,19 @@ export default function SeriesDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <Skeleton className="h-8 w-48" />
-        <div className="flex space-x-6">
-          <Skeleton className="h-64 w-48" />
-          <div className="flex-1 space-y-4">
-            <Skeleton className="h-8 w-3/4" />
-            <Skeleton className="h-4 w-1/2" />
-            <Skeleton className="h-4 w-1/3" />
+      <div className="p-5 space-y-4">
+        <Skeleton className="h-6 w-64" />
+        <div
+          className="grid gap-7"
+          style={{ gridTemplateColumns: "140px 1fr 260px" }}
+        >
+          <Skeleton className="aspect-[2/3] w-[140px]" />
+          <div className="space-y-3">
+            <Skeleton className="h-8 w-2/3" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-4/5" />
           </div>
+          <Skeleton className="h-40 w-full" />
         </div>
       </div>
     );
@@ -53,14 +56,27 @@ export default function SeriesDetailPage() {
 
   if (error || !seriesData) {
     return (
-      <div className="text-center py-12">
-        <p className="text-red-600 text-lg">Failed to load series</p>
-        <p className="text-muted-foreground text-sm mt-2">
-          {error?.message || "Series not found"}
-        </p>
-        <Link to="/library" className="mt-4 inline-block">
-          <Button variant="outline">Back to Library</Button>
-        </Link>
+      <div className="p-5">
+        <div
+          className="rounded-[6px] border p-4"
+          style={{
+            borderColor:
+              "color-mix(in oklab, var(--status-error) 30%, transparent)",
+            background: "var(--status-error-bg)",
+            color: "var(--status-error)",
+          }}
+        >
+          <div className="font-semibold mb-1">Failed to load series</div>
+          <div className="text-[12px]">
+            {error?.message || "Series not found."}
+          </div>
+          <Link
+            to="/library"
+            className="inline-block mt-3 font-mono text-[11px] underline"
+          >
+            ← back to library
+          </Link>
+        </div>
       </div>
     );
   }
@@ -68,24 +84,35 @@ export default function SeriesDetailPage() {
   const comic: ComicOrManga = Array.isArray(seriesData.comic)
     ? seriesData.comic[0]
     : seriesData.comic;
-  const issues = seriesData.issues || [];
+  const issues: Issue[] = seriesData.issues || [];
   const isPaused = comic.Status?.toLowerCase() === "paused";
 
-  // Check if this is a manga (either by ContentType field or ComicID prefix)
   const isManga =
     comic.ContentType === "manga" ||
     comicId?.startsWith("md-") ||
     comicId?.startsWith("mal-");
-  const itemLabel = isManga ? "Chapters" : "Issues";
+
+  const have = comic.Have || 0;
+  const total = comic.Total || 0;
+  const missing = Math.max(0, total - have);
+  const completionPct = total > 0 ? Math.round((have / total) * 100) : 0;
+  const slug = (comic.ComicName || "").toLowerCase().replace(/\s+/g, "-");
+
+  const haveCount = issues.filter((i) => i.Status === "Downloaded").length;
+  const missingCount = issues.filter((i) => i.Status !== "Downloaded").length;
+
+  const filteredIssues =
+    filter === "have"
+      ? issues.filter((i) => i.Status === "Downloaded")
+      : filter === "missing"
+        ? issues.filter((i) => i.Status !== "Downloaded")
+        : issues;
 
   const handlePauseResume = async () => {
     if (!comicId) return;
     try {
-      if (isPaused) {
-        await resumeMutation.mutateAsync(comicId);
-      } else {
-        await pauseMutation.mutateAsync(comicId);
-      }
+      if (isPaused) await resumeMutation.mutateAsync(comicId);
+      else await pauseMutation.mutateAsync(comicId);
     } catch {
       addToast({
         type: "error",
@@ -122,202 +149,393 @@ export default function SeriesDetailPage() {
     }
   };
 
+  const ghostBtn =
+    "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[5px] border text-[12px] hover:bg-secondary/50 transition-colors";
+
   return (
-    <div className="space-y-6 page-transition">
-      {/* Breadcrumb Navigation */}
-      <nav className="flex items-center text-sm">
-        <Link
-          to="/library"
-          className="flex items-center text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <BookOpen className="w-4 h-4 mr-1" />
-          Library
+    <div className="h-full flex flex-col page-transition">
+      {/* Breadcrumb bar */}
+      <div
+        className="px-5 py-3.5 border-b flex items-center gap-2.5 font-mono text-[11px]"
+        style={{
+          borderColor: "var(--border)",
+          color: "var(--muted-foreground)",
+        }}
+      >
+        <Link to="/library" className="hover:text-foreground transition-colors">
+          library
         </Link>
-        <ChevronRight className="w-4 h-4 mx-2 text-muted-foreground/50" />
-        <span className="text-foreground font-medium truncate max-w-md">
-          {comic.ComicName}
-          {comic.ComicYear && (
-            <span className="text-muted-foreground font-normal">
-              {" "}
-              ({comic.ComicYear})
-            </span>
-          )}
+        <span style={{ color: "var(--text-muted)" }}>/</span>
+        <span>{isManga ? "manga" : "comics"}</span>
+        <span style={{ color: "var(--text-muted)" }}>/</span>
+        <span style={{ color: "var(--foreground)" }}>{slug}</span>
+        <span className="ml-auto">
+          cv:{comic.ComicID} ·{" "}
+          {comic.LatestDate ? `last sync ${comic.LatestDate}` : "unsynced"}
         </span>
-      </nav>
+      </div>
 
-      {/* Series Info */}
-      <div className="bg-card rounded-xl border border-border overflow-hidden">
-        <div className="p-6">
-          <div className="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-7">
-            {/* Cover Image */}
-            {comic.ComicImage && (
-              <div className="flex-shrink-0">
-                <img
-                  src={comic.ComicImage}
-                  alt={comic.ComicName}
-                  className="w-[200px] h-auto rounded-lg shadow-[0_8px_24px_rgba(0,0,0,0.25)]"
-                  onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
-                    e.currentTarget.src =
-                      "https://via.placeholder.com/300x450?text=No+Cover";
-                  }}
-                />
-              </div>
+      {/* Hero */}
+      <div
+        className="px-5 py-6 border-b grid gap-7"
+        style={{
+          borderColor: "var(--border)",
+          gridTemplateColumns: "140px 1fr 260px",
+        }}
+      >
+        {/* Cover */}
+        <div
+          className="aspect-[2/3] rounded-[5px] overflow-hidden border"
+          style={{ borderColor: "var(--border)" }}
+        >
+          {comic.ComicImage && (
+            <img
+              src={comic.ComicImage}
+              alt={comic.ComicName}
+              className="w-full h-full object-cover"
+              onError={(e: React.SyntheticEvent<HTMLImageElement>) => {
+                e.currentTarget.style.display = "none";
+              }}
+            />
+          )}
+        </div>
+
+        {/* Info */}
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 mb-2 font-mono text-[10px] tracking-[0.08em] uppercase">
+            <span
+              className="px-1.5 py-0.5 rounded-[3px]"
+              style={{
+                background:
+                  "color-mix(in oklab, var(--primary) 14%, transparent)",
+                color: "var(--primary)",
+              }}
+            >
+              {isManga ? "MANGA" : "COMIC"}
+            </span>
+            {comic.ComicPublisher && (
+              <span style={{ color: "var(--muted-foreground)" }}>
+                {comic.ComicPublisher}
+              </span>
             )}
+            {comic.ComicYear && (
+              <>
+                <span style={{ color: "var(--text-muted)" }}>·</span>
+                <span style={{ color: "var(--muted-foreground)" }}>
+                  {comic.ComicYear}
+                </span>
+              </>
+            )}
+            <span style={{ color: "var(--text-muted)" }}>·</span>
+            <span
+              style={{
+                color: isPaused ? "var(--text-muted)" : "var(--status-active)",
+              }}
+            >
+              ● {isPaused ? "paused" : "ongoing"}
+            </span>
+            <span style={{ color: "var(--text-muted)" }}>·</span>
+            <span style={{ color: "var(--muted-foreground)" }}>monitored</span>
+          </div>
 
-            {/* Series Details */}
-            <div className="flex-1 space-y-5">
-              <div className="space-y-2">
-                <h1 className="text-[32px] font-bold tracking-tight text-foreground">
-                  {comic.ComicName}
-                </h1>
-                <div className="flex items-center gap-4 text-sm">
-                  {comic.ComicYear && (
-                    <span
-                      className="text-muted-foreground"
-                      style={{ fontFamily: "var(--font-mono)" }}
-                    >
-                      {comic.ComicYear}
-                    </span>
-                  )}
-                  {comic.ComicYear && comic.ComicPublisher && (
-                    <span className="w-1 h-1 rounded-full bg-[var(--text-disabled,#4A4A4E)]" />
-                  )}
-                  {comic.ComicPublisher && (
-                    <span className="text-muted-foreground">
-                      {comic.ComicPublisher}
-                    </span>
-                  )}
-                  <StatusBadge status={comic.Status} />
-                </div>
-              </div>
+          <h1 className="text-[28px] font-bold tracking-[-0.02em] leading-tight mb-2">
+            {comic.ComicName}
+          </h1>
 
-              {comic.Description && (
-                <p className="text-muted-foreground text-sm leading-relaxed">
-                  {comic.Description}
-                </p>
+          {comic.Description && (
+            <p
+              className="text-[13px] leading-relaxed mb-3.5 max-w-[640px]"
+              style={{ color: "var(--muted-foreground)" }}
+            >
+              {comic.Description}
+            </p>
+          )}
+
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-[5px] text-[12px] font-semibold"
+              style={{
+                background: "var(--primary)",
+                color: "var(--primary-foreground)",
+              }}
+            >
+              <Search className="w-3.5 h-3.5" />
+              Search all missing
+            </button>
+            <button
+              type="button"
+              onClick={handleRefresh}
+              disabled={refreshMutation.isPending}
+              className={ghostBtn}
+              style={{ borderColor: "var(--border)" }}
+            >
+              <RefreshCw
+                className={`w-3.5 h-3.5 ${refreshMutation.isPending ? "animate-spin" : ""}`}
+              />
+              Refresh
+            </button>
+            <button
+              type="button"
+              onClick={handlePauseResume}
+              disabled={pauseMutation.isPending || resumeMutation.isPending}
+              className={ghostBtn}
+              style={{ borderColor: "var(--border)" }}
+            >
+              {isPaused ? (
+                <Play className="w-3.5 h-3.5" />
+              ) : (
+                <Pause className="w-3.5 h-3.5" />
               )}
-
-              <div className="flex items-center gap-8">
-                {isManga && (
-                  <Badge variant="default" className="flex items-center gap-1">
-                    <BookOpen className="w-3 h-3" />
-                    Manga
-                  </Badge>
-                )}
-                <div className="flex flex-col gap-1">
-                  <span
-                    className="text-[32px] font-medium text-foreground"
-                    style={{ fontFamily: "var(--font-mono)" }}
-                  >
-                    {comic.Total || 0}
-                  </span>
-                  <span className="text-xs font-medium text-[var(--text-muted,#6B6B70)] tracking-wider">
-                    Total {itemLabel}
-                  </span>
-                </div>
-                <div className="flex flex-col gap-1">
-                  <span
-                    className="text-[32px] font-medium text-primary"
-                    style={{ fontFamily: "var(--font-mono)" }}
-                  >
-                    {comic.Have || 0}
-                  </span>
-                  <span className="text-xs font-medium text-[var(--text-muted,#6B6B70)] tracking-wider">
-                    Downloaded
-                  </span>
-                </div>
-                <div className="flex flex-col gap-1">
-                  <span
-                    className="text-[32px] font-medium text-[#22C55E]"
-                    style={{ fontFamily: "var(--font-mono)" }}
-                  >
-                    {(comic.Total || 0) > 0
-                      ? Math.round(
-                          ((comic.Have || 0) / (comic.Total || 1)) * 100,
-                        )
-                      : 0}
-                    %
-                  </span>
-                  <span className="text-xs font-medium text-[var(--text-muted,#6B6B70)] tracking-wider">
-                    Complete
-                  </span>
-                </div>
-              </div>
-
-              {/* Actions */}
-              <div className="flex flex-wrap items-center gap-3 pt-2">
-                <Button
-                  onClick={handlePauseResume}
-                  disabled={pauseMutation.isPending || resumeMutation.isPending}
-                  variant="outline"
-                  size="sm"
+              {isPaused ? "Resume" : "Pause"}
+            </button>
+            {!showDeleteConfirm ? (
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                className={ghostBtn}
+                style={{
+                  borderColor: "var(--border)",
+                  color: "var(--muted-foreground)",
+                }}
+                aria-label="More actions"
+              >
+                <MoreHorizontal className="w-3.5 h-3.5" />
+              </button>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  disabled={deleteMutation.isPending}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[5px] text-[12px] font-semibold"
+                  style={{ background: "var(--status-error)", color: "white" }}
                 >
-                  {isPaused ? (
-                    <>
-                      <Play className="w-4 h-4 mr-2" />
-                      Resume
-                    </>
-                  ) : (
-                    <>
-                      <Pause className="w-4 h-4 mr-2" />
-                      Pause
-                    </>
-                  )}
-                </Button>
-
-                <Button
-                  onClick={handleRefresh}
-                  disabled={refreshMutation.isPending}
-                  variant="outline"
-                  size="sm"
+                  <Trash2 className="w-3.5 h-3.5" />
+                  Confirm delete
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowDeleteConfirm(false)}
+                  className={ghostBtn}
+                  style={{ borderColor: "var(--border)" }}
                 >
-                  <RefreshCw
-                    className={`w-4 h-4 mr-2 ${refreshMutation.isPending ? "animate-spin" : ""}`}
-                  />
-                  Refresh
-                </Button>
+                  Cancel
+                </button>
+              </>
+            )}
+          </div>
+        </div>
 
-                {!showDeleteConfirm ? (
-                  <Button
-                    onClick={() => setShowDeleteConfirm(true)}
-                    variant="destructive"
-                    size="sm"
-                  >
-                    <Trash2 className="w-4 h-4 mr-2" />
-                    Delete
-                  </Button>
-                ) : (
-                  <div className="flex items-center space-x-2">
-                    <span className="text-sm text-red-600 font-medium">
-                      Confirm delete?
-                    </span>
-                    <Button
-                      onClick={handleDelete}
-                      disabled={deleteMutation.isPending}
-                      variant="destructive"
-                      size="sm"
-                    >
-                      Yes, Delete
-                    </Button>
-                    <Button
-                      onClick={() => setShowDeleteConfirm(false)}
-                      variant="outline"
-                      size="sm"
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                )}
+        {/* Status card */}
+        <div
+          className="rounded-[6px] border"
+          style={{ borderColor: "var(--border)", background: "var(--card)" }}
+        >
+          <div
+            className="px-3 py-2.5 border-b font-mono text-[10px] tracking-[0.1em] uppercase"
+            style={{ borderColor: "var(--border)", color: "var(--text-muted)" }}
+          >
+            Status
+          </div>
+          <div className="px-3 py-2.5">
+            <div className="flex items-baseline gap-2 mb-1.5">
+              <div className="text-[28px] font-bold tracking-[-0.02em] leading-none">
+                {completionPct}%
               </div>
+              <div
+                className="font-mono text-[10px]"
+                style={{
+                  color:
+                    completionPct === 100
+                      ? "var(--status-active)"
+                      : "var(--muted-foreground)",
+                }}
+              >
+                {completionPct === 100 ? "complete" : "in progress"}
+              </div>
+            </div>
+            <div
+              className="h-1 rounded-full overflow-hidden mb-2.5"
+              style={{ background: "var(--border)" }}
+            >
+              <div
+                className="h-full"
+                style={{
+                  width: `${completionPct}%`,
+                  background:
+                    completionPct === 100
+                      ? "var(--status-active)"
+                      : "var(--primary)",
+                }}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-x-3 font-mono text-[10px]">
+              {(
+                [
+                  ["have", String(have)],
+                  ["total", String(total)],
+                  ["missing", String(missing)],
+                  ["status", isPaused ? "paused" : "active"],
+                ] as const
+              ).map(([label, value], i) => (
+                <div
+                  key={label}
+                  className="flex justify-between py-1"
+                  style={{
+                    borderTop: i > 1 ? "1px solid var(--border)" : "none",
+                  }}
+                >
+                  <span style={{ color: "var(--text-muted)" }}>{label}</span>
+                  <span>{value}</span>
+                </div>
+              ))}
             </div>
           </div>
         </div>
       </div>
 
-      {/* Issues/Chapters */}
-      <div className="space-y-4">
-        <h2 className="text-2xl font-bold">{itemLabel}</h2>
-        <IssuesTable issues={issues} isManga={isManga} comicId={comicId} />
+      {/* Issues header */}
+      <div
+        className="px-5 py-2.5 border-b flex items-center gap-3"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <div className="text-[13px] font-semibold">
+          {isManga ? "Chapters" : "Issues"}
+        </div>
+        <div
+          className="font-mono text-[10px] tracking-[0.08em] uppercase"
+          style={{ color: "var(--text-muted)" }}
+        >
+          {total} · grouped by arc
+        </div>
+        <div className="ml-auto flex gap-1.5 font-mono text-[10px]">
+          {(
+            [
+              ["all", `All ${total}`],
+              ["have", `Have ${haveCount}`],
+              ["missing", `Missing ${missingCount}`],
+              ["monitored", `Monitored ${total}`],
+            ] as const
+          ).map(([key, label]) => {
+            const active = filter === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => setFilter(key as IssueFilter)}
+                className="px-2 py-0.5 rounded-full border transition-colors"
+                style={{
+                  borderColor: active ? "var(--primary)" : "var(--border)",
+                  color: active ? "var(--primary)" : "var(--muted-foreground)",
+                  background: active
+                    ? "color-mix(in oklab, var(--primary) 12%, transparent)"
+                    : "transparent",
+                }}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Issues table */}
+      <div className="flex-1 overflow-auto">
+        <div
+          className="px-5 py-2 grid gap-3 font-mono text-[10px] tracking-[0.1em] uppercase border-b"
+          style={{
+            gridTemplateColumns: "40px 40px 1fr 140px 110px 110px",
+            borderColor: "var(--border)",
+            color: "var(--text-muted)",
+            background: "var(--card)",
+          }}
+        >
+          <div />
+          <div>#</div>
+          <div>title</div>
+          <div>arc</div>
+          <div>date</div>
+          <div>status</div>
+        </div>
+
+        {filteredIssues.length === 0 ? (
+          <div
+            className="px-5 py-8 text-center font-mono text-[11px]"
+            style={{ color: "var(--text-muted)" }}
+          >
+            no issues to display
+          </div>
+        ) : (
+          filteredIssues.map((issue) => {
+            const haveIt = issue.Status === "Downloaded";
+            const wanted = issue.Status === "Wanted";
+            const arc = (issue as unknown as { Arc?: string }).Arc || "—";
+            return (
+              <div
+                key={issue.IssueID}
+                className="px-5 py-2 grid gap-3 items-center border-b text-[12px]"
+                style={{
+                  gridTemplateColumns: "40px 40px 1fr 140px 110px 110px",
+                  borderColor: "var(--border)",
+                }}
+              >
+                <div
+                  className="w-3 h-3 rounded-sm border"
+                  style={{ borderColor: "var(--border)" }}
+                />
+                <div
+                  className="font-mono"
+                  style={{ color: "var(--muted-foreground)" }}
+                >
+                  #{String(issue.Issue_Number).padStart(2, "0")}
+                </div>
+                <div className="truncate">
+                  <Link
+                    to={`/library/${comicId}/issue/${issue.IssueID}`}
+                    className="hover:text-primary transition-colors"
+                  >
+                    {issue.IssueName || `Issue ${issue.Issue_Number}`}
+                  </Link>
+                </div>
+                <div
+                  className="text-[11px] truncate"
+                  style={{ color: "var(--muted-foreground)" }}
+                >
+                  {arc}
+                </div>
+                <div
+                  className="font-mono text-[10px]"
+                  style={{ color: "var(--muted-foreground)" }}
+                >
+                  {issue.IssueDate || "—"}
+                </div>
+                <div
+                  className="inline-flex items-center gap-1.5 font-mono text-[10px]"
+                  style={{
+                    color: haveIt
+                      ? "var(--status-active)"
+                      : wanted
+                        ? "var(--primary)"
+                        : "var(--text-muted)",
+                  }}
+                >
+                  <span
+                    className="w-[5px] h-[5px] rounded-full"
+                    style={{
+                      background: haveIt
+                        ? "var(--status-active)"
+                        : wanted
+                          ? "var(--primary)"
+                          : "var(--text-muted)",
+                    }}
+                  />
+                  {haveIt ? "have" : wanted ? "wanted" : "skipped"}
+                </div>
+              </div>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -106,7 +106,9 @@ export default function SeriesDetailPage() {
       ? issues.filter((i) => i.Status === "Downloaded")
       : filter === "missing"
         ? issues.filter((i) => i.Status !== "Downloaded")
-        : issues;
+        : filter === "monitored"
+          ? issues.filter((i) => i.Status !== "Skipped")
+          : issues;
 
   const handlePauseResume = async () => {
     if (!comicId) return;
@@ -254,7 +256,9 @@ export default function SeriesDetailPage() {
           <div className="flex items-center gap-2">
             <button
               type="button"
-              className="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-[5px] text-[12px] font-semibold"
+              disabled
+              title="Bulk search is not yet wired up"
+              className="inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-[5px] text-[12px] font-semibold disabled:cursor-not-allowed disabled:opacity-60"
               style={{
                 background: "var(--primary)",
                 color: "var(--primary-foreground)",
@@ -470,7 +474,7 @@ export default function SeriesDetailPage() {
           filteredIssues.map((issue) => {
             const haveIt = issue.Status === "Downloaded";
             const wanted = issue.Status === "Wanted";
-            const arc = (issue as unknown as { Arc?: string }).Arc || "—";
+            const arc = issue.Arc || "—";
             return (
               <div
                 key={issue.IssueID}

--- a/frontend/src/pages/SeriesListPage.tsx
+++ b/frontend/src/pages/SeriesListPage.tsx
@@ -64,7 +64,7 @@ export default function SeriesListPage() {
             <Plus className="w-3.5 h-3.5" strokeWidth={2.5} />
             <span>Add</span>
             <Kbd
-              className="!bg-black/10 !border-black/20 !text-black/70"
+              className="bg-black/10! border-black/20! text-black/70!"
               style={{ color: "rgba(0,0,0,0.7)" }}
             >
               N

--- a/frontend/src/pages/SeriesListPage.tsx
+++ b/frontend/src/pages/SeriesListPage.tsx
@@ -1,8 +1,9 @@
 import { Link } from "react-router-dom";
-import { Plus, Search as SearchIcon } from "lucide-react";
+import { Plus } from "lucide-react";
 import { useSeries } from "@/hooks/useSeries";
 import SeriesTable from "@/components/series/SeriesTable";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
+import FilterField from "@/components/ui/FilterField";
 import { Kbd } from "@/components/ui/kbd";
 
 export default function SeriesListPage() {
@@ -44,13 +45,14 @@ export default function SeriesListPage() {
         </div>
 
         <div className="ml-auto flex items-center gap-2">
-          <div
-            className="hidden sm:flex items-center gap-2 px-2.5 py-1.5 rounded-[5px] border bg-card text-[12px] text-muted-foreground w-[220px]"
-            style={{ borderColor: "var(--border)" }}
-          >
-            <SearchIcon className="w-3 h-3 shrink-0" />
-            <span className="truncate">Filter series…</span>
-            <Kbd className="ml-auto">/</Kbd>
+          <div className="hidden sm:flex w-[240px]">
+            <FilterField
+              placeholder="Filter series…"
+              aria-label="Filter series"
+              shortcut="/"
+              widthCap="full"
+              disabled
+            />
           </div>
 
           <Link

--- a/frontend/src/pages/SeriesListPage.tsx
+++ b/frontend/src/pages/SeriesListPage.tsx
@@ -1,41 +1,84 @@
 import { Link } from "react-router-dom";
-import { Plus } from "lucide-react";
+import { Plus, Search as SearchIcon } from "lucide-react";
 import { useSeries } from "@/hooks/useSeries";
 import SeriesTable from "@/components/series/SeriesTable";
-import { Button } from "@/components/ui/button";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
+import { Kbd } from "@/components/ui/kbd";
 
 export default function SeriesListPage() {
   const { data: series = [], isLoading, error } = useSeries();
 
   if (error) {
     return (
-      <ErrorDisplay
-        error={error}
-        title="Unable to load your library"
-        onRetry={() => window.location.reload()}
-      />
+      <div className="p-8">
+        <ErrorDisplay
+          error={error}
+          title="Unable to load your library"
+          onRetry={() => window.location.reload()}
+        />
+      </div>
     );
   }
 
+  const total = series.length;
+  const mangaCount = series.filter(
+    (s) => (s.ContentType || "").toLowerCase() === "manga",
+  ).length;
+  const comicCount = total - mangaCount;
+
   return (
-    <div className="page-transition">
-      <div className="flex items-center justify-between mb-8">
+    <div className="h-full flex flex-col page-transition">
+      {/* Page header */}
+      <div className="px-5 py-3.5 border-b border-border flex items-center gap-3">
         <div>
-          <h1 className="text-[32px] font-bold tracking-tight">My Library</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            {series.length} series in your library
-          </p>
+          <div className="text-[18px] font-semibold tracking-tight leading-none">
+            Library
+          </div>
+          <div className="font-mono text-[11px] text-muted-foreground mt-1.5">
+            {isLoading
+              ? "loading…"
+              : total === 0
+                ? "0 series"
+                : `${total} series · ${comicCount} comic${comicCount === 1 ? "" : "s"} · ${mangaCount} manga`}
+          </div>
         </div>
-        <Link to="/search">
-          <Button className="flex items-center gap-2 bg-gradient-to-r from-[#FF5C00] to-[#FF8A4C] hover:from-[#FF6A1A] hover:to-[#FF9560] text-white border-0 h-10 px-5 rounded-lg">
-            <Plus className="w-[18px] h-[18px]" />
-            Add to Library
-          </Button>
-        </Link>
+
+        <div className="ml-auto flex items-center gap-2">
+          <div
+            className="hidden sm:flex items-center gap-2 px-2.5 py-1.5 rounded-[5px] border bg-card text-[12px] text-muted-foreground w-[220px]"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <SearchIcon className="w-3 h-3 shrink-0" />
+            <span className="truncate">Filter series…</span>
+            <Kbd className="ml-auto">/</Kbd>
+          </div>
+
+          <Link
+            to="/search"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[5px] text-[12px] font-semibold"
+            style={{
+              background: "var(--primary)",
+              color: "var(--primary-foreground)",
+            }}
+          >
+            <Plus className="w-3.5 h-3.5" strokeWidth={2.5} />
+            <span>Add</span>
+            <Kbd
+              className="!bg-black/10 !border-black/20 !text-black/70"
+              style={{ color: "rgba(0,0,0,0.7)" }}
+            >
+              N
+            </Kbd>
+          </Link>
+        </div>
       </div>
 
-      <SeriesTable data={series} isLoading={isLoading} />
+      {/* Table body */}
+      <div className="flex-1 min-h-0 overflow-auto">
+        <div className="px-5 py-4">
+          <SeriesTable data={series} isLoading={isLoading} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -12,7 +12,6 @@ import { NotificationsTab } from "@/components/settings/NotificationsTab";
 import { MediaManagementTab } from "@/components/settings/MediaManagementTab";
 import { SaveButton } from "@/components/settings/SaveButton";
 import PageHeader from "@/components/layout/PageHeader";
-import { Kbd } from "@/components/ui/kbd";
 
 type SectionId =
   | "general"
@@ -219,7 +218,6 @@ export default function SettingsPage() {
                 }}
               >
                 <span className="flex-1 truncate">{s.label}</span>
-                {active && <Kbd>↵</Kbd>}
               </button>
             );
           })}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { useConfig, useUpdateConfig } from "@/hooks/useConfig";
 import { useToast } from "@/components/ui/toast";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { GeneralTab } from "@/components/settings/GeneralTab";
 import { InterfaceTab } from "@/components/settings/InterfaceTab";
@@ -12,29 +11,53 @@ import { AiTab } from "@/components/settings/AiTab";
 import { NotificationsTab } from "@/components/settings/NotificationsTab";
 import { MediaManagementTab } from "@/components/settings/MediaManagementTab";
 import { SaveButton } from "@/components/settings/SaveButton";
-import { Settings } from "lucide-react";
+import PageHeader from "@/components/layout/PageHeader";
+import { Kbd } from "@/components/ui/kbd";
+
+type SectionId =
+  | "general"
+  | "interface"
+  | "api"
+  | "search"
+  | "media"
+  | "notifications"
+  | "clients"
+  | "ai"
+  | "about";
+
+const SECTIONS: { id: SectionId; label: string }[] = [
+  { id: "general", label: "General" },
+  { id: "interface", label: "Interface" },
+  { id: "api", label: "API & providers" },
+  { id: "search", label: "Search" },
+  { id: "media", label: "Media" },
+  { id: "notifications", label: "Notifications" },
+  { id: "clients", label: "Download clients" },
+  { id: "ai", label: "AI" },
+  { id: "about", label: "About" },
+];
 
 export default function SettingsPage() {
   const { data: config, isLoading, error } = useConfig();
   const updateConfigMutation = useUpdateConfig();
   const { addToast } = useToast();
 
+  const [section, setSection] = useState<SectionId>("general");
   const [formData, setFormData] = useState<Record<string, unknown>>({});
   const [originalData, setOriginalData] = useState<Record<string, unknown>>({});
 
-  // Initialize form data when config is loaded
   useEffect(() => {
     if (config && Object.keys(formData).length === 0) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Sync external data to local form state
       setFormData(config);
-
       setOriginalData(config);
     }
   }, [config, formData]);
 
-  const isDirty = useMemo(() => {
-    return JSON.stringify(formData) !== JSON.stringify(originalData);
-  }, [formData, originalData]);
+  const isDirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData),
+    [formData, originalData],
+  );
 
   const handleChange = (key: string, value: string | boolean | number) => {
     setFormData((prev) => ({ ...prev, [key]: value }));
@@ -50,27 +73,19 @@ export default function SettingsPage() {
     const comicvineEnabled = (data.comicvine_enabled as boolean) ?? true;
     const mangadexEnabled = (data.mangadex_enabled as boolean) ?? false;
 
-    // At least one content source must be enabled
     if (!comicvineEnabled && !mangadexEnabled) {
       errors.comicvine_enabled =
         "At least one content source (Comics or Manga) must be enabled";
     }
-
-    // Validate Comic Vine API key (should be 40 characters if provided)
     if (comicvineEnabled && comicvineApi && comicvineApi.length !== 40) {
       errors.comicvine_api = "Comic Vine API key must be 40 characters";
     }
-
-    // Validate min/max size
     if (data.use_minsize && (!minsize || parseInt(String(minsize)) <= 0)) {
       errors.minsize = "Minimum size must be a positive number";
     }
-
     if (data.use_maxsize && (!maxsize || parseInt(String(maxsize)) <= 0)) {
       errors.maxsize = "Maximum size must be a positive number";
     }
-
-    // Validate min < max if both are enabled
     if (
       data.use_minsize &&
       data.use_maxsize &&
@@ -78,32 +93,25 @@ export default function SettingsPage() {
     ) {
       errors.minsize = "Minimum size must be less than maximum size";
     }
-
     return errors;
   };
 
   const handleSave = async () => {
     const errors = validateForm(formData);
     if (Object.keys(errors).length > 0) {
-      const errorMessage = Object.values(errors)[0];
       addToast({
         type: "error",
-        message: `Validation error: ${errorMessage}`,
+        message: `Validation error: ${Object.values(errors)[0]}`,
       });
       return;
     }
-
     try {
-      // Don't send empty ai_api_key — it would clear the saved key
       const saveData = { ...formData };
       if (!saveData.ai_api_key && config?.ai_api_key_set) {
         delete saveData.ai_api_key;
       }
       await updateConfigMutation.mutateAsync(saveData);
-      addToast({
-        type: "success",
-        message: "Settings saved successfully",
-      });
+      addToast({ type: "success", message: "Settings saved successfully" });
       setOriginalData(formData);
     } catch (err) {
       addToast({
@@ -115,23 +123,15 @@ export default function SettingsPage() {
 
   const handleCancel = () => {
     setFormData(originalData);
-    addToast({
-      type: "info",
-      message: "Changes discarded",
-    });
+    addToast({ type: "info", message: "Changes discarded" });
   };
 
   if (isLoading) {
     return (
       <div className="p-6">
-        <div className="mb-6">
-          <Skeleton className="h-8 w-48 mb-2" />
-          <Skeleton className="h-4 w-96" />
-        </div>
-        <div className="space-y-4">
-          <Skeleton className="h-12 w-full" />
-          <Skeleton className="h-64 w-full" />
-        </div>
+        <Skeleton className="h-6 w-48 mb-2" />
+        <Skeleton className="h-4 w-96 mb-6" />
+        <Skeleton className="h-[480px] w-full" />
       </div>
     );
   }
@@ -139,107 +139,81 @@ export default function SettingsPage() {
   if (error) {
     return (
       <div className="p-6">
-        <div className="bg-[var(--status-error-bg)] border border-[var(--status-error)] rounded-lg p-4">
-          <h3 className="text-destructive font-semibold mb-2">
-            Error Loading Settings
-          </h3>
-          <p className="text-destructive text-sm">
-            {error.message || "Failed to load configuration. Please try again."}
-          </p>
+        <div
+          className="rounded-[6px] border p-4"
+          style={{
+            borderColor:
+              "color-mix(in oklab, var(--status-error) 30%, transparent)",
+            background: "var(--status-error-bg)",
+            color: "var(--status-error)",
+          }}
+        >
+          <div className="font-semibold mb-1">Error loading settings</div>
+          <div className="text-[12px]">
+            {error.message || "Failed to load configuration."}
+          </div>
         </div>
       </div>
     );
   }
 
+  const configPath =
+    (config?.config_path as string | undefined) || "/config/config.ini";
+  const version = config?.version ? `comicarr v${config.version}` : "comicarr";
+
+  const configData = (config ?? {}) as Record<string, unknown>;
+  const tabProps = { config: configData, formData, onChange: handleChange };
+
   return (
-    <div className="p-6 page-transition">
-      <div className="mb-6">
-        <div className="flex items-center space-x-3 mb-2">
-          <Settings className="h-6 w-6 text-muted-foreground" />
-          <h1 className="text-2xl font-bold text-foreground">Settings</h1>
-          {config?.version && (
-            <span className="text-sm text-muted-foreground font-normal">
-              v{config.version}
-            </span>
-          )}
+    <div className="h-full flex flex-col page-transition">
+      <PageHeader title="Settings" meta={`${version} · config ${configPath}`} />
+
+      <div
+        className="grid flex-1 min-h-0"
+        style={{ gridTemplateColumns: "220px 1fr" }}
+      >
+        {/* Left rail */}
+        <aside
+          className="border-r py-3 px-2 overflow-auto"
+          style={{ borderColor: "var(--border)" }}
+        >
+          {SECTIONS.map((s) => {
+            const active = section === s.id;
+            return (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => setSection(s.id)}
+                className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-[5px] text-[13px] text-left"
+                style={{
+                  color: active
+                    ? "var(--foreground)"
+                    : "var(--muted-foreground)",
+                  background: active ? "var(--secondary)" : "transparent",
+                }}
+              >
+                <span className="flex-1 truncate">{s.label}</span>
+                {active && <Kbd>↵</Kbd>}
+              </button>
+            );
+          })}
+        </aside>
+
+        {/* Content panel */}
+        <div className="overflow-auto">
+          <div className="px-6 py-6 max-w-3xl">
+            {section === "general" && <GeneralTab {...tabProps} />}
+            {section === "interface" && <InterfaceTab {...tabProps} />}
+            {section === "api" && <ApiTab {...tabProps} />}
+            {section === "search" && <SearchTab {...tabProps} />}
+            {section === "media" && <MediaManagementTab {...tabProps} />}
+            {section === "notifications" && <NotificationsTab {...tabProps} />}
+            {section === "clients" && <DownloadClientsTab config={formData} />}
+            {section === "ai" && <AiTab {...tabProps} />}
+            {section === "about" && <AboutSection config={configData} />}
+          </div>
         </div>
-        <p className="text-muted-foreground">
-          Configure Comicarr preferences and integrations
-        </p>
       </div>
-
-      <Tabs defaultValue="general" className="w-full">
-        <TabsList className="mb-6">
-          <TabsTrigger value="general">General</TabsTrigger>
-          <TabsTrigger value="interface">Interface</TabsTrigger>
-          <TabsTrigger value="api">API & Providers</TabsTrigger>
-          <TabsTrigger value="search">Search</TabsTrigger>
-          <TabsTrigger value="media">Media</TabsTrigger>
-          <TabsTrigger value="notifications">Notifications</TabsTrigger>
-          <TabsTrigger value="clients">Download Clients</TabsTrigger>
-          <TabsTrigger value="ai">AI</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="general">
-          <GeneralTab
-            config={(config ?? {}) as Record<string, unknown>}
-            formData={formData}
-            onChange={handleChange}
-          />
-        </TabsContent>
-
-        <TabsContent value="interface">
-          <InterfaceTab
-            config={(config ?? {}) as Record<string, unknown>}
-            formData={formData}
-            onChange={handleChange}
-          />
-        </TabsContent>
-
-        <TabsContent value="api">
-          <ApiTab
-            config={(config ?? {}) as Record<string, unknown>}
-            formData={formData}
-            onChange={handleChange}
-          />
-        </TabsContent>
-
-        <TabsContent value="search">
-          <SearchTab
-            config={(config ?? {}) as Record<string, unknown>}
-            formData={formData}
-            onChange={handleChange}
-          />
-        </TabsContent>
-
-        <TabsContent value="media">
-          <MediaManagementTab
-            config={(config ?? {}) as Record<string, unknown>}
-            formData={formData}
-            onChange={handleChange}
-          />
-        </TabsContent>
-
-        <TabsContent value="notifications">
-          <NotificationsTab
-            config={(config ?? {}) as Record<string, unknown>}
-            formData={formData}
-            onChange={handleChange}
-          />
-        </TabsContent>
-
-        <TabsContent value="clients">
-          <DownloadClientsTab config={formData} />
-        </TabsContent>
-
-        <TabsContent value="ai">
-          <AiTab
-            config={(config ?? {}) as Record<string, unknown>}
-            formData={formData}
-            onChange={handleChange}
-          />
-        </TabsContent>
-      </Tabs>
 
       <SaveButton
         isDirty={isDirty}
@@ -247,8 +221,46 @@ export default function SettingsPage() {
         onCancel={handleCancel}
         isSaving={updateConfigMutation.isPending}
       />
-
-      {isDirty && <div className="h-20" />}
     </div>
+  );
+}
+
+function AboutSection({ config }: { config: Record<string, unknown> }) {
+  const rows: Array<[string, string]> = [
+    ["version", (config.version as string) || "—"],
+    [
+      "config path",
+      (config.config_path as string | undefined) || "/config/config.ini",
+    ],
+    ["data directory", (config.data_dir as string | undefined) || "—"],
+    ["python", (config.python_version as string | undefined) || "—"],
+  ];
+
+  return (
+    <section>
+      <div className="mb-4">
+        <div className="text-[13px] font-semibold tracking-tight">About</div>
+        <div className="text-[12px] text-muted-foreground mt-0.5">
+          Build and environment info.
+        </div>
+      </div>
+      <div
+        className="rounded-[6px] border divide-y"
+        style={{ borderColor: "var(--border)" }}
+      >
+        {rows.map(([k, v]) => (
+          <div
+            key={k}
+            className="grid items-center px-3.5 py-2.5 font-mono text-[11.5px]"
+            style={{ gridTemplateColumns: "160px 1fr" }}
+          >
+            <div className="text-muted-foreground tracking-[0.05em] uppercase text-[10px]">
+              {k}
+            </div>
+            <div className="truncate">{v}</div>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -168,13 +168,39 @@ export default function SettingsPage() {
     <div className="h-full flex flex-col page-transition">
       <PageHeader title="Settings" meta={`${version} · config ${configPath}`} />
 
+      {/* Mobile section chips — horizontal scroll */}
       <div
-        className="grid flex-1 min-h-0"
-        style={{ gridTemplateColumns: "220px 1fr" }}
+        className="md:hidden border-b overflow-x-auto"
+        style={{ borderColor: "var(--border)" }}
       >
-        {/* Left rail */}
+        <div className="flex items-center gap-1.5 px-4 py-2 whitespace-nowrap">
+          {SECTIONS.map((s) => {
+            const active = section === s.id;
+            return (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => setSection(s.id)}
+                className="px-2.5 py-1 rounded-full border text-[12px] transition-colors shrink-0"
+                style={{
+                  borderColor: active ? "var(--primary)" : "var(--border)",
+                  color: active ? "var(--primary)" : "var(--muted-foreground)",
+                  background: active
+                    ? "color-mix(in oklab, var(--primary) 12%, transparent)"
+                    : "transparent",
+                }}
+              >
+                {s.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="grid flex-1 min-h-0 grid-cols-1 md:[grid-template-columns:220px_1fr]">
+        {/* Desktop left rail */}
         <aside
-          className="border-r py-3 px-2 overflow-auto"
+          className="hidden md:block border-r py-3 px-2 overflow-auto"
           style={{ borderColor: "var(--border)" }}
         >
           {SECTIONS.map((s) => {
@@ -200,8 +226,8 @@ export default function SettingsPage() {
         </aside>
 
         {/* Content panel */}
-        <div className="overflow-auto">
-          <div className="px-6 py-6 max-w-3xl">
+        <div className="overflow-auto min-w-0">
+          <div className="px-4 py-5 md:px-6 md:py-6 max-w-3xl pb-24">
             {section === "general" && <GeneralTab {...tabProps} />}
             {section === "interface" && <InterfaceTab {...tabProps} />}
             {section === "api" && <ApiTab {...tabProps} />}
@@ -251,13 +277,12 @@ function AboutSection({ config }: { config: Record<string, unknown> }) {
         {rows.map(([k, v]) => (
           <div
             key={k}
-            className="grid items-center px-3.5 py-2.5 font-mono text-[11.5px]"
-            style={{ gridTemplateColumns: "160px 1fr" }}
+            className="grid gap-1 sm:gap-0 sm:items-center px-3.5 py-2.5 font-mono text-[11.5px] grid-cols-1 sm:[grid-template-columns:160px_1fr]"
           >
             <div className="text-muted-foreground tracking-[0.05em] uppercase text-[10px]">
               {k}
             </div>
-            <div className="truncate">{v}</div>
+            <div className="truncate break-all">{v}</div>
           </div>
         ))}
       </div>

--- a/frontend/src/pages/StoryArcsPage.tsx
+++ b/frontend/src/pages/StoryArcsPage.tsx
@@ -20,7 +20,7 @@ export default function StoryArcsPage() {
   const count = arcs?.length ?? 0;
 
   return (
-    <div className="-mx-4 sm:-mx-6 lg:-mx-8 -my-8 page-transition">
+    <div className="page-transition">
       <PageHeader
         title="Story Arcs"
         meta={

--- a/frontend/src/pages/StoryArcsPage.tsx
+++ b/frontend/src/pages/StoryArcsPage.tsx
@@ -6,6 +6,7 @@ import ArcGenerator from "@/components/storyarcs/ArcGenerator";
 import StoryArcCard from "@/components/storyarcs/StoryArcCard";
 import StoryArcEmptyState from "@/components/storyarcs/StoryArcEmptyState";
 import { Skeleton } from "@/components/ui/skeleton";
+import PageHeader from "@/components/layout/PageHeader";
 
 export default function StoryArcsPage() {
   const { data: arcs, isLoading, error } = useStoryArcs();
@@ -16,52 +17,62 @@ export default function StoryArcsPage() {
     searchInputRef.current?.focus();
   };
 
+  const count = arcs?.length ?? 0;
+
   return (
-    <div className="space-y-8 page-transition">
-      <div>
-        <h1 className="text-2xl font-bold text-foreground mb-1">Story Arcs</h1>
-        <p className="text-sm text-muted-foreground">
-          Track story arcs that span across multiple series.
-        </p>
-      </div>
+    <div className="-mx-4 sm:-mx-6 lg:-mx-8 -my-8 page-transition">
+      <PageHeader
+        title="Story Arcs"
+        meta={
+          isLoading
+            ? "loading…"
+            : `${count} arc${count === 1 ? "" : "s"} tracked`
+        }
+      />
 
-      {/* AI Arc Generator (shown when AI configured) */}
-      {aiStatus?.configured && <ArcGenerator />}
+      <div className="px-5 py-4 space-y-6">
+        {aiStatus?.configured && <ArcGenerator />}
 
-      {/* Search section */}
-      <ArcSearch searchInputRef={searchInputRef} />
+        <ArcSearch searchInputRef={searchInputRef} />
 
-      {/* Arc list section */}
-      {isLoading ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div
-              key={i}
-              className="rounded-lg border border-card-border bg-card overflow-hidden"
-            >
-              <Skeleton className="h-32" />
-              <div className="p-3 space-y-2">
-                <Skeleton className="h-4 w-3/4" />
-                <Skeleton className="h-3 w-1/2" />
-                <Skeleton className="h-1.5 w-full" />
+        {isLoading ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="rounded-[6px] border border-border bg-card overflow-hidden"
+              >
+                <Skeleton className="h-32" />
+                <div className="p-3 space-y-2">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="h-3 w-1/2" />
+                  <Skeleton className="h-1.5 w-full" />
+                </div>
               </div>
+            ))}
+          </div>
+        ) : error ? (
+          <div className="py-12 text-center">
+            <div className="font-mono text-[10px] tracking-[0.12em] uppercase text-muted-foreground mb-2">
+              ARCS · ERROR
             </div>
-          ))}
-        </div>
-      ) : error ? (
-        <div className="text-center py-12">
-          <p className="text-red-600">Failed to load story arcs</p>
-          <p className="text-sm text-muted-foreground mt-1">{error.message}</p>
-        </div>
-      ) : arcs && arcs.length > 0 ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-          {arcs.map((arc) => (
-            <StoryArcCard key={arc.StoryArcID} arc={arc} />
-          ))}
-        </div>
-      ) : (
-        <StoryArcEmptyState onSearchFocus={handleSearchFocus} />
-      )}
+            <div className="text-[15px] font-semibold">
+              Failed to load story arcs
+            </div>
+            <div className="font-mono text-[11px] text-muted-foreground mt-1">
+              {error.message}
+            </div>
+          </div>
+        ) : arcs && arcs.length > 0 ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {arcs.map((arc) => (
+              <StoryArcCard key={arc.StoryArcID} arc={arc} />
+            ))}
+          </div>
+        ) : (
+          <StoryArcEmptyState onSearchFocus={handleSearchFocus} />
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/WantedPage.tsx
+++ b/frontend/src/pages/WantedPage.tsx
@@ -1,17 +1,17 @@
 import { useState } from "react";
-import { Search } from "lucide-react";
+import { Search, RefreshCw } from "lucide-react";
 import {
   useWanted,
   useForceSearch,
   useBulkUnqueueIssues,
 } from "@/hooks/useQueue";
 import { useToast } from "@/components/ui/toast";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import WantedTable from "@/components/queue/WantedTable";
 import BulkActionBar from "@/components/queue/BulkActionBar";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
+import PageHeader from "@/components/layout/PageHeader";
+import { Kbd } from "@/components/ui/kbd";
 
 export default function WantedPage() {
   const [page, setPage] = useState(0);
@@ -20,26 +20,25 @@ export default function WantedPage() {
   const limit = 50;
   const offset = page * limit;
 
-  const { data, isLoading, error } = useWanted(limit, offset);
+  const { data, isLoading, error, refetch } = useWanted(limit, offset);
   const issues = data?.issues || [];
   const pagination = data?.pagination;
 
-  const forceSearchMutation = useForceSearch();
-  const bulkUnqueueMutation = useBulkUnqueueIssues();
+  const forceSearch = useForceSearch();
+  const bulkUnqueue = useBulkUnqueueIssues();
   const { addToast } = useToast();
 
-  // Filter issues by search query (client-side)
   const filteredIssues = searchQuery
     ? issues.filter(
-        (issue) =>
-          issue.ComicName?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          issue.Issue_Number?.toLowerCase().includes(searchQuery.toLowerCase()),
+        (i) =>
+          i.ComicName?.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          i.Issue_Number?.toLowerCase().includes(searchQuery.toLowerCase()),
       )
     : issues;
 
   const handleBulkUnqueue = async () => {
     try {
-      await bulkUnqueueMutation.mutateAsync(selectedIds);
+      await bulkUnqueue.mutateAsync(selectedIds);
       addToast({
         type: "success",
         message: `${selectedIds.length} issue${selectedIds.length !== 1 ? "s" : ""} skipped`,
@@ -56,7 +55,7 @@ export default function WantedPage() {
   const handleForceSearch = async () => {
     if (window.confirm("Manual search may take several minutes. Continue?")) {
       try {
-        await forceSearchMutation.mutateAsync();
+        await forceSearch.mutateAsync();
         addToast({
           type: "info",
           message: "Search started for all wanted issues",
@@ -70,79 +69,110 @@ export default function WantedPage() {
     }
   };
 
-  const handleClearSelection = () => {
-    setSelectedIds([]);
-  };
-
-  const handleNextPage = () => {
-    setPage((p) => p + 1);
-    setSelectedIds([]);
-  };
-
-  const handlePrevPage = () => {
-    setPage((p) => Math.max(0, p - 1));
-    setSelectedIds([]);
-  };
+  const total = pagination?.total ?? issues.length;
 
   return (
-    <div className="max-w-7xl mx-auto px-4 py-6 page-transition">
-      <div className="mb-6">
-        <h1 className="text-3xl font-bold text-foreground mb-2">
-          Wanted Issues
-        </h1>
-        <p className="text-muted-foreground">
-          {pagination?.total || issues.length} wanted issue
-          {(pagination?.total || issues.length) !== 1 ? "s" : ""} in queue
-        </p>
-      </div>
+    <div className="-mx-4 sm:-mx-6 lg:-mx-8 -my-8 page-transition">
+      <PageHeader
+        title="Wanted"
+        meta={
+          isLoading
+            ? "loading…"
+            : `${total} issue${total === 1 ? "" : "s"} in queue`
+        }
+        actions={
+          <>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              disabled={isLoading}
+              className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-[5px] border font-mono text-[11px] text-muted-foreground"
+              style={{ borderColor: "var(--border)" }}
+            >
+              <RefreshCw
+                className={`w-3 h-3 ${isLoading ? "animate-spin" : ""}`}
+              />
+              refresh
+            </button>
+            <button
+              type="button"
+              onClick={handleForceSearch}
+              disabled={forceSearch.isPending}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[5px] text-[12px] font-semibold disabled:opacity-60"
+              style={{
+                background: "var(--primary)",
+                color: "var(--primary-foreground)",
+              }}
+            >
+              <Search className="w-3.5 h-3.5" />
+              Force search
+            </button>
+          </>
+        }
+      />
 
-      <div className="flex items-center justify-between mb-4">
-        <Input
-          placeholder="Search wanted issues..."
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="max-w-md"
-        />
-        <Button
-          onClick={handleForceSearch}
-          disabled={forceSearchMutation.isPending}
-        >
-          <Search className="w-4 h-4 mr-2" />
-          Force Search All
-        </Button>
-      </div>
-
-      {isLoading && (
-        <div className="space-y-4">
-          <Skeleton className="h-16" />
-          <Skeleton className="h-16" />
-          <Skeleton className="h-16" />
+      <div className="px-5 py-4">
+        <div className="flex items-center gap-3 mb-4">
+          <div
+            className="flex items-center gap-2 flex-1 max-w-md px-2.5 py-1.5 rounded-[5px] border bg-card"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <Search className="w-3.5 h-3.5 text-muted-foreground" />
+            <input
+              type="text"
+              placeholder="Filter wanted issues…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="flex-1 bg-transparent outline-none text-[12px] placeholder:text-[var(--text-muted)]"
+            />
+            <Kbd>/</Kbd>
+          </div>
+          {searchQuery && (
+            <div className="font-mono text-[11px] text-muted-foreground">
+              {filteredIssues.length} match
+              {filteredIssues.length === 1 ? "" : "es"}
+            </div>
+          )}
         </div>
-      )}
 
-      {error && (
-        <ErrorDisplay
-          error={error}
-          title="Unable to load wanted issues"
-          onRetry={() => window.location.reload()}
-        />
-      )}
+        {isLoading && (
+          <div className="space-y-2">
+            <Skeleton className="h-14" />
+            <Skeleton className="h-14" />
+            <Skeleton className="h-14" />
+          </div>
+        )}
 
-      {!isLoading && !error && (
-        <WantedTable
-          issues={filteredIssues}
-          pagination={pagination}
-          onNextPage={handleNextPage}
-          onPrevPage={handlePrevPage}
-          onSelectionChange={setSelectedIds}
-        />
-      )}
+        {error && (
+          <ErrorDisplay
+            error={error}
+            title="Unable to load wanted issues"
+            onRetry={() => refetch()}
+          />
+        )}
+
+        {!isLoading && !error && (
+          <WantedTable
+            issues={filteredIssues}
+            pagination={pagination}
+            onNextPage={() => {
+              setPage((p) => p + 1);
+              setSelectedIds([]);
+            }}
+            onPrevPage={() => {
+              setPage((p) => Math.max(0, p - 1));
+              setSelectedIds([]);
+            }}
+            onSelectionChange={setSelectedIds}
+          />
+        )}
+      </div>
 
       <BulkActionBar
         selectedCount={selectedIds.length}
         onSkip={handleBulkUnqueue}
-        onClear={handleClearSelection}
-        isLoading={bulkUnqueueMutation.isPending}
+        onClear={() => setSelectedIds([])}
+        isLoading={bulkUnqueue.isPending}
       />
     </div>
   );

--- a/frontend/src/pages/WantedPage.tsx
+++ b/frontend/src/pages/WantedPage.tsx
@@ -11,7 +11,7 @@ import WantedTable from "@/components/queue/WantedTable";
 import BulkActionBar from "@/components/queue/BulkActionBar";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 import PageHeader from "@/components/layout/PageHeader";
-import { Kbd } from "@/components/ui/kbd";
+import FilterField from "@/components/ui/FilterField";
 
 export default function WantedPage() {
   const [page, setPage] = useState(0);
@@ -113,20 +113,13 @@ export default function WantedPage() {
 
       <div className="px-5 py-4">
         <div className="flex items-center gap-3 mb-4">
-          <div
-            className="flex items-center gap-2 flex-1 max-w-md px-2.5 py-1.5 rounded-[5px] border bg-card"
-            style={{ borderColor: "var(--border)" }}
-          >
-            <Search className="w-3.5 h-3.5 text-muted-foreground" />
-            <input
-              type="text"
-              placeholder="Filter wanted issues…"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="flex-1 bg-transparent outline-none text-[12px] placeholder:text-[var(--text-muted)]"
-            />
-            <Kbd>/</Kbd>
-          </div>
+          <FilterField
+            placeholder="Filter wanted issues…"
+            aria-label="Filter wanted issues"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            shortcut="/"
+          />
           {searchQuery && (
             <div className="font-mono text-[11px] text-muted-foreground">
               {filteredIssues.length} match

--- a/frontend/src/pages/WantedPage.tsx
+++ b/frontend/src/pages/WantedPage.tsx
@@ -72,7 +72,7 @@ export default function WantedPage() {
   const total = pagination?.total ?? issues.length;
 
   return (
-    <div className="-mx-4 sm:-mx-6 lg:-mx-8 -my-8 page-transition">
+    <div className="page-transition">
       <PageHeader
         title="Wanted"
         meta={

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -53,6 +53,8 @@ export interface Issue {
   ImageURL?: string | null;
   ImageURL_ALT?: string | null;
   Int_IssueNumber?: number | null;
+  // Story arc label, populated by mock data today and (optionally) by the API.
+  Arc?: string | null;
   // Chapter/Volume fields for manga support
   chapterNumber?: string | null;
   volumeNumber?: string | null;

--- a/frontend/tests/pages/DashboardPage.test.tsx
+++ b/frontend/tests/pages/DashboardPage.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for the DashboardPage component.
+ * Tests for the DashboardPage component (Direction B redesign).
  *
  * Uses getByText / queryByText which throw or return null respectively.
  * No @testing-library/jest-dom needed.
@@ -26,78 +26,44 @@ describe("DashboardPage", () => {
     });
   });
 
-  it("renders collection stats", async () => {
+  it("renders KPI strip with stats", async () => {
     render(<DashboardPage />);
 
+    // KPI labels appear immediately; values arrive once the query resolves.
     await waitFor(() => {
-      expect(screen.getByText("Active Series")).toBeTruthy();
-      expect(screen.getByText("Issues Collected")).toBeTruthy();
-      expect(screen.getByText("Completion")).toBeTruthy();
+      expect(screen.getByText("50.0%")).toBeTruthy();
     });
 
+    expect(screen.getByText("Active series")).toBeTruthy();
+    expect(screen.getByText("Issues")).toBeTruthy();
+    expect(screen.getByText("Completion")).toBeTruthy();
+    expect(screen.getByText("Queue")).toBeTruthy();
     expect(screen.getByText("10")).toBeTruthy();
     expect(screen.getByText("250")).toBeTruthy();
-    expect(screen.getByText("50%")).toBeTruthy();
   });
 
-  it("renders recent downloads section", async () => {
+  it("renders queue & recent activity section", async () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Recent Downloads")).toBeTruthy();
-      expect(screen.getByText("Spider-Man")).toBeTruthy();
+      expect(screen.getByText("Queue & recent activity")).toBeTruthy();
+    });
+
+    // Activity row title is "<ComicName> #<Issue_Number>" inside a Link.
+    await waitFor(() => {
+      expect(screen.getByText("Spider-Man #1")).toBeTruthy();
     });
   });
 
-  it("renders upcoming releases section", async () => {
+  it("renders this-week upcoming list", async () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Upcoming This Week")).toBeTruthy();
+      expect(screen.getByText("This week")).toBeTruthy();
+    });
+
+    await waitFor(() => {
       expect(screen.getByText("Batman")).toBeTruthy();
-    });
-  });
-
-  it("shows discovery banner when AI is not configured", async () => {
-    render(<DashboardPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText("AI Features Available")).toBeTruthy();
-    });
-  });
-
-  it("shows AI activity panel when AI is configured", async () => {
-    server.use(
-      http.get("/api/dashboard", () => {
-        return HttpResponse.json({
-          recently_downloaded: [],
-          upcoming_releases: [],
-          stats: {
-            total_series: 5,
-            total_issues: 100,
-            total_expected: 200,
-            completion_pct: 50.0,
-          },
-          ai_activity: [
-            {
-              timestamp: "2026-04-05T12:00:00",
-              feature_type: "search",
-              action_description: "Expanded search query",
-              prompt_tokens: 100,
-              completion_tokens: 50,
-              success: true,
-            },
-          ],
-          ai_configured: true,
-        });
-      }),
-    );
-
-    render(<DashboardPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText("AI Activity")).toBeTruthy();
-      expect(screen.getByText("Expanded search query")).toBeTruthy();
     });
   });
 
@@ -122,22 +88,16 @@ describe("DashboardPage", () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("No recent downloads")).toBeTruthy();
-      expect(
-        screen.getByText("No upcoming releases this week"),
-      ).toBeTruthy();
+      expect(screen.getByText("no recent activity")).toBeTruthy();
+      expect(screen.getByText("nothing upcoming this week")).toBeTruthy();
     });
   });
 
-  it("hides discovery banner when dismissed", async () => {
-    localStorage.setItem("dismissed_ai_banner", "true");
-
+  it("renders command hint card", async () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Dashboard")).toBeTruthy();
+      expect(screen.getByText(/COMMAND HINT/)).toBeTruthy();
     });
-
-    expect(screen.queryByText("AI Features Available")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Full Direction B (Linear/Raycast-inspired dense & technical) redesign of the Comicarr frontend. Inter Tight + JetBrains Mono, `#ff6a1f` accent, hairline borders, accent-underline tabs, uppercase mono metadata, keyboard shortcut hints, edge-to-edge page shells.

### What changed

**Core shell**
- Retuned palette + typography in `index.css` (Inter Tight / JetBrains Mono), added `.mono-label` / `.mono-meta` utilities
- `AppSidebar`: dense layout with brand+version pill, ⌘K search (wired — focuses input with accent `focus-within` ring), section labels, per-item kbd hints, account footer
- `Layout`: full-bleed omni status bar with `mode · db · queue` + `MOCK` chip, full-bleed routes expanded to include `/library/:comicId` + `/series/:comicId`
- Shared `PageHeader` / `TabRow` / `Tab` components with accent-underline active state
- `Kbd`, `EmptyState`, `SettingGroup`, `SettingField` retheme cascades across every page

**Pages**
- `LoginPage` with cursor-warping canvas grid backdrop (`GridShader`), uppercase mono labels, accent-ringed focused inputs, show/hide password toggle, ↵ kbd hint
- `DashboardPage` KPI strip + sparklines, activity table, This Week list, ⌘K hint
- `SeriesListPage` edge-to-edge header + filter input with `/` kbd + `N` add
- `ReleasesPage` Mine/Industry tab row, filter chips, dense industry table
- `WantedPage`, `StoryArcsPage`, `ActivityPage`, `ImportPage` all rethemed with mono meta + rethemed empty states
- `SettingsPage` full-bleed: left-rail vertical nav → horizontal scrollable chip bar below `md`, content panel `px-4 md:px-6` + `pb-24` to clear SaveButton, responsive About rows, `SettingField` read-only rows stack on mobile
- `SeriesDetailPage` rewritten to match the `BSeriesDetail` design: breadcrumb + `cv:ID · last sync …` meta, 140/1fr/260 hero with COMIC/MANGA badge + `● ongoing/paused` dot + monitored chip, 28px hero title, accent `Search all missing` + ghost Refresh/Pause/⋯, Status card with big `%` + progress bar + 2-col metric grid, dense issues table (40/40/1fr/140/110/110) with `All/Have/Missing/Monitored` filter chips and colored status dots
- `SearchPage` condensed single-row toolbar (`h-8` input + inline Search + center meta + right sort), full-width `SearchResultsTable` matching the library: row index, 40×56 cover thumbnail, series + source badge (CV/Metron/MangaDex/MAL) + external-link, description subtitle, `PUBLISHER / YEAR / ISSUES` mono columns, accent-outlined ghost `+ add`

**Onboarding**
- Mylar3 migration page-hijack replaced with `OnboardingDialog` (Radix Dialog, 4 steps: Welcome → Migrate/Fresh → Running → Done), non-dismissable during migration; derived `visibleStep` from `step` + progress status (no setState-in-effect bug)

**Mock data**
- `isMockEnabled()` + `?mock=1` URL flag persisted to localStorage
- `apiRequest` interceptor and new mock routes for auth (check-setup, check-session, login, logout, migration/check) so mock mode bypasses the login gate entirely
- `mock-sw.js` service worker returns gradient SVG covers for `/api/metadata/art/*`
- 12 COVERS fixtures covering Absolute Batman, Chainsaw Man, 20th Century Boys, etc. — realistic content for Library, Series Detail, Dashboard, Releases, Wanted

**Keyboard**
- ⌘K / Ctrl+K now focuses the sidebar search input and selects existing text
- `/` still focuses the closest search input; `Esc` still closes dialogs/blurs inputs

## Test plan

- [ ] Run `?mock=1` and verify login is bypassed, Dashboard/Library/Releases/Wanted/Series Detail render with realistic content
- [ ] Verify ⌘K / Ctrl+K focuses sidebar search and shows accent ring
- [ ] Resize Settings below 768px — section chip bar appears, form fields stack, no overflow
- [ ] Series detail: breadcrumb + hero grid + Status card + filter chips all align on desktop
- [ ] Series detail: dynamic route `/library/:comicId` renders full-bleed (no layout padding)
- [ ] Search: toolbar condensed to single row; results span full container width
- [ ] Light mode + dark mode pass: verify accent, border, and card tokens render cleanly
- [ ] Onboarding: with `db_empty=true`, modal appears; Migrate path runs; dialog non-dismissable during migration
- [ ] Mobile sidebar: opens as Sheet; ⌘K search hint disappears when collapsed-icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mock mode with in-browser mock API + service worker and generated cover art; multi-step onboarding dialog for setup/migration
  * Global search keyboard shortcut (Cmd/Ctrl+K) and more visible shortcut hints

* **UI Improvements**
  * New PageHeader/tabs, KPI strip, and refreshed layouts across Dashboard, Activity, Search, Series, Releases, Import, Wanted, Settings, Login
  * Sidebar shows username, version badge, and shortcut hints; simplified search/results grid and compact controls

* **Style**
  * Switched fonts (Inter Tight + JetBrains Mono) and updated dark palette, spacing, and radii

* **Tests**
  * Dashboard tests updated to match the new UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->