### PR TITLE
docs: align agent docs with FastAPI and fix Vite proxy port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ images/generated-*.png
 # Claude agents/skills cache
 .agents/
 .claude/
-AGENTS.md
 
 # Internal planning docs (compound-engineering plugin)
 docs/plans/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+Agent-oriented project guide for Comicarr. Prefer retrieval-led reasoning: consult the codebase over general assumptions.
+
+## Stack (current)
+
+- **Python 3.10+** (`requires-python = ">=3.10"`)
+- **FastAPI + uvicorn** — `Comicarr.py` runs `uvicorn.run("comicarr.app.main:app", ...)`
+- **SQLAlchemy Core** (not ORM), INI config via `comicarr.config.Config`
+- **urllib3>=2.7.0**
+- **React 19 + Vite** frontend; production assets served from `frontend/dist`
+- Default HTTP port: **8090**
+
+## Commands
+
+| Action | Command |
+|--------|---------|
+| Install (backend) | `uv sync` |
+| Install (dev) | `uv sync --extra dev` |
+| Install (frontend) | `cd frontend && npm ci` |
+| Run app | `python3 Comicarr.py --nolaunch` |
+| Dev frontend | `cd frontend && npm run dev` |
+| Build frontend | `cd frontend && npm run build` |
+| Test backend | `pytest tests/unit -v` |
+| Test frontend | `cd frontend && npm run test:run` |
+| Lint backend | `ruff check comicarr/` |
+| Format check | `ruff format --check comicarr/` |
+| Format fix | `ruff format comicarr/` |
+| Lint frontend | `cd frontend && npm run lint` |
+| Typecheck | `cd frontend && npm run typecheck` |
+
+When using Vite (`npm run dev`) with a separate backend process, the proxy targets `http://localhost:8090`. Override with `VITE_API_PROXY_TARGET` if needed.
+
+## Architecture
+
+[Comicarr Code Index]|root: ./comicarr
+|Web Layer:{app/main.py:FastAPI app+lifespan,app/<domain>/router.py:HTTP routes,app/core/security.py:JWT+API key+OPDS auth,app/core/middleware.py:CSRF+headers+setup gate}
+|Business Logic:{search.py:provider search,postprocessor.py:post-processing,cv.py:ComicVine,metron.py:Metron,mangadex.py:MangaDex,importer.py:library scanning,rsscheck.py:RSS,weeklypull.py:pull list,app/downloads/:journal+recovery}
+|Config/Data:{config.py:INI config,encrypted.py:Fernet,db.py:SQLAlchemy Core,__init__.py:global state+scheduler,helpers.py:compat re-exports}
+|Downloaders:{downloaders/:Mega/MediaFire/Pixeldrain,torrent/clients/:qBittorrent/Deluge/Transmission/rTorrent,nzbget.py,sabnzbd.py}
+|Frontend:{frontend/src/pages,components,hooks,lib,contexts,types}
+|Tests:{tests/unit,tests/integration,frontend/tests}
+
+Domain packages under `comicarr/app/`: `series`, `search`, `downloads`, `system`, `dashboard`, `metadata`, `storyarcs`, `weekly`, `opds`, `ai`, plus `core` and `common`.
+
+## Tests
+
+- Backend: `tests/unit/`, `tests/integration/` via pytest
+- Frontend: `frontend/tests/` (unit) and Playwright e2e under `frontend/`
+- CI runs pytest, frontend tests, lint/format, and Playwright smoke
+
+## Style & anti-patterns
+
+- **Formatting**: `ruff format` enforced in CI; do not use Black
+- **Lint**: `ruff check comicarr/`
+- **Type hints**: do not mass-add to large legacy modules (`search.py`, `postprocessor.py`); new `comicarr/app/**` code may use annotations like neighboring files
+- Always `except Exception as e` — never bare `except:`
+- GPL license header on new Python files
+- Frontend: `npm` only (not bun)
+- Do not manually bump versions — Changesets automation
+
+## Common patterns
+
+```python
+from comicarr import logger
+logger.fdebug('[MODULE-CONTEXT] message')
+
+import comicarr
+comicarr.CONFIG.option_name
+
+from comicarr import db
+db.DBConnection().action("SELECT * FROM table WHERE id=?", [id])
+```
+
+Import order: stdlib → third-party → local (`from comicarr import ...`).
+
+## Adding new features
+
+1. Prefer FastAPI domain code: `comicarr/app/<domain>/router.py` + `service.py` (+ `queries.py`)
+2. Wire the router in `comicarr/app/main.py`
+3. Reuse existing business modules (`search.py`, `postprocessor.py`, providers) for heavy logic
+4. Frontend: pages/components under `frontend/src/`, API client in `frontend/src/lib/`
+
+## Gotchas
+
+- `SECURE_DIR` must be initialized before `encrypt_items()` / bcrypt migration in `config.py`
+- Fernet-encrypted config values start with `gAAAAA`
+- Auth: JWT session cookie `comicarr_session`; changing auth secrets invalidates sessions
+- Vite proxy default is 8090 to match `HTTP_PORT`
+
+Keep this file aligned with `CLAUDE.md` when architecture changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@ When using Vite (`npm run dev`) with a separate backend process, the proxy targe
 [Comicarr Code Index]|root: ./comicarr
 |Web Layer:{app/main.py:FastAPI app+lifespan,app/<domain>/router.py:HTTP routes,app/core/security.py:JWT+API key+OPDS auth,app/core/middleware.py:CSRF+headers+setup gate}
 |Business Logic:{search.py:provider search,postprocessor.py:post-processing,cv.py:ComicVine,metron.py:Metron,mangadex.py:MangaDex,importer.py:library scanning,rsscheck.py:RSS,weeklypull.py:pull list,app/downloads/:journal+recovery}
