### PR TITLE
fix: stamp torrentinfo snatch_status on all return paths

### DIFF
--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -372,10 +372,14 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
         from comicarr.torrent.clients import deluge as delu
 
         dp = delu.TorrentClient()
-        if not dp.connect(
+        # connect() returns the RPC client on success, or {"status": False, "error": ...}
+        # on failure. Failure dicts are truthy — bare `if not conn` never catches them.
+        conn = dp.connect(
             comicarr.CONFIG.DELUGE_HOST, comicarr.CONFIG.DELUGE_USERNAME, comicarr.CONFIG.DELUGE_PASSWORD
-        ):
+        )
+        if conn is False or conn is None or (isinstance(conn, dict) and conn.get("status") is False):
             logger.warn("Not connected to Deluge!")
+            return {"snatch_status": "MONITOR ERROR"}
 
         torrent_info = dp.get_torrent(torrent_hash)
     else:
@@ -383,7 +387,9 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
 
     logger.info("torrent_info: %s" % torrent_info)
 
-    if torrent_info is False or len(torrent_info) == 0:
+    # Falsy covers False (Deluge miss), None (rTorrent check-miss bare return), and {}.
+    # Use `not torrent_info` so None never hits len() and TypeErrors the worker.
+    if not torrent_info:
         # The client was queried and returned no torrent for this hash. This
         # is an EXPLICIT "hash not present in the client" signal — NOT the old
         # silent fall-through (previously this set a lost local snatch_status
@@ -393,7 +399,7 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
         # dict lets U5 recovery classification distinguish "absent from a
         # reachable client" (→ gone, after the done-signal cross-check) from a
         # transient client outage (MONITOR ERROR → unknown). Connection
-        # failures are logged/handled distinctly above and do not reach here.
+        # failures return MONITOR ERROR above and do not reach here.
         logger.warn("torrent not present in client for hash %s (explicit NOT FOUND)." % torrent_hash)
         return {"snatch_status": "NOT FOUND", "hash": torrent_hash}
     else:
@@ -485,9 +491,7 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
             # rather than NOT SNATCHED → absent/gone. NOT FOUND remains the only
             # explicit absent marker (returned above when the client has no hash).
             snatch_status = "IN PROGRESS"
-            if download is True:
-                snatch_status = "IN PROGRESS"
-            elif monitor is True:
+            if monitor is True:
                 if comicarr.USE_DELUGE:
                     pauseit = dp.stop_torrent(torrent_hash)
                     if pauseit is False:

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -374,9 +374,7 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
         dp = delu.TorrentClient()
         # connect() returns the RPC client on success, or {"status": False, "error": ...}
         # on failure. Failure dicts are truthy — bare `if not conn` never catches them.
-        conn = dp.connect(
-            comicarr.CONFIG.DELUGE_HOST, comicarr.CONFIG.DELUGE_USERNAME, comicarr.CONFIG.DELUGE_PASSWORD
-        )
+        conn = dp.connect(comicarr.CONFIG.DELUGE_HOST, comicarr.CONFIG.DELUGE_USERNAME, comicarr.CONFIG.DELUGE_PASSWORD)
         if conn is False or conn is None or (isinstance(conn, dict) and conn.get("status") is False):
             logger.warn("Not connected to Deluge!")
             return {"snatch_status": "MONITOR ERROR"}

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -345,13 +345,13 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
         cinfo = db.select_one(stmt)
         if cinfo is None:
             logger.warn("Unable to locate IssueID of : " + issueid)
-            snatch_status = "MONITOR ERROR"
+            return {"snatch_status": "MONITOR ERROR"}
 
         if cinfo["Status"] != "Snatched" or cinfo["Hash"] is None:
             logger.warn(
                 cinfo["ComicName"] + " #" + cinfo["Issue_Number"] + " is currently in a " + cinfo["Status"] + " Status."
             )
-            snatch_status = "MONITOR ERROR"
+            return {"snatch_status": "MONITOR ERROR"}
 
         torrent_hash = cinfo["Hash"]
 
@@ -361,26 +361,25 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
 
     if not len(torrent_hash) == 40:
         logger.error("Torrent hash is missing, or an invalid hash value has been passed")
-        snatch_status = "MONITOR ERROR"
+        return {"snatch_status": "MONITOR ERROR"}
+
+    if comicarr.USE_RTORRENT:
+        from comicarr import rtorrent_test_client
+
+        rp = rtorrent_test_client.RTorrent()
+        torrent_info = rp.main(torrent_hash, check=True)
+    elif comicarr.USE_DELUGE:
+        from comicarr.torrent.clients import deluge as delu
+
+        dp = delu.TorrentClient()
+        if not dp.connect(
+            comicarr.CONFIG.DELUGE_HOST, comicarr.CONFIG.DELUGE_USERNAME, comicarr.CONFIG.DELUGE_PASSWORD
+        ):
+            logger.warn("Not connected to Deluge!")
+
+        torrent_info = dp.get_torrent(torrent_hash)
     else:
