### PR TITLE
fix: correct Discord and webhook notifier success checks

### DIFF
--- a/.changeset/fix-webhook-notifier-success-checks.md
+++ b/.changeset/fix-webhook-notifier-success-checks.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix Discord and sibling webhook notifiers so successful deliveries are reported correctly and network errors return false instead of raising.

--- a/comicarr/notifiers.py
+++ b/comicarr/notifiers.py
@@ -483,10 +483,12 @@ class SLACK:
             "text": attachment_text
         }
 
+        response = None
         try:
             response = requests.post(self.webhook_url, json=payload, verify=True)
         except Exception as e:
             logger.info(module + "Slack notify failed: " + str(e))
+            return False
 
         # Error logging
         sent_successfuly = True
@@ -558,10 +560,12 @@ class MATTERMOST:
             "footer_icon": "https://github.com/frankieramirez/comicarr/raw/master/data/images/comicarrlogo.png",
             "attachments": attachments,
         }
+        response = None
         try:
             response = requests.post(self.webhook_url, json=payload, verify=True)
         except Exception as e:
             logger.info(module + "Mattermost notify failed: " + str(e))
+            return False
 
         # Error logging
         sent_successfuly = True
@@ -698,6 +702,7 @@ class DISCORD:
                         }
                     ]
 
+        response = None
         if imageFile is not None:
             files = {"payload_json": (None, json.dumps(payload)), "file1": ("image.jpg", base64.b64decode(imageFile))}
             try:
@@ -716,16 +721,18 @@ class DISCORD:
                 logger.info(module + "Discord notify failed: " + str(e))
 
         # Error logging
+        if response is None:
+            return False
         sent_successfuly = True
-        if not all([response.status_code == 204, response.status_code == 200]):
+        if response.status_code not in (200, 204):
             logger.info(
                 module
                 + "Could not send notification to Discord (webhook_url=%s). Response: [%s]"
                 % (self.webhook_url, response.text)
             )
             sent_successfuly = False
-
-        logger.info(module + "Discord notifications sent.")
+        else:
+            logger.info(module + "Discord notifications sent.")
         return sent_successfuly
 
     def test_notify(self):
@@ -780,10 +787,12 @@ class GOTIFY:
                 },
             }
 
+        response = None
         try:
             response = requests.post(self.webhook_url, json=payload, verify=True)
         except Exception as e:
             logger.info(module + "Gotify notify failed: " + str(e))
+            return False
 
         # Error logging
         sent_successfuly = True

--- a/tests/unit/notifiers/test_discord.py
+++ b/tests/unit/notifiers/test_discord.py
@@ -1,8 +1,7 @@
 """Tests for DISCORD notifier."""
 
 import json
-import re
-import pytest
+
 import responses
 
 
@@ -281,15 +280,10 @@ class TestDiscordNotifyErrors:
 
         assert result is False
 
