### PR TITLE
chore: add release changeset for import match fix

### DIFF
--- a/.changeset/fix-import-match-completion.md
+++ b/.changeset/fix-import-match-completion.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix manual import matching so selected manga imports are finalized and stale pending import records can be ignored or deleted from the review table.


### PR DESCRIPTION
## Summary

Adds the missing patch changeset for the user-visible import matching fix merged in #181.

Without this changeset, the Changesets release workflow has no release intent to process, so it correctly does not open a `Version Packages` PR. Merging this PR should let the next `Release` workflow run create/update the release PR.

## Release Impact

- [x] User-visible app change; changeset added
- [ ] No app release impact

## Validation

- `git diff --check -- .changeset/fix-import-match-completion.md`
- Confirmed the changeset file uses the standard Changesets patch format for package `comicarr`.

Note: root Changesets dependencies are not installed in this checkout, so local `changeset status` was not run without installing packages.