### PR TITLE
fix: improve manga import review

### DIFF
--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -13,7 +13,7 @@ Series domain queries — comics, issues, annuals, importresults tables.
 Uses SQLAlchemy Core via the existing db module.
 """
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, or_, select
 
 from comicarr import db
 from comicarr.app.core.database import paginated_query  # noqa: F401 — re-exported
@@ -249,6 +249,11 @@ def get_wanted_annuals():
 def get_import_pending(limit=50, offset=0, include_ignored=False):
     """Get pending import files grouped by DynamicName/Volume with pagination."""
     ir = t_importresults
+    group_key_expr = func.coalesce(
+        func.nullif(ir.c.DynamicName, ""),
+        func.nullif(ir.c.ComicName, ""),
+        ir.c.impID,
+    )
 
     base_conds = [
         (ir.c.WatchMatch.is_(None)) | (ir.c.WatchMatch.like("C%")),
@@ -257,18 +262,36 @@ def get_import_pending(limit=50, offset=0, include_ignored=False):
     if not include_ignored:
         base_conds.append((ir.c.IgnoreFile.is_(None)) | (ir.c.IgnoreFile == 0))
 
-    # Count distinct groups
-    count_expr = func.count(func.distinct(func.concat(ir.c.DynamicName, func.coalesce(ir.c.Volume, ""))))
-    count_stmt = select(count_expr).where(*base_conds)
+    # Count distinct groups. New import-inbox rows always carry DynamicName;
+    # older rows fall back to ComicName so they remain reviewable.
+    group_count_subq = (
+        select(group_key_expr.label("GroupKey"), ir.c.Volume)
+        .where(*base_conds)
+        .group_by(group_key_expr, ir.c.Volume)
+    )
+    count_stmt = select(func.count()).select_from(group_count_subq.subquery())
+    file_count_stmt = select(func.count()).select_from(ir).where(*base_conds)
     with db.get_engine().connect() as conn:
         total = conn.execute(count_stmt).scalar() or 0
+        file_total = conn.execute(file_count_stmt).scalar() or 0
 
     # Get paginated groups
     group_stmt = (
-        select(ir, func.count().label("FileCount"))
+        select(
+            group_key_expr.label("GroupKey"),
+            func.min(ir.c.ComicName).label("ComicName"),
+            ir.c.Volume.label("Volume"),
+            func.min(ir.c.ComicYear).label("ComicYear"),
+            func.min(ir.c.Status).label("Status"),
+            func.min(ir.c.SRID).label("SRID"),
+            func.min(ir.c.ComicID).label("ComicID"),
+            func.min(ir.c.SuggestedComicID).label("SuggestedComicID"),
+            func.min(ir.c.SuggestedComicName).label("SuggestedComicName"),
+            func.count().label("FileCount"),
+        )
         .where(*base_conds)
-        .group_by(ir.c.DynamicName, ir.c.Volume)
-        .order_by(ir.c.ComicName)
+        .group_by(group_key_expr, ir.c.Volume)
+        .order_by(func.min(ir.c.ComicName))
         .limit(limit)
         .offset(offset)
     )
@@ -276,19 +299,19 @@ def get_import_pending(limit=50, offset=0, include_ignored=False):
 
     imports = []
     for result in results:
-        dynamic_name = result["DynamicName"]
+        dynamic_name = result["GroupKey"]
         volume = result["Volume"]
 
         # Get all files for this group
         file_conds = list(base_conds)
-        file_conds.append(ir.c.DynamicName == dynamic_name)
+        file_conds.append(group_key_expr == dynamic_name)
 
         if volume is None or volume == "None":
             file_conds.append((ir.c.Volume.is_(None)) | (ir.c.Volume == "None"))
         else:
             file_conds.append(ir.c.Volume == volume)
 
-        files = db.select_all(select(ir).where(*file_conds))
+        files = db.select_all(select(ir).where(*file_conds).order_by(ir.c.ComicFilename))
 
         file_list = []
         for f in files:
@@ -337,6 +360,10 @@ def get_import_pending(limit=50, offset=0, include_ignored=False):
             "offset": offset,
             "has_more": (offset + limit) < total,
         },
+        "summary": {
+            "group_count": total,
+            "file_count": file_total,
+        },
     }
 
 
@@ -345,6 +372,28 @@ def get_import_rows(imp_ids):
     if not imp_ids:
         return []
     return db.select_all(select(t_importresults).where(t_importresults.c.impID.in_(imp_ids)))
+
+
+def get_import_row(imp_id):
+    """Get one raw import row by impID."""
+    return db.select_one(select(t_importresults).where(t_importresults.c.impID == imp_id))
+
+
+def get_issue_id_for_import(comic_id, issue_number):
+    """Find an issue/chapter ID for a manual import row."""
+    if issue_number is None:
+        return None
+    issue_number = str(issue_number).strip()
+    if not issue_number or issue_number == "None":
+        return None
+
+    row = db.select_one(
+        select(t_issues.c.IssueID)
+        .where(t_issues.c.ComicID == comic_id)
+        .where(or_(t_issues.c.ChapterNumber == issue_number, t_issues.c.Issue_Number == issue_number))
+        .limit(1)
+    )
+    return row["IssueID"] if row else None
 
 
 def match_import(imp_id, comic_id, comic_name, issue_id=None):
@@ -365,6 +414,11 @@ def match_import(imp_id, comic_id, comic_name, issue_id=None):
         update_values["SuggestedIssueID"] = issue_id
 
     db.upsert("importresults", update_values, {"impID": imp_id})
+
+
+def update_import_issue_number(imp_id, issue_number):
+    """Update editable file-level import metadata."""
+    db.upsert("importresults", {"IssueNumber": issue_number}, {"impID": imp_id})
 
 
 def ignore_import(imp_id, ignore=True):

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -265,9 +265,7 @@ def get_import_pending(limit=50, offset=0, include_ignored=False):
     # Count distinct groups. New import-inbox rows always carry DynamicName;
     # older rows fall back to ComicName so they remain reviewable.
     group_count_subq = (
-        select(group_key_expr.label("GroupKey"), ir.c.Volume)
-        .where(*base_conds)
-        .group_by(group_key_expr, ir.c.Volume)
+        select(group_key_expr.label("GroupKey"), ir.c.Volume).where(*base_conds).group_by(group_key_expr, ir.c.Volume)
     )
     count_stmt = select(func.count()).select_from(group_count_subq.subquery())
     file_count_stmt = select(func.count()).select_from(ir).where(*base_conds)

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -13,7 +13,7 @@ Series domain queries — comics, issues, annuals, importresults tables.
 Uses SQLAlchemy Core via the existing db module.
 """
 
-from sqlalchemy import delete, func, or_, select
+from sqlalchemy import delete, func, select
 
 from comicarr import db
 from comicarr.app.core.database import paginated_query  # noqa: F401 — re-exported
@@ -388,7 +388,16 @@ def get_issue_id_for_import(comic_id, issue_number):
     row = db.select_one(
         select(t_issues.c.IssueID)
         .where(t_issues.c.ComicID == comic_id)
-        .where(or_(t_issues.c.ChapterNumber == issue_number, t_issues.c.Issue_Number == issue_number))
+        .where(t_issues.c.ChapterNumber == issue_number)
+        .limit(1)
+    )
+    if row:
+        return row["IssueID"]
+
+    row = db.select_one(
+        select(t_issues.c.IssueID)
+        .where(t_issues.c.ComicID == comic_id)
+        .where(t_issues.c.Issue_Number == issue_number)
         .limit(1)
     )
     return row["IssueID"] if row else None