-    def test_notify_connection_error_raises_unbound_local(
+    def test_notify_connection_error_returns_false(
         self, notifiers_module, mock_notifier_config, mocker
     ):
-        """Connection error causes UnboundLocalError due to missing exception handling.
-
-        Note: This test documents a bug in the current implementation.
-        The notify method should catch the exception and return False,
-        but instead it tries to access `response` which was never assigned.
-        """
+        """Connection error returns False without raising UnboundLocalError."""
         import requests
 
         mocker.patch(
@@ -299,16 +293,14 @@ class TestDiscordNotifyErrors:
 
         discord = notifiers_module.DISCORD()
         # Use snatched format to avoid IndexError in message parsing
-        # The bug is that after the exception in requests.post,
-        # the code continues to check response.status_code which is unbound
-        with pytest.raises(UnboundLocalError):
-            discord.notify(
-                text="Comicarr Notification",
-                attachment_text="Snatched",
-                snatched_nzb="Spider-Man 001",
-                prov="NZBGeek",
-                sent_to="SABnzbd",
-            )
+        result = discord.notify(
+            text="Comicarr Notification",
+            attachment_text="Snatched",
+            snatched_nzb="Spider-Man 001",
+            prov="NZBGeek",
+            sent_to="SABnzbd",
+        )
+        assert result is False
 
 
 class TestDiscordTestNotify:

--- a/tests/unit/notifiers/test_discord.py
+++ b/tests/unit/notifiers/test_discord.py
@@ -15,13 +15,9 @@ class TestDiscordInit:
         assert discord.webhook_url == "https://discord.com/api/webhooks/test/webhook"
         assert discord.test is False
 
-    def test_init_test_webhook_sets_test_mode(
-        self, notifiers_module, mock_notifier_config
-    ):
+    def test_init_test_webhook_sets_test_mode(self, notifiers_module, mock_notifier_config):
         """Test webhook URL sets test mode to True."""
-        discord = notifiers_module.DISCORD(
-            test_webhook_url="https://discord.com/api/webhooks/override"
-        )
+        discord = notifiers_module.DISCORD(test_webhook_url="https://discord.com/api/webhooks/override")
 
         assert discord.webhook_url == "https://discord.com/api/webhooks/override"
         assert discord.test is True
@@ -31,9 +27,7 @@ class TestDiscordNotify:
     """Test DISCORD notify method."""
 
     @responses.activate
-    def test_notify_test_mode_simple_content(
-        self, notifiers_module, mock_notifier_config
-    ):
+    def test_notify_test_mode_simple_content(self, notifiers_module, mock_notifier_config):
         """Test mode sends simple content without embeds."""
         responses.add(
             responses.POST,
@@ -41,14 +35,10 @@ class TestDiscordNotify:
             status=204,
         )
 
-        discord = notifiers_module.DISCORD(
-            test_webhook_url="https://discord.com/api/webhooks/override"
-        )
+        discord = notifiers_module.DISCORD(test_webhook_url="https://discord.com/api/webhooks/override")
         result = discord.notify("Test", "Test message")
 
-        # Note: Current implementation has a bug in status check (all([x==204, x==200]))
-        # which is always False unless status is both 204 AND 200 simultaneously
-        # This test documents the actual behavior
+        assert result is True
         assert len(responses.calls) == 1
         request_body = json.loads(responses.calls[0].request.body)
         assert request_body["content"] == "Test message"
@@ -72,6 +62,7 @@ class TestDiscordNotify:
             sent_to="sent to SABnzbd",
         )
 
+        assert result is True
         assert len(responses.calls) == 1
         request_body = json.loads(responses.calls[0].request.body)
 
@@ -106,6 +97,7 @@ class TestDiscordNotify:
             sent_to="sent to DDL folder",
         )
 
+        assert result is True
         assert len(responses.calls) == 1
         request_body = json.loads(responses.calls[0].request.body)
         embeds = request_body["embeds"]
@@ -113,9 +105,7 @@ class TestDiscordNotify:
         assert sent_to_field["value"] == "DDL"
 
     @responses.activate
-    def test_notify_snatched_torrent_client_detection(
-        self, notifiers_module, mock_notifier_config
-    ):
+    def test_notify_snatched_torrent_client_detection(self, notifiers_module, mock_notifier_config):
         """Torrent client in sent_to is detected correctly."""
         responses.add(
             responses.POST,
@@ -132,6 +122,7 @@ class TestDiscordNotify:
             sent_to="sent to qBittorrent client",
         )
 
+        assert result is True
         assert len(responses.calls) == 1
         request_body = json.loads(responses.calls[0].request.body)
         embeds = request_body["embeds"]
@@ -139,9 +130,7 @@ class TestDiscordNotify:
         assert sent_to_field["value"] == "qBittorrent"
 
     @responses.activate
-    def test_notify_snatched_nzb_client_detection(
-        self, notifiers_module, mock_notifier_config
-    ):
+    def test_notify_snatched_nzb_client_detection(self, notifiers_module, mock_notifier_config):
         """NZB client (no 'client' keyword) extracts last word."""
         responses.add(
             responses.POST,
@@ -158,6 +147,7 @@ class TestDiscordNotify:
             sent_to="sent to SABnzbd",
         )
 
+        assert result is True
         assert len(responses.calls) == 1
         request_body = json.loads(responses.calls[0].request.body)
         embeds = request_body["embeds"]
@@ -179,6 +169,7 @@ class TestDiscordNotify:
             attachment_text="Error processing file",
         )
 
+        assert result is True
         assert len(responses.calls) == 1
         request_body = json.loads(responses.calls[0].request.body)
         embeds = request_body["embeds"]
@@ -203,6 +194,7 @@ class TestDiscordNotify:
             attachment_text="Comicarr has downloaded and post-processed: Spider-Man 001",
         )
 
