### PR TITLE
fix: validate artwork cache paths and restrict cover fetches

### DIFF
--- a/.changeset/fix-artwork-path-and-cover-ssrf.md
+++ b/.changeset/fix-artwork-path-and-cover-ssrf.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Harden artwork cache paths and cover image fetches against path traversal and SSRF (allowlisted hosts, no redirects, size and content-type caps).

--- a/comicarr/app/metadata/image_fetch.py
+++ b/comicarr/app/metadata/image_fetch.py
@@ -1,0 +1,102 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Safe cover/image URL fetching for the metadata domain.
+
+Shared allowlists and fetch helpers used by get_artwork and /image-proxy
+to prevent SSRF and oversized downloads.
+"""
+
+from urllib.parse import urlparse
+
+import requests
+
+from comicarr import logger
+
+# Hosts allowed for server-side cover/image fetches (SSRF protection).
+# Keep in sync with CSP img-src in middleware when adding new CDNs.
+ALLOWED_IMAGE_DOMAINS = {
+    "comicvine.gamespot.com",
+    "static.metron.cloud",
+    "uploads.mangadex.org",
+    "myanimelist.net",
+    "cdn.myanimelist.net",
+    "api-cdn.myanimelist.net",
+}
+
+ALLOWED_IMAGE_CONTENT_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "image/gif",
+    "image/avif",
+}
+
+MAX_IMAGE_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+
+def is_allowed_image_url(url):
+    """Return True if url is http(s), no userinfo, and host is allowlisted."""
+    if not url or not isinstance(url, str):
+        return False
+    try:
+        parsed = urlparse(url)
+    except Exception as e:
+        logger.fdebug("[METADATA-artwork] Invalid URL parse: %s" % e)
+        return False
+    if parsed.scheme not in ("http", "https"):
+        return False
+    if parsed.username or parsed.password:
+        return False
+    if not parsed.hostname:
+        return False
+    return parsed.hostname in ALLOWED_IMAGE_DOMAINS
+
+
+def fetch_allowed_image(url):
+    """Fetch image bytes from an allowlisted URL.
+
+    Returns (content_bytes, content_type) or None on any failure.
+    """
+    if not is_allowed_image_url(url):
+        logger.fdebug("[METADATA-artwork] Rejected non-allowlisted image URL: %s" % url)
+        return None
+
+    try:
+        resp = requests.get(
+            url,
+            timeout=(5, 10),
+            headers={"User-Agent": "Comicarr/1.0"},
+            allow_redirects=False,
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        logger.error("[METADATA-artwork] Failed to fetch image %s: %s" % (url, e))
+        return None
+
+    content_length = resp.headers.get("Content-Length")
+    if content_length:
+        try:
+            if int(content_length) > MAX_IMAGE_BYTES:
+                logger.error("[METADATA-artwork] Image Content-Length exceeds cap (%s): %s" % (content_length, url))
+                return None
+        except (ValueError, TypeError):
+            pass
+
+    content = resp.content
+    if len(content) > MAX_IMAGE_BYTES:
+        logger.error("[METADATA-artwork] Image body exceeds size cap: %s" % url)
+        return None
+
+    content_type = resp.headers.get("Content-Type", "image/jpeg").split(";")[0].strip().lower()
+    if content_type not in ALLOWED_IMAGE_CONTENT_TYPES:
+        logger.error("[METADATA-artwork] Invalid content type %s for %s" % (content_type, url))
+        return None
+
+    return content, content_type

--- a/comicarr/app/metadata/image_fetch.py
+++ b/comicarr/app/metadata/image_fetch.py
@@ -85,19 +85,14 @@ def fetch_allowed_image(url):
     try:
         # raise_for_status only fails 4xx/5xx; with allow_redirects=False, 3xx must not succeed
         if resp.status_code != 200:
-            logger.error(
-                "[METADATA-artwork] Unexpected HTTP %s for image %s" % (resp.status_code, url)
-            )
+            logger.error("[METADATA-artwork] Unexpected HTTP %s for image %s" % (resp.status_code, url))
             return None
 
         content_length = resp.headers.get("Content-Length")
         if content_length:
             try:
                 if int(content_length) > MAX_IMAGE_BYTES:
-                    logger.error(
-                        "[METADATA-artwork] Image Content-Length exceeds cap (%s): %s"
-                        % (content_length, url)
-                    )
+                    logger.error("[METADATA-artwork] Image Content-Length exceeds cap (%s): %s" % (content_length, url))
                     return None
             except (ValueError, TypeError):
                 pass

--- a/comicarr/app/metadata/image_fetch.py
+++ b/comicarr/app/metadata/image_fetch.py
@@ -39,6 +39,7 @@ ALLOWED_IMAGE_CONTENT_TYPES = {
 }
 
 MAX_IMAGE_BYTES = 10 * 1024 * 1024  # 10 MiB
+_CHUNK_SIZE = 64 * 1024
 
 
 def is_allowed_image_url(url):
@@ -63,6 +64,7 @@ def fetch_allowed_image(url):
     """Fetch image bytes from an allowlisted URL.
 
     Returns (content_bytes, content_type) or None on any failure.
