### PR TITLE
ci: auto-close fixed issues awaiting confirmation

### DIFF
--- a/.github/workflows/stale-fixed-issues.yml
+++ b/.github/workflows/stale-fixed-issues.yml
@@ -1,0 +1,38 @@
+name: Stale Fixed Issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 15 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  stale-fixed-issues:
+    name: Close fixed issues awaiting confirmation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark and close fixed issues with no follow-up
+        uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-issue-labels: "status: fixed-awaiting-confirmation"
+          stale-issue-label: "status: stale-confirmation"
+          stale-issue-message: |
+            This issue was marked fixed and has not had follow-up activity for 14 days.
+
+            If the problem still reproduces, please comment with fresh details and this will stay open.
+            Otherwise, it will be closed automatically in 7 days.
+          close-issue-message: |
+            Closing this as completed because it was marked fixed and there has been no follow-up activity.
+
+            If this still reproduces on the latest release, please open a new issue with updated logs and reproduction steps.
+          close-issue-reason: completed
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-issue-stale-when-updated: true
+          operations-per-run: 20


### PR DESCRIPTION
## Summary

Adds a label-gated stale issue workflow for issues that have been marked fixed and are waiting on reporter confirmation.

- Runs daily and on manual dispatch.
- Processes only issues with `status: fixed-awaiting-confirmation`.
- Adds `status: stale-confirmation` after 14 idle days with a warning comment.
- Closes the issue as `completed` after 7 more idle days with no follow-up.
- Disables PR stale processing entirely.

## Why

This avoids broad stale-bot behavior while still cleaning up issues that have already been addressed and did not receive follow-up after a reasonable confirmation window.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/stale-fixed-issues.yml'); puts 'stale workflow yaml ok'"`
- `git diff --check -- .github/workflows/stale-fixed-issues.yml`

Note: `actionlint` is not installed locally, so workflow schema validation was limited to YAML parsing and diff whitespace checks.

## Maintainer Notes

Use the `status: fixed-awaiting-confirmation` label when an issue appears fixed but you want reporter confirmation before closing. The workflow will only operate on those explicitly labeled issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to manage issues awaiting confirmation. Fixed issues marked for confirmation will be labeled as stale after 14 days of inactivity and automatically closed after an additional 7 days, improving issue tracking and repository maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->