--- a/comicarr/app/series/router.py
+++ b/comicarr/app/series/router.py
@@ -251,6 +251,31 @@ def match_import(
     return result
 
 
+@router.patch("/import/{imp_id}", dependencies=[Depends(require_session)])
+def update_import_metadata(
+    imp_id: str,
+    request_body: dict = None,
+    ctx: AppContext = Depends(get_context),
+):
+    """Update editable metadata for one pending import file."""
+    if request_body is None:
+        request_body = {}
+
+    if "issue_number" not in request_body:
+        return JSONResponse(status_code=400, content={"detail": "Missing issue_number"})
+
+    result = series_service.update_import_metadata(ctx, imp_id, request_body.get("issue_number"))
+    if not result.get("success"):
+        if result.get("not_found"):
+            status = 404
+        elif result.get("imported"):
+            status = 409
+        else:
+            status = 400
+        return JSONResponse(status_code=status, content={"detail": result.get("error")})
+    return result
+
+
 @router.post("/import/ignore", dependencies=[Depends(require_session)])
 def ignore_import(
     request_body: dict = None,

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -340,14 +340,17 @@ def _destination_for_import_row(row, comic_id, comic_name, comic_location, issue
     source_path = row.get("ComicLocation")
     original_filename = row.get("ComicFilename") or os.path.basename(source_path)
     destination_filename = original_filename
+    row_issue_id = row.get("_ResolvedIssueID") or issue_id
 
     if getattr(comicarr.CONFIG, "IMP_RENAME", False) and getattr(comicarr.CONFIG, "FILE_FORMAT", ""):
         issue_number = _issue_number_for_import(row)
-        if issue_number or issue_id:
+        if issue_number or row_issue_id:
             from comicarr import helpers
 
             try:
-                renameit = helpers.rename_param(comic_id, comic_name, issue_number, original_filename, issueid=issue_id)
+                renameit = helpers.rename_param(
+                    comic_id, comic_name, issue_number, original_filename, issueid=row_issue_id
+                )
             except Exception as e:
                 logger.fdebug(
                     "[IMPORT-MATCH] Could not rename import file %s, keeping original filename: %s" % (source_path, e)
@@ -372,7 +375,9 @@ def _move_plan_import_rows(rows, comic_id, comic_name, comic_location, issue_id=
 
     for row in rows:
         source_path = row.get("ComicLocation")
-        destination_path = _destination_for_import_row(row, comic_id, comic_name, comic_location, issue_id=issue_id)
+        destination_path = _destination_for_import_row(
+            row, comic_id, comic_name, comic_location, issue_id=row.get("_ResolvedIssueID") or issue_id
+        )
         if destination_path in destination_paths:
             return _import_error("Multiple import files resolve to the same destination: %s" % destination_path)
         if os.path.exists(destination_path):
@@ -466,6 +471,17 @@ def _finalize_import_rows(rows, comic_id, comic_name, comic_location, issue_id=N
     return _archive_import_rows(rows, comic_id)
 
 
+def _with_resolved_import_issue_ids(rows, comic_id, fallback_issue_id=None):
+    resolved_rows = []
+    for row in rows:
+        resolved_row = dict(row)
+        issue_number = _issue_number_for_import(resolved_row)
+        resolved_issue_id = series_queries.get_issue_id_for_import(comic_id, issue_number) if issue_number else None
+        resolved_row["_ResolvedIssueID"] = resolved_issue_id or fallback_issue_id
+        resolved_rows.append(resolved_row)
+    return resolved_rows
+
+
 def match_import(ctx, imp_ids, comic_id, comic_name=None, issue_id=None):
     """Manually match import files to a comic series."""
     clean_imp_ids = _clean_import_ids(imp_ids)
@@ -494,9 +510,10 @@ def match_import(ctx, imp_ids, comic_id, comic_name=None, issue_id=None):
     import_rows = _get_import_rows(clean_imp_ids)
     if not import_rows["success"]:
         return import_rows
+    rows = _with_resolved_import_issue_ids(import_rows["rows"], comic_id, fallback_issue_id=issue_id)
 
     finalized = _finalize_import_rows(
-        import_rows["rows"],
+        rows,
         comic_id,
         comic_name,
         comic_location,
@@ -506,8 +523,13 @@ def match_import(ctx, imp_ids, comic_id, comic_name=None, issue_id=None):
         return finalized
 
     matched = 0
-    for imp_id in clean_imp_ids:
-        series_queries.match_import(imp_id, comic_id, comic_name, issue_id=issue_id)
+    for row in rows:
+        series_queries.match_import(
+            row["impID"],
+            comic_id,
+            comic_name,
+            issue_id=row.get("_ResolvedIssueID") or issue_id,
+        )
         matched += 1
 
     return {
@@ -519,6 +541,25 @@ def match_import(ctx, imp_ids, comic_id, comic_name=None, issue_id=None):
         "moved": finalized.get("moved", 0),
         "archived": finalized.get("archived", 0),
     }
+
+
+def update_import_metadata(ctx, imp_id, issue_number):
+    """Update editable file-level metadata on a pending import row."""
+    if imp_id is None or not str(imp_id).strip():
+        return {"success": False, "error": "Missing impID"}
+    if issue_number is None or not str(issue_number).strip():
+        return {"success": False, "error": "Issue number cannot be blank"}
+
+    imp_id = str(imp_id).strip()
+    issue_number = str(issue_number).strip()
+    row = series_queries.get_import_row(imp_id)
+    if not row:
+        return {"success": False, "error": "Import record not found: %s" % imp_id, "not_found": True}
+    if row.get("Status") == "Imported":
+        return {"success": False, "error": "Imported records cannot be edited", "imported": True}
+
+    series_queries.update_import_issue_number(imp_id, issue_number)
+    return {"success": True, "imp_id": imp_id, "issue_number": issue_number}
 
 
 def ignore_import(ctx, imp_ids, ignore=True):

--- a/comicarr/importinbox.py
+++ b/comicarr/importinbox.py
@@ -177,7 +177,8 @@ def _collect_file_groups(import_dir):
             else:
                 # Use top-level directory name as group
                 group_name = rel_path.split(os.sep)[0]
-                group_key = "folder:%s" % normalize_title(group_name)
+                folder_path = os.path.join(import_dir, group_name)
+                group_key = "folder:%s" % _filepath_to_impid(folder_path)
 
             if group_key not in file_groups:
                 file_groups[group_key] = {"group_name": group_name, "files": []}

--- a/comicarr/importinbox.py
+++ b/comicarr/importinbox.py
@@ -30,7 +30,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from sqlalchemy import select
 
 import comicarr
-from comicarr import db, logger
+from comicarr import db, logger, manga_parser
 from comicarr.scanutil import COMIC_EXTENSIONS, name_similarity, normalize_title
 from comicarr.tables import comics
 
@@ -101,7 +101,7 @@ def inboxScan():
         # Step 1: Walk import directory and group files by parent folder
         file_groups = _collect_file_groups(import_dir)
 
-        total_files = sum(len(files) for files in file_groups.values())
+        total_files = sum(len(group_info["files"]) for group_info in file_groups.values())
         INBOX_SCAN_PROGRESS["total_files"] = total_files
         results["total_files"] = total_files
         logger.info("[IMPORT-INBOX] Found %d files in %d groups" % (total_files, len(file_groups)))
@@ -115,12 +115,13 @@ def inboxScan():
             # Step 3: Match each group against library series using ThreadPoolExecutor
             with ThreadPoolExecutor(max_workers=4) as executor:
                 futures = {}
-                for group_name, files in file_groups.items():
-                    future = executor.submit(_match_group, group_name, files, series_list)
-                    futures[future] = group_name
+                for group_key, group_info in file_groups.items():
+                    future = executor.submit(_match_group, group_key, group_info, series_list)
+                    futures[future] = group_key
 
                 for future in as_completed(futures):
-                    group_name = futures[future]
+                    group_key = futures[future]
+                    group_name = file_groups[group_key]["group_name"]
                     INBOX_SCAN_PROGRESS["current_group"] = group_name
 
                     try:
@@ -134,7 +135,7 @@ def inboxScan():
                         results["errors"].append({"group": group_name, "error": str(e)})
                         INBOX_SCAN_PROGRESS["errors"].append(str(e))
 
-                    INBOX_SCAN_PROGRESS["processed_files"] += len(file_groups[group_name])
+                    INBOX_SCAN_PROGRESS["processed_files"] += len(file_groups[group_key]["files"])
 
         logger.info(
             "[IMPORT-INBOX] Scan complete. Auto-imported: %d, Queued: %d"
@@ -156,7 +157,7 @@ def inboxScan():
 def _collect_file_groups(import_dir):
     """Walk import_dir and group comic files by parent directory.
 
-    Returns dict: {group_name: [filepath, ...]}
+    Returns dict: {group_key: {"group_name": str, "files": [filepath, ...]}}
     """
     file_groups = {}
 
@@ -170,14 +171,17 @@ def _collect_file_groups(import_dir):
 
             if rel_path == ".":
                 # Files directly in import_dir — each is its own group
-                group_name = os.path.splitext(filename)[0]
+                parsed = manga_parser.parse_manga_filename(filename)
+                group_name = parsed["series_name"] if parsed else os.path.splitext(filename)[0]
+                group_key = "file:%s" % _filepath_to_impid(filepath)
             else:
                 # Use top-level directory name as group
                 group_name = rel_path.split(os.sep)[0]
+                group_key = "folder:%s" % normalize_title(group_name)
 
-            if group_name not in file_groups:
-                file_groups[group_name] = []
-            file_groups[group_name].append(filepath)
+            if group_key not in file_groups:
+                file_groups[group_key] = {"group_name": group_name, "files": []}
+            file_groups[group_key]["files"].append(filepath)
 
     return file_groups
 
@@ -203,7 +207,7 @@ def _load_library_series():
     return series_list
 
 
-def _match_group(group_name, files, series_list):
+def _match_group(group_key, group_info, series_list):
     """Match a file group against library series.
 
     If best match >= AUTO_IMPORT_CONFIDENCE, auto-import all files.
@@ -212,6 +216,8 @@ def _match_group(group_name, files, series_list):
     Returns dict with auto_imported and queued_for_review counts.
     """
     result = {"auto_imported": 0, "queued_for_review": 0}
+    group_name = group_info["group_name"]
+    files = group_info["files"]
 
     best_match = None
     best_score = 0.0
@@ -258,7 +264,7 @@ def _match_group(group_name, files, series_list):
             % (group_name, suggested_name or "none", confidence)
         )
         for filepath in files:
-            _queue_for_review(filepath, group_name, suggested_id, suggested_name, confidence)
+            _queue_for_review(filepath, group_key, group_name, suggested_id, suggested_name, confidence)
             result["queued_for_review"] += 1
 
     return result
@@ -274,6 +280,7 @@ def _auto_import_file(filepath, series, confidence):
     filename = os.path.basename(filepath)
     imp_id = _filepath_to_impid(filepath)
     import_date = time.strftime("%Y-%m-%d %H:%M:%S")
+    chapter_number = _format_chapter_number(manga_parser.parse_manga_chapter_number(filename))
 
     db.upsert(
         "importresults",
@@ -289,6 +296,7 @@ def _auto_import_file(filepath, series, confidence):
             "SuggestedComicName": series.get("ComicName", ""),
             "MatchSource": "inbox",
             "DynamicName": series.get("DynamicName", ""),
+            "IssueNumber": chapter_number,
         },
         {"impID": imp_id},
     )
@@ -296,11 +304,13 @@ def _auto_import_file(filepath, series, confidence):
     logger.fdebug("[IMPORT-INBOX] Auto-imported: %s -> %s" % (filename, series.get("ComicName", "")))
 
 
-def _queue_for_review(filepath, group_name, suggested_id, suggested_name, confidence):
+def _queue_for_review(filepath, group_key, group_name, suggested_id, suggested_name, confidence):
     """Queue a file in importresults for manual review."""
     filename = os.path.basename(filepath)
     imp_id = _filepath_to_impid(filepath)
     import_date = time.strftime("%Y-%m-%d %H:%M:%S")
+    parsed = manga_parser.parse_manga_filename(filename, series_name=group_name)
+    chapter_number = _format_chapter_number(parsed["chapter_number"]) if parsed else None
 
     db.upsert(
         "importresults",
@@ -314,11 +324,22 @@ def _queue_for_review(filepath, group_name, suggested_id, suggested_name, confid
             "SuggestedComicID": suggested_id,
             "SuggestedComicName": suggested_name,
             "MatchSource": "inbox",
+            "DynamicName": group_key,
+            "IssueNumber": chapter_number,
         },
         {"impID": imp_id},
     )
 
     logger.fdebug("[IMPORT-INBOX] Queued for review: %s" % filename)
+
+
+def _format_chapter_number(chapter_number):
+    """Format parsed chapter numbers for importresults.IssueNumber."""
+    if chapter_number is None:
+        return None
+    if float(chapter_number).is_integer():
+        return str(int(chapter_number))
+    return str(chapter_number)
 
 
 def run():

--- a/comicarr/manga_parser.py
+++ b/comicarr/manga_parser.py
@@ -28,6 +28,7 @@ Handles common naming conventions found in manga libraries:
     Title Vol.01 Ch.001.cbz
     Title 001.cbz              (bare number = chapter)
     Title v01.cbz              (volume only)
+    chapter 001.cbz            (when series_name is supplied)
 """
 
 import os
@@ -97,6 +98,18 @@ _PAT_BARE_NUMBER = re.compile(
     r"\s*$",
 )
 
+# Folder-context patterns. These infer the chapter from filenames that omit the
+# series title because the parent folder carries it.
+_PAT_CHAPTER_ONLY_LABEL = re.compile(
+    r"^(?:[Cc]h(?:apter)?\.?)\s*(?P<chapter>\d+(?:\.\d+)?)"
+    r"\s*$",
+)
+
+_PAT_CHAPTER_ONLY_NUMBER = re.compile(
+    r"^(?P<chapter>\d+(?:\.\d+)?)"
+    r"\s*$",
+)
+
 # Ordered list — first match wins.
 _PATTERNS = [
     _PAT_GROUP_FULL,
@@ -109,11 +122,14 @@ _PATTERNS = [
 ]
 
 
-def parse_manga_filename(filename):
+def parse_manga_filename(filename, series_name=None):
     """Parse a manga filename and return extracted metadata.
 
     Args:
         filename: The filename (with or without directory path) to parse.
+        series_name: Optional folder-derived series name. When supplied, the
+            parser can infer chapter-only names like ``chapter 1.cbz`` without
+            replacing the caller's series name.
 
     Returns:
         A dict with keys ``series_name``, ``chapter_number`` (float or None),
@@ -133,13 +149,72 @@ def parse_manga_filename(filename):
     if not stem or len(stem) > 512:
         return None
 
+    chapter_only = _parse_chapter_only_stem(stem)
+    if chapter_only is not None:
+        if not series_name:
+            return None
+        return _build_context_result(series_name, chapter_only)
+
     for pattern in _PATTERNS:
         m = pattern.match(stem)
         if m:
             return _build_result(m)
 
+    if series_name:
+        chapter = parse_manga_chapter_number(filename)
+        if chapter is not None:
+            return {
+                "series_name": str(series_name).strip(),
+                "chapter_number": chapter,
+                "volume_number": None,
+                "group": None,
+                "quality": None,
+            }
+
     # No pattern matched — unparseable.
     return None
+
+
+def parse_manga_chapter_number(filename):
+    """Return an inferred chapter number from a manga filename, or None."""
+    basename = os.path.basename(filename)
+    stem, ext = os.path.splitext(basename)
+    if ext.lower() not in VALID_EXTENSIONS:
+        return None
+
+    stem = stem.strip()
+    if not stem or len(stem) > 512:
+        return None
+
+    for pattern in _PATTERNS:
+        m = pattern.match(stem)
+        if m:
+            groups = m.groupdict()
+            return _to_chapter_number(groups.get("chapter"))
+
+    return _parse_chapter_only_stem(stem)
+
+
+def _parse_chapter_only_stem(stem):
+    """Parse chapter-only filename stems."""
+    for pattern in (_PAT_CHAPTER_ONLY_LABEL, _PAT_CHAPTER_ONLY_NUMBER):
+        m = pattern.match(stem)
+        if m:
+            return _to_chapter_number(m.group("chapter"))
+    return None
+
+
+def _build_context_result(series_name, chapter):
+    series = str(series_name).strip()
+    if not series:
+        return None
+    return {
+        "series_name": series,
+        "chapter_number": chapter,
+        "volume_number": None,
+        "group": None,
+        "quality": None,
+    }
 
 
 def _build_result(match):

--- a/frontend/src/components/import/ImportBulkActions.tsx
+++ b/frontend/src/components/import/ImportBulkActions.tsx
@@ -1,8 +1,15 @@
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { EyeOff, Eye, Trash2, X } from "lucide-react";
 
 interface ImportBulkActionsProps {
-  selectedCount: number;
+  selectedFileCount: number;
+  selectedGroupCount: number;
   onIgnore: () => void;
   onUnignore: () => void;
   onDelete: () => void;
@@ -12,7 +19,8 @@ interface ImportBulkActionsProps {
 }
 
 export default function ImportBulkActions({
-  selectedCount,
+  selectedFileCount,
+  selectedGroupCount,
   onIgnore,
   onUnignore,
   onDelete,
@@ -20,59 +28,85 @@ export default function ImportBulkActions({
   isLoading = false,
   showUnignore = false,
 }: ImportBulkActionsProps) {
-  if (selectedCount === 0) return null;
+  if (selectedFileCount === 0) return null;
+
+  const groupLabel = selectedGroupCount === 1 ? "group" : "groups";
+  const fileLabel = selectedFileCount === 1 ? "file" : "files";
 
   return (
     <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-in slide-in-from-bottom-4 duration-200">
       <div className="bg-card border border-card-border rounded-lg shadow-lg px-4 py-3 flex items-center gap-4">
         <span className="text-sm font-medium text-foreground">
-          {selectedCount} selected
+          {selectedGroupCount} {groupLabel} · {selectedFileCount} {fileLabel} selected
         </span>
 
         <div className="h-4 w-px bg-border" />
 
-        <div className="flex items-center gap-2">
-          {showUnignore ? (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={onUnignore}
-              disabled={isLoading}
-            >
-              <Eye className="w-4 h-4 mr-1" />
-              Unignore
-            </Button>
-          ) : (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={onIgnore}
-              disabled={isLoading}
-            >
-              <EyeOff className="w-4 h-4 mr-1" />
-              Ignore
-            </Button>
-          )}
+        <TooltipProvider delayDuration={150}>
+          <div className="flex items-center gap-2">
+            {showUnignore ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={onUnignore}
+                    disabled={isLoading}
+                  >
+                    <Eye className="w-4 h-4 mr-1" />
+                    Unignore
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Unignore selected import files</TooltipContent>
+              </Tooltip>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={onIgnore}
+                    disabled={isLoading}
+                  >
+                    <EyeOff className="w-4 h-4 mr-1" />
+                    Ignore
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Ignore selected import files</TooltipContent>
+              </Tooltip>
+            )}
 
-          <Button
-            size="sm"
-            variant="destructive"
-            onClick={onDelete}
-            disabled={isLoading}
-          >
-            <Trash2 className="w-4 h-4 mr-1" />
-            Delete
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={onDelete}
+                disabled={isLoading}
+              >
+                <Trash2 className="w-4 h-4 mr-1" />
+                Delete
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Delete selected import records</TooltipContent>
+          </Tooltip>
 
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onClear}
-            disabled={isLoading}
-          >
-            <X className="w-4 h-4" />
-          </Button>
-        </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={onClear}
+                disabled={isLoading}
+                aria-label="Clear selected imports"
+              >
+                <X className="w-4 h-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Clear selection</TooltipContent>
+          </Tooltip>
+          </div>
+        </TooltipProvider>
       </div>
     </div>
   );

--- a/frontend/src/components/import/ImportBulkActions.tsx
+++ b/frontend/src/components/import/ImportBulkActions.tsx
@@ -37,7 +37,8 @@ export default function ImportBulkActions({
     <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 animate-in slide-in-from-bottom-4 duration-200">
       <div className="bg-card border border-card-border rounded-lg shadow-lg px-4 py-3 flex items-center gap-4">
         <span className="text-sm font-medium text-foreground">
-          {selectedGroupCount} {groupLabel} · {selectedFileCount} {fileLabel} selected
+          {selectedGroupCount} {groupLabel} · {selectedFileCount} {fileLabel}{" "}
+          selected
         </span>
 
         <div className="h-4 w-px bg-border" />
@@ -76,35 +77,35 @@ export default function ImportBulkActions({
               </Tooltip>
             )}
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                size="sm"
-                variant="destructive"
-                onClick={onDelete}
-                disabled={isLoading}
-              >
-                <Trash2 className="w-4 h-4 mr-1" />
-                Delete
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Delete selected import records</TooltipContent>
-          </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={onDelete}
+                  disabled={isLoading}
+                >
+                  <Trash2 className="w-4 h-4 mr-1" />
+                  Delete
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Delete selected import records</TooltipContent>
+            </Tooltip>
 
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={onClear}
-                disabled={isLoading}
-                aria-label="Clear selected imports"
-              >
-                <X className="w-4 h-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Clear selection</TooltipContent>
-          </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={onClear}
+                  disabled={isLoading}
+                  aria-label="Clear selected imports"
+                >
+                  <X className="w-4 h-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Clear selection</TooltipContent>
+            </Tooltip>
           </div>
         </TooltipProvider>
       </div>

--- a/frontend/src/components/import/ImportTable.tsx
+++ b/frontend/src/components/import/ImportTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   useReactTable,
   getCoreRowModel,
@@ -43,6 +43,29 @@ const columnHelper = createColumnHelper<ImportGroup>();
 
 function getImportGroupRowId(row: ImportGroup): string {
   return `${row.DynamicName}-${row.Volume || "null"}`;
+}
+
+function getSelectedImportIds(
+  imports: ImportGroup[],
+  selection: RowSelectionState,
+): { selectedIds: string[]; selectedGroupIds: string[] } {
+  const selectedIds: string[] = [];
+  const selectedGroupIds: string[] = [];
+
+  Object.keys(selection).forEach((rowId) => {
+    if (!selection[rowId]) {
+      return;
+    }
+    const group = imports.find(
+      (importGroup) => getImportGroupRowId(importGroup) === rowId,
+    );
+    if (group?.files) {
+      selectedGroupIds.push(rowId);
+      group.files.forEach((file) => selectedIds.push(file.impID));
+    }
+  });
+
+  return { selectedIds, selectedGroupIds };
 }
 
 interface ImportTableProps {
@@ -98,8 +121,11 @@ function FileRow({
   isMetadataSaving?: boolean;
 }) {
   const [issueNumber, setIssueNumber] = useState(file.IssueNumber ?? "");
+  const [savedIssueNumber, setSavedIssueNumber] = useState(
+    file.IssueNumber ?? "",
+  );
   const [saveState, setSaveState] = useState<SaveState>("idle");
-  const currentIssueNumber = file.IssueNumber ?? "";
+  const skipNextBlurSaveRef = useRef(false);
   const hasMatchMetadata = Boolean(
     file.SuggestedComicName ||
     file.SuggestedComicID ||
@@ -108,8 +134,8 @@ function FileRow({
 
   const saveIssueNumber = async () => {
     const nextIssueNumber = issueNumber.trim();
-    if (nextIssueNumber === currentIssueNumber) {
-      setIssueNumber(currentIssueNumber);
+    if (nextIssueNumber === savedIssueNumber) {
+      setIssueNumber(savedIssueNumber);
       setSaveState("idle");
       return;
     }
@@ -120,6 +146,7 @@ function FileRow({
     try {
       setSaveState("saving");
       await onIssueNumberChange?.(file, nextIssueNumber);
+      setSavedIssueNumber(nextIssueNumber);
       setIssueNumber(nextIssueNumber);
       setSaveState("saved");
     } catch {
@@ -152,17 +179,24 @@ function FileRow({
             const nextValue = event.target.value;
             setIssueNumber(nextValue);
             setSaveState(
-              nextValue.trim() === currentIssueNumber ? "idle" : "dirty",
+              nextValue.trim() === savedIssueNumber ? "idle" : "dirty",
             );
           }}
-          onBlur={saveIssueNumber}
+          onBlur={() => {
+            if (skipNextBlurSaveRef.current) {
+              skipNextBlurSaveRef.current = false;
+              return;
+            }
+            void saveIssueNumber();
+          }}
           onKeyDown={(event) => {
             if (event.key === "Enter") {
               event.preventDefault();
               void saveIssueNumber();
             }
             if (event.key === "Escape") {
-              setIssueNumber(currentIssueNumber);
+              skipNextBlurSaveRef.current = true;
+              setIssueNumber(savedIssueNumber);
               setSaveState("idle");
               event.currentTarget.blur();
             }
@@ -222,6 +256,30 @@ export default function ImportTable({
 }: ImportTableProps) {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [expanded, setExpanded] = useState<ExpandedState>({});
+  const lastSelectionKeyRef = useRef(JSON.stringify([[], []]));
+
+  const emitSelectionChange = useCallback(
+    (selection: RowSelectionState) => {
+      if (!onSelectionChange) {
+        return;
+      }
+      const { selectedIds, selectedGroupIds } = getSelectedImportIds(
+        imports,
+        selection,
+      );
+      const selectionKey = JSON.stringify([selectedIds, selectedGroupIds]);
+      if (lastSelectionKeyRef.current === selectionKey) {
+        return;
+      }
+      lastSelectionKeyRef.current = selectionKey;
+      onSelectionChange(selectedIds, selectedGroupIds);
+    },
+    [imports, onSelectionChange],
+  );
+
+  useEffect(() => {
+    emitSelectionChange(rowSelection);
+  }, [emitSelectionChange, rowSelection]);
 
   const columns = useMemo(
     () => [
@@ -443,26 +501,10 @@ export default function ImportTable({
     columns,
     state: { rowSelection, expanded },
     onRowSelectionChange: (updater: Updater<RowSelectionState>) => {
-      setRowSelection(updater);
-      if (onSelectionChange) {
-        const newSelection =
-          typeof updater === "function" ? updater(rowSelection) : updater;
-        const selectedIds: string[] = [];
-        const selectedGroupIds: string[] = [];
-        Object.keys(newSelection).forEach((rowId) => {
-          if (!newSelection[rowId]) {
-            return;
-          }
-          const group = imports.find(
-            (importGroup) => getImportGroupRowId(importGroup) === rowId,
-          );
-          if (group?.files) {
-            selectedGroupIds.push(rowId);
-            group.files.forEach((file) => selectedIds.push(file.impID));
-          }
-        });
-        onSelectionChange(selectedIds, selectedGroupIds);
-      }
+      const newSelection =
+        typeof updater === "function" ? updater(rowSelection) : updater;
+      setRowSelection(newSelection);
+      emitSelectionChange(newSelection);
     },
     onExpandedChange: setExpanded,
     getCoreRowModel: getCoreRowModel(),

--- a/frontend/src/components/import/ImportTable.tsx
+++ b/frontend/src/components/import/ImportTable.tsx
@@ -50,11 +50,17 @@ interface ImportTableProps {
   pagination?: PaginationMeta;
   onNextPage?: () => void;
   onPrevPage?: () => void;
-  onSelectionChange?: (selectedIds: string[], selectedGroupIds: string[]) => void;
+  onSelectionChange?: (
+    selectedIds: string[],
+    selectedGroupIds: string[],
+  ) => void;
   onMatchClick?: (group: ImportGroup) => void;
   onIgnoreClick?: (group: ImportGroup, ignore: boolean) => void;
   onDeleteClick?: (group: ImportGroup) => void;
-  onIssueNumberChange?: (file: ImportFile, issueNumber: string) => Promise<void>;
+  onIssueNumberChange?: (
+    file: ImportFile,
+    issueNumber: string,
+  ) => Promise<void>;
   isActionLoading?: boolean;
   isMetadataSaving?: boolean;
 }
@@ -85,14 +91,19 @@ function FileRow({
 }: {
   file: ImportFile;
   label: string;
-  onIssueNumberChange?: (file: ImportFile, issueNumber: string) => Promise<void>;
+  onIssueNumberChange?: (
+    file: ImportFile,
+    issueNumber: string,
+  ) => Promise<void>;
   isMetadataSaving?: boolean;
 }) {
   const [issueNumber, setIssueNumber] = useState(file.IssueNumber ?? "");
   const [saveState, setSaveState] = useState<SaveState>("idle");
   const currentIssueNumber = file.IssueNumber ?? "";
   const hasMatchMetadata = Boolean(
-    file.SuggestedComicName || file.SuggestedComicID || file.MatchConfidence != null,
+    file.SuggestedComicName ||
+    file.SuggestedComicID ||
+    file.MatchConfidence != null,
   );
 
   const saveIssueNumber = async () => {
@@ -134,7 +145,9 @@ function FileRow({
           aria-label={`${label} for ${file.ComicFilename}`}
           value={issueNumber}
           placeholder="Unknown"
-          disabled={isMetadataSaving || !onIssueNumberChange || saveState === "saving"}
+          disabled={
+            isMetadataSaving || !onIssueNumberChange || saveState === "saving"
+          }
           onChange={(event) => {
             const nextValue = event.target.value;
             setIssueNumber(nextValue);
@@ -170,10 +183,14 @@ function FileRow({
       {hasMatchMetadata && (
         <div className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground sm:col-span-3 md:pl-8">
           {file.SuggestedComicName && (
-            <span className="truncate">Suggested: {file.SuggestedComicName}</span>
+            <span className="truncate">
+              Suggested: {file.SuggestedComicName}
+            </span>
           )}
           {file.SuggestedComicID && !file.SuggestedComicName && (
-            <span className="truncate">Suggested ID: {file.SuggestedComicID}</span>
+            <span className="truncate">
+              Suggested ID: {file.SuggestedComicID}
+            </span>
           )}
           {file.MatchConfidence != null && (
             <ConfidenceBadge confidence={file.MatchConfidence} />
@@ -297,7 +314,10 @@ export default function ImportTable({
       columnHelper.accessor("MatchConfidence", {
         header: "Confidence",
         cell: ({ row, getValue }) => {
-          if (!row.original.SuggestedComicID && !row.original.SuggestedComicName) {
+          if (
+            !row.original.SuggestedComicID &&
+            !row.original.SuggestedComicName
+          ) {
             return (
               <span className="text-xs text-muted-foreground/70">
                 No suggestion

--- a/frontend/src/components/import/ImportTable.tsx
+++ b/frontend/src/components/import/ImportTable.tsx
@@ -19,44 +19,170 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import StatusBadge from "@/components/StatusBadge";
 import EmptyState from "@/components/ui/EmptyState";
 import ConfidenceBadge from "./ConfidenceBadge";
 import { DataTable } from "@/components/data-table/DataTable";
 import { DataTableServerPagination } from "@/components/data-table/DataTableServerPagination";
 import { TableCell, TableRow } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import {
+  getImportGroupTypeLabel,
+  getImportIssueLabel,
+} from "@/lib/importUtils";
 import type { ImportGroup, ImportFile, PaginationMeta } from "@/types";
 
 const columnHelper = createColumnHelper<ImportGroup>();
+
+function getImportGroupRowId(row: ImportGroup): string {
+  return `${row.DynamicName}-${row.Volume || "null"}`;
+}
 
 interface ImportTableProps {
   imports?: ImportGroup[];
   pagination?: PaginationMeta;
   onNextPage?: () => void;
   onPrevPage?: () => void;
-  onSelectionChange?: (selectedIds: string[]) => void;
+  onSelectionChange?: (selectedIds: string[], selectedGroupIds: string[]) => void;
   onMatchClick?: (group: ImportGroup) => void;
   onIgnoreClick?: (group: ImportGroup, ignore: boolean) => void;
   onDeleteClick?: (group: ImportGroup) => void;
+  onIssueNumberChange?: (file: ImportFile, issueNumber: string) => Promise<void>;
   isActionLoading?: boolean;
+  isMetadataSaving?: boolean;
 }
 
-function FileRow({ file }: { file: ImportFile }) {
+type SaveState = "idle" | "dirty" | "saving" | "saved" | "error" | "required";
+
+function FileSaveState({ state }: { state: SaveState }) {
+  if (state === "saving") {
+    return <span className="text-muted-foreground">Saving...</span>;
+  }
+  if (state === "saved") {
+    return <span className="text-success">Saved</span>;
+  }
+  if (state === "error") {
+    return <span className="text-destructive">Save failed</span>;
+  }
+  if (state === "required") {
+    return <span className="text-destructive">Required</span>;
+  }
+  return null;
+}
+
+function FileRow({
+  file,
+  label,
+  onIssueNumberChange,
+  isMetadataSaving = false,
+}: {
+  file: ImportFile;
+  label: string;
+  onIssueNumberChange?: (file: ImportFile, issueNumber: string) => Promise<void>;
+  isMetadataSaving?: boolean;
+}) {
+  const [issueNumber, setIssueNumber] = useState(file.IssueNumber ?? "");
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const currentIssueNumber = file.IssueNumber ?? "";
+  const hasMatchMetadata = Boolean(
+    file.SuggestedComicName || file.SuggestedComicID || file.MatchConfidence != null,
+  );
+
+  const saveIssueNumber = async () => {
+    const nextIssueNumber = issueNumber.trim();
+    if (nextIssueNumber === currentIssueNumber) {
+      setIssueNumber(currentIssueNumber);
+      setSaveState("idle");
+      return;
+    }
+    if (!nextIssueNumber) {
+      setSaveState("required");
+      return;
+    }
+    try {
+      setSaveState("saving");
+      await onIssueNumberChange?.(file, nextIssueNumber);
+      setIssueNumber(nextIssueNumber);
+      setSaveState("saved");
+    } catch {
+      setSaveState("error");
+    }
+  };
+
   return (
-    <div className="flex items-center gap-4 py-2 px-6 text-sm bg-muted/30 border-t border-card-border">
-      <FileText className="w-4 h-4 text-muted-foreground flex-shrink-0 ml-8" />
-      <span
-        className="font-mono text-xs truncate flex-1"
-        title={file.ComicFilename}
-      >
-        {file.ComicFilename}
-      </span>
-      {file.IssueNumber && (
-        <span className="text-muted-foreground">#{file.IssueNumber}</span>
+    <div className="grid grid-cols-1 gap-2 border-t border-card-border bg-muted/20 px-4 py-3 text-sm sm:grid-cols-[minmax(0,1fr)_minmax(8rem,10rem)_minmax(5rem,7rem)] sm:items-center md:px-6">
+      <div className="flex min-w-0 items-center gap-2 md:pl-8">
+        <FileText className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+        <span
+          className="font-mono text-xs truncate min-w-0"
+          title={file.ComicFilename}
+        >
+          {file.ComicFilename}
+        </span>
+      </div>
+
+      <label className="grid gap-1 text-xs text-muted-foreground sm:max-w-[10rem]">
+        <span className="font-mono uppercase tracking-wider">{label}</span>
+        <Input
+          aria-label={`${label} for ${file.ComicFilename}`}
+          value={issueNumber}
+          placeholder="Unknown"
+          disabled={isMetadataSaving || !onIssueNumberChange || saveState === "saving"}
+          onChange={(event) => {
+            const nextValue = event.target.value;
+            setIssueNumber(nextValue);
+            setSaveState(
+              nextValue.trim() === currentIssueNumber ? "idle" : "dirty",
+            );
+          }}
+          onBlur={saveIssueNumber}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              void saveIssueNumber();
+            }
+            if (event.key === "Escape") {
+              setIssueNumber(currentIssueNumber);
+              setSaveState("idle");
+              event.currentTarget.blur();
+            }
+          }}
+          className={cn(
+            "h-8 w-full border-card-border bg-background/80 px-2 py-0 font-mono text-xs focus-visible:ring-primary",
+            saveState === "dirty" && "border-primary/60",
+            (saveState === "error" || saveState === "required") &&
+              "border-destructive focus-visible:ring-destructive",
+          )}
+        />
+      </label>
+
+      <div className="min-h-5 text-xs sm:text-right">
+        <FileSaveState state={saveState} />
+      </div>
+
+      {hasMatchMetadata && (
+        <div className="flex min-w-0 flex-wrap items-center gap-2 text-xs text-muted-foreground sm:col-span-3 md:pl-8">
+          {file.SuggestedComicName && (
+            <span className="truncate">Suggested: {file.SuggestedComicName}</span>
+          )}
+          {file.SuggestedComicID && !file.SuggestedComicName && (
+            <span className="truncate">Suggested ID: {file.SuggestedComicID}</span>
+          )}
+          {file.MatchConfidence != null && (
+            <ConfidenceBadge confidence={file.MatchConfidence} />
+          )}
+        </div>
       )}
-      <ConfidenceBadge confidence={file.MatchConfidence} />
+
       {file.IgnoreFile === 1 && (
-        <span className="text-xs bg-gray-500/20 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded">
+        <span className="text-xs bg-gray-500/20 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded sm:col-span-3 md:ml-8 w-fit">
           Ignored
         </span>
       )}
@@ -73,7 +199,9 @@ export default function ImportTable({
   onMatchClick,
   onIgnoreClick,
   onDeleteClick,
+  onIssueNumberChange,
   isActionLoading = false,
+  isMetadataSaving = false,
 }: ImportTableProps) {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [expanded, setExpanded] = useState<ExpandedState>({});
@@ -106,19 +234,31 @@ export default function ImportTable({
         cell: ({ row }) => {
           const canExpand = row.original.files && row.original.files.length > 0;
           return canExpand ? (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                row.toggleExpanded();
-              }}
-              className="p-1 hover:bg-muted rounded"
-            >
-              {row.getIsExpanded() ? (
-                <ChevronDown className="w-4 h-4" />
-              ) : (
-                <ChevronRight className="w-4 h-4" />
-              )}
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  aria-label={
+                    row.getIsExpanded()
+                      ? "Collapse import files"
+                      : "Expand import files"
+                  }
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    row.toggleExpanded();
+                  }}
+                  className="p-1 hover:bg-muted rounded"
+                >
+                  {row.getIsExpanded() ? (
+                    <ChevronDown className="w-4 h-4" />
+                  ) : (
+                    <ChevronRight className="w-4 h-4" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {row.getIsExpanded() ? "Collapse files" : "Review files"}
+              </TooltipContent>
+            </Tooltip>
           ) : null;
         },
         size: 40,
@@ -128,6 +268,11 @@ export default function ImportTable({
         cell: ({ row }) => (
           <div>
             <div className="font-medium">{row.original.ComicName}</div>
+            <div className="mt-1">
+              <span className="inline-flex items-center rounded border border-border/70 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                {getImportGroupTypeLabel(row.original)}
+              </span>
+            </div>
             {row.original.Volume && (
               <div className="text-sm text-muted-foreground">
                 Volume {row.original.Volume}
@@ -151,9 +296,17 @@ export default function ImportTable({
       }),
       columnHelper.accessor("MatchConfidence", {
         header: "Confidence",
-        cell: ({ getValue }) => (
-          <ConfidenceBadge confidence={getValue() ?? null} />
-        ),
+        cell: ({ row, getValue }) => {
+          if (!row.original.SuggestedComicID && !row.original.SuggestedComicName) {
+            return (
+              <span className="text-xs text-muted-foreground/70">
+                No suggestion
+              </span>
+            );
+          }
+
+          return <ConfidenceBadge confidence={getValue() ?? null} />;
+        },
         enableSorting: false,
       }),
       columnHelper.accessor("SuggestedComicName", {
@@ -197,53 +350,66 @@ export default function ImportTable({
 
           return (
             <div className="flex items-center gap-1">
-              <Button
-                size="icon"
-                variant="outline"
-                aria-label="Match import"
-                title="Match import"
-                disabled={isActionLoading}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onMatchClick?.(row.original);
-                }}
-              >
-                <Link2 className="w-4 h-4" />
-                <span className="sr-only">Match</span>
-              </Button>
-              <Button
-                size="icon"
-                variant="outline"
-                aria-label={ignoreLabel}
-                title={ignoreLabel}
-                disabled={isActionLoading}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onIgnoreClick?.(row.original, !allIgnored);
-                }}
-              >
-                {allIgnored ? (
-                  <Eye className="w-4 h-4" />
-                ) : (
-                  <EyeOff className="w-4 h-4" />
-                )}
-                <span className="sr-only">{ignoreLabel}</span>
-              </Button>
-              <Button
-                size="icon"
-                variant="ghost"
-                aria-label="Delete import record"
-                title="Delete import record"
-                disabled={isActionLoading}
-                className="text-destructive hover:text-destructive"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDeleteClick?.(row.original);
-                }}
-              >
-                <Trash2 className="w-4 h-4" />
-                <span className="sr-only">Delete</span>
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    aria-label="Match import"
+                    disabled={isActionLoading}
+                    className="h-8 px-2"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onMatchClick?.(row.original);
+                    }}
+                  >
+                    <Link2 className="w-4 h-4" />
+                    Match
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Match this review group</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="outline"
+                    aria-label={ignoreLabel}
+                    disabled={isActionLoading}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onIgnoreClick?.(row.original, !allIgnored);
+                    }}
+                  >
+                    {allIgnored ? (
+                      <Eye className="w-4 h-4" />
+                    ) : (
+                      <EyeOff className="w-4 h-4" />
+                    )}
+                    <span className="sr-only">{ignoreLabel}</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{ignoreLabel}</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    aria-label="Delete import record"
+                    disabled={isActionLoading}
+                    className="text-destructive hover:text-destructive"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDeleteClick?.(row.original);
+                    }}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                    <span className="sr-only">Delete</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Delete import record</TooltipContent>
+              </Tooltip>
             </div>
           );
         },
@@ -262,19 +428,26 @@ export default function ImportTable({
         const newSelection =
           typeof updater === "function" ? updater(rowSelection) : updater;
         const selectedIds: string[] = [];
-        Object.keys(newSelection).forEach((index) => {
-          const group = imports[parseInt(index)];
+        const selectedGroupIds: string[] = [];
+        Object.keys(newSelection).forEach((rowId) => {
+          if (!newSelection[rowId]) {
+            return;
+          }
+          const group = imports.find(
+            (importGroup) => getImportGroupRowId(importGroup) === rowId,
+          );
           if (group?.files) {
+            selectedGroupIds.push(rowId);
             group.files.forEach((file) => selectedIds.push(file.impID));
           }
         });
-        onSelectionChange(selectedIds);
+        onSelectionChange(selectedIds, selectedGroupIds);
       }
     },
     onExpandedChange: setExpanded,
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
-    getRowId: (row) => `${row.DynamicName}-${row.Volume || "null"}`,
+    getRowId: getImportGroupRowId,
     enableRowSelection: true,
     getRowCanExpand: (row) =>
       !!(row.original.files && row.original.files.length > 0),
@@ -291,9 +464,10 @@ export default function ImportTable({
   }
 
   return (
-    <div>
+    <TooltipProvider delayDuration={150}>
       <DataTable
         table={table}
+        className="overflow-x-auto"
         onRowClick={(row) => {
           const tableRow = table
             .getRowModel()
@@ -306,7 +480,13 @@ export default function ImportTable({
               <TableCell colSpan={colSpan} className="p-0">
                 <div className="bg-muted/20">
                   {row.original.files.map((file) => (
-                    <FileRow key={file.impID} file={file} />
+                    <FileRow
+                      key={`${file.impID}-${file.IssueNumber ?? ""}`}
+                      file={file}
+                      label={getImportIssueLabel(row.original)}
+                      onIssueNumberChange={onIssueNumberChange}
+                      isMetadataSaving={isMetadataSaving}
+                    />
                   ))}
                 </div>
               </TableCell>
@@ -321,6 +501,6 @@ export default function ImportTable({
           onPrevPage={onPrevPage}
         />
       )}
-    </div>
+    </TooltipProvider>
   );
 }

--- a/frontend/src/components/import/MatchModal.tsx
+++ b/frontend/src/components/import/MatchModal.tsx
@@ -4,7 +4,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useSearchComics, useSearchManga } from "@/hooks/useSearch";
 import { useContentSources } from "@/hooks/useContentSources";
-import { detectImportSearchMode } from "@/lib/importUtils";
+import {
+  detectImportSearchMode,
+  getImportGroupTypeLabel,
+  getImportIssueRange,
+} from "@/lib/importUtils";
 import type { ImportGroup, SearchResult } from "@/types";
 
 interface MatchModalProps {
@@ -57,6 +61,14 @@ function MatchModalContent({
     searchMode === "manga"
       ? "Search for a manga series..."
       : "Search for a comic series...";
+  const fileCount = importGroup?.FileCount ?? importGroup?.files.length ?? 0;
+  const matchContext = importGroup
+    ? [
+        getImportGroupTypeLabel(importGroup),
+        `${fileCount} file${fileCount === 1 ? "" : "s"}`,
+        getImportIssueRange(importGroup),
+      ].filter(Boolean)
+    : [];
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -77,8 +89,7 @@ function MatchModalContent({
                 {importGroup.ComicName}
                 {importGroup.Volume && ` (${importGroup.Volume})`}
                 {" - "}
-                {importGroup.FileCount} file
-                {importGroup.FileCount !== 1 ? "s" : ""}
+                {matchContext.join(" | ")}
               </p>
             )}
           </div>

--- a/frontend/src/hooks/useImport.ts
+++ b/frontend/src/hooks/useImport.ts
@@ -6,11 +6,17 @@ import {
   type UseMutationResult,
 } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/api";
-import type { ImportGroup, PaginationMeta, ScanProgress } from "@/types";
+import type {
+  ImportGroup,
+  ImportPendingSummary,
+  PaginationMeta,
+  ScanProgress,
+} from "@/types";
 
 interface ImportPendingResponse {
   imports: ImportGroup[];
   pagination: PaginationMeta;
+  summary?: ImportPendingSummary;
 }
 
 interface MatchImportResponse {
@@ -28,6 +34,12 @@ interface IgnoreImportResponse {
 
 interface DeleteImportResponse {
   deleted: number;
+}
+
+interface UpdateImportMetadataResponse {
+  success: boolean;
+  imp_id: string;
+  issue_number: string;
 }
 
 interface RefreshImportResponse {
@@ -101,6 +113,23 @@ export function useDeleteImport(): UseMutationResult<
     mutationFn: (impIds: string[]) =>
       apiRequest<DeleteImportResponse>("DELETE", "/api/import", {
         imp_ids: impIds,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["importPending"] });
+    },
+  });
+}
+
+export function useUpdateImportMetadata(): UseMutationResult<
+  UpdateImportMetadataResponse,
+  Error,
+  { impId: string; issueNumber: string }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ impId, issueNumber }) =>
+      apiRequest<UpdateImportMetadataResponse>("PATCH", `/api/import/${impId}`, {
+        issue_number: issueNumber,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["importPending"] });

--- a/frontend/src/hooks/useImport.ts
+++ b/frontend/src/hooks/useImport.ts
@@ -128,9 +128,13 @@ export function useUpdateImportMetadata(): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ impId, issueNumber }) =>
-      apiRequest<UpdateImportMetadataResponse>("PATCH", `/api/import/${impId}`, {
-        issue_number: issueNumber,
-      }),
+      apiRequest<UpdateImportMetadataResponse>(
+        "PATCH",
+        `/api/import/${impId}`,
+        {
+          issue_number: issueNumber,
+        },
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["importPending"] });
     },

--- a/frontend/src/lib/importUtils.ts
+++ b/frontend/src/lib/importUtils.ts
@@ -2,6 +2,7 @@ import type { ImportGroup } from "@/types";
 
 const MANGA_ID_PREFIXES = ["md-", "mal-"];
 const MANGA_FILENAME_PATTERN = /\b(ch\.?|chapter)\s*\d+/i;
+const NUMERIC_CHAPTER_FILENAME_PATTERN = /^\d+(?:\.\d+)?$/;
 
 export type ImportSearchMode = "comic" | "manga";
 export type ImportGroupType = "folder" | "file" | "unknown";
@@ -29,6 +30,10 @@ export function detectImportSearchMode(
       MANGA_FILENAME_PATTERN.test(file.ComicFilename),
     )
   ) {
+    return "manga";
+  }
+
+  if (hasFolderChapterContext(importGroup)) {
     return "manga";
   }
 
@@ -63,6 +68,31 @@ export function getImportGroupTypeLabel(
 
 export function getImportIssueLabel(importGroup: ImportGroup | null): string {
   return detectImportSearchMode(importGroup) === "manga" ? "Chapter" : "Issue";
+}
+
+function getFilenameStem(filename: string): string {
+  return filename.replace(/\.[^/.]+$/, "").trim();
+}
+
+function hasFolderChapterContext(importGroup: ImportGroup): boolean {
+  if (getImportGroupType(importGroup) !== "folder") {
+    return false;
+  }
+
+  return Boolean(
+    importGroup.files?.some((file) => {
+      const issueNumber = file.IssueNumber?.trim();
+      if (!issueNumber) {
+        return false;
+      }
+
+      const filenameStem = getFilenameStem(file.ComicFilename);
+      return (
+        MANGA_FILENAME_PATTERN.test(file.ComicFilename) ||
+        NUMERIC_CHAPTER_FILENAME_PATTERN.test(filenameStem)
+      );
+    }),
+  );
 }
 
 function compareIssueValues(left: string, right: string): number {

--- a/frontend/src/lib/importUtils.ts
+++ b/frontend/src/lib/importUtils.ts
@@ -4,6 +4,7 @@ const MANGA_ID_PREFIXES = ["md-", "mal-"];
 const MANGA_FILENAME_PATTERN = /\b(ch\.?|chapter)\s*\d+/i;
 
 export type ImportSearchMode = "comic" | "manga";
+export type ImportGroupType = "folder" | "file" | "unknown";
 
 /**
  * Detect whether an import group should search manga or comic providers.
@@ -32,4 +33,66 @@ export function detectImportSearchMode(
   }
 
   return "comic";
+}
+
+export function getImportGroupType(
+  importGroup: ImportGroup | null,
+): ImportGroupType {
+  const dynamicName = importGroup?.DynamicName ?? "";
+  if (dynamicName.startsWith("folder:")) {
+    return "folder";
+  }
+  if (dynamicName.startsWith("file:")) {
+    return "file";
+  }
+  return "unknown";
+}
+
+export function getImportGroupTypeLabel(importGroup: ImportGroup | null): string {
+  const groupType = getImportGroupType(importGroup);
+  if (groupType === "folder") {
+    return "Folder group";
+  }
+  if (groupType === "file") {
+    return "Single file";
+  }
+  return "Review group";
+}
+
+export function getImportIssueLabel(importGroup: ImportGroup | null): string {
+  return detectImportSearchMode(importGroup) === "manga" ? "Chapter" : "Issue";
+}
+
+function compareIssueValues(left: string, right: string): number {
+  const leftNumber = Number(left);
+  const rightNumber = Number(right);
+  if (Number.isFinite(leftNumber) && Number.isFinite(rightNumber)) {
+    return leftNumber - rightNumber;
+  }
+  return left.localeCompare(right, undefined, { numeric: true });
+}
+
+export function getImportIssueRange(importGroup: ImportGroup | null): string | null {
+  if (!importGroup?.files?.length) {
+    return null;
+  }
+
+  const values = Array.from(
+    new Set(
+      importGroup.files
+        .map((file) => file.IssueNumber?.trim())
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ).sort(compareIssueValues);
+
+  if (values.length === 0) {
+    return null;
+  }
+
+  const label = getImportIssueLabel(importGroup);
+  if (values.length === 1) {
+    return `${label} ${values[0]}`;
+  }
+
+  return `${label}s ${values[0]}-${values[values.length - 1]}`;
 }

--- a/frontend/src/lib/importUtils.ts
+++ b/frontend/src/lib/importUtils.ts
@@ -48,7 +48,9 @@ export function getImportGroupType(
   return "unknown";
 }
 
-export function getImportGroupTypeLabel(importGroup: ImportGroup | null): string {
+export function getImportGroupTypeLabel(
+  importGroup: ImportGroup | null,
+): string {
   const groupType = getImportGroupType(importGroup);
   if (groupType === "folder") {
     return "Folder group";
@@ -72,7 +74,9 @@ function compareIssueValues(left: string, right: string): number {
   return left.localeCompare(right, undefined, { numeric: true });
 }
 
-export function getImportIssueRange(importGroup: ImportGroup | null): string | null {
+export function getImportIssueRange(
+  importGroup: ImportGroup | null,
+): string | null {
   if (!importGroup?.files?.length) {
     return null;
   }

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -1,12 +1,16 @@
 import { useState } from "react";
-import { EyeOff, Eye } from "lucide-react";
+import { EyeOff, Eye, Inbox, RefreshCw } from "lucide-react";
 import {
   useImportPending,
   useMatchImport,
   useIgnoreImport,
   useDeleteImport,
+  useUpdateImportMetadata,
+  useRefreshImport,
 } from "@/hooks/useImport";
+import { useConfig } from "@/hooks/useConfig";
 import { useToast } from "@/components/ui/toast";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import ImportTable from "@/components/import/ImportTable";
 import ImportBulkActions from "@/components/import/ImportBulkActions";
@@ -16,6 +20,10 @@ import LibraryScanSection from "@/components/import/LibraryScanSection";
 import ImportInboxSection from "@/components/import/ImportInboxSection";
 import PageHeader from "@/components/layout/PageHeader";
 import type { ImportGroup } from "@/types";
+
+function pluralize(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
 
 function SectionHeader({
   label,
@@ -43,6 +51,7 @@ export default function ImportPage() {
   const [page, setPage] = useState(0);
   const [showIgnored, setShowIgnored] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
   const [matchModalOpen, setMatchModalOpen] = useState(false);
   const [matchingGroup, setMatchingGroup] = useState<ImportGroup | null>(null);
   const limit = 50;
@@ -55,10 +64,22 @@ export default function ImportPage() {
   );
   const imports = data?.imports || [];
   const pagination = data?.pagination;
+  const summary = data?.summary;
+  const visibleFileCount = imports.reduce(
+    (total, importGroup) =>
+      total + (importGroup.FileCount ?? importGroup.files.length),
+    0,
+  );
+  const groupCount = summary?.group_count ?? pagination?.total ?? imports.length;
+  const fileCount = summary?.file_count ?? visibleFileCount;
+  const pendingReviewMeta = `${pluralize(groupCount, "group")} · ${pluralize(fileCount, "file")} awaiting review`;
 
   const matchImportMutation = useMatchImport();
   const ignoreImportMutation = useIgnoreImport();
   const deleteImportMutation = useDeleteImport();
+  const updateImportMetadataMutation = useUpdateImportMetadata();
+  const refreshImportMutation = useRefreshImport();
+  const { data: appConfig } = useConfig();
   const { addToast } = useToast();
 
   const handleMatchClick = (group: ImportGroup) => {
@@ -85,6 +106,34 @@ export default function ImportPage() {
     }
   };
 
+  const handleIssueNumberChange = async (
+    file: ImportGroup["files"][number],
+    issueNumber: string,
+  ) => {
+    try {
+      await updateImportMetadataMutation.mutateAsync({
+        impId: file.impID,
+        issueNumber,
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to update import metadata: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+      throw err;
+    }
+  };
+
+  const clearSelection = () => {
+    setSelectedIds([]);
+    setSelectedGroupIds([]);
+  };
+
+  const handleSelectionChange = (fileIds: string[], groupIds: string[]) => {
+    setSelectedIds(fileIds);
+    setSelectedGroupIds(groupIds);
+  };
+
   const handleGroupIgnore = async (group: ImportGroup, ignore: boolean) => {
     const impIds = group.files.map((f) => f.impID);
     try {
@@ -93,7 +142,7 @@ export default function ImportPage() {
         type: "success",
         message: `${impIds.length} file${impIds.length !== 1 ? "s" : ""} ${ignore ? "ignored" : "unignored"}`,
       });
-      setSelectedIds([]);
+      clearSelection();
     } catch (err) {
       addToast({
         type: "error",
@@ -117,7 +166,7 @@ export default function ImportPage() {
         type: "success",
         message: `${impIds.length} import record${impIds.length !== 1 ? "s" : ""} deleted`,
       });
-      setSelectedIds([]);
+      clearSelection();
     } catch (err) {
       addToast({
         type: "error",
@@ -136,7 +185,7 @@ export default function ImportPage() {
         type: "success",
         message: `${selectedIds.length} file${selectedIds.length !== 1 ? "s" : ""} ignored`,
       });
-      setSelectedIds([]);
+      clearSelection();
     } catch (err) {
       addToast({
         type: "error",
@@ -155,7 +204,7 @@ export default function ImportPage() {
         type: "success",
         message: `${selectedIds.length} file${selectedIds.length !== 1 ? "s" : ""} unignored`,
       });
-      setSelectedIds([]);
+      clearSelection();
     } catch (err) {
       addToast({
         type: "error",
@@ -178,7 +227,7 @@ export default function ImportPage() {
         type: "success",
         message: `${selectedIds.length} import record${selectedIds.length !== 1 ? "s" : ""} deleted`,
       });
-      setSelectedIds([]);
+      clearSelection();
     } catch (err) {
       addToast({
         type: "error",
@@ -187,46 +236,41 @@ export default function ImportPage() {
     }
   };
 
-  const pendingCount = pagination?.total ?? imports.length;
+  const handleScanInboxNow = async () => {
+    try {
+      await refreshImportMutation.mutateAsync();
+      addToast({
+        type: "success",
+        message: "Import inbox scan started",
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message: `Failed to scan inbox: ${err instanceof Error ? err.message : "Unknown error"}`,
+      });
+    }
+  };
+
+  const importDirectoryConfigured = Boolean(appConfig?.import_dir);
 
   return (
     <div className="page-transition">
       <PageHeader
         title="Import"
-        meta={
-          isLoading
-            ? "loading…"
-            : `${pendingCount} file${pendingCount === 1 ? "" : "s"} awaiting review`
-        }
+        meta={isLoading ? "loading…" : pendingReviewMeta}
       />
 
       <div className="px-5 py-5 space-y-8">
-        {/* Library scan */}
-        <section>
-          <SectionHeader
-            label="LIBRARY · SCAN"
-            title="Scan existing directories"
-            meta="Find and import series already present on disk."
-          />
-          <LibraryScanSection />
-        </section>
-
-        {/* Inbox */}
-        <section>
-          <SectionHeader
-            label="INBOX · AUTO-MATCH"
-            title="Monitor an import directory"
-            meta="Drop files into a watched folder to auto-match against your library."
-          />
-          <ImportInboxSection />
-        </section>
-
         {/* Pending */}
         <section>
           <SectionHeader
             label="PENDING · REVIEW"
             title="Files awaiting review"
-            meta={`${pendingCount} file${pendingCount === 1 ? "" : "s"} need a match before being imported.`}
+            meta={
+              isLoading
+                ? "Loading review groups."
+                : `${pendingReviewMeta}. Correct chapters or issues, then match a group to import.`
+            }
           />
 
           <div className="flex items-center gap-3 mb-4">
@@ -236,7 +280,7 @@ export default function ImportPage() {
               onClick={() => {
                 setShowIgnored((prev) => !prev);
                 setPage(0);
-                setSelectedIds([]);
+                clearSelection();
               }}
               className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border font-mono text-[11px]"
               style={{
@@ -279,41 +323,113 @@ export default function ImportPage() {
             />
           )}
 
-          {!isLoading && !error && (
-            <ImportTable
-              imports={imports}
-              pagination={pagination}
-              onNextPage={() => {
-                setPage((p) => p + 1);
-                setSelectedIds([]);
-              }}
-              onPrevPage={() => {
-                setPage((p) => Math.max(0, p - 1));
-                setSelectedIds([]);
-              }}
-              onSelectionChange={setSelectedIds}
-              onMatchClick={handleMatchClick}
-              onIgnoreClick={handleGroupIgnore}
-              onDeleteClick={handleGroupDelete}
-              isActionLoading={
-                matchImportMutation.isPending ||
-                ignoreImportMutation.isPending ||
-                deleteImportMutation.isPending
-              }
-            />
-          )}
+          {!isLoading &&
+            !error &&
+            (imports.length > 0 ? (
+              <ImportTable
+                imports={imports}
+                pagination={pagination}
+                onNextPage={() => {
+                  setPage((p) => p + 1);
+                  clearSelection();
+                }}
+                onPrevPage={() => {
+                  setPage((p) => Math.max(0, p - 1));
+                  clearSelection();
+                }}
+                onSelectionChange={handleSelectionChange}
+                onMatchClick={handleMatchClick}
+                onIgnoreClick={handleGroupIgnore}
+                onDeleteClick={handleGroupDelete}
+                onIssueNumberChange={handleIssueNumberChange}
+                isActionLoading={
+                  matchImportMutation.isPending ||
+                  ignoreImportMutation.isPending ||
+                  deleteImportMutation.isPending
+                }
+                isMetadataSaving={updateImportMetadataMutation.isPending}
+              />
+            ) : (
+              <div className="rounded-md border border-dashed border-card-border bg-card/40 px-5 py-8">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex items-start gap-3">
+                    <div className="mt-0.5 rounded-md border border-card-border bg-muted/40 p-2">
+                      <Inbox className="h-4 w-4 text-muted-foreground" />
+                    </div>
+                    <div>
+                      <div className="text-sm font-semibold">
+                        No pending imports
+                      </div>
+                      <div className="mt-1 max-w-xl text-sm text-muted-foreground">
+                        The review queue is clear. Scan the watched inbox to
+                        check for new files.
+                      </div>
+                    </div>
+                  </div>
+                  {importDirectoryConfigured ? (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={handleScanInboxNow}
+                      disabled={refreshImportMutation.isPending}
+                    >
+                      <RefreshCw
+                        className={
+                          refreshImportMutation.isPending
+                            ? "h-4 w-4 animate-spin"
+                            : "h-4 w-4"
+                        }
+                      />
+                      Scan inbox now
+                    </Button>
+                  ) : (
+                    <span className="font-mono text-[11px] uppercase tracking-wider text-muted-foreground">
+                      Import directory not configured
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
 
           <ImportBulkActions
-            selectedCount={selectedIds.length}
+            selectedGroupCount={selectedGroupIds.length}
+            selectedFileCount={selectedIds.length}
             onIgnore={handleBulkIgnore}
             onUnignore={handleBulkUnignore}
             onDelete={handleBulkDelete}
-            onClear={() => setSelectedIds([])}
+            onClear={clearSelection}
             isLoading={
               ignoreImportMutation.isPending || deleteImportMutation.isPending
             }
             showUnignore={showIgnored}
           />
+        </section>
+
+        {/* Sources and scans */}
+        <section>
+          <SectionHeader
+            label="SOURCES · SCANS"
+            title="Sources and scans"
+            meta="Setup and maintenance tools for library directories and the watched inbox."
+          />
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.65fr)]">
+            <div>
+              <SectionHeader
+                label="LIBRARY · SCAN"
+                title="Scan existing directories"
+                meta="Find and import series already present on disk."
+              />
+              <LibraryScanSection />
+            </div>
+            <div>
+              <SectionHeader
+                label="INBOX · AUTO-MATCH"
+                title="Monitor an import directory"
+                meta="Drop files into a watched folder to auto-match against your library."
+              />
+              <ImportInboxSection />
+            </div>
+          </div>
         </section>
       </div>
 

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -73,7 +73,12 @@ export default function ImportPage() {
   const groupCount =
     summary?.group_count ?? pagination?.total ?? imports.length;
   const fileCount = summary?.file_count ?? visibleFileCount;
-  const pendingReviewMeta = `${pluralize(groupCount, "group")} · ${pluralize(fileCount, "file")} awaiting review`;
+  const pendingReviewMeta = error
+    ? "Unable to load pending imports"
+    : `${pluralize(groupCount, "group")} · ${pluralize(fileCount, "file")} awaiting review`;
+  const pendingReviewHelp = error
+    ? "Resolve the loading error before reviewing imports."
+    : `${pendingReviewMeta}. Correct chapters or issues, then match a group to import.`;
 
   const matchImportMutation = useMatchImport();
   const ignoreImportMutation = useIgnoreImport();
@@ -267,11 +272,7 @@ export default function ImportPage() {
           <SectionHeader
             label="PENDING · REVIEW"
             title="Files awaiting review"
-            meta={
-              isLoading
-                ? "Loading review groups."
-                : `${pendingReviewMeta}. Correct chapters or issues, then match a group to import.`
-            }
+            meta={isLoading ? "Loading review groups." : pendingReviewHelp}
           />
 
           <div className="flex items-center gap-3 mb-4">

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -70,7 +70,8 @@ export default function ImportPage() {
       total + (importGroup.FileCount ?? importGroup.files.length),
     0,
   );
-  const groupCount = summary?.group_count ?? pagination?.total ?? imports.length;
+  const groupCount =
+    summary?.group_count ?? pagination?.total ?? imports.length;
   const fileCount = summary?.file_count ?? visibleFileCount;
   const pendingReviewMeta = `${pluralize(groupCount, "group")} · ${pluralize(fileCount, "file")} awaiting review`;
 

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -190,6 +190,12 @@ export interface ImportFile {
   MatchSource: string | null;
 }
 
+/** Summary counts returned by GET /api/import */
+export interface ImportPendingSummary {
+  group_count: number;
+  file_count: number;
+}
+
 /** Story Arc status for individual issues */
 export type ArcIssueStatus =
   | "Downloaded"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -31,6 +31,7 @@ export type {
   VolumeGroup,
   ImportFile,
   ImportGroup,
+  ImportPendingSummary,
   ScanResult,
   ScanResultMatch,
   ScanProgress,

--- a/frontend/tests/components/ImportTable.test.tsx
+++ b/frontend/tests/components/ImportTable.test.tsx
@@ -79,7 +79,9 @@ describe("ImportTable", () => {
       }),
     ];
 
-    renderMinimal(<ImportTable imports={groups} onIssueNumberChange={vi.fn()} />);
+    renderMinimal(
+      <ImportTable imports={groups} onIssueNumberChange={vi.fn()} />,
+    );
 
     expect(screen.getByText("Manga A")).toBeTruthy();
     expect(screen.getByText("Manga B")).toBeTruthy();
@@ -89,10 +91,12 @@ describe("ImportTable", () => {
       screen.getAllByRole("button", { name: "Expand import files" })[0],
     );
 
-    expect(screen.getByRole("textbox", { name: "Chapter for chapter 1.cbz" }))
-      .toHaveProperty("value", "1");
-    expect(screen.getByRole("textbox", { name: "Chapter for chapter 2.cbz" }))
-      .toHaveProperty("value", "2");
+    expect(
+      screen.getByRole("textbox", { name: "Chapter for chapter 1.cbz" }),
+    ).toHaveProperty("value", "1");
+    expect(
+      screen.getByRole("textbox", { name: "Chapter for chapter 2.cbz" }),
+    ).toHaveProperty("value", "2");
   });
 
   it("renders root files as one review group per file", () => {
@@ -174,6 +178,45 @@ describe("ImportTable", () => {
       expect(onIssueNumberChange).toHaveBeenCalledWith(file, "3");
     });
     expect(screen.getByText("Saved")).toBeTruthy();
+  });
+
+  it("keeps the last saved chapter as the edit baseline before refetch", async () => {
+    const file = makeFile();
+    const onIssueNumberChange = vi.fn().mockResolvedValue(undefined);
+
+    renderMinimal(
+      <ImportTable
+        imports={[makeGroup({ files: [file] })]}
+        onIssueNumberChange={onIssueNumberChange}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Expand import files" }),
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "Chapter for chapter 1.cbz",
+    });
+    await userEvent.clear(input);
+    await userEvent.type(input, "3{Enter}");
+
+    await waitFor(() => {
+      expect(onIssueNumberChange).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Saved")).toBeTruthy();
+    });
+
+    await userEvent.tab();
+    expect(onIssueNumberChange).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(input);
+    await userEvent.clear(input);
+    await userEvent.type(input, "4{Escape}");
+
+    expect(onIssueNumberChange).toHaveBeenCalledTimes(1);
+    expect(input).toHaveProperty("value", "3");
   });
 
   it("shows saving feedback while chapter updates are pending", async () => {
@@ -284,5 +327,50 @@ describe("ImportTable", () => {
       ["1", "2"],
       ["folder:manga-a-null"],
     );
+  });
+
+  it("recomputes selected import file IDs when imports refresh", async () => {
+    const onSelectionChange = vi.fn();
+    const { rerender } = renderMinimal(
+      <ImportTable
+        imports={[
+          makeGroup({
+            files: [
+              makeFile({ impID: "1" }),
+              makeFile({ impID: "2", ComicFilename: "chapter 2.cbz" }),
+            ],
+          }),
+        ]}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await userEvent.click(screen.getAllByRole("checkbox")[1]);
+    expect(onSelectionChange).toHaveBeenCalledWith(
+      ["1", "2"],
+      ["folder:manga-a-null"],
+    );
+
+    onSelectionChange.mockClear();
+    rerender(
+      <ImportTable
+        imports={[
+          makeGroup({
+            files: [
+              makeFile({ impID: "3" }),
+              makeFile({ impID: "4", ComicFilename: "chapter 2.cbz" }),
+            ],
+          }),
+        ]}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onSelectionChange).toHaveBeenCalledWith(
+        ["3", "4"],
+        ["folder:manga-a-null"],
+      );
+    });
   });
 });

--- a/frontend/tests/components/ImportTable.test.tsx
+++ b/frontend/tests/components/ImportTable.test.tsx
@@ -1,0 +1,288 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { screen, renderMinimal } from "../test-utils";
+import ImportTable from "@/components/import/ImportTable";
+import type { ImportGroup } from "@/types";
+
+type ImportFile = ImportGroup["files"][number];
+
+function makeFile(overrides: Partial<ImportFile> = {}): ImportFile {
+  return {
+    impID: "1",
+    ComicFilename: "chapter 1.cbz",
+    ComicLocation: "/imports/Manga A/chapter 1.cbz",
+    IssueNumber: "1",
+    ComicYear: null,
+    Status: "Unmatched",
+    IgnoreFile: 0,
+    MatchConfidence: null,
+    SuggestedComicID: null,
+    SuggestedComicName: null,
+    SuggestedIssueID: null,
+    MatchSource: null,
+    ...overrides,
+  };
+}
+
+function makeGroup(overrides: Partial<ImportGroup> = {}): ImportGroup {
+  const files = overrides.files ?? [makeFile()];
+  return {
+    DynamicName: "folder:manga-a",
+    ComicName: "Manga A",
+    Volume: null,
+    ComicYear: null,
+    FileCount: files.length,
+    Status: "Unmatched",
+    SRID: null,
+    ComicID: null,
+    MatchConfidence: null,
+    SuggestedComicID: null,
+    SuggestedComicName: null,
+    files,
+    ...overrides,
+  };
+}
+
+describe("ImportTable", () => {
+  it("renders nested manga folders as separate review groups with chapters", async () => {
+    const groups = [
+      makeGroup({
+        DynamicName: "folder:manga-a",
+        ComicName: "Manga A",
+        files: [
+          makeFile({ impID: "1", ComicFilename: "chapter 1.cbz" }),
+          makeFile({
+            impID: "2",
+            ComicFilename: "chapter 2.cbz",
+            ComicLocation: "/imports/Manga A/chapter 2.cbz",
+            IssueNumber: "2",
+          }),
+        ],
+      }),
+      makeGroup({
+        DynamicName: "folder:manga-b",
+        ComicName: "Manga B",
+        files: [
+          makeFile({
+            impID: "3",
+            ComicFilename: "chapter 1.cbz",
+            ComicLocation: "/imports/Manga B/chapter 1.cbz",
+          }),
+          makeFile({
+            impID: "4",
+            ComicFilename: "chapter 2.cbz",
+            ComicLocation: "/imports/Manga B/chapter 2.cbz",
+            IssueNumber: "2",
+          }),
+        ],
+      }),
+    ];
+
+    renderMinimal(<ImportTable imports={groups} onIssueNumberChange={vi.fn()} />);
+
+    expect(screen.getByText("Manga A")).toBeTruthy();
+    expect(screen.getByText("Manga B")).toBeTruthy();
+    expect(screen.getAllByText("Folder group")).toHaveLength(2);
+
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Expand import files" })[0],
+    );
+
+    expect(screen.getByRole("textbox", { name: "Chapter for chapter 1.cbz" }))
+      .toHaveProperty("value", "1");
+    expect(screen.getByRole("textbox", { name: "Chapter for chapter 2.cbz" }))
+      .toHaveProperty("value", "2");
+  });
+
+  it("renders root files as one review group per file", () => {
+    renderMinimal(
+      <ImportTable
+        imports={[
+          makeGroup({
+            DynamicName: "file:root-a",
+            ComicName: "Root Manga A",
+            FileCount: 1,
+            files: [
+              makeFile({
+                impID: "1",
+                ComicFilename: "Root Manga A - Chapter 1.cbz",
+                ComicLocation: "/imports/Root Manga A - Chapter 1.cbz",
+              }),
+            ],
+          }),
+          makeGroup({
+            DynamicName: "file:root-b",
+            ComicName: "Root Manga B",
+            FileCount: 1,
+            files: [
+              makeFile({
+                impID: "2",
+                ComicFilename: "Root Manga B - Chapter 1.cbz",
+                ComicLocation: "/imports/Root Manga B - Chapter 1.cbz",
+              }),
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Root Manga A")).toBeTruthy();
+    expect(screen.getByText("Root Manga B")).toBeTruthy();
+    expect(screen.getAllByText("Single file")).toHaveLength(2);
+  });
+
+  it("shows no suggestion instead of a misleading zero confidence", () => {
+    renderMinimal(
+      <ImportTable
+        imports={[
+          makeGroup({
+            MatchConfidence: 0,
+            SuggestedComicID: null,
+            SuggestedComicName: null,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("No suggestion")).toBeTruthy();
+    expect(screen.queryByText("0%")).toBeNull();
+  });
+
+  it("saves edited chapter values from expanded file rows", async () => {
+    const file = makeFile();
+    const onIssueNumberChange = vi.fn().mockResolvedValue(undefined);
+
+    renderMinimal(
+      <ImportTable
+        imports={[makeGroup({ files: [file] })]}
+        onIssueNumberChange={onIssueNumberChange}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Expand import files" }),
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "Chapter for chapter 1.cbz",
+    });
+    await userEvent.clear(input);
+    await userEvent.type(input, "3{Enter}");
+
+    await waitFor(() => {
+      expect(onIssueNumberChange).toHaveBeenCalledWith(file, "3");
+    });
+    expect(screen.getByText("Saved")).toBeTruthy();
+  });
+
+  it("shows saving feedback while chapter updates are pending", async () => {
+    let resolveSave: () => void = () => {};
+    const onIssueNumberChange = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+
+    renderMinimal(
+      <ImportTable
+        imports={[makeGroup()]}
+        onIssueNumberChange={onIssueNumberChange}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Expand import files" }),
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "Chapter for chapter 1.cbz",
+    });
+    await userEvent.clear(input);
+    await userEvent.type(input, "4{Enter}");
+
+    expect(screen.getByText("Saving...")).toBeTruthy();
+    resolveSave();
+
+    await waitFor(() => {
+      expect(screen.getByText("Saved")).toBeTruthy();
+    });
+  });
+
+  it("shows save feedback when chapter update fails", async () => {
+    const onIssueNumberChange = vi
+      .fn()
+      .mockRejectedValue(new Error("Unable to save"));
+
+    renderMinimal(
+      <ImportTable
+        imports={[makeGroup()]}
+        onIssueNumberChange={onIssueNumberChange}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Expand import files" }),
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "Chapter for chapter 1.cbz",
+    });
+    await userEvent.clear(input);
+    await userEvent.type(input, "4{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByText("Save failed")).toBeTruthy();
+    });
+  });
+
+  it("validates blank chapter values before saving", async () => {
+    const onIssueNumberChange = vi.fn().mockResolvedValue(undefined);
+
+    renderMinimal(
+      <ImportTable
+        imports={[makeGroup()]}
+        onIssueNumberChange={onIssueNumberChange}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Expand import files" }),
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "Chapter for chapter 1.cbz",
+    });
+    await userEvent.clear(input);
+    await userEvent.tab();
+
+    expect(screen.getByText("Required")).toBeTruthy();
+    expect(onIssueNumberChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps bulk row selection mapped to import file IDs", async () => {
+    const onSelectionChange = vi.fn();
+
+    renderMinimal(
+      <ImportTable
+        imports={[
+          makeGroup({
+            files: [
+              makeFile({ impID: "1" }),
+              makeFile({ impID: "2", ComicFilename: "chapter 2.cbz" }),
+            ],
+          }),
+        ]}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await userEvent.click(screen.getAllByRole("checkbox")[1]);
+
+    expect(onSelectionChange).toHaveBeenCalledWith(
+      ["1", "2"],
+      ["folder:manga-a-null"],
+    );
+  });
+});

--- a/frontend/tests/lib/importUtils.test.ts
+++ b/frontend/tests/lib/importUtils.test.ts
@@ -58,6 +58,46 @@ describe("detectImportSearchMode", () => {
     expect(detectImportSearchMode(group)).toBe("manga");
   });
 
+  it("returns manga for folder groups with numeric chapter-only filenames", () => {
+    const group = makeImportGroup({
+      DynamicName: "folder:manga-a",
+      files: [
+        {
+          impID: "1",
+          ComicFilename: "001.cbz",
+          ComicLocation: "/imports/Manga A/001.cbz",
+          IssueNumber: "1",
+          ComicYear: null,
+          Status: "Unmatched",
+          IgnoreFile: 0,
+          MatchConfidence: null,
+          SuggestedComicID: null,
+          SuggestedComicName: null,
+          SuggestedIssueID: null,
+          MatchSource: null,
+        },
+        {
+          impID: "2",
+          ComicFilename: "002.cbz",
+          ComicLocation: "/imports/Manga A/002.cbz",
+          IssueNumber: "2",
+          ComicYear: null,
+          Status: "Unmatched",
+          IgnoreFile: 0,
+          MatchConfidence: null,
+          SuggestedComicID: null,
+          SuggestedComicName: null,
+          SuggestedIssueID: null,
+          MatchSource: null,
+        },
+      ],
+    });
+
+    expect(detectImportSearchMode(group)).toBe("manga");
+    expect(getImportIssueLabel(group)).toBe("Chapter");
+    expect(getImportIssueRange(group)).toBe("Chapters 1-2");
+  });
+
   it("defaults to comic when no manga signals are present", () => {
     const group = makeImportGroup({
       ComicID: "4050-12345",
@@ -89,7 +129,9 @@ describe("detectImportSearchMode", () => {
 describe("import group review helpers", () => {
   it("labels folder and single-file groups from DynamicName", () => {
     expect(
-      getImportGroupTypeLabel(makeImportGroup({ DynamicName: "folder:manga-a" })),
+      getImportGroupTypeLabel(
+        makeImportGroup({ DynamicName: "folder:manga-a" }),
+      ),
     ).toBe("Folder group");
     expect(
       getImportGroupTypeLabel(makeImportGroup({ DynamicName: "file:imp-1" })),

--- a/frontend/tests/lib/importUtils.test.ts
+++ b/frontend/tests/lib/importUtils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { detectImportSearchMode } from "@/lib/importUtils";
+import {
+  detectImportSearchMode,
+  getImportGroupTypeLabel,
+  getImportIssueLabel,
+  getImportIssueRange,
+} from "@/lib/importUtils";
 import type { ImportGroup } from "@/types";
 
 function makeImportGroup(overrides: Partial<ImportGroup> = {}): ImportGroup {
@@ -78,5 +83,56 @@ describe("detectImportSearchMode", () => {
 
   it("returns comic for null import group", () => {
     expect(detectImportSearchMode(null)).toBe("comic");
+  });
+});
+
+describe("import group review helpers", () => {
+  it("labels folder and single-file groups from DynamicName", () => {
+    expect(
+      getImportGroupTypeLabel(makeImportGroup({ DynamicName: "folder:manga-a" })),
+    ).toBe("Folder group");
+    expect(
+      getImportGroupTypeLabel(makeImportGroup({ DynamicName: "file:imp-1" })),
+    ).toBe("Single file");
+    expect(getImportGroupTypeLabel(makeImportGroup())).toBe("Review group");
+  });
+
+  it("uses chapter labels and ranges for manga-style groups", () => {
+    const group = makeImportGroup({
+      DynamicName: "folder:manga-a",
+      files: [
+        {
+          impID: "1",
+          ComicFilename: "chapter 2.cbz",
+          ComicLocation: "/imports/manga-a/chapter 2.cbz",
+          IssueNumber: "2",
+          ComicYear: null,
+          Status: "Unmatched",
+          IgnoreFile: 0,
+          MatchConfidence: null,
+          SuggestedComicID: null,
+          SuggestedComicName: null,
+          SuggestedIssueID: null,
+          MatchSource: null,
+        },
+        {
+          impID: "2",
+          ComicFilename: "chapter 1.cbz",
+          ComicLocation: "/imports/manga-a/chapter 1.cbz",
+          IssueNumber: "1",
+          ComicYear: null,
+          Status: "Unmatched",
+          IgnoreFile: 0,
+          MatchConfidence: null,
+          SuggestedComicID: null,
+          SuggestedComicName: null,
+          SuggestedIssueID: null,
+          MatchSource: null,
+        },
+      ],
+    });
+
+    expect(getImportIssueLabel(group)).toBe("Chapter");
+    expect(getImportIssueRange(group)).toBe("Chapters 1-2");
   });
 });

--- a/frontend/tests/pages/ImportPage.test.tsx
+++ b/frontend/tests/pages/ImportPage.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/server";
+import { render, screen } from "../test-utils";
+import ImportPage from "@/pages/ImportPage";
+import type { ImportGroup } from "@/types";
+
+type ImportFile = ImportGroup["files"][number];
+
+function makeFile(overrides: Partial<ImportFile> = {}): ImportFile {
+  return {
+    impID: "imp-1",
+    ComicFilename: "chapter 1.cbz",
+    ComicLocation: "/imports/Manga A/chapter 1.cbz",
+    IssueNumber: "1",
+    ComicYear: null,
+    Status: "Unmatched",
+    IgnoreFile: 0,
+    MatchConfidence: null,
+    SuggestedComicID: null,
+    SuggestedComicName: null,
+    SuggestedIssueID: null,
+    MatchSource: null,
+    ...overrides,
+  };
+}
+
+function makeGroup(overrides: Partial<ImportGroup> = {}): ImportGroup {
+  const files = overrides.files ?? [
+    makeFile(),
+    makeFile({
+      impID: "imp-2",
+      ComicFilename: "chapter 2.cbz",
+      ComicLocation: "/imports/Manga A/chapter 2.cbz",
+      IssueNumber: "2",
+    }),
+  ];
+
+  return {
+    DynamicName: "folder:manga-a",
+    ComicName: "Manga A",
+    Volume: null,
+    ComicYear: null,
+    FileCount: files.length,
+    Status: "Unmatched",
+    SRID: null,
+    ComicID: null,
+    MatchConfidence: null,
+    SuggestedComicID: null,
+    SuggestedComicName: null,
+    files,
+    ...overrides,
+  };
+}
+
+describe("ImportPage", () => {
+  it("puts pending review before sources and scans when imports exist", async () => {
+    server.use(
+      http.get("/api/import", () =>
+        HttpResponse.json({
+          imports: [makeGroup()],
+          pagination: { total: 1, limit: 50, offset: 0, has_more: false },
+          summary: { group_count: 1, file_count: 2 },
+        }),
+      ),
+    );
+
+    render(<ImportPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Manga A")).toBeTruthy();
+    });
+
+    expect(
+      screen.getAllByText(/1 group · 2 files awaiting review/).length,
+    ).toBeGreaterThan(0);
+
+    const pendingHeader = screen.getByText("Files awaiting review");
+    const sourcesHeader = screen.getByText("Sources and scans");
+    expect(
+      pendingHeader.compareDocumentPosition(sourcesHeader) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("shows scan action in the empty pending state when inbox is configured", async () => {
+    server.use(
+      http.get("/api/import", () =>
+        HttpResponse.json({
+          imports: [],
+          pagination: { total: 0, limit: 50, offset: 0, has_more: false },
+          summary: { group_count: 0, file_count: 0 },
+        }),
+      ),
+      http.get("/api/config", () =>
+        HttpResponse.json({
+          comic_dir: "/comics",
+          import_dir: "/imports",
+          api_enabled: true,
+        }),
+      ),
+    );
+
+    render(<ImportPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No pending imports")).toBeTruthy();
+    });
+    expect(screen.getByRole("button", { name: "Scan inbox now" })).toBeTruthy();
+    expect(screen.getByText("Sources and scans")).toBeTruthy();
+  });
+});

--- a/frontend/tests/pages/ImportPage.test.tsx
+++ b/frontend/tests/pages/ImportPage.test.tsx
@@ -110,4 +110,24 @@ describe("ImportPage", () => {
     expect(screen.getByRole("button", { name: "Scan inbox now" })).toBeTruthy();
     expect(screen.getByText("Sources and scans")).toBeTruthy();
   });
+
+  it("does not show zero pending counts when pending imports fail to load", async () => {
+    server.use(
+      http.get("/api/import", () =>
+        HttpResponse.json({ error: "Unable to load" }, { status: 500 }),
+      ),
+    );
+
+    render(<ImportPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Unable to load pending imports").length,
+      ).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(/0 groups · 0 files awaiting review/)).toBeNull();
+    expect(
+      screen.getByText("Resolve the loading error before reviewing imports."),
+    ).toBeTruthy();
+  });
 });

--- a/tests/unit/test_importinbox.py
+++ b/tests/unit/test_importinbox.py
@@ -58,10 +58,24 @@ class TestCollectFileGroups:
             ]
             result = importinbox._collect_file_groups("/import")
 
-        assert "Batman" in result
-        assert len(result["Batman"]) == 2
-        assert "Superman" in result
-        assert len(result["Superman"]) == 1
+        assert result["folder:batman"]["group_name"] == "Batman"
+        assert len(result["folder:batman"]["files"]) == 2
+        assert result["folder:superman"]["group_name"] == "Superman"
+        assert len(result["folder:superman"]["files"]) == 1
+
+    def test_issue_186_nested_manga_folders_stay_separate(self, importinbox):
+        with patch("os.walk") as mock_walk:
+            mock_walk.return_value = [
+                ("/import/Manga A", [], ["chapter 1.cbz", "chapter 2.cbz"]),
+                ("/import/Manga B", [], ["chapter 1.cbz", "chapter 2.cbz"]),
+            ]
+            result = importinbox._collect_file_groups("/import")
+
+        assert set(result.keys()) == {"folder:manga a", "folder:manga b"}
+        assert result["folder:manga a"]["group_name"] == "Manga A"
+        assert len(result["folder:manga a"]["files"]) == 2
+        assert result["folder:manga b"]["group_name"] == "Manga B"
+        assert len(result["folder:manga b"]["files"]) == 2
 
     def test_root_files_grouped_individually(self, importinbox):
         with patch("os.walk") as mock_walk:
@@ -70,8 +84,9 @@ class TestCollectFileGroups:
             ]
             result = importinbox._collect_file_groups("/import")
 
-        assert "Batman 001" in result
-        assert "Superman 001" in result
+        assert len(result) == 2
+        assert sorted(group["group_name"] for group in result.values()) == ["Batman", "Superman"]
+        assert all(key.startswith("file:") for key in result)
 
     def test_skips_non_comic_files(self, importinbox):
         with patch("os.walk") as mock_walk:
@@ -80,7 +95,7 @@ class TestCollectFileGroups:
             ]
             result = importinbox._collect_file_groups("/import")
 
-        assert len(result["Batman"]) == 1
+        assert len(result["folder:batman"]["files"]) == 1
 
     def test_empty_directory(self, importinbox):
         with patch("os.walk") as mock_walk:
@@ -101,7 +116,9 @@ class TestMatchGroup:
         _mock_globals["db"].upsert = MagicMock()
 
         result = importinbox._match_group(
-            "Batman", ["/import/Batman/001.cbz", "/import/Batman/002.cbz"], series_list
+            "folder:batman",
+            {"group_name": "Batman", "files": ["/import/Batman/001.cbz", "/import/Batman/002.cbz"]},
+            series_list,
         )
 
         assert result["auto_imported"] == 2
@@ -115,7 +132,9 @@ class TestMatchGroup:
         _mock_globals["db"].upsert = MagicMock()
 
         result = importinbox._match_group(
-            "Completely Unknown Series", ["/import/Unknown/001.cbz"], series_list
+            "folder:unknown",
+            {"group_name": "Completely Unknown Series", "files": ["/import/Unknown/001.cbz"]},
+            series_list,
         )
 
         assert result["auto_imported"] == 0
@@ -125,11 +144,18 @@ class TestMatchGroup:
         _mock_globals["db"].upsert = MagicMock()
 
         result = importinbox._match_group(
-            "Batman", ["/import/Batman/001.cbz"], []
+            "folder:batman",
+            {"group_name": "Batman", "files": ["/import/Batman/chapter 1.cbz"]},
+            [],
         )
 
         assert result["auto_imported"] == 0
         assert result["queued_for_review"] == 1
+        _mock_globals["db"].upsert.assert_called_once()
+        queued_values = _mock_globals["db"].upsert.call_args.args[1]
+        assert queued_values["DynamicName"] == "folder:batman"
+        assert queued_values["ComicName"] == "Batman"
+        assert queued_values["IssueNumber"] == "1"
 
     def test_multiple_series_takes_highest(self, importinbox, _mock_globals):
         series_list = [
@@ -141,7 +167,9 @@ class TestMatchGroup:
 
         # Exact match to "Batman" should win
         result = importinbox._match_group(
-            "Batman", ["/import/Batman/001.cbz"], series_list
+            "folder:batman",
+            {"group_name": "Batman", "files": ["/import/Batman/001.cbz"]},
+            series_list,
         )
 
         assert result["auto_imported"] == 1
@@ -162,8 +190,8 @@ class TestInboxScan:
         with (
             patch("os.path.isdir", return_value=True),
             patch.object(importinbox, "_collect_file_groups", return_value={
-                "Batman": ["/import/Batman/001.cbz"],
-                "Unknown": ["/import/Unknown/001.cbz"],
+                "folder:batman": {"group_name": "Batman", "files": ["/import/Batman/001.cbz"]},
+                "folder:unknown": {"group_name": "Unknown", "files": ["/import/Unknown/001.cbz"]},
             }),
             patch.object(importinbox, "_match_group", side_effect=[
                 {"auto_imported": 1, "queued_for_review": 0},

--- a/tests/unit/test_importinbox.py
+++ b/tests/unit/test_importinbox.py
@@ -58,10 +58,12 @@ class TestCollectFileGroups:
             ]
             result = importinbox._collect_file_groups("/import")
 
-        assert result["folder:batman"]["group_name"] == "Batman"
-        assert len(result["folder:batman"]["files"]) == 2
-        assert result["folder:superman"]["group_name"] == "Superman"
-        assert len(result["folder:superman"]["files"]) == 1
+        batman_key = "folder:%s" % importinbox._filepath_to_impid("/import/Batman")
+        superman_key = "folder:%s" % importinbox._filepath_to_impid("/import/Superman")
+        assert result[batman_key]["group_name"] == "Batman"
+        assert len(result[batman_key]["files"]) == 2
+        assert result[superman_key]["group_name"] == "Superman"
+        assert len(result[superman_key]["files"]) == 1
 
     def test_issue_186_nested_manga_folders_stay_separate(self, importinbox):
         with patch("os.walk") as mock_walk:
@@ -71,11 +73,28 @@ class TestCollectFileGroups:
             ]
             result = importinbox._collect_file_groups("/import")
 
-        assert set(result.keys()) == {"folder:manga a", "folder:manga b"}
-        assert result["folder:manga a"]["group_name"] == "Manga A"
-        assert len(result["folder:manga a"]["files"]) == 2
-        assert result["folder:manga b"]["group_name"] == "Manga B"
-        assert len(result["folder:manga b"]["files"]) == 2
+        manga_a_key = "folder:%s" % importinbox._filepath_to_impid("/import/Manga A")
+        manga_b_key = "folder:%s" % importinbox._filepath_to_impid("/import/Manga B")
+        assert set(result.keys()) == {manga_a_key, manga_b_key}
+        assert result[manga_a_key]["group_name"] == "Manga A"
+        assert len(result[manga_a_key]["files"]) == 2
+        assert result[manga_b_key]["group_name"] == "Manga B"
+        assert len(result[manga_b_key]["files"]) == 2
+
+    def test_folder_group_keys_do_not_collapse_similar_normalized_names(self, importinbox):
+        with patch("os.walk") as mock_walk:
+            mock_walk.return_value = [
+                ("/import/Batman", [], ["001.cbz"]),
+                ("/import/Batman - Year One", [], ["001.cbz"]),
+            ]
+            result = importinbox._collect_file_groups("/import")
+
+        assert len(result) == 2
+        assert sorted(group["group_name"] for group in result.values()) == [
+            "Batman",
+            "Batman - Year One",
+        ]
+        assert all(key.startswith("folder:") for key in result)
 
     def test_root_files_grouped_individually(self, importinbox):
         with patch("os.walk") as mock_walk:
@@ -95,7 +114,8 @@ class TestCollectFileGroups:
             ]
             result = importinbox._collect_file_groups("/import")
 
-        assert len(result["folder:batman"]["files"]) == 1
+        batman_key = "folder:%s" % importinbox._filepath_to_impid("/import/Batman")
+        assert len(result[batman_key]["files"]) == 1
 
     def test_empty_directory(self, importinbox):
         with patch("os.walk") as mock_walk:
@@ -160,7 +180,12 @@ class TestMatchGroup:
     def test_multiple_series_takes_highest(self, importinbox, _mock_globals):
         series_list = [
             {"ComicID": "cv-100", "ComicName": "Batman", "ComicSortName": "Batman", "DynamicName": "batman"},
-            {"ComicID": "cv-200", "ComicName": "Batman Beyond", "ComicSortName": "Batman Beyond", "DynamicName": "batmanbeyond"},
+            {
+                "ComicID": "cv-200",
+                "ComicName": "Batman Beyond",
+                "ComicSortName": "Batman Beyond",
+                "DynamicName": "batmanbeyond",
+            },
         ]
 
         _mock_globals["db"].upsert = MagicMock()
@@ -189,14 +214,22 @@ class TestInboxScan:
 
         with (
             patch("os.path.isdir", return_value=True),
-            patch.object(importinbox, "_collect_file_groups", return_value={
-                "folder:batman": {"group_name": "Batman", "files": ["/import/Batman/001.cbz"]},
-                "folder:unknown": {"group_name": "Unknown", "files": ["/import/Unknown/001.cbz"]},
-            }),
-            patch.object(importinbox, "_match_group", side_effect=[
-                {"auto_imported": 1, "queued_for_review": 0},
-                {"auto_imported": 0, "queued_for_review": 1},
-            ]),
+            patch.object(
+                importinbox,
+                "_collect_file_groups",
+                return_value={
+                    "folder:batman": {"group_name": "Batman", "files": ["/import/Batman/001.cbz"]},
+                    "folder:unknown": {"group_name": "Unknown", "files": ["/import/Unknown/001.cbz"]},
+                },
+            ),
+            patch.object(
+                importinbox,
+                "_match_group",
+                side_effect=[
+                    {"auto_imported": 1, "queued_for_review": 0},
+                    {"auto_imported": 0, "queued_for_review": 1},
+                ],
+            ),
         ):
             result = importinbox.inboxScan()
 

--- a/tests/unit/test_manga_parser.py
+++ b/tests/unit/test_manga_parser.py
@@ -124,6 +124,48 @@ class TestExplicitChapterLabel:
         assert result["chapter_number"] == 1.0
 
 
+class TestFolderContextChapterOnly:
+    """Filenames where the parent folder provides the series name."""
+
+    def test_chapter_only_label_with_folder_series(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("chapter 1.cbz", series_name="Manga A")
+        assert result is not None
+        assert result["series_name"] == "Manga A"
+        assert result["chapter_number"] == 1.0
+        assert result["volume_number"] is None
+
+    def test_chapter_only_abbreviation_with_folder_series(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Ch. 2.cbz", series_name="Manga A")
+        assert result is not None
+        assert result["series_name"] == "Manga A"
+        assert result["chapter_number"] == 2.0
+
+    def test_bare_number_with_folder_series(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("001.cbz", series_name="Manga A")
+        assert result is not None
+        assert result["series_name"] == "Manga A"
+        assert result["chapter_number"] == 1.0
+
+    def test_chapter_only_without_folder_series_stays_unparseable(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("chapter 1.cbz")
+        assert result is None
+
+    def test_parse_chapter_number_without_series(self):
+        from comicarr.manga_parser import parse_manga_chapter_number
+
+        assert parse_manga_chapter_number("chapter 1.cbz") == 1.0
+        assert parse_manga_chapter_number("Ch. 2.cbz") == 2.0
+        assert parse_manga_chapter_number("001.cbz") == 1.0
+
+
 class TestAbbreviatedVolChapter:
     """Pattern: Title Vol.01 Ch.001.cbz"""
 

--- a/tests/unit/test_series_import_matching.py
+++ b/tests/unit/test_series_import_matching.py
@@ -17,7 +17,7 @@ Tests for manual import matching behavior.
 """
 
 from types import SimpleNamespace
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -53,10 +53,113 @@ def test_match_import_marks_record_imported_with_manual_match_metadata():
     )
 
 
+def test_update_import_issue_number_persists_file_metadata():
+    with patch.object(queries.db, "upsert") as mock_upsert:
+        queries.update_import_issue_number("imp-1", "12.5")
+
+    mock_upsert.assert_called_once_with("importresults", {"IssueNumber": "12.5"}, {"impID": "imp-1"})
+
+
+def test_get_import_pending_returns_group_and_file_summary_counts():
+    engine = MagicMock()
+    conn = MagicMock()
+    engine.connect.return_value.__enter__.return_value = conn
+    conn.execute.side_effect = [
+        MagicMock(scalar=MagicMock(return_value=2)),
+        MagicMock(scalar=MagicMock(return_value=4)),
+    ]
+
+    group_rows = [
+        {
+            "GroupKey": "folder:manga-a",
+            "ComicName": "Manga A",
+            "Volume": None,
+            "ComicYear": None,
+            "Status": "Unmatched",
+            "SRID": None,
+            "ComicID": None,
+            "SuggestedComicID": None,
+            "SuggestedComicName": None,
+            "FileCount": 2,
+        },
+        {
+            "GroupKey": "file:root-a",
+            "ComicName": "Root A",
+            "Volume": None,
+            "ComicYear": None,
+            "Status": "Unmatched",
+            "SRID": None,
+            "ComicID": None,
+            "SuggestedComicID": None,
+            "SuggestedComicName": None,
+            "FileCount": 1,
+        },
+    ]
+    file_rows = [
+        {
+            "impID": "imp-1",
+            "ComicFilename": "chapter 1.cbz",
+            "ComicLocation": "/imports/Manga A/chapter 1.cbz",
+            "IssueNumber": "1",
+            "ComicYear": None,
+            "Status": "Unmatched",
+            "IgnoreFile": 0,
+            "MatchConfidence": None,
+            "SuggestedComicID": None,
+            "SuggestedComicName": None,
+            "SuggestedIssueID": None,
+            "MatchSource": None,
+        }
+    ]
+
+    with (
+        patch.object(queries.db, "get_engine", return_value=engine),
+        patch.object(queries.db, "select_all", side_effect=[group_rows, file_rows, file_rows]),
+    ):
+        result = queries.get_import_pending(limit=50, offset=0)
+
+    assert result["pagination"]["total"] == 2
+    assert result["summary"] == {"group_count": 2, "file_count": 4}
+    assert [import_group["DynamicName"] for import_group in result["imports"]] == ["folder:manga-a", "file:root-a"]
+
+
 def test_clean_import_ids_handles_empty_scalar_and_duplicate_values():
     assert service._clean_import_ids(None) == []
     assert service._clean_import_ids("imp-1") == ["imp-1"]
     assert service._clean_import_ids([" imp-1 ", None, "", "imp-1", "imp-2"]) == ["imp-1", "imp-2"]
+
+
+def test_update_import_metadata_rejects_blank_issue_number():
+    result = service.update_import_metadata(None, "imp-1", " ")
+    assert result["success"] is False
+    assert "blank" in result["error"]
+
+
+def test_update_import_metadata_rejects_missing_record():
+    with patch.object(service.series_queries, "get_import_row", return_value=None):
+        result = service.update_import_metadata(None, "imp-missing", "1")
+
+    assert result["success"] is False
+    assert result["not_found"] is True
+
+
+def test_update_import_metadata_rejects_imported_record():
+    with patch.object(service.series_queries, "get_import_row", return_value={"impID": "imp-1", "Status": "Imported"}):
+        result = service.update_import_metadata(None, "imp-1", "1")
+
+    assert result["success"] is False
+    assert result["imported"] is True
+
+
+def test_update_import_metadata_updates_pending_record():
+    with (
+        patch.object(service.series_queries, "get_import_row", return_value={"impID": "imp-1", "Status": "Not Imported"}),
+        patch.object(service.series_queries, "update_import_issue_number") as mock_update,
+    ):
+        result = service.update_import_metadata(None, " imp-1 ", " 2.5 ")
+
+    assert result == {"success": True, "imp_id": "imp-1", "issue_number": "2.5"}
+    mock_update.assert_called_once_with("imp-1", "2.5")
 
 
 def test_match_import_empty_ids_does_not_add_or_finalize_manga():
@@ -167,6 +270,87 @@ def test_match_import_uses_existing_library_name_without_readding_manga():
     assert result["matched"] == 1
     assert result["comic_name"] == "Existing Berserk"
     mock_match.assert_called_once_with("imp-1", "mal-123", "Existing Berserk", issue_id=None)
+
+
+def test_match_import_resolves_issue_id_per_import_row():
+    import_rows_seen = []
+
+    def finalize(rows, *args, **kwargs):
+        import_rows_seen.extend(rows)
+        return {"success": True}
+
+    with (
+        patch.object(service.series_queries, "get_comic_name", return_value="Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": "/library/Berserk"},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": "/import/Berserk/chapter 1.cbz",
+                    "ComicFilename": "chapter 1.cbz",
+                    "IssueNumber": "1",
+                },
+                {
+                    "impID": "imp-2",
+                    "ComicLocation": "/import/Berserk/chapter 2.cbz",
+                    "ComicFilename": "chapter 2.cbz",
+                    "IssueNumber": "2",
+                },
+            ],
+        ),
+        patch.object(
+            service.series_queries, "get_issue_id_for_import", side_effect=["mal-123-ch1", "mal-123-ch2"]
+        ) as mock_get_issue,
+        patch.object(service, "_finalize_import_rows", side_effect=finalize),
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1", "imp-2"], "mal-123", comic_name="Berserk")
+
+    assert result["success"] is True
+    assert [row["_ResolvedIssueID"] for row in import_rows_seen] == ["mal-123-ch1", "mal-123-ch2"]
+    mock_get_issue.assert_has_calls([call("mal-123", "1"), call("mal-123", "2")])
+    mock_match.assert_has_calls(
+        [
+            call("imp-1", "mal-123", "Berserk", issue_id="mal-123-ch1"),
+            call("imp-2", "mal-123", "Berserk", issue_id="mal-123-ch2"),
+        ]
+    )
+
+
+def test_match_import_uses_request_issue_id_as_fallback():
+    with (
+        patch.object(service.series_queries, "get_comic_name", return_value="Berserk"),
+        patch.object(
+            service.series_queries,
+            "get_comic_for_import",
+            return_value={"ComicName": "Berserk", "ComicLocation": "/library/Berserk"},
+        ),
+        patch.object(
+            service.series_queries,
+            "get_import_rows",
+            return_value=[
+                {
+                    "impID": "imp-1",
+                    "ComicLocation": "/import/Berserk/chapter x.cbz",
+                    "ComicFilename": "chapter x.cbz",
+                    "IssueNumber": "x",
+                }
+            ],
+        ),
+        patch.object(service.series_queries, "get_issue_id_for_import", return_value=None),
+        patch.object(service, "_finalize_import_rows", return_value={"success": True}),
+        patch.object(service.series_queries, "match_import") as mock_match,
+    ):
+        result = service.match_import(None, ["imp-1"], "mal-123", comic_name="Berserk", issue_id="fallback-ch")
+
+    assert result["success"] is True
+    mock_match.assert_called_once_with("imp-1", "mal-123", "Berserk", issue_id="fallback-ch")
 
 
 def test_match_import_moves_files_before_marking_rows_imported(tmp_path):

--- a/tests/unit/test_series_import_matching.py
+++ b/tests/unit/test_series_import_matching.py
@@ -60,6 +60,26 @@ def test_update_import_issue_number_persists_file_metadata():
     mock_upsert.assert_called_once_with("importresults", {"IssueNumber": "12.5"}, {"impID": "imp-1"})
 
 
+def test_get_issue_id_for_import_prefers_chapter_number_match():
+    with patch.object(queries.db, "select_one", return_value={"IssueID": "chapter-row"}) as mock_select_one:
+        result = queries.get_issue_id_for_import("mal-123", "1")
+
+    assert result == "chapter-row"
+    assert mock_select_one.call_count == 1
+
+
+def test_get_issue_id_for_import_falls_back_to_issue_number_match():
+    with patch.object(
+        queries.db,
+        "select_one",
+        side_effect=[None, {"IssueID": "issue-row"}],
+    ) as mock_select_one:
+        result = queries.get_issue_id_for_import("mal-123", "1")
+
+    assert result == "issue-row"
+    assert mock_select_one.call_count == 2
+
+
 def test_get_import_pending_returns_group_and_file_summary_counts():
     engine = MagicMock()
     conn = MagicMock()
@@ -153,7 +173,9 @@ def test_update_import_metadata_rejects_imported_record():
 
 def test_update_import_metadata_updates_pending_record():
     with (
-        patch.object(service.series_queries, "get_import_row", return_value={"impID": "imp-1", "Status": "Not Imported"}),
+        patch.object(
+            service.series_queries, "get_import_row", return_value={"impID": "imp-1", "Status": "Not Imported"}
+        ),
         patch.object(service.series_queries, "update_import_issue_number") as mock_update,
     ):
         result = service.update_import_metadata(None, " imp-1 ", " 2.5 ")


### PR DESCRIPTION
## Summary

Manga imports now preserve the user's actual folder and file intent instead of collapsing chapter-only filenames into ambiguous review rows. Nested folders become folder review groups, root files remain separate single-file groups, inferred chapters are visible and editable per file, and matching uses the reviewed per-row chapter values during finalization.

The Import page now opens on the review queue when pending work exists. It shows accurate group/file counts, clearer folder vs single-file labels, inline chapter/issue save states, safer match handoff context, and keeps library scans plus the watched inbox below as setup and maintenance tools.

Fixes frankieramirez/comicarr#186.

## Design Notes

- `GET /api/import` keeps `pagination.total` as the group count and adds `summary.group_count` plus `summary.file_count` for accurate page copy.
- Import Inbox grouping uses stable `DynamicName` keys so folder groups and root single files stay distinct through pending review.
- Chapter edits update only `importresults.IssueNumber`; no new columns or schema migration are required.
- Match finalization resolves issue/chapter IDs per import row, so mixed chapter groups do not reuse one shared issue ID.
- The review UI treats scan/setup surfaces as secondary when pending imports exist, while preserving the existing scan and inbox flows.

## Validation

- `.venv/bin/python -m pytest tests/unit/test_importinbox.py tests/unit/test_manga_parser.py tests/unit/test_series_import_matching.py -q` — 80 passed
- `cd frontend && npm run lint`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run test:run` — 62 passed
- `cd frontend && npm run build`
- `git diff --check`
- Captured local production-build screenshots for desktop collapsed, expanded, saving, saved, save-error, empty, mobile expanded, mobile empty, and mobile action-scroll states.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline editing for issue/chapter numbers on pending import files.
  * Added clearer import group summaries, including separate counts for groups and files.
  * Added a “Scan inbox now” action when no pending imports are found.

* **Bug Fixes**
  * Improved import grouping and selection handling for folders and single files.
  * Better chapter detection for filenames that only include chapter information.
  * Updated match and review labels to show more helpful context and confidence messages.

* **UI Improvements**
  * Added tooltips and clearer buttons across import review actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->