+    Streams the body and aborts once MAX_IMAGE_BYTES would be exceeded.
     """
     if not is_allowed_image_url(url):
         logger.fdebug("[METADATA-artwork] Rejected non-allowlisted image URL: %s" % url)
@@ -74,29 +76,60 @@ def fetch_allowed_image(url):
             timeout=(5, 10),
             headers={"User-Agent": "Comicarr/1.0"},
             allow_redirects=False,
+            stream=True,
         )
-        resp.raise_for_status()
     except Exception as e:
         logger.error("[METADATA-artwork] Failed to fetch image %s: %s" % (url, e))
         return None
 
-    content_length = resp.headers.get("Content-Length")
-    if content_length:
-        try:
-            if int(content_length) > MAX_IMAGE_BYTES:
-                logger.error("[METADATA-artwork] Image Content-Length exceeds cap (%s): %s" % (content_length, url))
+    try:
+        # raise_for_status only fails 4xx/5xx; with allow_redirects=False, 3xx must not succeed
+        if resp.status_code != 200:
+            logger.error(
+                "[METADATA-artwork] Unexpected HTTP %s for image %s" % (resp.status_code, url)
+            )
+            return None
+
+        content_length = resp.headers.get("Content-Length")
+        if content_length:
+            try:
+                if int(content_length) > MAX_IMAGE_BYTES:
+                    logger.error(
+                        "[METADATA-artwork] Image Content-Length exceeds cap (%s): %s"
+                        % (content_length, url)
+                    )
+                    return None
+            except (ValueError, TypeError):
+                pass
+
+        raw_ct = resp.headers.get("Content-Type")
+        if not raw_ct:
+            logger.error("[METADATA-artwork] Missing Content-Type for %s" % url)
+            return None
+        content_type = raw_ct.split(";")[0].strip().lower()
+        if content_type not in ALLOWED_IMAGE_CONTENT_TYPES:
+            logger.error("[METADATA-artwork] Invalid content type %s for %s" % (content_type, url))
+            return None
+
+        chunks = []
+        total = 0
+        for chunk in resp.iter_content(chunk_size=_CHUNK_SIZE):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > MAX_IMAGE_BYTES:
+                logger.error("[METADATA-artwork] Image body exceeds size cap: %s" % url)
                 return None
-        except (ValueError, TypeError):
+            chunks.append(chunk)
+
+        content = b"".join(chunks)
+        if not content:
+            logger.error("[METADATA-artwork] Empty image body for %s" % url)
+            return None
+
+        return content, content_type
+    finally:
+        try:
+            resp.close()
+        except Exception:
             pass
-
-    content = resp.content
-    if len(content) > MAX_IMAGE_BYTES:
-        logger.error("[METADATA-artwork] Image body exceeds size cap: %s" % url)
-        return None
-
-    content_type = resp.headers.get("Content-Type", "image/jpeg").split(";")[0].strip().lower()
-    if content_type not in ALLOWED_IMAGE_CONTENT_TYPES:
-        logger.error("[METADATA-artwork] Invalid content type %s for %s" % (content_type, url))
-        return None
-
-    return content, content_type

--- a/comicarr/app/metadata/router.py
+++ b/comicarr/app/metadata/router.py
@@ -13,9 +13,6 @@ Metadata domain router — comic search, metadata lookup, metatag operations.
 Low cross-domain dependency, well-bounded. Validates the domain pattern.
 """
 