+        assert result is True
         assert len(responses.calls) == 1
         request_body = json.loads(responses.calls[0].request.body)
         embeds = request_body["embeds"]
@@ -210,9 +202,7 @@ class TestDiscordNotify:
         assert embeds[0]["color"] == 32768  # Green
 
     @responses.activate
-    def test_notify_with_image_multipart(
-        self, notifiers_module, mock_notifier_config, sample_image_base64
-    ):
+    def test_notify_with_image_multipart(self, notifiers_module, mock_notifier_config, sample_image_base64):
         """Image notification uses multipart form data."""
         responses.add(
             responses.POST,
@@ -227,11 +217,10 @@ class TestDiscordNotify:
             imageFile=sample_image_base64,
         )
 
+        assert result is True
         assert len(responses.calls) == 1
         # Multipart form data
-        assert "multipart/form-data" in responses.calls[0].request.headers.get(
-            "Content-Type", ""
-        )
+        assert "multipart/form-data" in responses.calls[0].request.headers.get("Content-Type", "")
 
 
 class TestDiscordNotifyErrors:
@@ -280,9 +269,7 @@ class TestDiscordNotifyErrors:
 
         assert result is False
 
-    def test_notify_connection_error_returns_false(
-        self, notifiers_module, mock_notifier_config, mocker
-    ):
+    def test_notify_connection_error_returns_false(self, notifiers_module, mock_notifier_config, mocker):
         """Connection error returns False without raising UnboundLocalError."""
         import requests
 
@@ -302,14 +289,31 @@ class TestDiscordNotifyErrors:
         )
         assert result is False
 
+    def test_notify_image_multipart_connection_error_returns_false(
+        self, notifiers_module, mock_notifier_config, mocker, sample_image_base64
+    ):
+        """Multipart image path returns False on connection error without raising."""
+        import requests
+
+        mocker.patch(
+            "requests.post",
+            side_effect=requests.exceptions.ConnectionError("Network error"),
+        )
+
+        discord = notifiers_module.DISCORD()
+        result = discord.notify(
+            text="Comicarr Notification",
+            attachment_text="Comicarr has downloaded and post-processed: Spider-Man 001",
+            imageFile=sample_image_base64,
+        )
+        assert result is False
+
 
 class TestDiscordTestNotify:
     """Test DISCORD test_notify method."""
 
     @responses.activate
-    def test_test_notify_uses_test_mode(
-        self, notifiers_module, mock_notifier_config
-    ):
+    def test_test_notify_uses_test_mode(self, notifiers_module, mock_notifier_config):
         """test_notify uses test webhook and test mode when provided."""
         responses.add(
             responses.POST,
@@ -317,12 +321,11 @@ class TestDiscordTestNotify:
             status=204,
         )
 
-        discord = notifiers_module.DISCORD(
-            test_webhook_url="https://discord.com/api/webhooks/override"
-        )
+        discord = notifiers_module.DISCORD(test_webhook_url="https://discord.com/api/webhooks/override")
         result = discord.test_notify()
 
         # Test mode sends simple content
+        assert result is True
         assert len(responses.calls) == 1
         request_body = json.loads(responses.calls[0].request.body)
         assert "Release the Ninjas" in request_body["content"]