-        if comicarr.USE_RTORRENT:
-            from . import rtorrent_test_client
-
-            rp = rtorrent_test_client.RTorrent()
-            torrent_info = rp.main(torrent_hash, check=True)
-        elif comicarr.USE_DELUGE:
-            from comicarr.torrent.clients import deluge as delu
-
-            dp = delu.TorrentClient()
-            if not dp.connect(
-                comicarr.CONFIG.DELUGE_HOST, comicarr.CONFIG.DELUGE_USERNAME, comicarr.CONFIG.DELUGE_PASSWORD
-            ):
-                logger.warn("Not connected to Deluge!")
-
-            torrent_info = dp.get_torrent(torrent_hash)
-        else:
-            snatch_status = "MONITOR ERROR"
-            return
+        return {"snatch_status": "MONITOR ERROR"}
 
     logger.info("torrent_info: %s" % torrent_info)
 
@@ -466,7 +465,7 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
                 logger.fdebug("Script result: %s" % out)
             except OSError as e:
                 logger.warn("Unable to run extra_script: %s" % e)
-                snatch_status = "MONITOR ERROR"
+                torrent_info["snatch_status"] = "MONITOR ERROR"
             else:
                 if "Access failed: No such file" in str(out):
                     logger.fdebug(
@@ -481,6 +480,11 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
                 torrent_info["copied_filepath"] = os.path.join(comicarr.CONFIG.PP_SSHLOCALCD, torrent_info["name"])
                 torrent_info["snatch_status"] = snatch_status
         else:
+            # Present in client but not finished (or not in download/complete path).
+            # Prefer IN PROGRESS so recovery classifies present torrents as "still"
+            # rather than NOT SNATCHED → absent/gone. NOT FOUND remains the only
+            # explicit absent marker (returned above when the client has no hash).
+            snatch_status = "IN PROGRESS"
             if download is True:
                 snatch_status = "IN PROGRESS"
             elif monitor is True:
@@ -503,8 +507,7 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
                             torrent_info["copied_filepath"] = torrent_path
                         else:
                             dp.start_torrent(torrent_hash)
-            else:
-                snatch_status = "NOT SNATCHED"
+            torrent_info["snatch_status"] = snatch_status
 
     return torrent_info
 

--- a/tests/unit/test_torrentinfo.py
+++ b/tests/unit/test_torrentinfo.py
@@ -145,3 +145,52 @@ def test_download_false_present_incomplete_is_in_progress(monkeypatch):
 
     assert isinstance(result, dict)
     assert result["snatch_status"] == "IN PROGRESS"
+
+
+def test_deluge_connect_failure_dict_is_monitor_error_not_not_found(monkeypatch):
+    """Deluge connect returns truthy {status: False}; must not fall through to NOT FOUND."""
+    monkeypatch.setattr(comicarr, "USE_DELUGE", True)
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", False)
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = {"status": False, "error": "connection refused"}
+    fake_client.get_torrent.return_value = False
+
+    with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=fake_client):
+        result = service.torrentinfo(torrent_hash=HASH40, download=True)
+
+    assert isinstance(result, dict)
+    assert result["snatch_status"] == "MONITOR ERROR"
+    fake_client.get_torrent.assert_not_called()
+
+
+def test_deluge_connect_false_is_monitor_error(monkeypatch):
+    monkeypatch.setattr(comicarr, "USE_DELUGE", True)
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", False)
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = False
+
+    with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=fake_client):
+        result = service.torrentinfo(torrent_hash=HASH40, download=True)
+
+    assert isinstance(result, dict)
+    assert result["snatch_status"] == "MONITOR ERROR"
+    fake_client.get_torrent.assert_not_called()
+
+
+def test_rtorrent_none_missing_hash_is_not_found_dict(monkeypatch):
+    """rTorrent check-miss bare-returns None; must not TypeError on len(None)."""
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", True)
+    monkeypatch.setattr(comicarr, "USE_DELUGE", False)
+
+    class FakeRTorrent:
+        def main(self, torrent_hash=None, check=False):
+            return None
+
+    with patch("comicarr.rtorrent_test_client.RTorrent", return_value=FakeRTorrent()):
+        result = service.torrentinfo(torrent_hash=HASH40, download=True)
+
+    assert isinstance(result, dict)
+    assert result["snatch_status"] == "NOT FOUND"
+    assert result["hash"] == HASH40