-from urllib.parse import urlparse
-
-import requests
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import FileResponse, JSONResponse, Response
 
@@ -24,6 +21,7 @@ from comicarr.app.core.context import AppContext, get_context
 from comicarr.app.core.exceptions import NotFoundError
 from comicarr.app.core.security import require_session
 from comicarr.app.metadata import service as metadata_service
+from comicarr.app.metadata.image_fetch import fetch_allowed_image
 
 router = APIRouter(prefix="/api/metadata", tags=["metadata"])
 
@@ -124,48 +122,25 @@ def get_artwork(comic_id: str, ctx: AppContext = Depends(get_context)):
     return FileResponse(image_path, media_type="image/jpeg")
 
 
-# Allowed domains for image proxy to prevent SSRF
-_ALLOWED_IMAGE_DOMAINS = {
-    "myanimelist.net",
-    "cdn.myanimelist.net",
-    "api-cdn.myanimelist.net",
-    "uploads.mangadex.org",
-}
-
-
-_ALLOWED_IMAGE_CONTENT_TYPES = {
-    "image/jpeg",
-    "image/png",
-    "image/webp",
-    "image/gif",
-    "image/avif",
-}
-
-
 @router.get("/image-proxy", dependencies=[Depends(require_session)])
 def image_proxy(url: str = Query(..., description="External image URL to proxy")):
     """Proxy external cover images to avoid CORS issues.
 
-    Only allows requests to known manga metadata CDNs.
+    Only allows requests to known metadata CDNs (shared allowlist with get_artwork).
     """
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        return JSONResponse({"error": "Invalid URL scheme"}, status_code=403)
-    if parsed.hostname not in _ALLOWED_IMAGE_DOMAINS:
-        return JSONResponse({"error": "Domain not allowed"}, status_code=403)
-    if parsed.username or parsed.password:
-        return JSONResponse({"error": "Credentials in URL not allowed"}, status_code=403)
+    result = fetch_allowed_image(url)
+    if result is None:
+        # Distinguish policy reject (403) vs fetch/type failure (502) is hard after
+        # the shared helper; treat as forbidden for non-allowlisted URLs via helper log.
+        from comicarr.app.metadata.image_fetch import is_allowed_image_url
 
-    try:
-        resp = requests.get(url, timeout=(5, 10), headers={"User-Agent": "Comicarr/1.0"}, allow_redirects=False)
-        resp.raise_for_status()
-        content_type = resp.headers.get("Content-Type", "image/jpeg").split(";")[0].strip()
-        if content_type not in _ALLOWED_IMAGE_CONTENT_TYPES:
-            return JSONResponse({"error": "Invalid content type"}, status_code=502)
-        return Response(content=resp.content, media_type=content_type)
-    except Exception as e:
-        logger.error("[IMAGE-PROXY] Failed to fetch %s: %s" % (url, e))
+        if not is_allowed_image_url(url):
+            return JSONResponse({"error": "Domain not allowed"}, status_code=403)
+        logger.error("[IMAGE-PROXY] Failed to fetch %s" % url)
         return JSONResponse({"error": "Failed to fetch image"}, status_code=502)
+
+    content, content_type = result
+    return Response(content=content, media_type=content_type)
 
 
 @router.get("/series-image/{series_id}", dependencies=[Depends(require_session)])

--- a/comicarr/app/metadata/service.py
+++ b/comicarr/app/metadata/service.py
@@ -108,27 +108,52 @@ def get_issue_info(ctx, issue_id):
     return None
 
 
+# ComicIDs: CV volume ids (digits / 4050-N), MangaDex (md-*), MAL (mal-*), etc.
+_SAFE_COMIC_ID_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z._-]*$")
+
+
+def _is_safe_comic_id(comic_id):
+    """Reject empty, path separators, traversal, and absolute path segments."""
+    if comic_id is None:
+        return False
+    comic_id = str(comic_id)
+    if not comic_id or ".." in comic_id:
+        return False
+    if "/" in comic_id or "\\" in comic_id:
+        return False
+    return bool(_SAFE_COMIC_ID_RE.fullmatch(comic_id))
+
+
 def get_artwork(ctx, comic_id):
     """Get or cache comic artwork. Returns file path or None."""
-    from PIL import Image
+    from io import BytesIO
 
