### PR TITLE
chore: gitignore local feval and agent skill lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,12 @@ docs/ideation/
 # Advisor /improve handoff plans (local only; keep out of public tree)
 plans/
 
+# Local agent / eval tooling (feval harness, skill locks, visual baselines)
+feval.config.json
+skills-lock.json
+benchmarks/
+.feval/
+
 # Pencil design files
 *.pen
 


### PR DESCRIPTION
## Summary
Ignore remaining local agent/eval artifacts so they do not show as untracked or risk being committed to the public repo.

- `feval.config.json` — local feval harness config
- `skills-lock.json` — agent skill lock (pairs with ignored `.agents/`)
- `benchmarks/` — visual/eval baselines
- `.feval/` — feval runtime cache if present

## Test plan
- [x] `git check-ignore -v` matches the four paths
- [ ] `git status` no longer lists these as untracked