### PR TITLE
fix: Render issue rows on series detail page

### DIFF
--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -98,17 +98,22 @@ export default function SeriesDetailPage() {
   const completionPct = total > 0 ? Math.round((have / total) * 100) : 0;
   const slug = (comic.ComicName || "").toLowerCase().replace(/\s+/g, "-");
 
-  const haveCount = issues.filter((i) => i.Status === "Downloaded").length;
-  const missingCount = issues.filter((i) => i.Status !== "Downloaded").length;
-  const monitoredCount = issues.filter((i) => i.Status !== "Skipped").length;
+  const getStatus = (i: Issue) => i.status ?? i.Status;
+  const haveCount = issues.filter((i) => getStatus(i) === "Downloaded").length;
+  const missingCount = issues.filter(
+    (i) => getStatus(i) !== "Downloaded",
+  ).length;
+  const monitoredCount = issues.filter(
+    (i) => getStatus(i) !== "Skipped",
+  ).length;
 
   const filteredIssues =
     filter === "have"
-      ? issues.filter((i) => i.Status === "Downloaded")
+      ? issues.filter((i) => getStatus(i) === "Downloaded")
       : filter === "missing"
-        ? issues.filter((i) => i.Status !== "Downloaded")
+        ? issues.filter((i) => getStatus(i) !== "Downloaded")
         : filter === "monitored"
-          ? issues.filter((i) => i.Status !== "Skipped")
+          ? issues.filter((i) => getStatus(i) !== "Skipped")
           : issues;
 
   const handlePauseResume = async () => {
@@ -473,12 +478,17 @@ export default function SeriesDetailPage() {
           </div>
         ) : (
           filteredIssues.map((issue) => {
-            const haveIt = issue.Status === "Downloaded";
-            const wanted = issue.Status === "Wanted";
+            const status = getStatus(issue);
+            const haveIt = status === "Downloaded";
+            const wanted = status === "Wanted";
+            const issueId = issue.id ?? issue.IssueID;
+            const issueNumber = issue.number ?? issue.Issue_Number;
+            const issueName = issue.name ?? issue.IssueName;
+            const issueDate = issue.issueDate ?? issue.IssueDate;
             const arc = issue.Arc || "—";
             return (
               <div
-                key={issue.IssueID}
+                key={issueId}
                 className="px-5 py-2 grid gap-3 items-center border-b text-[12px]"
                 style={{
                   gridTemplateColumns: "40px 40px 1fr 140px 110px 110px",
@@ -493,14 +503,14 @@ export default function SeriesDetailPage() {
                   className="font-mono"
                   style={{ color: "var(--muted-foreground)" }}
                 >
-                  #{String(issue.Issue_Number).padStart(2, "0")}
+                  #{String(issueNumber ?? "").padStart(2, "0")}
                 </div>
                 <div className="truncate">
                   <Link
-                    to={`/library/${comicId}/issue/${issue.IssueID}`}
+                    to={`/library/${comicId}/issue/${issueId}`}
                     className="hover:text-primary transition-colors"
                   >
-                    {issue.IssueName || `Issue ${issue.Issue_Number}`}
+                    {issueName || `Issue ${issueNumber}`}
                   </Link>
                 </div>
                 <div
@@ -513,7 +523,7 @@ export default function SeriesDetailPage() {
                   className="font-mono text-[10px]"
                   style={{ color: "var(--muted-foreground)" }}
                 >
-                  {issue.IssueDate || "—"}
+                  {issueDate || "—"}
                 </div>
                 <div
                   className="inline-flex items-center gap-1.5 font-mono text-[10px]"

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -63,9 +63,9 @@ export interface Issue {
   number?: string;
   name?: string;
   releaseDate?: string;
-  issueDate?: string;
+  issueDate?: string | null;
   status?: string;
-  imageURL?: string;
+  imageURL?: string | null;
   comicName?: string;
 }
 

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -63,7 +63,10 @@ export interface Issue {
   number?: string;
   name?: string;
   releaseDate?: string;
+  issueDate?: string;
   status?: string;
+  imageURL?: string;
+  comicName?: string;
 }
 
 /** Search result from findComic */


### PR DESCRIPTION
## Summary
- Series detail rows were rendering as \`#undefined / Issue undefined\` with every issue marked \`skipped\`.
- \`/api/series/{id}\` projects issues with camelCase labels (\`id\`, \`name\`, \`number\`, \`issueDate\`, \`status\`) — see \`comicarr/app/series/queries.py:45-56\` — but \`SeriesDetailPage.tsx\` still read the legacy PascalCase/snake_case fields (\`IssueID\`, \`Issue_Number\`, \`IssueName\`, \`IssueDate\`, \`Status\`) that other tables were migrated away from in #139.
- Read the camelCase fields with a fallback to the legacy names, and extend the \`Issue\` type's alt-name block to include \`issueDate\`, \`imageURL\`, and \`comicName\`.

## Test plan
- [ ] \`npm run typecheck\` / \`npm run lint\` pass (verified locally).
- [ ] Load a series page (e.g. Absolute Batman, cv:160294) and confirm issue numbers, titles, dates, and Have/Wanted/Skipped statuses render correctly.
- [ ] Have / Missing / Monitored filter tabs produce the expected counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable issue status and field handling with automatic fallbacks to ensure counts, filters, and list displays remain correct across varied data formats.

* **New Features**
  * Issue data model accepts additional optional metadata (issue date, cover image URL, comic title) so lists and detail views show richer, consistent information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->