+    from comicarr.app.common.filesystem import is_path_within_allowed_dirs
+    from comicarr.app.metadata.image_fetch import fetch_allowed_image
+
+    if not _is_safe_comic_id(comic_id):
+        logger.fdebug("[METADATA-artwork] Rejected unsafe comic_id: %r" % (comic_id,))
+        return None
+
+    comic_id = str(comic_id)
     cache_dir = getattr(ctx.config, "CACHE_DIR", None) if ctx.config else None
     if not cache_dir:
         return None
 
-    image_path = os.path.join(cache_dir, str(comic_id) + ".jpg")
+    image_path = os.path.join(cache_dir, comic_id + ".jpg")
+    if not is_path_within_allowed_dirs(image_path, [cache_dir]):
+        logger.error("[METADATA-artwork] Cache path outside CACHE_DIR for comic_id=%s" % comic_id)
+        return None
 
     if os.path.isfile(image_path):
         try:
             img = Image.open(image_path)
             if img.get_format_mimetype():
                 return image_path
-        except Exception:
-            pass
+        except Exception as e:
+            logger.fdebug("[METADATA-artwork] Cached image unreadable for %s: %s" % (comic_id, e))
 
-    # Try fetching from DB URLs
-    import urllib.request
-
+    # Try fetching from DB URLs (allowlisted hosts only)
     from sqlalchemy import select
 
     from comicarr import db
@@ -141,24 +166,26 @@ def get_artwork(ctx, comic_id):
     img_data = None
     for url_key in ["ComicImageURL", "ComicImageALTURL"]:
         url = comic[0].get(url_key)
-        if url:
-            try:
-                img_data = urllib.request.urlopen(url).read()
-                break
-            except Exception:
-                continue
+        if not url:
+            continue
+        result = fetch_allowed_image(url)
+        if result is not None:
+            img_data = result[0]
+            break
 
     if img_data:
         try:
-            from io import BytesIO
-
             img = Image.open(BytesIO(img_data))
             if img.get_format_mimetype():
+                # Re-check containment before write
+                if not is_path_within_allowed_dirs(image_path, [cache_dir]):
+                    logger.error("[METADATA-artwork] Refusing write outside CACHE_DIR for %s" % comic_id)
+                    return None
                 with open(image_path, "wb") as f:
                     f.write(img_data)
                 return image_path
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error("[METADATA-artwork] Failed to cache artwork for %s: %s" % (comic_id, e))
 
     return None
 

--- a/tests/unit/test_metadata_domain.py
+++ b/tests/unit/test_metadata_domain.py
@@ -1,12 +1,15 @@
 """
 Tests for comicarr.app.metadata domain — Phase 2.
 
-Covers: search routing, comic/issue info lookup, metatag operations.
+Covers: search routing, comic/issue info lookup, metatag operations,
+artwork path validation and cover fetch allowlisting.
 """
 
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+from PIL import Image
 
 from comicarr.app.core.context import AppContext
 from comicarr.app.metadata import service as metadata_service
@@ -27,6 +30,13 @@ def _make_test_ctx(**overrides):
     }
     defaults.update(overrides)
     return AppContext(**defaults)
+
+
+def _jpeg_bytes(size=(2, 2), color="red"):
+    """Minimal valid JPEG bytes for cache/fetch tests."""
+    buf = BytesIO()
+    Image.new("RGB", size, color=color).save(buf, format="JPEG")
+    return buf.getvalue()
 
 
 # =============================================================================
@@ -107,7 +117,7 @@ class TestSearchManga:
             "pagination": {"total": 1},
         }
 
-        result = metadata_service.search_manga(ctx, name="One Piece")
+        metadata_service.search_manga(ctx, name="One Piece")
         mock_mangadex.search_manga.assert_called_once()
 
 
@@ -204,3 +214,135 @@ class TestMetatag:
         result = metadata_service.manual_metatag(ctx, "issue123")
         assert result["success"] is False
         assert "tagging failed" in result["error"]
