### PR TITLE
fix: complete manual import matches

### DIFF
--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -337,11 +337,14 @@ def match_import(imp_id, comic_id, comic_name, issue_id=None):
     """Manually match an import file to a comic series."""
     update_values = {
         "ComicID": comic_id,
+        "ComicName": comic_name,
+        "Status": "Imported",
         "SuggestedComicID": comic_id,
         "SuggestedComicName": comic_name,
         "MatchSource": "manual",
         "MatchConfidence": 100,
         "WatchMatch": "C" + comic_id,
+        "IgnoreFile": 0,
     }
     if issue_id:
         update_values["IssueID"] = issue_id

--- a/comicarr/app/series/router.py
+++ b/comicarr/app/series/router.py
@@ -244,7 +244,11 @@ def match_import(
         imp_ids = [iid.strip() for iid in imp_ids.split(",") if iid.strip()]
 
     issue_id = request_body.get("issue_id")
-    return series_service.match_import(ctx, imp_ids, comic_id, issue_id=issue_id)
+    comic_name = request_body.get("comic_name")
+    result = series_service.match_import(ctx, imp_ids, comic_id, comic_name=comic_name, issue_id=issue_id)
+    if not result.get("success"):
+        return JSONResponse(status_code=500, content={"detail": result.get("error")})
+    return result
 
 
 @router.post("/import/ignore", dependencies=[Depends(require_session)])

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -224,9 +224,46 @@ def get_import_pending(ctx, limit=50, offset=0, include_ignored=False):
     return series_queries.get_import_pending(limit=limit, offset=offset, include_ignored=include_ignored)
 
 
-def match_import(ctx, imp_ids, comic_id, issue_id=None):
+def _is_manga_provider_id(comic_id):
+    return str(comic_id).startswith("md-") or str(comic_id).startswith("mal-")
+
+
+def _ensure_import_series(comic_id, comic_name=None):
+    """Ensure provider-backed manga exists locally before finalizing an import match."""
+    existing_name = series_queries.get_comic_name(comic_id)
+    if existing_name:
+        return {"success": True, "comic_name": existing_name}
+
+    if not _is_manga_provider_id(comic_id):
+        return {"success": True, "comic_name": comic_name or "Unknown"}
+
+    from comicarr import importer
+
+    try:
+        if str(comic_id).startswith("mal-"):
+            result = importer.addMangaToDB_MAL(comic_id)
+        else:
+            result = importer.addMangaToDB(comic_id)
+    except Exception as e:
+        logger.error("[IMPORT-MATCH] Error adding manga %s: %s" % (comic_id, e))
+        return {"success": False, "error": "Error adding manga: %s" % str(e)}
+
+    if not result or result.get("status") != "complete":
+        return {"success": False, "error": "Failed to add manga: %s" % comic_id}
+
+    return {
+        "success": True,
+        "comic_name": result.get("comicname") or comic_name or series_queries.get_comic_name(comic_id) or "Unknown",
+    }
+
+
+def match_import(ctx, imp_ids, comic_id, comic_name=None, issue_id=None):
     """Manually match import files to a comic series."""
-    comic_name = series_queries.get_comic_name(comic_id) or "Unknown"
+    ensured = _ensure_import_series(comic_id, comic_name=comic_name)
+    if not ensured["success"]:
+        return ensured
+
+    comic_name = ensured["comic_name"]
 
     matched = 0
     for imp_id in imp_ids:
@@ -236,7 +273,7 @@ def match_import(ctx, imp_ids, comic_id, issue_id=None):
         series_queries.match_import(imp_id, comic_id, comic_name, issue_id=issue_id)
         matched += 1
 
-    return {"matched": matched, "comic_id": comic_id, "comic_name": comic_name}
+    return {"success": True, "matched": matched, "imported": matched, "comic_id": comic_id, "comic_name": comic_name}
 
 
 def ignore_import(ctx, imp_ids, ignore=True):

--- a/frontend/src/components/import/ImportTable.tsx
+++ b/frontend/src/components/import/ImportTable.tsx
@@ -192,8 +192,7 @@ export default function ImportTable({
         header: "Actions",
         cell: ({ row }) => {
           const allIgnored =
-            row.original.files?.every((file) => file.IgnoreFile === 1) ??
-            false;
+            row.original.files?.every((file) => file.IgnoreFile === 1) ?? false;
           const ignoreLabel = allIgnored ? "Unignore import" : "Ignore import";
 
           return (

--- a/frontend/src/components/import/ImportTable.tsx
+++ b/frontend/src/components/import/ImportTable.tsx
@@ -8,7 +8,15 @@ import {
   type ExpandedState,
   type Updater,
 } from "@tanstack/react-table";
-import { ChevronRight, ChevronDown, FileText, Link2 } from "lucide-react";
+import {
+  ChevronRight,
+  ChevronDown,
+  FileText,
+  Link2,
+  Eye,
+  EyeOff,
+  Trash2,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import StatusBadge from "@/components/StatusBadge";
@@ -28,6 +36,9 @@ interface ImportTableProps {
   onPrevPage?: () => void;
   onSelectionChange?: (selectedIds: string[]) => void;
   onMatchClick?: (group: ImportGroup) => void;
+  onIgnoreClick?: (group: ImportGroup, ignore: boolean) => void;
+  onDeleteClick?: (group: ImportGroup) => void;
+  isActionLoading?: boolean;
 }
 
 function FileRow({ file }: { file: ImportFile }) {
@@ -60,6 +71,9 @@ export default function ImportTable({
   onPrevPage,
   onSelectionChange,
   onMatchClick,
+  onIgnoreClick,
+  onDeleteClick,
+  isActionLoading = false,
 }: ImportTableProps) {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [expanded, setExpanded] = useState<ExpandedState>({});
@@ -176,21 +190,67 @@ export default function ImportTable({
       columnHelper.display({
         id: "actions",
         header: "Actions",
-        cell: ({ row }) => (
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={(e) => {
-              e.stopPropagation();
-              onMatchClick?.(row.original);
-            }}
-          >
-            Match
-          </Button>
-        ),
+        cell: ({ row }) => {
+          const allIgnored =
+            row.original.files?.every((file) => file.IgnoreFile === 1) ??
+            false;
+          const ignoreLabel = allIgnored ? "Unignore import" : "Ignore import";
+
+          return (
+            <div className="flex items-center gap-1">
+              <Button
+                size="icon"
+                variant="outline"
+                aria-label="Match import"
+                title="Match import"
+                disabled={isActionLoading}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMatchClick?.(row.original);
+                }}
+              >
+                <Link2 className="w-4 h-4" />
+                <span className="sr-only">Match</span>
+              </Button>
+              <Button
+                size="icon"
+                variant="outline"
+                aria-label={ignoreLabel}
+                title={ignoreLabel}
+                disabled={isActionLoading}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onIgnoreClick?.(row.original, !allIgnored);
+                }}
+              >
+                {allIgnored ? (
+                  <Eye className="w-4 h-4" />
+                ) : (
+                  <EyeOff className="w-4 h-4" />
+                )}
+                <span className="sr-only">{ignoreLabel}</span>
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                aria-label="Delete import record"
+                title="Delete import record"
+                disabled={isActionLoading}
+                className="text-destructive hover:text-destructive"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDeleteClick?.(row.original);
+                }}
+              >
+                <Trash2 className="w-4 h-4" />
+                <span className="sr-only">Delete</span>
+              </Button>
+            </div>
+          );
+        },
       }),
     ],
-    [onMatchClick],
+    [isActionLoading, onDeleteClick, onIgnoreClick, onMatchClick],
   );
 
   const table = useReactTable({

--- a/frontend/src/hooks/useImport.ts
+++ b/frontend/src/hooks/useImport.ts
@@ -14,7 +14,9 @@ interface ImportPendingResponse {
 }
 
 interface MatchImportResponse {
+  success: boolean;
   matched: number;
+  imported: number;
   comic_id: string;
   comic_name: string;
 }
@@ -54,14 +56,15 @@ export function useImportPending(
 export function useMatchImport(): UseMutationResult<
   MatchImportResponse,
   Error,
-  { impIds: string[]; comicId: string; issueId?: string }
+  { impIds: string[]; comicId: string; comicName?: string; issueId?: string }
 > {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ impIds, comicId, issueId }) =>
+    mutationFn: ({ impIds, comicId, comicName, issueId }) =>
       apiRequest<MatchImportResponse>("POST", "/api/import/match", {
         imp_ids: impIds,
         comic_id: comicId,
+        comic_name: comicName,
         issue_id: issueId,
       }),
     onSuccess: () => {

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -70,10 +70,10 @@ export default function ImportPage() {
     if (!matchingGroup) return;
     const impIds = matchingGroup.files.map((f) => f.impID);
     try {
-      await matchImportMutation.mutateAsync({ impIds, comicId });
+      await matchImportMutation.mutateAsync({ impIds, comicId, comicName });
       addToast({
         type: "success",
-        message: `Matched ${impIds.length} file${impIds.length !== 1 ? "s" : ""} to ${comicName}`,
+        message: `Imported ${impIds.length} file${impIds.length !== 1 ? "s" : ""} as ${comicName}`,
       });
       setMatchModalOpen(false);
       setMatchingGroup(null);
@@ -81,6 +81,47 @@ export default function ImportPage() {
       addToast({
         type: "error",
         message: `Failed to match: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+    }
+  };
+
+  const handleGroupIgnore = async (group: ImportGroup, ignore: boolean) => {
+    const impIds = group.files.map((f) => f.impID);
+    try {
+      await ignoreImportMutation.mutateAsync({ impIds, ignore });
+      addToast({
+        type: "success",
+        message: `${impIds.length} file${impIds.length !== 1 ? "s" : ""} ${ignore ? "ignored" : "unignored"}`,
+      });
+      setSelectedIds([]);
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to ${ignore ? "ignore" : "unignore"} files: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+    }
+  };
+
+  const handleGroupDelete = async (group: ImportGroup) => {
+    const impIds = group.files.map((f) => f.impID);
+    if (
+      !window.confirm(
+        `Delete ${impIds.length} import record${impIds.length !== 1 ? "s" : ""}? (Files on disk are untouched.)`,
+      )
+    ) {
+      return;
+    }
+    try {
+      await deleteImportMutation.mutateAsync(impIds);
+      addToast({
+        type: "success",
+        message: `${impIds.length} import record${impIds.length !== 1 ? "s" : ""} deleted`,
+      });
+      setSelectedIds([]);
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to delete records: ${err instanceof Error ? err.message : "Unknown error"}`,
       });
     }
   };
@@ -252,6 +293,13 @@ export default function ImportPage() {
               }}
               onSelectionChange={setSelectedIds}
               onMatchClick={handleMatchClick}
+              onIgnoreClick={handleGroupIgnore}
+              onDeleteClick={handleGroupDelete}
+              isActionLoading={
+                matchImportMutation.isPending ||
+                ignoreImportMutation.isPending ||
+                deleteImportMutation.isPending
+              }
             />
           )}
 

--- a/tests/unit/test_series_import_matching.py
+++ b/tests/unit/test_series_import_matching.py
@@ -1,0 +1,91 @@
+#  Copyright (C) 2025-2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+
+"""
+Tests for manual import matching behavior.
+"""
+
+from unittest.mock import patch
+
+from comicarr.app.series import queries, service
+
+
+def test_match_import_marks_record_imported_with_manual_match_metadata():
+    with patch.object(queries.db, "upsert") as mock_upsert:
+        queries.match_import("imp-1", "mal-123", "Berserk", issue_id="mal-123-ch1")
+
+    mock_upsert.assert_called_once_with(
+        "importresults",
+        {
+            "ComicID": "mal-123",
+            "ComicName": "Berserk",
+            "Status": "Imported",
+            "SuggestedComicID": "mal-123",
+            "SuggestedComicName": "Berserk",
+            "MatchSource": "manual",
+            "MatchConfidence": 100,
+            "WatchMatch": "Cmal-123",
+            "IgnoreFile": 0,
+            "IssueID": "mal-123-ch1",
+            "SuggestedIssueID": "mal-123-ch1",
+        },
+        {"impID": "imp-1"},
+    )
+
+
+def test_match_import_adds_missing_mal_manga_before_finalizing_rows():
+    with (
+        patch.object(service.series_queries, "get_comic_name", return_value=None),
+        patch(
+            "comicarr.importer.addMangaToDB_MAL",
+            return_value={"status": "complete", "comicname": "Berserk"},
+        ) as mock_add_manga,
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1"], "mal-123", comic_name="Berserk")
+
+    assert result == {
+        "success": True,
+        "matched": 1,
+        "imported": 1,
+        "comic_id": "mal-123",
+        "comic_name": "Berserk",
+    }
+    mock_add_manga.assert_called_once_with("mal-123")
+    mock_match.assert_called_once_with("imp-1", "mal-123", "Berserk", issue_id=None)
+
+
+def test_match_import_does_not_finalize_rows_when_manga_add_fails():
+    with (
+        patch.object(service.series_queries, "get_comic_name", return_value=None),
+        patch("comicarr.importer.addMangaToDB", return_value={"status": "incomplete"}),
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1"], "md-abc", comic_name="Berserk")
+
+    assert result == {"success": False, "error": "Failed to add manga: md-abc"}
+    mock_match.assert_not_called()
+
+
+def test_match_import_uses_existing_library_name_without_readding_manga():
+    with (
+        patch.object(service.series_queries, "get_comic_name", return_value="Existing Berserk"),
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1", ""], "mal-123", comic_name="Berserk")
+
+    assert result["success"] is True
+    assert result["matched"] == 1
+    assert result["comic_name"] == "Existing Berserk"
+    mock_match.assert_called_once_with("imp-1", "mal-123", "Existing Berserk", issue_id=None)


### PR DESCRIPTION
## Summary

Fixes the follow-up reported on #158 where Match Import could select the correct manga but the pending row stayed `Not Imported`.

- Manual import matches now finalize selected import records as `Imported` with manual match metadata, so matched rows leave the pending review list.
- If the selected match is a MangaDex or MyAnimeList manga that is not yet in the local library, the backend adds the manga metadata first and only finalizes the import records if that add succeeds.
- The Import pending table now exposes direct row actions to match, ignore/unignore, or delete import records without relying on bulk selection.
- The frontend sends the selected provider result name through the match API so newly added manga records and import metadata keep the selected display name.

## Validation

- `.venv/bin/python -m pytest tests/unit/test_series_import_matching.py tests/unit/test_importinbox.py tests/unit/test_mangasync.py tests/unit/test_importer_manga_dir.py -q` -> 38 passed
- `.venv/bin/python -m pytest tests/unit/test_series_import_matching.py -q` -> 4 passed
- `.venv/bin/python -m py_compile comicarr/app/series/queries.py comicarr/app/series/service.py comicarr/app/series/router.py tests/unit/test_series_import_matching.py`
- `cd frontend && npm run lint`
- `cd frontend && npm run format:check`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`
- `git diff --check`

## Post-Deploy Validation

- Re-test #158 flow with a manga file in `IMPORT_DIR`: run inbox scan, open Match Import, select the correct manga, and verify the row leaves pending review.
- Confirm a selected MAL/MangaDex manga appears in Library after matching.
- Confirm row-level Ignore/Delete controls remove stale pending rows from normal review.