### PR TITLE
fix: redact 32P runtime credentials

### DIFF
--- a/.changeset/redact-runtime-32p-credentials.md
+++ b/.changeset/redact-runtime-32p-credentials.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Stop logging 32P runtime credentials and scrub previously written credential lines from support carepackages.

--- a/comicarr/auth32p.py
+++ b/comicarr/auth32p.py
@@ -141,7 +141,7 @@ class info32p(object):
         if self.test:
             return {"status": True, "inkdrops": comicarr.INKDROPS_32P}
 
-        logger.info("uid:%s / authkey:%s / passkey:%s" % (self.uid, self.authkey, self.passkey))
+        logger.info("%s Successfully authenticated using keyed credentials." % self.module)
         if comicarr.KEYS_32P is None:
             comicarr.KEYS_32P = {
                 "user": str(self.uid),

--- a/comicarr/carepackage.py
+++ b/comicarr/carepackage.py
@@ -15,6 +15,12 @@ import comicarr
 from comicarr import config as config_module
 from comicarr import encrypted, logger, versioncheck
 
+_LEGACY_32P_CREDENTIAL_LINE_PATTERN = re.compile(
+    r"\buid\s*:\s*[^/\r\n]+\s*/\s*authkey\s*:\s*[^/\r\n]+\s*/\s*passkey\s*:\s*\S+",
+    re.IGNORECASE,
+)
+_RUNTIME_32P_CREDENTIAL_FIELDS = ("auth", "authkey", "passkey")
+
 
 class carePackage(object):
     def __init__(self, maintenance=False):
@@ -66,6 +72,20 @@ class carePackage(object):
             ("DDL", "http_proxy"),
             ("DDL", "https_proxy"),
         }
+
+    def _collect_runtime_secrets(self):
+        """Add derived 32P tokens that are not persisted in config.ini."""
+        runtime_32p_keys = getattr(comicarr, "KEYS_32P", None)
+        if not isinstance(runtime_32p_keys, dict):
+            return
+
+        for key in _RUNTIME_32P_CREDENTIAL_FIELDS:
+            value = runtime_32p_keys.get(key)
+            if value is None:
+                continue
+            secret = str(value)
+            if secret and secret != "None" and secret not in self.keylist:
+                self.keylist.append(secret)
 
     def loaders(self):
         self.cleaned_config()
@@ -296,6 +316,12 @@ class carePackage(object):
         return flattened
 
     def panicbutton(self):
+        self._collect_runtime_secrets()
+        redaction_keys = sorted(
+            (key for key in self.keylist if len(key) > 4 and not key.isdigit()),
+            key=len,
+            reverse=True,
+        )
         dbpath = os.path.join(comicarr.DATA_DIR, "comicarr.db")
         with zipfile.ZipFile(self.panicfile, "w") as zip:
             zip.write(self.filename, os.path.basename(self.filename))
@@ -327,8 +353,12 @@ class carePackage(object):
                         with open(fname, "r") as f:
                             line = f.readline()
                             while line:
-                                for keyed in self.keylist:
-                                    if keyed in line and len(keyed) > 0 and (len(keyed) > 4 and not keyed.isdigit()):
+                                line, structured_redactions = _LEGACY_32P_CREDENTIAL_LINE_PATTERN.subn(
+                                    "uid:-REDACTED- / authkey:-REDACTED- / passkey:-REDACTED-", line
+                                )
+                                cnt += structured_redactions
+                                for keyed in redaction_keys:
+                                    if keyed in line:
                                         cnt += 1
                                         line = line.replace(keyed, "-REDACTED-")
                                 output.write(line)