+
+
+# =============================================================================
+# Artwork path validation + cover fetch allowlist
+# =============================================================================
+
+
+class TestGetArtwork:
+    @pytest.mark.parametrize(
+        "comic_id",
+        [
+            "",
+            "../etc/passwd",
+            "/etc/passwd",
+            "foo/bar",
+            r"foo\bar",
+            "..",
+            "....//",
+            None,
+        ],
+    )
+    def test_rejects_unsafe_comic_id(self, comic_id, tmp_path):
+        """Unsafe comic_id values return None without path escape."""
+        ctx = _make_test_ctx()
+        ctx.config.CACHE_DIR = str(tmp_path)
+
+        with patch("comicarr.db") as mock_db:
+            result = metadata_service.get_artwork(ctx, comic_id)
+            assert result is None
+            mock_db.select_all.assert_not_called()
+
+    def test_accepts_numeric_and_prefixed_ids_cache_hit(self, tmp_path):
+        """Safe ComicIDs (digits, 4050-N, md-*) return cached path on hit."""
+        ctx = _make_test_ctx()
+        ctx.config.CACHE_DIR = str(tmp_path)
+        comic_id = "4050-12345"
+        cache_file = tmp_path / (comic_id + ".jpg")
+        cache_file.write_bytes(_jpeg_bytes())
+
+        result = metadata_service.get_artwork(ctx, comic_id)
+        assert result == str(cache_file)
+        assert str(result).startswith(str(tmp_path))
+
+    def test_md_comic_id_cache_hit(self, tmp_path):
+        """MangaDex-style md-* ids are accepted for cache paths."""
+        ctx = _make_test_ctx()
+        ctx.config.CACHE_DIR = str(tmp_path)
+        comic_id = "md-abc123"
+        cache_file = tmp_path / (comic_id + ".jpg")
+        cache_file.write_bytes(_jpeg_bytes())
+
+        result = metadata_service.get_artwork(ctx, comic_id)
+        assert result == str(cache_file)
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
+    @patch("comicarr.db")
+    def test_ssrf_url_does_not_call_network(self, mock_db, mock_get, tmp_path):
+        """Loopback / evil hosts must not trigger requests.get; returns None."""
+        ctx = _make_test_ctx()
+        ctx.config.CACHE_DIR = str(tmp_path)
+        mock_db.select_all.return_value = [
+            {
+                "ComicID": "12345",
+                "ComicImageURL": "http://127.0.0.1/secret",
+                "ComicImageALTURL": "https://evil.example/cover.jpg",
+            }
+        ]
+
+        result = metadata_service.get_artwork(ctx, "12345")
+        assert result is None
+        mock_get.assert_not_called()
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
+    @patch("comicarr.db")
+    def test_allowlisted_fetch_writes_cache(self, mock_db, mock_get, tmp_path):
+        """Allowlisted ComicVine host is fetched and written under CACHE_DIR."""
+        ctx = _make_test_ctx()
+        ctx.config.CACHE_DIR = str(tmp_path)
+        comic_id = "12345"
+        jpeg = _jpeg_bytes()
+        mock_db.select_all.return_value = [
+            {
+                "ComicID": comic_id,
+                "ComicImageURL": "https://comicvine.gamespot.com/a/uploads/scale_large/cover.jpg",
+                "ComicImageALTURL": None,
+            }
+        ]
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.headers = {"Content-Type": "image/jpeg", "Content-Length": str(len(jpeg))}
+        mock_resp.content = jpeg
+        mock_get.return_value = mock_resp
+
+        result = metadata_service.get_artwork(ctx, comic_id)
+        expected = str(tmp_path / (comic_id + ".jpg"))
+        assert result == expected
+        assert (tmp_path / (comic_id + ".jpg")).read_bytes() == jpeg
+        mock_get.assert_called_once()
+        call_kwargs = mock_get.call_args.kwargs
+        assert call_kwargs.get("allow_redirects") is False
+        assert call_kwargs.get("timeout") == (5, 10)
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
+    @patch("comicarr.db")
+    def test_allowlisted_metron_host(self, mock_db, mock_get, tmp_path):
+        """static.metron.cloud is allowed for cover fetches."""
+        ctx = _make_test_ctx()
+        ctx.config.CACHE_DIR = str(tmp_path)
+        comic_id = "99"
+        jpeg = _jpeg_bytes(color="blue")
+        mock_db.select_all.return_value = [
+            {
+                "ComicID": comic_id,
+                "ComicImageURL": "https://static.metron.cloud/media/series/cover.jpg",
+                "ComicImageALTURL": None,
+            }
+        ]
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.headers = {"Content-Type": "image/jpeg"}
+        mock_resp.content = jpeg
+        mock_get.return_value = mock_resp
+
+        result = metadata_service.get_artwork(ctx, comic_id)
+        assert result == str(tmp_path / (comic_id + ".jpg"))
+        mock_get.assert_called_once()
+
+    def test_missing_cache_dir_returns_none(self):
+        """No CACHE_DIR configured returns None."""
+        ctx = _make_test_ctx()
+        ctx.config.CACHE_DIR = None
+        assert metadata_service.get_artwork(ctx, "12345") is None