-|Config/Data:{config.py:INI config,encrypted.py:Fernet,db.py:SQLAlchemy Core,__init__.py:global state+scheduler,helpers.py:compat re-exports}
-|Downloaders:{downloaders/:Mega/MediaFire/Pixeldrain,torrent/clients/:qBittorrent/Deluge/Transmission/rTorrent,nzbget.py,sabnzbd.py}
+|Config/Data:{config.py:INI config,encrypted.py:Fernet,db.py:SQLAlchemy Core,__init__.py:global state+scheduler,helpers.py:compat re-exports,migration.py:Mylar3 migration}
+|Downloaders:{downloaders/:Mega/MediaFire/Pixeldrain,torrent/clients/:qBittorrent/Deluge/Transmission/rTorrent/uTorrent,nzbget.py,sabnzbd.py}
 |Frontend:{frontend/src/pages,components,hooks,lib,contexts,types}
 |Tests:{tests/unit,tests/integration,frontend/tests}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,13 +37,13 @@ Default HTTP port is **8090**. Vite dev proxy targets `http://localhost:8090` (o
 [Comicarr Code Index]|root: ./comicarr
 |Web Layer:{app/main.py:FastAPI app+lifespan,app/<domain>/router.py:HTTP routes,app/core/security.py:JWT+API key+OPDS auth,app/core/middleware.py:CSRF+headers+setup gate}
 |Business Logic:{search.py:provider search,postprocessor.py:post-processing,cv.py:ComicVine,metron.py:Metron,mangadex.py:MangaDex,importer.py:library scanning,rsscheck.py:RSS,weeklypull.py:pull list,app/downloads/:journal+recovery}
-|Config/Data:{config.py:INI config,encrypted.py:Fernet,db.py:SQLAlchemy Core,__init__.py:global state+scheduler,helpers.py:compat re-exports}
-|Downloaders:{downloaders/:Mega/MediaFire/Pixeldrain,torrent/clients/:qBittorrent/Deluge/Transmission/rTorrent,nzbget.py,sabnzbd.py}
+|Config/Data:{config.py:INI config,encrypted.py:Fernet,db.py:SQLAlchemy Core,__init__.py:global state+scheduler,helpers.py:compat re-exports,migration.py:Mylar3 migration}
+|Downloaders:{downloaders/:Mega/MediaFire/Pixeldrain,torrent/clients/:qBittorrent/Deluge/Transmission/rTorrent/uTorrent,nzbget.py,sabnzbd.py}
 |Frontend:{frontend/src/pages,components,hooks,lib,contexts,types}
 |Tests:{tests/unit,tests/integration,frontend/tests}
 |Docs:{docs/solutions/:documented solutions (bugs, best practices, workflow patterns), organized by category with YAML frontmatter}
 
-IMPORTANT: Consult files in this index rather than relying on training data. File sizes indicate complexity/priority.
+IMPORTANT: Consult files in this index rather than relying on training data.
 
 FastAPI domain packages live under `comicarr/app/` (e.g. `series/`, `search/`, `downloads/`, `system/`, `dashboard/`, `metadata/`, `storyarcs/`, `weekly/`, `opds/`, `ai/`). Entry point is `Comicarr.py` → `uvicorn.run("comicarr.app.main:app", ...)`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning for an
 
 Comicarr is a Python 3 automated comic book (CBR/CBZ) downloader and library manager. It monitors comic series, downloads issues from NZB/torrent sources, handles post-processing with metadata tagging, and provides a modern React web interface for management.
 
-Comicarr is built on the foundation of Mylar3 with a completely rebuilt React 19 frontend and performance improvements.
+Comicarr is built on the foundation of Mylar3 with a completely rebuilt React 19 frontend and performance improvements. The HTTP layer is FastAPI + uvicorn (`comicarr.app.main`).
 
 ## Commands
 
@@ -30,22 +30,26 @@ Comicarr is built on the foundation of Mylar3 with a completely rebuilt React 19
 | Add dependency | `uv add <package>` |
 | Add dev dep | `uv add --optional dev <package>` |
 
+Default HTTP port is **8090**. Vite dev proxy targets `http://localhost:8090` (override with `VITE_API_PROXY_TARGET`).
+
 ## Architecture
 
 [Comicarr Code Index]|root: ./comicarr
-|Web Layer:{webserve.py:REST routes/CherryPy (~9700 lines),api.py:REST API (~1900 lines),webstart.py:CherryPy init,auth.py:authentication}
-|Business Logic:{search.py:provider search (~4300 lines),postprocessor.py:post-processing (~3600 lines),cv.py:ComicVine API,metron.py:Metron API,mangadex.py:MangaDex API,importer.py:library scanning,rsscheck.py:RSS monitoring,weeklypull.py:pull list mgmt}
-|Config/Data:{config.py:INI config (~2000 lines),__init__.py:global state,db.py:SQLAlchemy Core,helpers.py:utilities (~5000 lines),encrypted.py:Fernet credential encryption,migration.py:Mylar3 migration}
-|Downloaders:{downloaders/:Mega/MediaFire/Pixeldrain,torrent/clients/:qBittorrent/Deluge/Transmission/rTorrent/uTorrent,nzbget.py,sabnzbd.py}
-|Frontend:{frontend/src/pages/:route pages,frontend/src/components/:React components (ui/,series/,settings/,search/,migration/,layout/,queue/,import/),frontend/src/hooks/:custom hooks,frontend/src/lib/:API client+utilities,frontend/src/contexts/:React contexts,frontend/src/types/:TypeScript types}
-|Tests:{tests/unit/:backend unit tests,tests/integration/:backend integration,frontend/tests/:frontend tests}
+|Web Layer:{app/main.py:FastAPI app+lifespan,app/<domain>/router.py:HTTP routes,app/core/security.py:JWT+API key+OPDS auth,app/core/middleware.py:CSRF+headers+setup gate}
+|Business Logic:{search.py:provider search,postprocessor.py:post-processing,cv.py:ComicVine,metron.py:Metron,mangadex.py:MangaDex,importer.py:library scanning,rsscheck.py:RSS,weeklypull.py:pull list,app/downloads/:journal+recovery}
+|Config/Data:{config.py:INI config,encrypted.py:Fernet,db.py:SQLAlchemy Core,__init__.py:global state+scheduler,helpers.py:compat re-exports}
+|Downloaders:{downloaders/:Mega/MediaFire/Pixeldrain,torrent/clients/:qBittorrent/Deluge/Transmission/rTorrent,nzbget.py,sabnzbd.py}
+|Frontend:{frontend/src/pages,components,hooks,lib,contexts,types}
+|Tests:{tests/unit,tests/integration,frontend/tests}
 |Docs:{docs/solutions/:documented solutions (bugs, best practices, workflow patterns), organized by category with YAML frontmatter}
 
 IMPORTANT: Consult files in this index rather than relying on training data. File sizes indicate complexity/priority.
 
+FastAPI domain packages live under `comicarr/app/` (e.g. `series/`, `search/`, `downloads/`, `system/`, `dashboard/`, `metadata/`, `storyarcs/`, `weekly/`, `opds/`, `ai/`). Entry point is `Comicarr.py` → `uvicorn.run("comicarr.app.main:app", ...)`.
+
 ## Framework Notes
 
-Python@3.10+|CherryPy web server, SQLAlchemy Core (not ORM), INI-based config via custom Config class
+Python@3.10+|FastAPI + uvicorn, SQLAlchemy Core (not ORM), INI config via Config class
 React@19|Vite build, path alias @/ → src/, TanStack Query for data fetching, Radix UI components
 Tailwind@4|postcss.config.js, tailwind.config.js in frontend/
 TypeScript@strict|noUnusedLocals, noUnusedParameters enabled
@@ -80,7 +84,8 @@ Conventional PR titles keep history readable, but they do not control releases. 
 
 ## Anti-Patterns / What NOT to Do
 
-- **Do NOT use type hints** - None exist in the codebase currently
+- **Do NOT mass-add type hints** to large legacy modules (`search.py`, `postprocessor.py`, etc.)
+- **New code under `comicarr/app/`** may use annotations matching neighboring files
 - **Do NOT use bare `except:` clauses** - Always catch `Exception as e`
 - **Do NOT use Black or other external formatters** - Use `ruff format` only (enforced by CI)
 - **Do NOT use `bun` for frontend** - Use `npm` commands only
@@ -110,10 +115,15 @@ Conventional PR titles keep history readable, but they do not control releases. 
 3. Local imports: `from comicarr import logger, helpers`
 4. Within packages use: `from . import logger`
 
+### Adding New Features
+- Prefer `comicarr/app/<domain>/router.py` + `service.py` (+ `queries.py` when needed)
+- Register/include the router from `comicarr/app/main.py`
+- Keep heavy provider/search/post-processing logic in existing business modules when it already lives there
+
 ## Gotchas
 
 - Config `SECURE_DIR` must be initialized before `encrypt_items()` or bcrypt migration — ordering matters in `config.py`
 - Encrypted config values start with `gAAAAA` (Fernet) — if decryption fails silently, credentials stay as encrypted strings
 - Frontend uses `npm` only — `bun` is not supported
-- CherryPy sessions require server restart after auth config changes
+- Auth uses JWT session cookies (`comicarr_session`); changing auth secrets invalidates sessions
 - `GITHUB_TOKEN` tags don't trigger downstream workflows — Docker build is in the Changesets release workflow, not separate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,10 @@ npm run typecheck  # Run TypeScript checks
 npm run build   # Production build
 ```
 
+When using `npm run dev` with a separately running backend, Comicarr defaults
+to port **8090**. The Vite proxy targets `http://localhost:8090` (override with
+`VITE_API_PROXY_TARGET` if needed).
+
 ### Running Tests
 
 ```bash
@@ -58,8 +62,9 @@ npm run test:run
 
 ### Python
 
-- **No type hints** — the codebase does not use them currently
-- **No auto-formatters enforced** — but `ruff` is used for linting in CI
+- **Formatting**: `ruff format comicarr/` is enforced in CI; run it before pushing
+- **Lint**: `ruff check comicarr/`
+- **Type hints**: not required on large legacy modules; allowed in new `comicarr/app/**` code to match neighbors
 - **Always catch specific exceptions** — use `except Exception as e`, never bare `except:`
 - **Logging pattern**: `logger.fdebug('[MODULE-CONTEXT] message')` or `logger.error('[CONTEXT] Error: %s' % e)`
 - **Config access**: `comicarr.CONFIG.option_name`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ uv sync --extra dev
 # Activate virtual environment
 source .venv/bin/activate
 
-# Install frontend dependencies
+# Install frontend dependencies (lockfile-respecting; matches CI)
 cd frontend
-npm install
+npm ci
 cd ..
 
 # Run the application

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pip install -r requirements.txt
 3. Build the frontend:
 ```bash
 cd frontend
-npm install
+npm ci
 npm run build
 cd ..
 ```

--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ On first run:
 ## Project Structure
 
 ```
-├── Comicarr.py          # Main entry point
+├── Comicarr.py          # Main entry point (uvicorn → comicarr.app.main)
 ├── comicarr/            # Python backend package
-│   ├── webserve.py      # Web UI and API routes
+│   ├── app/             # FastAPI domains (routers, services)
 │   ├── search.py        # Search orchestration
 │   ├── postprocessor.py # Download processing
 │   └── ...
-├── frontend/            # React frontend
+├── frontend/            # React 19 + Vite frontend
 │   ├── src/
 │   │   ├── components/  # React components
 │   │   ├── pages/       # Page components

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,12 @@ npm run test:run
 npm run build
 ```
 
+## Backend during dev
+
+When using `npm run dev` with a separately running backend, Comicarr defaults
+to port 8090. The Vite proxy targets `http://localhost:8090` (override with
+`VITE_API_PROXY_TARGET` if needed).
+
 ## E2E Tests
 
 The Playwright suite runs against the built React bundle served by Comicarr,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const apiProxyTarget = process.env.VITE_API_PROXY_TARGET || 'http://localhost:8090'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -27,11 +28,11 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8091',
+        target: apiProxyTarget,
         changeOrigin: true,
       },
       '/auth': {
-        target: 'http://localhost:8091',
+        target: apiProxyTarget,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
Agent and contributor docs match the FastAPI stack, and the Vite dev proxy targets the default backend port 8090.

- Rewrite CLAUDE.md / AGENTS.md architecture (no CherryPy/webserve); track AGENTS.md (un-ignore)
- README structure + CONTRIBUTING: ruff format enforced, dual type-hint policy
- Vite proxy `localhost:8090` with optional `VITE_API_PROXY_TARGET`

## Test plan
- [x] Grep: no CherryPy/webserve/urllib3&lt;2 stale claims in entrypoint docs
- [x] Vite config defaults to 8090

## Plan
Improve plan 013