--- a/tests/unit/test_torrentinfo.py
+++ b/tests/unit/test_torrentinfo.py
@@ -1,0 +1,147 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Unit tests for torrentinfo() snatch_status contract.
+
+torrentinfo is the probe used by the auto-snatch worker and restart recovery.
+Every return path that callers index must be a dict with snatch_status set.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import comicarr
+from comicarr.app.search import service
+
+HASH40 = "a" * 40
+
+
+@pytest.fixture(autouse=True)
+def _torrent_flags(monkeypatch):
+    """Default to no torrent client; tests opt in to Deluge/rTorrent."""
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", False, raising=False)
+    monkeypatch.setattr(comicarr, "USE_DELUGE", False, raising=False)
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        type(
+            "C",
+            (),
+            {
+                "DELUGE_HOST": "localhost",
+                "DELUGE_USERNAME": "u",
+                "DELUGE_PASSWORD": "p",
+                "AUTO_SNATCH_SCRIPT": "",
+                "PP_SSHHOST": "",
+                "PP_SSHPORT": "",
+                "PP_SSHUSER": "",
+                "PP_SSHLOCALCD": "/tmp",
+                "PP_SSHKEYFILE": None,
+                "PP_SSHPASSWD": None,
+            },
+        )(),
+        raising=False,
+    )
+
+
+def _deluge_torrent(finished=False):
+    return {
+        "is_finished": finished,
+        "num_files": 1,
+        "save_path": "/downloads",
+        "total_size": 1000,
+        "total_uploaded": 0,
+        "total_payload_download": 500,
+        "time_added": 1,
+        "files": [{"path": "Saga.cbz"}],
+        "name": "Saga.cbz",
+    }
+
+
+def test_missing_issue_returns_monitor_error_dict(monkeypatch):
+    """Missing issue row must return a dict, not crash indexing None."""
+    monkeypatch.setattr(service.db, "select_one", lambda stmt: None)
+
+    result = service.torrentinfo(issueid="999")
+
+    assert isinstance(result, dict)
+    assert result["snatch_status"] == "MONITOR ERROR"
+
+
+def test_rtorrent_import_path_no_importerror_and_status(monkeypatch):
+    """rTorrent path must import from comicarr (not relative under app.search)."""
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", True)
+    monkeypatch.setattr(comicarr, "USE_DELUGE", False)
+
+    class FakeRTorrent:
+        def main(self, torrent_hash=None, check=False):
+            return {"completed": False, "files": ["a.cbz"], "folder": "/dl"}
+
+    with patch("comicarr.rtorrent_test_client.RTorrent", return_value=FakeRTorrent()):
+        result = service.torrentinfo(torrent_hash=HASH40, download=True)
+
+    assert isinstance(result, dict)
+    assert "snatch_status" in result
+    assert result["snatch_status"] == "IN PROGRESS"
+
+
+def test_deluge_unfinished_download_true_is_in_progress(monkeypatch):
+    monkeypatch.setattr(comicarr, "USE_DELUGE", True)
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", False)
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = True
+    fake_client.get_torrent.return_value = _deluge_torrent(finished=False)
+
+    with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=fake_client):
+        result = service.torrentinfo(torrent_hash=HASH40, download=True)
+
+    assert isinstance(result, dict)
+    assert result["snatch_status"] == "IN PROGRESS"
+
+
+def test_neither_client_returns_monitor_error_dict():
+    result = service.torrentinfo(torrent_hash=HASH40, download=True)
+
+    assert isinstance(result, dict)
+    assert result is not None
+    assert result["snatch_status"] == "MONITOR ERROR"
+
+
+def test_not_found_path_still_works(monkeypatch):
+    monkeypatch.setattr(comicarr, "USE_DELUGE", True)
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", False)
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = True
+    fake_client.get_torrent.return_value = False
+
+    with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=fake_client):
+        result = service.torrentinfo(torrent_hash=HASH40, download=True)
+
+    assert isinstance(result, dict)
+    assert result["snatch_status"] == "NOT FOUND"
+    assert result["hash"] == HASH40
+
+
+def test_download_false_present_incomplete_is_in_progress(monkeypatch):
+    """Recovery probes with download=False; present incomplete must not be absent."""
+    monkeypatch.setattr(comicarr, "USE_DELUGE", True)
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", False)
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = True
+    fake_client.get_torrent.return_value = _deluge_torrent(finished=False)
+
+    with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=fake_client):
+        result = service.torrentinfo(torrent_hash=HASH40, download=False, monitor=False)
+
+    assert isinstance(result, dict)
+    assert result["snatch_status"] == "IN PROGRESS"


### PR DESCRIPTION
## Summary
Make `torrentinfo()` always return a dict with `snatch_status` so auto-snatch workers and restart recovery never `KeyError` or mis-classify live torrents.

- Early error paths (missing issue, bad hash, no client) return `{"snatch_status": "MONITOR ERROR"}` instead of crashing or bare-returning
- Fix rTorrent import to `from comicarr import rtorrent_test_client` (was package-relative under `app.search`)
- Stamp `IN PROGRESS` on incomplete/present torrents so recovery classifies them as still in client
- Unit tests for the contract (`tests/unit/test_torrentinfo.py`)

## Test plan
- [x] `pytest tests/unit/test_torrentinfo.py tests/unit/test_recovery_classify.py -v`
- [x] ruff check/format on touched files

## Plan
Improve plan 009