--- a/tests/unit/test_metadata_domain.py
+++ b/tests/unit/test_metadata_domain.py
@@ -301,10 +301,7 @@ class TestGetArtwork:
                 "ComicImageALTURL": None,
             }
         ]
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.headers = {"Content-Type": "image/jpeg", "Content-Length": str(len(jpeg))}
-        mock_resp.content = jpeg
+        mock_resp = _mock_image_response(jpeg)
         mock_get.return_value = mock_resp
 
         result = metadata_service.get_artwork(ctx, comic_id)
@@ -315,6 +312,7 @@ class TestGetArtwork:
         call_kwargs = mock_get.call_args.kwargs
         assert call_kwargs.get("allow_redirects") is False
         assert call_kwargs.get("timeout") == (5, 10)
+        assert call_kwargs.get("stream") is True
 
     @patch("comicarr.app.metadata.image_fetch.requests.get")
     @patch("comicarr.db")
@@ -331,11 +329,7 @@ class TestGetArtwork:
                 "ComicImageALTURL": None,
             }
         ]
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.headers = {"Content-Type": "image/jpeg"}
-        mock_resp.content = jpeg
-        mock_get.return_value = mock_resp
+        mock_get.return_value = _mock_image_response(jpeg)
 
         result = metadata_service.get_artwork(ctx, comic_id)
         assert result == str(tmp_path / (comic_id + ".jpg"))
@@ -346,3 +340,132 @@ class TestGetArtwork:
         ctx = _make_test_ctx()
         ctx.config.CACHE_DIR = None
         assert metadata_service.get_artwork(ctx, "12345") is None
