### PR TITLE
fix: redact encrypted config secrets in carepackages

### DIFF
--- a/comicarr/carepackage.py
+++ b/comicarr/carepackage.py
@@ -12,6 +12,7 @@ import zipfile
 from glob import glob
 
 import comicarr
+from comicarr import config as config_module
 from comicarr import encrypted, logger, versioncheck
 
 
@@ -23,48 +24,28 @@ class carePackage(object):
         self.lastrelpath = os.path.join(comicarr.PROG_DIR, ".LASTRELEASE")
         self.keylist = []
         self.pass_thru_vals = None
-        self.cleaned_list = {
+        # Fernet-encrypted secrets stay in sync via ENCRYPTED_CONFIG_ITEMS.
+        # extras: sensitive values not Fernet-encrypted (usernames, bcrypt password, etc.)
+        base = set(config_module.ENCRYPTED_CONFIG_ITEMS.values())
+        extras = {
             ("Interface", "http_password"),
             ("SABnzbd", "sab_username"),
-            ("SABnzbd", "sab_password"),
-            ("SABnzbd", "sab_apikey"),
             ("NZBGet", "nzbget_username"),
-            ("NZBGet", "nzbget_password"),
             ("NZBsu", "nzbsu_apikey"),
             ("DOGnzb", "dognzb_apikey"),
             ("uTorrent", "utorrent_username"),
-            ("uTorrent", "utorrent_password"),
             ("Transmission", "transmission_username"),
-            ("Transmission", "transmission_password"),
             ("Deluge", "deluge_username"),
-            ("Deluge", "deluge_password"),
             ("qBittorrent", "qbittorrent_username"),
-            ("qBittorrent", "qbittorrent_password"),
             ("Rtorrent", "rtorrent_username"),
-            ("Rtorrent", "rtorrent_password"),
-            ("Prowl", "prowl_keys"),
-            ("PUSHOVER", "pushover_apikey"),
-            ("PUSHOVER", "pushover_userkey"),
-            ("BOXCAR", "boxcar_token"),
-            ("PUSHBULLET", "pushbullet_apikey"),
             ("NMA", "nma_apikey"),
-            ("TELEGRAM", "telegram_token"),
-            ("GOTIFY", "gotify_token"),
-            ("CV", "comicvine_api"),
             ("Seedbox", "seedbox_user"),
-            ("Seedbox", "seedbox_pass"),
             ("Seedbox", "seedbox_port"),
-            ("Tablet", "tab_pass"),
-            ("API", "api_key"),
-            ("OPDS", "opds_password"),
-            ("AutoSnatch", "pp_sshpasswd"),
             ("AutoSnatch", "pp_sshport"),
-            ("Email", "email_password"),
             ("Email", "email_user"),
-            ("DISCORD", "discord_webhook_url"),
             ("DDL", "external_username"),
-            ("DDL", "external_apikey"),
         }
+        self.cleaned_list = base | extras
         self.hostname_list = {
             ("SABnzbd", "sab_host"),
             ("NZBGet", "nzbget_host"),
@@ -340,17 +321,18 @@ class carePackage(object):
                     cnt = 0
                     # remove the apikeys first.
                     filename = os.path.join(caredir, os.path.basename(fname))
-                    output = open(filename, "w")
-                    # output = pathlib.Path(filename) #open(filename, 'w')
-                    with open(fname, "r") as f:
-                        line = f.readline()
-                        while line:
-                            for keyed in self.keylist:
-                                if keyed in line and len(keyed) > 0 and (len(keyed) > 4 and not keyed.isdigit()):
-                                    cnt += 1
-                                    line = line.replace(keyed, "-REDACTED-")
-                            output.write(line)
+                    # Close/flush the redacted file before zip.write so the archive
+                    # sees the full content (open buffers are not on disk yet).
+                    with open(filename, "w") as output:
+                        with open(fname, "r") as f:
                             line = f.readline()
+                            while line:
+                                for keyed in self.keylist:
+                                    if keyed in line and len(keyed) > 0 and (len(keyed) > 4 and not keyed.isdigit()):
+                                        cnt += 1
+                                        line = line.replace(keyed, "-REDACTED-")
+                                output.write(line)
+                                line = f.readline()
 
                     logger.fdebug("removed %s keys from %s" % (cnt, fname))
                     try:
@@ -361,7 +343,6 @@ class carePackage(object):
                     except Exception as e:
                         logger.warn(e)
                     else:
-                        output.close()
                         os.unlink(filename)
 
         try:

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -1245,6 +1245,17 @@ class Config(object):
             if current_value is None:
                 continue
 
+            # configure() rewrites GIT_TOKEN to (token, "x-oauth-basic") for requests
+            # Basic auth before encrypt_items() may run. Encrypt/decrypt the string
+            # token only; never call str methods on the auth tuple.
+            if isinstance(current_value, (tuple, list)) and current_value:
+                current_value = current_value[0]
+            if not isinstance(current_value, str):
+                logger.warn(
+                    "Skipping encryption for %s: expected string, got %s" % (ini_key, type(current_value).__name__)
+                )
+                continue
+
             # Skip values already encrypted with Fernet
             if current_value.startswith("gAAAAA"):
                 if mode == "decrypt":

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -503,6 +503,47 @@ _BAD_DEFINITIONS = OrderedDict(
     }
 )
 
+# section/key only — no live values. Used by encrypt_items and carepackage redaction.
+# HTTP_PASSWORD excluded — it uses bcrypt (one-way hash), not Fernet.
+ENCRYPTED_CONFIG_ITEMS = OrderedDict(
+    {
+        "SAB_PASSWORD": ("SABnzbd", "sab_password"),
+        "SAB_APIKEY": ("SABnzbd", "sab_apikey"),
+        "NZBGET_PASSWORD": ("NZBGet", "nzbget_password"),
+        "UTORRENT_PASSWORD": ("uTorrent", "utorrent_password"),
+        "TRANSMISSION_PASSWORD": ("Transmission", "transmission_password"),
+        "DELUGE_PASSWORD": ("Deluge", "deluge_password"),
+        "QBITTORRENT_PASSWORD": ("qBittorrent", "qbittorrent_password"),
+        "RTORRENT_PASSWORD": ("Rtorrent", "rtorrent_password"),
+        "PROWL_KEYS": ("Prowl", "prowl_keys"),
+        "PUSHOVER_APIKEY": ("PUSHOVER", "pushover_apikey"),
+        "PUSHOVER_USERKEY": ("PUSHOVER", "pushover_userkey"),
+        "BOXCAR_TOKEN": ("BOXCAR", "boxcar_token"),
+        "PUSHBULLET_APIKEY": ("PUSHBULLET", "pushbullet_apikey"),
+        "TELEGRAM_TOKEN": ("TELEGRAM", "telegram_token"),
+        "COMICVINE_API": ("CV", "comicvine_api"),
+        "PASSWORD_32P": ("32P", "password_32p"),
+        "PASSKEY_32P": ("32P", "passkey_32p"),
+        "USERNAME_32P": ("32P", "username_32p"),
+        "SEEDBOX_PASS": ("Seedbox", "seedbox_pass"),
+        "TAB_PASS": ("Tablet", "tab_pass"),
+        "API_KEY": ("API", "api_key"),
+        "OPDS_PASSWORD": ("OPDS", "opds_password"),
+        "PP_SSHPASSWD": ("AutoSnatch", "pp_sshpasswd"),
+        "EMAIL_PASSWORD": ("Email", "email_password"),
+        "GIT_TOKEN": ("Git", "git_token"),
+        "METRON_PASSWORD": ("Metron", "metron_password"),
+        "GOTIFY_TOKEN": ("GOTIFY", "gotify_token"),
+        "MATRIX_ACCESS_TOKEN": ("MATRIX", "matrix_access_token"),
+        "EXTERNAL_APIKEY": ("DDL", "external_apikey"),
+        "SLACK_WEBHOOK_URL": ("SLACK", "slack_webhook_url"),
+        "MATTERMOST_WEBHOOK_URL": ("MATTERMOST", "mattermost_webhook_url"),
+        "DISCORD_WEBHOOK_URL": ("DISCORD", "discord_webhook_url"),
+        "DATABASE_URL": ("Database", "database_url"),
+        "AI_API_KEY": ("AI", "ai_api_key"),
+    }
+)
+
 
 class Config(object):
     def __init__(self, config_file):
@@ -1193,45 +1234,9 @@ class Config(object):
 
     def encrypt_items(self, mode="encrypt", updateconfig=False):
         # HTTP_PASSWORD excluded — it uses bcrypt (one-way hash), not Fernet
-        encryption_list = OrderedDict(
-            {
-                # key                      section         key            value
-                "SAB_PASSWORD": ("SABnzbd", "sab_password", self.SAB_PASSWORD),
-                "SAB_APIKEY": ("SABnzbd", "sab_apikey", self.SAB_APIKEY),
-                "NZBGET_PASSWORD": ("NZBGet", "nzbget_password", self.NZBGET_PASSWORD),
-                "UTORRENT_PASSWORD": ("uTorrent", "utorrent_password", self.UTORRENT_PASSWORD),
-                "TRANSMISSION_PASSWORD": ("Transmission", "transmission_password", self.TRANSMISSION_PASSWORD),
-                "DELUGE_PASSWORD": ("Deluge", "deluge_password", self.DELUGE_PASSWORD),
-                "QBITTORRENT_PASSWORD": ("qBittorrent", "qbittorrent_password", self.QBITTORRENT_PASSWORD),
-                "RTORRENT_PASSWORD": ("Rtorrent", "rtorrent_password", self.RTORRENT_PASSWORD),
-                "PROWL_KEYS": ("Prowl", "prowl_keys", self.PROWL_KEYS),
-                "PUSHOVER_APIKEY": ("PUSHOVER", "pushover_apikey", self.PUSHOVER_APIKEY),
-                "PUSHOVER_USERKEY": ("PUSHOVER", "pushover_userkey", self.PUSHOVER_USERKEY),
-                "BOXCAR_TOKEN": ("BOXCAR", "boxcar_token", self.BOXCAR_TOKEN),
-                "PUSHBULLET_APIKEY": ("PUSHBULLET", "pushbullet_apikey", self.PUSHBULLET_APIKEY),
-                "TELEGRAM_TOKEN": ("TELEGRAM", "telegram_token", self.TELEGRAM_TOKEN),
-                "COMICVINE_API": ("CV", "comicvine_api", self.COMICVINE_API),
-                "PASSWORD_32P": ("32P", "password_32p", self.PASSWORD_32P),
-                "PASSKEY_32P": ("32P", "passkey_32p", self.PASSKEY_32P),
-                "USERNAME_32P": ("32P", "username_32p", self.USERNAME_32P),
-                "SEEDBOX_PASS": ("Seedbox", "seedbox_pass", self.SEEDBOX_PASS),
-                "TAB_PASS": ("Tablet", "tab_pass", self.TAB_PASS),
-                "API_KEY": ("API", "api_key", self.API_KEY),
-                "OPDS_PASSWORD": ("OPDS", "opds_password", self.OPDS_PASSWORD),
-                "PP_SSHPASSWD": ("AutoSnatch", "pp_sshpasswd", self.PP_SSHPASSWD),
-                "EMAIL_PASSWORD": ("Email", "email_password", self.EMAIL_PASSWORD),
-                "GIT_TOKEN": ("Git", "git_token", self.GIT_TOKEN),
-                "METRON_PASSWORD": ("Metron", "metron_password", self.METRON_PASSWORD),
-                "GOTIFY_TOKEN": ("GOTIFY", "gotify_token", self.GOTIFY_TOKEN),
-                "MATRIX_ACCESS_TOKEN": ("MATRIX", "matrix_access_token", self.MATRIX_ACCESS_TOKEN),
-                "EXTERNAL_APIKEY": ("DDL", "external_apikey", self.EXTERNAL_APIKEY),
-                "SLACK_WEBHOOK_URL": ("SLACK", "slack_webhook_url", self.SLACK_WEBHOOK_URL),
-                "MATTERMOST_WEBHOOK_URL": ("MATTERMOST", "mattermost_webhook_url", self.MATTERMOST_WEBHOOK_URL),
-                "DISCORD_WEBHOOK_URL": ("DISCORD", "discord_webhook_url", self.DISCORD_WEBHOOK_URL),
-                "DATABASE_URL": ("Database", "database_url", self.DATABASE_URL),
-                "AI_API_KEY": ("AI", "ai_api_key", self.AI_API_KEY),
-            }
-        )
+        encryption_list = OrderedDict()
+        for attr_name, (section, ini_key) in ENCRYPTED_CONFIG_ITEMS.items():
+            encryption_list[attr_name] = (section, ini_key, getattr(self, attr_name, None))
 
         new_encrypted = 0
         for k, v in encryption_list.items():

--- a/tests/unit/test_carepackage_security.py
+++ b/tests/unit/test_carepackage_security.py
@@ -50,7 +50,8 @@ def test_carepackage_clean_config_and_logs_redact_newer_secrets(tmp_path, monkey
 
     log_path = log_dir / "comicarr.log"
     log_path.write_text(
-        "slack-secret mattermost-secret matrix-secret ai-secret postgres://user:database-secret@example/db\n"
+        "slack-secret mattermost-secret matrix-secret ai-secret "
+        "github-secret postgres://user:database-secret@example/db\n"
     )
     (data_dir / "comicarr.db").write_text("")
 
@@ -64,16 +65,44 @@ def test_carepackage_clean_config_and_logs_redact_newer_secrets(tmp_path, monkey
     with open(package.filename, "w") as environment_file:
         environment_file.write("environment\n")
 
-    clean_config = (log_dir / "clean_config.ini").read_text()
-    for secret in ("slack-secret", "mattermost-secret", "matrix-secret", "ai-secret", "database-secret"):
-        assert secret not in clean_config
-    assert clean_config.count("xXX[REMOVED]XXx") >= 5
+    secrets = (
+        "slack-secret",
+        "mattermost-secret",
+        "matrix-secret",
+        "ai-secret",
+        "database-secret",
+        "github-secret",
+    )
+    expected_redacted_options = (
+        ("Git", "git_token"),
+        ("SLACK", "slack_webhook_url"),
+        ("MATTERMOST", "mattermost_webhook_url"),
+        ("MATRIX", "matrix_access_token"),
+        ("AI", "ai_api_key"),
+        ("Database", "database_url"),
+    )
+
+    clean_config_text = (log_dir / "clean_config.ini").read_text()
+    for secret in secrets:
+        assert secret not in clean_config_text
+
+    clean_parser = configparser.ConfigParser()
+    clean_parser.read_string(clean_config_text)
+    for section, option in expected_redacted_options:
+        assert clean_parser.get(section, option) == "xXX[REMOVED]XXx"
 
     package.panicbutton()
 
     with zipfile.ZipFile(log_dir / "carepackage.zip", "r") as bundle:
         redacted_log = bundle.read("comicarr.log").decode("utf-8")
+        zip_clean_config = bundle.read("clean_config.ini").decode("utf-8")
 
-    for secret in ("slack-secret", "mattermost-secret", "matrix-secret", "ai-secret", "database-secret"):
+    for secret in secrets:
         assert secret not in redacted_log
+        assert secret not in zip_clean_config
     assert "-REDACTED-" in redacted_log
+
+    zip_parser = configparser.ConfigParser()
+    zip_parser.read_string(zip_clean_config)
+    for section, option in expected_redacted_options:
+        assert zip_parser.get(section, option) == "xXX[REMOVED]XXx"

--- a/tests/unit/test_carepackage_security.py
+++ b/tests/unit/test_carepackage_security.py
@@ -14,6 +14,7 @@ import zipfile
 
 import comicarr
 from comicarr import config as config_module
+from comicarr import encrypted as encrypted_module
 from comicarr.carepackage import carePackage
 
 
@@ -106,3 +107,42 @@ def test_carepackage_clean_config_and_logs_redact_newer_secrets(tmp_path, monkey
     zip_parser.read_string(zip_clean_config)
     for section, option in expected_redacted_options:
         assert zip_parser.get(section, option) == "xXX[REMOVED]XXx"
+
+
+def test_encrypt_items_handles_git_token_auth_tuple(tmp_path, monkeypatch):
+    """configure() rewrites GIT_TOKEN to a requests auth tuple before encrypt_items.
+
+    encrypt_items must encrypt the string token without AttributeError on .startswith.
+    """
+    secure_dir = tmp_path / "secure"
+    secure_dir.mkdir()
+    config_path = tmp_path / "config.ini"
+    config_path.write_text("")
+
+    # Reset Fernet cache so master.key is loaded from this test's SECURE_DIR.
+    encrypted_module._fernet_instance = None
+
+    cfg = config_module.Config(str(config_path))
+    for attr_name in config_module.ENCRYPTED_CONFIG_ITEMS:
+        setattr(cfg, attr_name, None)
+    cfg.GIT_TOKEN = ("ghp_test_token_value", "x-oauth-basic")
+    cfg.SECURE_DIR = str(secure_dir)
+    cfg.WRITE_THE_CONFIG = False
+
+    monkeypatch.setattr(comicarr, "CONFIG", cfg)
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+
+    parser = config_module.config
+    if not parser.has_section("Git"):
+        parser.add_section("Git")
+
+    # Must not raise; must Fernet-encrypt the string token into the parser.
+    cfg.encrypt_items(mode="encrypt", updateconfig=True)
+
+    encrypted_token = parser.get("Git", "git_token")
+    assert encrypted_token.startswith("gAAAAA")
+    assert "ghp_test_token_value" not in encrypted_token
+    # Runtime auth tuple shape is unchanged (encrypt writes the parser only).
+    assert cfg.GIT_TOKEN == ("ghp_test_token_value", "x-oauth-basic")
+
+    encrypted_module._fernet_instance = None

--- a/tests/unit/test_carepackage_security.py
+++ b/tests/unit/test_carepackage_security.py
@@ -1,0 +1,79 @@
+#  Copyright (C) 2025-2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Security regression tests for support carepackage redaction."""
+
+import configparser
+import zipfile
+
+import comicarr
+from comicarr import config as config_module
+from comicarr.carepackage import carePackage
+
+
+def test_carepackage_redacts_every_encrypted_config_item(tmp_path, monkeypatch):
+    """Carepackages should redact the same secrets config encryption protects."""
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "PROG_DIR", str(tmp_path))
+    configured_redactions = carePackage().cleaned_list
+
+    for section, key in config_module.ENCRYPTED_CONFIG_ITEMS.values():
+        assert (section, key) in configured_redactions
+
+
+def test_carepackage_clean_config_and_logs_redact_newer_secrets(tmp_path, monkeypatch):
+    """Previously omitted encrypted secrets must not appear in bundles or logs."""
+    data_dir = tmp_path / "data"
+    log_dir = tmp_path / "logs"
+    data_dir.mkdir()
+    log_dir.mkdir()
+
+    config_path = data_dir / "config.ini"
+    parser = configparser.ConfigParser()
+    parser["Logs"] = {"log_dir": str(log_dir)}
+    parser["Git"] = {"git_user": "comicarr", "git_branch": "main", "git_token": "github-secret", "git_path": ""}
+    parser["Newznab"] = {"extra_newznabs": ""}
+    parser["Torznab"] = {"extra_torznabs": ""}
+    parser["SLACK"] = {"slack_webhook_url": "slack-secret"}
+    parser["MATTERMOST"] = {"mattermost_webhook_url": "mattermost-secret"}
+    parser["MATRIX"] = {"matrix_access_token": "matrix-secret"}
+    parser["AI"] = {"ai_api_key": "ai-secret"}
+    parser["Database"] = {"database_url": "postgres://user:database-secret@example/db"}
+    with open(config_path, "w") as config_file:
+        parser.write(config_file)
+
+    log_path = log_dir / "comicarr.log"
+    log_path.write_text(
+        "slack-secret mattermost-secret matrix-secret ai-secret postgres://user:database-secret@example/db\n"
+    )
+    (data_dir / "comicarr.db").write_text("")
+
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(data_dir))
+    monkeypatch.setattr(comicarr, "PROG_DIR", str(tmp_path))
+
+    package = carePackage(maintenance=True)
+    package.cleaned_config()
+    package.filename = str(log_dir / "ComicarrRunningEnvironment.txt")
+    package.panicfile = str(log_dir / "carepackage.zip")
+    with open(package.filename, "w") as environment_file:
+        environment_file.write("environment\n")
+
+    clean_config = (log_dir / "clean_config.ini").read_text()
+    for secret in ("slack-secret", "mattermost-secret", "matrix-secret", "ai-secret", "database-secret"):
+        assert secret not in clean_config
+    assert clean_config.count("xXX[REMOVED]XXx") >= 5
+
+    package.panicbutton()
+
+    with zipfile.ZipFile(log_dir / "carepackage.zip", "r") as bundle:
+        redacted_log = bundle.read("comicarr.log").decode("utf-8")
+
+    for secret in ("slack-secret", "mattermost-secret", "matrix-secret", "ai-secret", "database-secret"):
+        assert secret not in redacted_log
+    assert "-REDACTED-" in redacted_log


### PR DESCRIPTION
## Summary
Carepackage support bundles now redact every secret Fernet-encrypts in config (plus existing username/extras), so debug zips do not ship Metron/Matrix/Slack/AI/Git/32P/database credentials.

- Introduce shared `ENCRYPTED_CONFIG_ITEMS` in `config.py`; `encrypt_items` builds from it
- `carePackage.cleaned_list` is derived from that map so redaction cannot drift
- Flush redacted log files before zipping so log scrubbing is actually packaged
- `tests/unit/test_carepackage_security.py`

## Test plan
- [x] `pytest tests/unit/test_carepackage_security.py -v`

## Plan
Improve plan 011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved carepackage redaction so more sensitive configuration values and credentials are consistently removed from generated bundles.
  * Fixed log redaction handling to ensure cleaned files are fully written before packaging, reducing the chance of unredacted content slipping through.

* **Tests**
  * Added coverage for secret redaction in configuration files and packaged logs to verify sensitive values are excluded from exported carepackages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->