--- a/tests/unit/test_auth32p_security.py
+++ b/tests/unit/test_auth32p_security.py
@@ -1,0 +1,46 @@
+#  Copyright (C) 2025-2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Security regression tests for 32P authentication logging."""
+
+import comicarr
+from comicarr import logger
+from comicarr.auth32p import info32p
+
+
+def test_authenticate_logs_success_without_derived_credentials(monkeypatch):
+    """Successful authentication must not write runtime credentials to logs."""
+    authentication = info32p.__new__(info32p)
+    authentication.module = "[32P-AUTHENTICATION]"
+    authentication.status = True
+    authentication.status_msg = None
+    authentication.error = None
+    authentication.test = False
+    authentication.mode = None
+    authentication.uid = "24680"
+    authentication.auth = "runtime-auth-token"
+    authentication.authkey = "runtime-auth-key"
+    authentication.passkey = "runtime-pass-key"
+
+    messages = []
+    monkeypatch.setattr(comicarr, "KEYS_32P", None)
+    monkeypatch.setattr(comicarr, "INKDROPS_32P", 0)
+    monkeypatch.setattr(logger, "info", messages.append)
+
+    result = authentication.authenticate()
+
+    assert result["status"] is True
+    assert messages == ["[32P-AUTHENTICATION] Successfully authenticated using keyed credentials."]
+    for credential in (
+        authentication.uid,
+        authentication.auth,
+        authentication.authkey,
+        authentication.passkey,
+    ):
+        assert credential not in messages[0]

--- a/tests/unit/test_carepackage_security.py
+++ b/tests/unit/test_carepackage_security.py
@@ -49,10 +49,20 @@ def test_carepackage_clean_config_and_logs_redact_newer_secrets(tmp_path, monkey
     with open(config_path, "w") as config_file:
         parser.write(config_file)
 
+    runtime_32p_credentials = {
+        "user": "24680",
+        "auth": "runtime-auth-token",
+        "authkey": "runtime-auth-key",
+        "passkey": "runtime-pass-key",
+    }
+    monkeypatch.setattr(comicarr, "KEYS_32P", runtime_32p_credentials)
+
     log_path = log_dir / "comicarr.log"
     log_path.write_text(
         "slack-secret mattermost-secret matrix-secret ai-secret "
         "github-secret postgres://user:database-secret@example/db\n"
+        "uid:24680 / authkey:runtime-auth-key / passkey:runtime-pass-key\n"
+        "32P feed auth=runtime-auth-token\n"
     )
     (data_dir / "comicarr.db").write_text("")
 
@@ -73,6 +83,7 @@ def test_carepackage_clean_config_and_logs_redact_newer_secrets(tmp_path, monkey
         "ai-secret",
         "database-secret",
         "github-secret",
+        *runtime_32p_credentials.values(),
     )
     expected_redacted_options = (
         ("Git", "git_token"),


### PR DESCRIPTION
## Summary

Successful 32P authentication no longer writes live UID, auth-key, or passkey values to Comicarr logs. Support carepackages now collect derived runtime 32P secrets immediately before export and scrub both those values and the historical structured credential line.

## Testing

- Added proof-first authentication logging and carepackage redaction regressions.
- Focused security suite: 4 passed.
- Combined Wave 1 backend suite: 895 passed.
- Ruff lint and format checks passed.

## Post-Deploy Monitoring & Validation

- **Window/owner:** Maintainers should inspect the next 32P authentication and any carepackage created during the first 24 hours after deploy.
- **Healthy signals:** Authentication succeeds with only the generic keyed-credentials success message; exported logs contain -REDACTED- in place of legacy credential fields.
- **Watch:** Search fresh logs and support bundles for the labels uid:, authkey:, and passkey: near 32P authentication messages without copying their values into tickets.
- **Failure trigger:** Any newly emitted raw credential value, failed keyed authentication, or unredacted carepackage should stop support-bundle sharing.
- **Mitigation:** Disable the 32P provider/support export as applicable, rotate exposed credentials, and revert the behavioral change only if authentication itself regresses.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Authentication logs no longer include runtime credential details.
  - Support care packages now scrub runtime credentials and legacy credential log entries.
  - Credential redaction is applied consistently to cleaned configuration and bundled logs.

- **Tests**
  - Added regression coverage to verify credentials never appear in authentication logs or support bundles.

- **Release**
  - Recorded a patch release for the `comicarr` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->