+
+
+def _mock_image_response(body, status_code=200, content_type="image/jpeg", content_length=None):
+    """Mock requests response for streaming fetch_allowed_image."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    headers = {}
+    if content_type is not None:
+        headers["Content-Type"] = content_type
+    if content_length is not None:
+        headers["Content-Length"] = str(content_length)
+    elif body is not None:
+        headers["Content-Length"] = str(len(body))
+    mock_resp.headers = headers
+    mock_resp.iter_content = MagicMock(return_value=[body] if body else [])
+    mock_resp.close = MagicMock()
+    return mock_resp
+
+
+# =============================================================================
+# image_fetch allowlist + size/type guards
+# =============================================================================
+
+
+class TestImageFetch:
+    def test_is_allowed_image_url_rejects_bad_urls(self):
+        from comicarr.app.metadata.image_fetch import is_allowed_image_url
+
+        assert is_allowed_image_url(None) is False
+        assert is_allowed_image_url("") is False
+        assert is_allowed_image_url("ftp://comicvine.gamespot.com/x.jpg") is False
+        assert is_allowed_image_url("https://user:pass@comicvine.gamespot.com/x.jpg") is False
+        assert is_allowed_image_url("https://evil.example/cover.jpg") is False
+        assert is_allowed_image_url("https://evil.comicvine.gamespot.com/x.jpg") is False
+        assert is_allowed_image_url("http://127.0.0.1/secret") is False
+
+    def test_is_allowed_image_url_accepts_allowlisted(self):
+        from comicarr.app.metadata.image_fetch import ALLOWED_IMAGE_DOMAINS, is_allowed_image_url
+
+        for host in ALLOWED_IMAGE_DOMAINS:
+            assert is_allowed_image_url("https://%s/cover.jpg" % host) is True
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
+    def test_fetch_rejects_non_200(self, mock_get):
+        from comicarr.app.metadata.image_fetch import fetch_allowed_image
+
+        mock_get.return_value = _mock_image_response(b"x", status_code=302)
+        assert fetch_allowed_image("https://comicvine.gamespot.com/c.jpg") is None
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
+    def test_fetch_rejects_missing_content_type(self, mock_get):
+        from comicarr.app.metadata.image_fetch import fetch_allowed_image
+
+        mock_get.return_value = _mock_image_response(b"\xff\xd8", content_type=None)
+        assert fetch_allowed_image("https://comicvine.gamespot.com/c.jpg") is None
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
+    def test_fetch_rejects_disallowed_content_type(self, mock_get):
+        from comicarr.app.metadata.image_fetch import fetch_allowed_image
+
+        mock_get.return_value = _mock_image_response(b"{}", content_type="application/json")
+        assert fetch_allowed_image("https://comicvine.gamespot.com/c.jpg") is None
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
+    def test_fetch_rejects_content_length_over_cap(self, mock_get):
+        from comicarr.app.metadata import image_fetch as image_fetch_mod
+
+        mock_get.return_value = _mock_image_response(
+            b"x",
+            content_length=image_fetch_mod.MAX_IMAGE_BYTES + 1,
+        )
+        assert image_fetch_mod.fetch_allowed_image("https://comicvine.gamespot.com/c.jpg") is None
+        mock_get.return_value.iter_content.assert_not_called()
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
+    def test_fetch_aborts_when_stream_exceeds_cap(self, mock_get):
+        from comicarr.app.metadata import image_fetch as image_fetch_mod
+
+        oversized = b"a" * (image_fetch_mod.MAX_IMAGE_BYTES + 1)
+        mock_resp = _mock_image_response(oversized, content_length=None)
+        # omit Content-Length so only streaming budget applies
+        mock_resp.headers = {"Content-Type": "image/jpeg"}
+        mock_get.return_value = mock_resp
+        assert image_fetch_mod.fetch_allowed_image("https://comicvine.gamespot.com/c.jpg") is None
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
+    def test_fetch_success_returns_bytes_and_type(self, mock_get):
+        from comicarr.app.metadata.image_fetch import fetch_allowed_image
+
+        jpeg = _jpeg_bytes()
+        mock_get.return_value = _mock_image_response(jpeg, content_type="image/jpeg; charset=binary")
+        result = fetch_allowed_image("https://comicvine.gamespot.com/c.jpg")
+        assert result == (jpeg, "image/jpeg")
+        assert mock_get.call_args.kwargs.get("stream") is True
+
+
+# =============================================================================
+# image-proxy router (shared helper)
+# =============================================================================
+
+
+class TestImageProxy:
+    def test_non_allowlisted_returns_403(self):
+        from comicarr.app.metadata.router import image_proxy
+
+        response = image_proxy(url="https://evil.example/cover.jpg")
+        assert response.status_code == 403
+        assert response.body  # JSONResponse
+        assert b"Domain not allowed" in response.body
+
+    @patch("comicarr.app.metadata.router.fetch_allowed_image")
+    def test_allowlisted_fetch_failure_returns_502(self, mock_fetch):
+        from comicarr.app.metadata.router import image_proxy
+
+        mock_fetch.return_value = None
+        response = image_proxy(url="https://comicvine.gamespot.com/c.jpg")
+        assert response.status_code == 502
+        assert b"Failed to fetch image" in response.body
+
+    @patch("comicarr.app.metadata.router.fetch_allowed_image")
+    def test_success_returns_image_bytes(self, mock_fetch):
+        from comicarr.app.metadata.router import image_proxy
+
+        jpeg = _jpeg_bytes()
+        mock_fetch.return_value = (jpeg, "image/jpeg")
+        response = image_proxy(url="https://comicvine.gamespot.com/c.jpg")
+        assert response.status_code == 200
+        assert response.body == jpeg
+        assert response.media_type == "image/jpeg"


### PR DESCRIPTION
## Summary
Harden `GET /api/metadata/art/{comic_id}` against path traversal and SSRF when caching cover images.

- Validate comic IDs and enforce cache path containment under `CACHE_DIR`
- Replace unrestricted `urlopen` with allowlisted `requests.get` (ComicVine/Metron/MangaDex/MAL hosts, no redirects, size/type caps)
- Shared helper `comicarr/app/metadata/image_fetch.py` also used by image-proxy
- Extended metadata domain unit tests

## Test plan
- [x] `pytest tests/unit/test_metadata_domain.py -v`

## Plan
Improve plan 012