--- a/tests/unit/test_notifiers_webhooks.py
+++ b/tests/unit/test_notifiers_webhooks.py
@@ -1,0 +1,133 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Success-check and exception-path tests for webhook notifiers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+WEBHOOK_URL = "https://example.test/webhook"
+
+
+@pytest.fixture
+def mock_webhook_config(monkeypatch):
+    """Minimal comicarr.CONFIG for Slack/Mattermost/Discord/Gotify constructors."""
+    import comicarr
+
+    monkeypatch.setattr(comicarr, "LOG_LEVEL", 1)
+
+    config = MagicMock()
+    config.SLACK_WEBHOOK_URL = WEBHOOK_URL
+    config.MATTERMOST_WEBHOOK_URL = WEBHOOK_URL
+    config.DISCORD_WEBHOOK_URL = WEBHOOK_URL
+    config.GOTIFY_SERVER_URL = "https://example.test/"
+    config.GOTIFY_TOKEN = "fake-gotify-token"
+    monkeypatch.setattr(comicarr, "CONFIG", config)
+    return config
+
+
+def _mock_response(status_code, text=""):
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    return response
+
+
+class TestDiscordWebhookSuccess:
+    def test_status_204_returns_true(self, mock_webhook_config):
+        from comicarr.notifiers import DISCORD
+
+        with patch("requests.post", return_value=_mock_response(204)):
+            result = DISCORD(test_webhook_url=WEBHOOK_URL).notify("Test Message", "Release the Ninjas!")
+        assert result is True
+
+    def test_status_200_returns_true(self, mock_webhook_config):
+        from comicarr.notifiers import DISCORD
+
+        with patch("requests.post", return_value=_mock_response(200)):
+            result = DISCORD(test_webhook_url=WEBHOOK_URL).notify("Test Message", "Release the Ninjas!")
+        assert result is True
+
+    def test_status_500_returns_false(self, mock_webhook_config):
+        from comicarr.notifiers import DISCORD
+
+        with patch("requests.post", return_value=_mock_response(500, "error")):
+            result = DISCORD(test_webhook_url=WEBHOOK_URL).notify("Test Message", "Release the Ninjas!")
+        assert result is False
+
+    def test_request_exception_returns_false(self, mock_webhook_config):
+        from comicarr.notifiers import DISCORD
+
+        with patch(
+            "requests.post",
+            side_effect=requests.RequestException("network down"),
+        ):
+            result = DISCORD(test_webhook_url=WEBHOOK_URL).notify("Test Message", "Release the Ninjas!")
+        assert result is False
+
+
+class TestSlackWebhookSuccess:
+    def test_status_200_returns_true(self, mock_webhook_config):
+        from comicarr.notifiers import SLACK
+
+        with patch("requests.post", return_value=_mock_response(200, "ok")):
+            result = SLACK(test_webhook_url=WEBHOOK_URL).notify("Test Message", "Release the Ninjas!")
+        assert result is True
+
+    def test_status_500_returns_false(self, mock_webhook_config):
+        from comicarr.notifiers import SLACK
+
+        with patch("requests.post", return_value=_mock_response(500, "error")):
+            result = SLACK(test_webhook_url=WEBHOOK_URL).notify("Test Message", "Release the Ninjas!")
+        assert result is False
+
+    def test_request_exception_returns_false(self, mock_webhook_config):
+        from comicarr.notifiers import SLACK
+
+        with patch(
+            "requests.post",
+            side_effect=requests.RequestException("network down"),
+        ):
+            result = SLACK(test_webhook_url=WEBHOOK_URL).notify("Test Message", "Release the Ninjas!")
+        assert result is False
+
+
+@pytest.mark.parametrize(
+    "notifier_name",
+    ["MATTERMOST", "GOTIFY"],
+)
+class TestSiblingWebhookSuccess:
+    def test_status_200_returns_true(self, mock_webhook_config, notifier_name):
+        from comicarr import notifiers
+
+        cls = getattr(notifiers, notifier_name)
+        with patch("requests.post", return_value=_mock_response(200, "ok")):
+            result = cls(test_webhook_url=WEBHOOK_URL).notify("Test Message", "Release the Ninjas!")
+        assert result is True
+
+    def test_status_500_returns_false(self, mock_webhook_config, notifier_name):
+        from comicarr import notifiers
+
+        cls = getattr(notifiers, notifier_name)
+        with patch("requests.post", return_value=_mock_response(500, "error")):
+            result = cls(test_webhook_url=WEBHOOK_URL).notify("Test Message", "Release the Ninjas!")
+        assert result is False
+
+    def test_request_exception_returns_false(self, mock_webhook_config, notifier_name):
+        from comicarr import notifiers
+
+        cls = getattr(notifiers, notifier_name)
+        with patch(
+            "requests.post",
+            side_effect=requests.RequestException("network down"),
+        ):
+            result = cls(test_webhook_url=WEBHOOK_URL).notify("Test Message", "Release the Ninjas!")
+        assert result is False


### PR DESCRIPTION
## Summary
Discord (and sibling webhook) notifications no longer always report failure or raise `NameError` on network errors.

- Discord treats HTTP 200 **or** 204 as success (was `all([code==204, code==200])`, always false)
- Slack / Mattermost / Gotify initialize `response` and return `False` on exceptions instead of unbound-local errors
- New `tests/unit/test_notifiers_webhooks.py`; update legacy Discord test that documented the old crash

## Test plan
- [x] `pytest tests/unit/test_notifiers_webhooks.py tests/unit/notifiers/test_discord.py -v`

## Plan
Improve plan 010