### PR TITLE
fix: finalize manual import matches

### DIFF
--- a/.changeset/finalize-manual-import-matches.md
+++ b/.changeset/finalize-manual-import-matches.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix manual import matching so selected files are finalized before pending import rows are marked imported.

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -106,9 +106,7 @@ def get_comic_name(comic_id):
 def get_comic_for_import(comic_id):
     """Get series fields needed to finalize manual imports."""
     return db.select_one(
-        select(t_comics.c.ComicID, t_comics.c.ComicName, t_comics.c.ComicLocation).where(
-            t_comics.c.ComicID == comic_id
-        )
+        select(t_comics.c.ComicID, t_comics.c.ComicName, t_comics.c.ComicLocation).where(t_comics.c.ComicID == comic_id)
     )
 
 

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -103,6 +103,15 @@ def get_comic_name(comic_id):
     return row["ComicName"] if row else None
 
 
+def get_comic_for_import(comic_id):
+    """Get series fields needed to finalize manual imports."""
+    return db.select_one(
+        select(t_comics.c.ComicID, t_comics.c.ComicName, t_comics.c.ComicLocation).where(
+            t_comics.c.ComicID == comic_id
+        )
+    )
+
+
 def get_comic_for_refresh(comic_id):
     """Get comic name/year for refresh validation."""
     return db.select_one(select(t_comics.c.ComicName, t_comics.c.ComicYear).where(t_comics.c.ComicID == comic_id))
@@ -331,6 +340,13 @@ def get_import_pending(limit=50, offset=0, include_ignored=False):
             "has_more": (offset + limit) < total,
         },
     }
