### PR TITLE
fix: surface setup token in quiet Docker logs

### DIFF
--- a/Comicarr.py
+++ b/Comicarr.py
@@ -539,10 +539,9 @@ def main():
     # Generate setup token if first-run setup is needed
     if not comicarr.CONFIG.HTTP_USERNAME or not comicarr.CONFIG.HTTP_PASSWORD:
         import secrets
+        from comicarr.app.system import service as system_service
         comicarr.SETUP_TOKEN = secrets.token_urlsafe(32)
-        logger.info('[SETUP] *** First-run setup required ***')
-        logger.info('[SETUP] Setup token: %s' % comicarr.SETUP_TOKEN)
-        logger.info('[SETUP] Provide this token when setting up credentials via the web interface.')
+        system_service.announce_setup_token(comicarr.SETUP_TOKEN)
 
     #check for version here after web server initialized so it doesn't try to repeatidly hit github
     #for version info if it's already running

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -102,6 +102,22 @@ def _migrate_password(ctx, plaintext_password):
     logger.info("[AUTH] Password migrated to bcrypt")
 
 
+def announce_setup_token(setup_token):
+    """Announce the first-run setup token, including stdout in quiet mode."""
+    messages = [
+        "[SETUP] *** First-run setup required ***",
+        "[SETUP] Setup token: %s" % setup_token,
+        "[SETUP] Provide this token when setting up credentials via the web interface.",
+    ]
+
+    for message in messages:
+        logger.info(message)
+
+    if comicarr.QUIET or comicarr.LOG_LEVEL == 0:
+        for message in messages:
+            print(message, flush=True)
+
+
 def initial_setup(ctx, username, password, setup_token):
     """Handle first-run credential setup."""
     import comicarr

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -138,6 +138,59 @@ class TestJWTIntegration:
 # =============================================================================
 
 
+class TestAnnounceSetupToken:
+    def test_quiet_mode_prints_token_and_logs(self, monkeypatch, capsys):
+        """Quiet mode still prints the setup token to container stdout."""
+        expected = [
+            "[SETUP] *** First-run setup required ***",
+            "[SETUP] Setup token: secret-token",
+            "[SETUP] Provide this token when setting up credentials via the web interface.",
+        ]
+        monkeypatch.setattr(comicarr, "QUIET", True)
+        monkeypatch.setattr(comicarr, "LOG_LEVEL", 1)
+
+        with patch.object(system_service.logger, "info") as mock_info:
+            system_service.announce_setup_token("secret-token")
+
+        captured = capsys.readouterr()
+        assert captured.out.splitlines() == expected
+        assert [call.args[0] for call in mock_info.call_args_list] == expected
+
+    def test_normal_mode_logs_without_stdout_duplicate(self, monkeypatch, capsys):
+        """Normal logging mode relies on the configured logger only."""
+        expected = [
+            "[SETUP] *** First-run setup required ***",
+            "[SETUP] Setup token: secret-token",
+            "[SETUP] Provide this token when setting up credentials via the web interface.",
+        ]
+        monkeypatch.setattr(comicarr, "QUIET", False)
+        monkeypatch.setattr(comicarr, "LOG_LEVEL", 1)
+
+        with patch.object(system_service.logger, "info") as mock_info:
+            system_service.announce_setup_token("secret-token")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert [call.args[0] for call in mock_info.call_args_list] == expected
+
+    def test_log_level_zero_prints_token_even_when_not_quiet(self, monkeypatch, capsys):
+        """Console-suppressed log level still exposes the setup token."""
+        expected = [
+            "[SETUP] *** First-run setup required ***",
+            "[SETUP] Setup token: secret-token",
+            "[SETUP] Provide this token when setting up credentials via the web interface.",
+        ]
+        monkeypatch.setattr(comicarr, "QUIET", False)
+        monkeypatch.setattr(comicarr, "LOG_LEVEL", 0)
+
+        with patch.object(system_service.logger, "info") as mock_info:
+            system_service.announce_setup_token("secret-token")
+
+        captured = capsys.readouterr()
+        assert captured.out.splitlines() == expected
+        assert [call.args[0] for call in mock_info.call_args_list] == expected
+
+
 class TestInitialSetup:
     @patch("comicarr.encrypted")
     def test_setup_succeeds(self, mock_encrypted):


### PR DESCRIPTION
## Summary

Fixes #179.

Docker starts Comicarr with `--quiet`, which disables the console logger. First-run setup still generated `comicarr.SETUP_TOKEN`, but the only visible setup-token message was emitted through `logger.info`, so Docker users could not find `[SETUP] Setup token:` in `docker logs` and setup failed with repeated `400 Bad Request` responses.

This PR moves setup-token announcement into a small system-service helper that keeps the existing logger messages and additionally prints the same setup block to stdout when quiet mode or `LOG_LEVEL == 0` would otherwise hide it.

## Validation

- `.venv/bin/python -m pytest tests/unit/test_system_domain.py tests/unit/test_app_core.py -q` -> 70 passed
- `.venv/bin/python -m pytest -q` -> 787 passed
- `.venv/bin/python -m py_compile Comicarr.py comicarr/app/system/service.py tests/unit/test_system_domain.py`
- `git diff --check`

## Post-Deploy Monitoring & Validation

- Check first-run Docker logs for `[SETUP] Setup token:` after starting with an empty `/config`.
- Expected healthy signal: setup token appears once during first-run setup, and `/api/auth/setup` succeeds when submitted with that token.
- Failure signals: missing setup token in `docker logs`, repeated `POST /api/auth/setup` `400 Bad Request`, or users reporting they cannot complete first-run setup.
- Rollback trigger: if quiet Docker startup starts leaking unrelated noisy logs or setup-token output appears outside first-run setup, revert this change.
- Validation window: first Docker release after merge; owner: maintainer performing release smoke test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined first-run setup token announcement to better handle quiet mode and logging level configurations.

* **Tests**
  * Added comprehensive test coverage for setup token announcement functionality across different configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->