### PR TITLE
chore: reduce Dependabot update noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    open-pull-requests-limit: 3
+    groups:
+      python-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "python"
@@ -13,7 +26,22 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "monday"
+      time: "09:15"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    open-pull-requests-limit: 2
+    versioning-strategy: "increase-if-necessary"
+    groups:
+      release-tooling-minor-and-patch:
+        dependency-type: "development"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "ci"
@@ -22,7 +50,29 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "monday"
+      time: "09:30"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    open-pull-requests-limit: 4
+    versioning-strategy: "increase-if-necessary"
+    groups:
+      frontend-production-minor-and-patch:
+        dependency-type: "production"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      frontend-development-minor-and-patch:
+        dependency-type: "development"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "frontend"
@@ -31,7 +81,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "monday"
+      time: "09:45"
+      timezone: "America/New_York"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "ci"


### PR DESCRIPTION
## Summary
- pin Dependabot update windows to Monday morning Eastern instead of random weekly timing
- group minor/patch updates for pip, root npm tooling, and frontend npm dependencies
- group GitHub Actions updates into one PR, lower open PR caps, and add cooldown windows for version updates
- use npm `increase-if-necessary` to avoid unnecessary manifest bumps when ranges already allow the update

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml'); puts 'dependabot.yml parses'"`\n- `git diff --check -- .github/dependabot.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management configuration to optimize automation workflows and scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->