+
+
+def get_import_rows(imp_ids):
+    """Get raw import rows by impID."""
+    if not imp_ids:
+        return []
+    return db.select_all(select(t_importresults).where(t_importresults.c.impID.in_(imp_ids)))
 
 
 def match_import(imp_id, comic_id, comic_name, issue_id=None):

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -357,22 +357,60 @@ def _destination_for_import_row(row, comic_id, comic_name, comic_location, issue
     return os.path.join(comic_location, destination_filename)
 
 
-def _move_import_rows(rows, comic_id, comic_name, comic_location, issue_id=None):
-    from comicarr import updater
+def _move_plan_import_rows(rows, comic_id, comic_name, comic_location, issue_id=None):
+    move_plan = []
+    destination_paths = set()
 
     for row in rows:
         source_path = row.get("ComicLocation")
         destination_path = _destination_for_import_row(row, comic_id, comic_name, comic_location, issue_id=issue_id)
+        if destination_path in destination_paths:
+            return _import_error("Multiple import files resolve to the same destination: %s" % destination_path)
+        if os.path.exists(destination_path):
+            return _import_error("Import destination already exists: %s" % destination_path)
+        destination_paths.add(destination_path)
+        move_plan.append((source_path, destination_path))
+
+    return {"success": True, "move_plan": move_plan}
+
+
+def _rollback_import_moves(moved_files):
+    rollback_errors = []
+    for source_path, destination_path in reversed(moved_files):
+        if not os.path.exists(destination_path):
+            continue
+        try:
+            shutil.move(destination_path, source_path)
+            logger.warn("[IMPORT-MATCH] Rolled back moved import file %s to %s" % (destination_path, source_path))
+        except (OSError, IOError) as e:
+            rollback_errors.append("%s -> %s: %s" % (destination_path, source_path, e))
+
+    if rollback_errors:
+        logger.error("[IMPORT-MATCH] Failed to roll back import moves: %s" % "; ".join(rollback_errors))
+
+
+def _move_import_rows(rows, comic_id, comic_name, comic_location, issue_id=None):
+    from comicarr import updater
+
+    move_plan = _move_plan_import_rows(rows, comic_id, comic_name, comic_location, issue_id=issue_id)
+    if not move_plan["success"]:
+        return move_plan
+
+    moved_files = []
+    for source_path, destination_path in move_plan["move_plan"]:
         logger.info("[IMPORT-MATCH] Moving %s to %s" % (source_path, destination_path))
 
         try:
             shutil.move(source_path, destination_path)
         except (OSError, IOError) as e:
+            _rollback_import_moves(moved_files)
             return _import_error("Failed to move import file %s to %s: %s" % (source_path, destination_path, e))
+        moved_files.append((source_path, destination_path))
 
     try:
         updater.forceRescan(comic_id)
     except Exception as e:
+        _rollback_import_moves(moved_files)
         return _import_error("Failed to rescan imported series %s: %s" % (comic_id, e))
 
     return {"success": True, "moved": len(rows), "archived": 0}

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -350,8 +350,7 @@ def _destination_for_import_row(row, comic_id, comic_name, comic_location, issue
                 renameit = helpers.rename_param(comic_id, comic_name, issue_number, original_filename, issueid=issue_id)
             except Exception as e:
                 logger.fdebug(
-                    "[IMPORT-MATCH] Could not rename import file %s, keeping original filename: %s"
-                    % (source_path, e)
+                    "[IMPORT-MATCH] Could not rename import file %s, keeping original filename: %s" % (source_path, e)
                 )
             else:
                 if renameit and renameit.get("nfilename"):

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -257,23 +257,221 @@ def _ensure_import_series(comic_id, comic_name=None):
     }
 
 
+def _import_error(message):
+    logger.error("[IMPORT-MATCH] %s" % message)
+    return {"success": False, "error": message}
+
+
+def _clean_import_ids(imp_ids):
+    clean_ids = []
+    seen_ids = set()
+    for imp_id in imp_ids:
+        imp_id = str(imp_id).strip()
+        if imp_id and imp_id not in seen_ids:
+            clean_ids.append(imp_id)
+            seen_ids.add(imp_id)
+    return clean_ids
+
+
+def _get_import_rows(imp_ids):
+    rows = series_queries.get_import_rows(imp_ids)
+    rows_by_id = {}
+    for row in rows:
+        rows_by_id[row["impID"]] = row
+
+    missing = [imp_id for imp_id in imp_ids if imp_id not in rows_by_id]
+    if missing:
+        return _import_error("Missing import record(s): %s" % ", ".join(missing))
+
+    return {"success": True, "rows": [rows_by_id[imp_id] for imp_id in imp_ids]}
+
+
+def _validate_import_rows(rows):
+    for row in rows:
+        source_path = row.get("ComicLocation")
+        if not source_path:
+            return _import_error("Import record %s has no source path" % row.get("impID"))
+        if not os.path.isfile(source_path):
+            return _import_error("Import source file does not exist: %s" % source_path)
+    return {"success": True}
+
+
+def _ensure_import_target_dir(comic_location):
+    if not comic_location or comic_location == "None":
+        return _import_error("Target series has no library directory")
+
+    if os.path.isdir(comic_location):
+        return {"success": True}
+
+    from comicarr import filechecker
+
+    try:
+        checkdirectory = filechecker.validateAndCreateDirectory(comic_location, True)
+    except Exception as e:
+        return _import_error("Error creating import target directory %s: %s" % (comic_location, e))
+
+    if not checkdirectory:
+        return _import_error("Could not create import target directory: %s" % comic_location)
+
+    return {"success": True}
+
+
+def _issue_number_for_import(row):
+    issue_number = row.get("IssueNumber")
+    if issue_number is None:
+        return None
+    issue_number = str(issue_number).strip()
+    if not issue_number or issue_number == "None":
+        return None
+    return issue_number
+
+
+def _destination_for_import_row(row, comic_id, comic_name, comic_location, issue_id=None):
+    source_path = row.get("ComicLocation")
+    original_filename = row.get("ComicFilename") or os.path.basename(source_path)
+    destination_filename = original_filename
+
+    if getattr(comicarr.CONFIG, "IMP_RENAME", False) and getattr(comicarr.CONFIG, "FILE_FORMAT", ""):
+        issue_number = _issue_number_for_import(row)
+        if issue_number or issue_id:
+            from comicarr import helpers
+
+            try:
+                renameit = helpers.rename_param(comic_id, comic_name, issue_number, original_filename, issueid=issue_id)
+            except Exception as e:
+                logger.warn(
+                    "[IMPORT-MATCH] Could not rename import file %s, keeping original filename: %s"
+                    % (source_path, e)
+                )
+            else:
+                if renameit and renameit.get("nfilename"):
+                    destination_filename = renameit["nfilename"]
+                else:
+                    logger.warn(
+                        "[IMPORT-MATCH] Could not resolve renamed filename for %s, keeping original filename"
+                        % source_path
+                    )
+        else:
+            logger.fdebug("[IMPORT-MATCH] No issue number for %s, keeping original filename" % source_path)
+
+    return os.path.join(comic_location, destination_filename)
+
+
+def _move_import_rows(rows, comic_id, comic_name, comic_location, issue_id=None):
+    from comicarr import updater
+
+    for row in rows:
+        source_path = row.get("ComicLocation")
+        destination_path = _destination_for_import_row(row, comic_id, comic_name, comic_location, issue_id=issue_id)
+        logger.info("[IMPORT-MATCH] Moving %s to %s" % (source_path, destination_path))
+
+        try:
+            shutil.move(source_path, destination_path)
+        except (OSError, IOError) as e:
+            return _import_error("Failed to move import file %s to %s: %s" % (source_path, destination_path, e))
+
+    try:
+        updater.forceRescan(comic_id)
+    except Exception as e:
+        return _import_error("Failed to rescan imported series %s: %s" % (comic_id, e))
+
+    return {"success": True, "moved": len(rows), "archived": 0}
+
+
+def _archive_import_rows(rows, comic_id):
+    from comicarr import updater
+
+    archive_dirs = []
+    for row in rows:
+        archive_dir = os.path.abspath(os.path.dirname(row.get("ComicLocation")))
+        if archive_dir not in archive_dirs:
+            archive_dirs.append(archive_dir)
+
+    for archive_dir in archive_dirs:
+        logger.info("[IMPORT-MATCH] Archiving import directory in place: %s" % archive_dir)
+        try:
+            updater.forceRescan(comic_id, archive=archive_dir)
+        except Exception as e:
+            return _import_error("Failed to archive import directory %s: %s" % (archive_dir, e))
+
+    try:
+        updater.forceRescan(comic_id)
+    except Exception as e:
+        return _import_error("Failed to rescan imported series %s: %s" % (comic_id, e))
+
+    return {"success": True, "moved": 0, "archived": len(rows)}
+
+
+def _finalize_import_rows(rows, comic_id, comic_name, comic_location, issue_id=None):
+    valid_rows = _validate_import_rows(rows)
+    if not valid_rows["success"]:
+        return valid_rows
+
+    target_dir = _ensure_import_target_dir(comic_location)
+    if not target_dir["success"]:
+        return target_dir
+
+    if getattr(comicarr.CONFIG, "IMP_MOVE", False):
+        logger.info("[IMPORT-MATCH] Finalizing %d import file(s) with move enabled" % len(rows))
+        return _move_import_rows(rows, comic_id, comic_name, comic_location, issue_id=issue_id)
+
+    logger.info("[IMPORT-MATCH] Finalizing %d import file(s) in archive-in-place mode" % len(rows))
+    return _archive_import_rows(rows, comic_id)
+
+
 def match_import(ctx, imp_ids, comic_id, comic_name=None, issue_id=None):
     """Manually match import files to a comic series."""
     ensured = _ensure_import_series(comic_id, comic_name=comic_name)
     if not ensured["success"]:
         return ensured
 
-    comic_name = ensured["comic_name"]
+    clean_imp_ids = _clean_import_ids(imp_ids)
+    if not clean_imp_ids:
+        return {
+            "success": True,
+            "matched": 0,
+            "imported": 0,
+            "comic_id": comic_id,
+            "comic_name": ensured["comic_name"],
+            "moved": 0,
+            "archived": 0,
+        }
+
+    comic = series_queries.get_comic_for_import(comic_id)
+    if not comic:
+        return _import_error("Target series not found in library: %s" % comic_id)
+
+    comic_name = comic.get("ComicName") or ensured["comic_name"]
+    comic_location = comic.get("ComicLocation")
+
+    import_rows = _get_import_rows(clean_imp_ids)
+    if not import_rows["success"]:
+        return import_rows
+
+    finalized = _finalize_import_rows(
+        import_rows["rows"],
+        comic_id,
+        comic_name,
+        comic_location,
+        issue_id=issue_id,
+    )
+    if not finalized["success"]:
+        return finalized
 
     matched = 0
-    for imp_id in imp_ids:
-        imp_id = imp_id.strip()
-        if not imp_id:
-            continue
+    for imp_id in clean_imp_ids:
         series_queries.match_import(imp_id, comic_id, comic_name, issue_id=issue_id)
         matched += 1
 
-    return {"success": True, "matched": matched, "imported": matched, "comic_id": comic_id, "comic_name": comic_name}
+    return {
+        "success": True,
+        "matched": matched,
+        "imported": matched,
+        "comic_id": comic_id,
+        "comic_name": comic_name,
+        "moved": finalized.get("moved", 0),
+        "archived": finalized.get("archived", 0),
+    }
 
 
 def ignore_import(ctx, imp_ids, ignore=True):

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -263,9 +263,16 @@ def _import_error(message):
 
 
 def _clean_import_ids(imp_ids):
+    if not imp_ids:
+        return []
+    if isinstance(imp_ids, str):
+        imp_ids = [imp_ids]
+
     clean_ids = []
     seen_ids = set()
     for imp_id in imp_ids:
+        if imp_id is None:
+            continue
         imp_id = str(imp_id).strip()
         if imp_id and imp_id not in seen_ids:
             clean_ids.append(imp_id)
@@ -303,6 +310,9 @@ def _ensure_import_target_dir(comic_location):
     if os.path.isdir(comic_location):
         return {"success": True}
 
+    if os.path.exists(comic_location):
+        return _import_error("Import target path is not a directory: %s" % comic_location)
+
     from comicarr import filechecker
 
     try:
@@ -339,7 +349,7 @@ def _destination_for_import_row(row, comic_id, comic_name, comic_location, issue
             try:
                 renameit = helpers.rename_param(comic_id, comic_name, issue_number, original_filename, issueid=issue_id)
             except Exception as e:
-                logger.warn(
+                logger.fdebug(
                     "[IMPORT-MATCH] Could not rename import file %s, keeping original filename: %s"
                     % (source_path, e)
                 )
@@ -347,7 +357,7 @@ def _destination_for_import_row(row, comic_id, comic_name, comic_location, issue
                 if renameit and renameit.get("nfilename"):
                     destination_filename = renameit["nfilename"]
                 else:
-                    logger.warn(
+                    logger.fdebug(
                         "[IMPORT-MATCH] Could not resolve renamed filename for %s, keeping original filename"
                         % source_path
                     )
@@ -381,7 +391,7 @@ def _rollback_import_moves(moved_files):
             continue
         try:
             shutil.move(destination_path, source_path)
-            logger.warn("[IMPORT-MATCH] Rolled back moved import file %s to %s" % (destination_path, source_path))
+            logger.fdebug("[IMPORT-MATCH] Rolled back moved import file %s to %s" % (destination_path, source_path))
         except (OSError, IOError) as e:
             rollback_errors.append("%s -> %s: %s" % (destination_path, source_path, e))
 
@@ -398,7 +408,7 @@ def _move_import_rows(rows, comic_id, comic_name, comic_location, issue_id=None)
 
     moved_files = []
     for source_path, destination_path in move_plan["move_plan"]:
-        logger.info("[IMPORT-MATCH] Moving %s to %s" % (source_path, destination_path))
+        logger.fdebug("[IMPORT-MATCH] Moving %s to %s" % (source_path, destination_path))
 
         try:
             shutil.move(source_path, destination_path)
@@ -426,7 +436,7 @@ def _archive_import_rows(rows, comic_id):
             archive_dirs.append(archive_dir)
 
     for archive_dir in archive_dirs:
-        logger.info("[IMPORT-MATCH] Archiving import directory in place: %s" % archive_dir)
+        logger.fdebug("[IMPORT-MATCH] Archiving import directory in place: %s" % archive_dir)
         try:
             updater.forceRescan(comic_id, archive=archive_dir)
         except Exception as e:
@@ -450,19 +460,15 @@ def _finalize_import_rows(rows, comic_id, comic_name, comic_location, issue_id=N
         return target_dir
 
     if getattr(comicarr.CONFIG, "IMP_MOVE", False):
-        logger.info("[IMPORT-MATCH] Finalizing %d import file(s) with move enabled" % len(rows))
+        logger.fdebug("[IMPORT-MATCH] Finalizing %d import file(s) with move enabled" % len(rows))
         return _move_import_rows(rows, comic_id, comic_name, comic_location, issue_id=issue_id)
 
-    logger.info("[IMPORT-MATCH] Finalizing %d import file(s) in archive-in-place mode" % len(rows))
+    logger.fdebug("[IMPORT-MATCH] Finalizing %d import file(s) in archive-in-place mode" % len(rows))
     return _archive_import_rows(rows, comic_id)
 
 
 def match_import(ctx, imp_ids, comic_id, comic_name=None, issue_id=None):
     """Manually match import files to a comic series."""
-    ensured = _ensure_import_series(comic_id, comic_name=comic_name)
-    if not ensured["success"]:
-        return ensured
-
     clean_imp_ids = _clean_import_ids(imp_ids)
     if not clean_imp_ids:
         return {
@@ -470,10 +476,14 @@ def match_import(ctx, imp_ids, comic_id, comic_name=None, issue_id=None):
             "matched": 0,
             "imported": 0,
             "comic_id": comic_id,
-            "comic_name": ensured["comic_name"],
+            "comic_name": series_queries.get_comic_name(comic_id) or comic_name or "Unknown",
             "moved": 0,
             "archived": 0,
         }
+
+    ensured = _ensure_import_series(comic_id, comic_name=comic_name)
+    if not ensured["success"]:
+        return ensured
 
     comic = series_queries.get_comic_for_import(comic_id)
     if not comic:

--- a/tests/unit/test_series_import_matching.py
+++ b/tests/unit/test_series_import_matching.py
@@ -16,9 +16,18 @@
 Tests for manual import matching behavior.
 """
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import call, patch
+
+import pytest
 
 from comicarr.app.series import queries, service
+
+
+@pytest.fixture(autouse=True)
+def _mock_service_logger():
+    with patch.object(service, "logger"):
+        yield
 
 
 def test_match_import_marks_record_imported_with_manual_match_metadata():
@@ -51,6 +60,24 @@ def test_match_import_adds_missing_mal_manga_before_finalizing_rows():
             "comicarr.importer.addMangaToDB_MAL",
             return_value={"status": "complete", "comicname": "Berserk"},
         ) as mock_add_manga,
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": "/library/Berserk"},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": "/import/Berserk/chapter 1.cbz",
+                    "ComicFilename": "chapter 1.cbz",
+                    "IssueNumber": None,
+                }
+            ],
+        ),
+        patch.object(service, "_finalize_import_rows", return_value={"success": True}),
         patch.object(service.series_queries, "match_import") as mock_match,
     ):
         result = service.match_import(None, ["imp-1"], "mal-123", comic_name="Berserk")
@@ -61,6 +88,8 @@ def test_match_import_adds_missing_mal_manga_before_finalizing_rows():
         "imported": 1,
         "comic_id": "mal-123",
         "comic_name": "Berserk",
+        "moved": 0,
+        "archived": 0,
     }
     mock_add_manga.assert_called_once_with("mal-123")
     mock_match.assert_called_once_with("imp-1", "mal-123", "Berserk", issue_id=None)
@@ -81,11 +110,215 @@ def test_match_import_does_not_finalize_rows_when_manga_add_fails():
 def test_match_import_uses_existing_library_name_without_readding_manga():
     with (
         patch.object(service.series_queries, "get_comic_name", return_value="Existing Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Existing Berserk", "ComicLocation": "/library/Berserk"},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": "/import/Berserk/chapter 1.cbz",
+                    "ComicFilename": "chapter 1.cbz",
+                    "IssueNumber": None,
+                }
+            ],
+        ),
+        patch.object(service, "_finalize_import_rows", return_value={"success": True}),
         patch.object(service.series_queries, "match_import") as mock_match,
     ):
-        result = service.match_import(None, ["imp-1", ""], "mal-123", comic_name="Berserk")
+        result = service.match_import(None, ["imp-1", "", "imp-1"], "mal-123", comic_name="Berserk")
 
     assert result["success"] is True
     assert result["matched"] == 1
     assert result["comic_name"] == "Existing Berserk"
     mock_match.assert_called_once_with("imp-1", "mal-123", "Existing Berserk", issue_id=None)
+
+
+def test_match_import_moves_files_before_marking_rows_imported(tmp_path):
+    import_dir = tmp_path / "import" / "Berserk"
+    target_dir = tmp_path / "library" / "Berserk"
+    import_dir.mkdir(parents=True)
+    target_dir.mkdir(parents=True)
+    source_file = import_dir / "chapter 1.cbz"
+    source_file.write_text("chapter")
+
+    events = []
+
+    def mark_import(*args, **kwargs):
+        events.append("mark")
+
+    def force_rescan(*args, **kwargs):
+        events.append("rescan")
+
+    config = SimpleNamespace(IMP_MOVE=True, IMP_RENAME=False, FILE_FORMAT="")
+
+    with (
+        patch.object(service.comicarr, "CONFIG", config),
+        patch.object(service.series_queries, "get_comic_name", return_value="Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": str(target_dir)},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": str(source_file),
+                    "ComicFilename": "chapter 1.cbz",
+                    "IssueNumber": None,
+                }
+            ],
+        ),
+        patch("comicarr.updater.forceRescan", side_effect=force_rescan) as mock_rescan,
+        patch.object(service.series_queries, "match_import", side_effect=mark_import) as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1"], "mal-123", comic_name="Berserk")
+
+    assert result["success"] is True
+    assert result["moved"] == 1
+    assert result["archived"] == 0
+    assert not source_file.exists()
+    assert (target_dir / "chapter 1.cbz").exists()
+    assert events == ["rescan", "mark"]
+    mock_rescan.assert_called_once_with("mal-123")
+    mock_match.assert_called_once_with("imp-1", "mal-123", "Berserk", issue_id=None)
+
+
+def test_match_import_archive_mode_rescans_source_directory_before_marking_rows_imported(tmp_path):
+    import_dir = tmp_path / "import" / "Berserk"
+    target_dir = tmp_path / "library" / "Berserk"
+    import_dir.mkdir(parents=True)
+    target_dir.mkdir(parents=True)
+    source_file = import_dir / "chapter 1.cbz"
+    source_file.write_text("chapter")
+
+    events = []
+
+    def mark_import(*args, **kwargs):
+        events.append("mark")
+
+    def force_rescan(*args, **kwargs):
+        events.append("rescan")
+
+    config = SimpleNamespace(IMP_MOVE=False, IMP_RENAME=False, FILE_FORMAT="")
+
+    with (
+        patch.object(service.comicarr, "CONFIG", config),
+        patch.object(service.series_queries, "get_comic_name", return_value="Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": str(target_dir)},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": str(source_file),
+                    "ComicFilename": "chapter 1.cbz",
+                    "IssueNumber": None,
+                }
+            ],
+        ),
+        patch("comicarr.updater.forceRescan", side_effect=force_rescan) as mock_rescan,
+        patch.object(service.series_queries, "match_import", side_effect=mark_import) as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1"], "mal-123", comic_name="Berserk")
+
+    assert result["success"] is True
+    assert result["moved"] == 0
+    assert result["archived"] == 1
+    assert source_file.exists()
+    assert events == ["rescan", "rescan", "mark"]
+    mock_rescan.assert_has_calls(
+        [
+            call("mal-123", archive=str(import_dir)),
+            call("mal-123"),
+        ]
+    )
+    mock_match.assert_called_once_with("imp-1", "mal-123", "Berserk", issue_id=None)
+
+
+def test_match_import_missing_source_file_does_not_mark_row_imported(tmp_path):
+    target_dir = tmp_path / "library" / "Berserk"
+    target_dir.mkdir(parents=True)
+    missing_file = tmp_path / "import" / "Berserk" / "missing.cbz"
+    config = SimpleNamespace(IMP_MOVE=True, IMP_RENAME=False, FILE_FORMAT="")
+
+    with (
+        patch.object(service.comicarr, "CONFIG", config),
+        patch.object(service.series_queries, "get_comic_name", return_value="Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": str(target_dir)},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": str(missing_file),
+                    "ComicFilename": "missing.cbz",
+                    "IssueNumber": None,
+                }
+            ],
+        ),
+        patch("comicarr.updater.forceRescan") as mock_rescan,
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1"], "mal-123", comic_name="Berserk")
+
+    assert result["success"] is False
+    assert "does not exist" in result["error"]
+    mock_rescan.assert_not_called()
+    mock_match.assert_not_called()
+
+
+def test_match_import_missing_target_location_does_not_mark_row_imported(tmp_path):
+    import_dir = tmp_path / "import" / "Berserk"
+    import_dir.mkdir(parents=True)
+    source_file = import_dir / "chapter 1.cbz"
+    source_file.write_text("chapter")
+    config = SimpleNamespace(IMP_MOVE=True, IMP_RENAME=False, FILE_FORMAT="")
+
+    with (
+        patch.object(service.comicarr, "CONFIG", config),
+        patch.object(service.series_queries, "get_comic_name", return_value="Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": None},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": str(source_file),
+                    "ComicFilename": "chapter 1.cbz",
+                    "IssueNumber": None,
+                }
+            ],
+        ),
+        patch("comicarr.updater.forceRescan") as mock_rescan,
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1"], "mal-123", comic_name="Berserk")
+
+    assert result["success"] is False
+    assert "no library directory" in result["error"]
+    assert source_file.exists()
+    mock_rescan.assert_not_called()
+    mock_match.assert_not_called()

--- a/tests/unit/test_series_import_matching.py
+++ b/tests/unit/test_series_import_matching.py
@@ -191,6 +191,151 @@ def test_match_import_moves_files_before_marking_rows_imported(tmp_path):
     mock_match.assert_called_once_with("imp-1", "mal-123", "Berserk", issue_id=None)
 
 
+def test_match_import_move_mode_fails_when_destination_exists_without_marking_imported(tmp_path):
+    import_dir = tmp_path / "import" / "Berserk"
+    target_dir = tmp_path / "library" / "Berserk"
+    import_dir.mkdir(parents=True)
+    target_dir.mkdir(parents=True)
+    source_file = import_dir / "chapter 1.cbz"
+    destination_file = target_dir / "chapter 1.cbz"
+    source_file.write_text("new chapter")
+    destination_file.write_text("existing chapter")
+    config = SimpleNamespace(IMP_MOVE=True, IMP_RENAME=False, FILE_FORMAT="")
+
+    with (
+        patch.object(service.comicarr, "CONFIG", config),
+        patch.object(service.series_queries, "get_comic_name", return_value="Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": str(target_dir)},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": str(source_file),
+                    "ComicFilename": "chapter 1.cbz",
+                    "IssueNumber": None,
+                }
+            ],
+        ),
+        patch("comicarr.updater.forceRescan") as mock_rescan,
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1"], "mal-123", comic_name="Berserk")
+
+    assert result["success"] is False
+    assert "already exists" in result["error"]
+    assert source_file.read_text() == "new chapter"
+    assert destination_file.read_text() == "existing chapter"
+    mock_rescan.assert_not_called()
+    mock_match.assert_not_called()
+
+
+def test_match_import_move_failure_rolls_back_prior_moves_without_marking_imported(tmp_path):
+    import_dir = tmp_path / "import" / "Berserk"
+    target_dir = tmp_path / "library" / "Berserk"
+    import_dir.mkdir(parents=True)
+    target_dir.mkdir(parents=True)
+    first_source = import_dir / "chapter 1.cbz"
+    second_source = import_dir / "chapter 2.cbz"
+    first_source.write_text("chapter one")
+    second_source.write_text("chapter two")
+    config = SimpleNamespace(IMP_MOVE=True, IMP_RENAME=False, FILE_FORMAT="")
+    original_move = service.shutil.move
+
+    def move_with_second_failure(source_path, destination_path):
+        if source_path == str(second_source):
+            raise OSError("disk full")
+        return original_move(source_path, destination_path)
+
+    with (
+        patch.object(service.comicarr, "CONFIG", config),
+        patch.object(service.series_queries, "get_comic_name", return_value="Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": str(target_dir)},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": str(first_source),
+                    "ComicFilename": "chapter 1.cbz",
+                    "IssueNumber": None,
+                },
+                {
+                    "impID": "imp-2",
+                    "ComicLocation": str(second_source),
+                    "ComicFilename": "chapter 2.cbz",
+                    "IssueNumber": None,
+                },
+            ],
+        ),
+        patch("comicarr.updater.forceRescan") as mock_rescan,
+        patch.object(service.shutil, "move", side_effect=move_with_second_failure),
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1", "imp-2"], "mal-123", comic_name="Berserk")
+
+    assert result["success"] is False
+    assert "Failed to move import file" in result["error"]
+    assert first_source.read_text() == "chapter one"
+    assert second_source.read_text() == "chapter two"
+    assert not (target_dir / "chapter 1.cbz").exists()
+    assert not (target_dir / "chapter 2.cbz").exists()
+    mock_rescan.assert_not_called()
+    mock_match.assert_not_called()
+
+
+def test_match_import_rescan_failure_rolls_back_move_without_marking_imported(tmp_path):
+    import_dir = tmp_path / "import" / "Berserk"
+    target_dir = tmp_path / "library" / "Berserk"
+    import_dir.mkdir(parents=True)
+    target_dir.mkdir(parents=True)
+    source_file = import_dir / "chapter 1.cbz"
+    source_file.write_text("chapter")
+    config = SimpleNamespace(IMP_MOVE=True, IMP_RENAME=False, FILE_FORMAT="")
+
+    with (
+        patch.object(service.comicarr, "CONFIG", config),
+        patch.object(service.series_queries, "get_comic_name", return_value="Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": str(target_dir)},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": str(source_file),
+                    "ComicFilename": "chapter 1.cbz",
+                    "IssueNumber": None,
+                }
+            ],
+        ),
+        patch("comicarr.updater.forceRescan", side_effect=RuntimeError("scan failed")) as mock_rescan,
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1"], "mal-123", comic_name="Berserk")
+
+    assert result["success"] is False
+    assert "Failed to rescan" in result["error"]
+    assert source_file.read_text() == "chapter"
+    assert not (target_dir / "chapter 1.cbz").exists()
+    mock_rescan.assert_called_once_with("mal-123")
+    mock_match.assert_not_called()
+
+
 def test_match_import_archive_mode_rescans_source_directory_before_marking_rows_imported(tmp_path):
     import_dir = tmp_path / "import" / "Berserk"
     target_dir = tmp_path / "library" / "Berserk"

--- a/tests/unit/test_series_import_matching.py
+++ b/tests/unit/test_series_import_matching.py
@@ -53,6 +53,37 @@ def test_match_import_marks_record_imported_with_manual_match_metadata():
     )
 
 
+def test_clean_import_ids_handles_empty_scalar_and_duplicate_values():
+    assert service._clean_import_ids(None) == []
+    assert service._clean_import_ids("imp-1") == ["imp-1"]
+    assert service._clean_import_ids([" imp-1 ", None, "", "imp-1", "imp-2"]) == ["imp-1", "imp-2"]
+
+
+def test_match_import_empty_ids_does_not_add_or_finalize_manga():
+    with (
+        patch.object(service, "_ensure_import_series") as mock_ensure_series,
+        patch.object(service.series_queries, "get_comic_name", return_value="Existing Berserk"),
+        patch.object(service.series_queries, "get_comic_for_import") as mock_get_comic,
+        patch.object(service.series_queries, "get_import_rows") as mock_get_rows,
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, None, "mal-123", comic_name="Berserk")
+
+    assert result == {
+        "success": True,
+        "matched": 0,
+        "imported": 0,
+        "comic_id": "mal-123",
+        "comic_name": "Existing Berserk",
+        "moved": 0,
+        "archived": 0,
+    }
+    mock_ensure_series.assert_not_called()
+    mock_get_comic.assert_not_called()
+    mock_get_rows.assert_not_called()
+    mock_match.assert_not_called()
+
+
 def test_match_import_adds_missing_mal_manga_before_finalizing_rows():
     with (
         patch.object(service.series_queries, "get_comic_name", return_value=None),
@@ -465,5 +496,49 @@ def test_match_import_missing_target_location_does_not_mark_row_imported(tmp_pat
     assert result["success"] is False
     assert "no library directory" in result["error"]
     assert source_file.exists()
+    mock_rescan.assert_not_called()
+    mock_match.assert_not_called()
+
+
+def test_match_import_target_file_location_does_not_mark_row_imported(tmp_path):
+    import_dir = tmp_path / "import" / "Berserk"
+    library_dir = tmp_path / "library"
+    import_dir.mkdir(parents=True)
+    library_dir.mkdir(parents=True)
+    source_file = import_dir / "chapter 1.cbz"
+    target_file = library_dir / "Berserk"
+    source_file.write_text("chapter")
+    target_file.write_text("not a directory")
+    config = SimpleNamespace(IMP_MOVE=False, IMP_RENAME=False, FILE_FORMAT="")
+
+    with (
+        patch.object(service.comicarr, "CONFIG", config),
+        patch.object(service.series_queries, "get_comic_name", return_value="Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": str(target_file)},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": str(source_file),
+                    "ComicFilename": "chapter 1.cbz",
+                    "IssueNumber": None,
+                }
+            ],
+        ),
+        patch("comicarr.updater.forceRescan") as mock_rescan,
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1"], "mal-123", comic_name="Berserk")
+
+    assert result["success"] is False
+    assert "not a directory" in result["error"]
+    assert source_file.exists()
+    assert target_file.is_file()
     mock_rescan.assert_not_called()
     mock_match.assert_not_called()


### PR DESCRIPTION
## Summary
Manual import matches now finalize the selected files before hiding the pending rows, so a matched manga file is moved into its library series directory or archived in place depending on `IMP_MOVE`, then rescanned before the import row is marked imported.

This keeps the `/api/import/match` request shape intact and leaves failed rows pending when the source file or target location is invalid.

Fixes https://github.com/frankieramirez/comicarr/issues/185.

## Validation
- `.venv/bin/python -m pytest tests/unit/test_series_import_matching.py tests/unit/test_importinbox.py`
- `.venv/bin/python -m ruff check comicarr/app/series/queries.py comicarr/app/series/service.py tests/unit/test_series_import_matching.py`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved comic import finalization with automatic file handling, including moving imported files or keeping them in place with a rescan.
  * Import results now include moved and archived counts for clearer feedback.

* **Bug Fixes**
  * Added stronger validation for missing import records, invalid source paths, missing files, and unavailable target folders.
  * Prevents imports from being marked complete when file operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->