### PR TITLE
fix: report open dependabot PRs in project monitor

### DIFF
--- a/.github/workflows/project-monitor.yml
+++ b/.github/workflows/project-monitor.yml
@@ -70,13 +70,12 @@ jobs:
               .slice(0, 20);
 
             const dependencyPrSearch = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${owner}/${repo} is:pr label:dependencies updated:>=${sinceDate}`,
+              q: `repo:${owner}/${repo} is:pr is:open author:app/dependabot`,
               sort: 'updated',
               order: 'desc',
               per_page: 50,
             });
             const dependencyPrs = dependencyPrSearch.data.items
-              .filter((item) => new Date(item.updated_at) >= since)
               .slice(0, 20);
 
             let dependabotAlerts = [];
@@ -121,13 +120,13 @@ jobs:
               `## Project monitor check-in - ${checkInTime} ET`,
               '',
               `Repository: ${owner}/${repo}`,
-              `Monitoring window: changes updated since ${sinceIso}.`,
+              `Monitoring window: issue changes updated since ${sinceIso}. Open dependency PRs are reported regardless of update time.`,
               '',
               '### Issue activity',
               updatedIssues.length ? updatedIssues.map(issueLine).join('\n') : '- No issue activity updated in the last 24 hours.',
               '',
-              '### Dependency update pull requests',
-              dependencyPrs.length ? dependencyPrs.map(issueLine).join('\n') : '- No dependency update pull requests updated in the last 24 hours.',
+              '### Open dependency update pull requests',
+              dependencyPrs.length ? dependencyPrs.map(issueLine).join('\n') : '- No open dependency update pull requests found.',
               '',
               '### Open Dependabot security alerts',
               dependabotAlerts.length ? dependabotAlerts.map(alertLine).join('\n') : `- No open Dependabot security alerts found.${dependabotAlertsNote ? `\n- ${dependabotAlertsNote}` : ''}`,
@@ -137,10 +136,10 @@ jobs:
             const publicSummary = [
               `## Project monitor check-in - ${checkInTime} ET`,
               '',
-              `Monitoring window: changes updated since ${sinceIso}.`,
+              `Monitoring window: issue changes updated since ${sinceIso}. Open dependency PRs are reported regardless of update time.`,
               '',
               `- Issue updates found: ${updatedIssues.length}`,
-              `- Dependency update PRs found: ${dependencyPrs.length}`,
+              `- Open dependency update PRs found: ${dependencyPrs.length}`,
               discordWebhookUrl
                 ? '- Detailed check-in sent to Discord via `PROJECT_MONITOR_DISCORD_WEBHOOK_URL`.'
                 : '- Detailed check-in not sent because `PROJECT_MONITOR_DISCORD_WEBHOOK_URL` is not configured.',


### PR DESCRIPTION
## Summary
The project monitor now reports the open Dependabot PR backlog directly, so unlabeled Dependabot PRs no longer disappear from the daily check-in. Issue activity remains a 24-hour window, while dependency updates are clearly labeled as an open backlog snapshot.

## Testing
- `gh api -X GET search/issues -f q='repo:frankieramirez/comicarr is:pr is:open author:app/dependabot' --jq '.total_count'` returned `9`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced the project monitoring workflow to improve how open dependency update pull requests are discovered and reported in activity summaries.
* Refined the monitoring window descriptions for clearer period reporting.
* Updated labeling and terminology for dependency pull request tracking to improve visibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->