### PR TITLE
fix: repair AI completion filters

### DIFF
--- a/.changeset/fix-ai-completion-filter.md
+++ b/.changeset/fix-ai-completion-filter.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix AI library completion filters so percentage queries work on SQLite and preserve inclusive bounds, ordering, and limits.

--- a/comicarr/app/ai/query_patterns.py
+++ b/comicarr/app/ai/query_patterns.py
@@ -28,7 +28,15 @@ QUERY_PATTERNS = {
     },
     "completion_filter": {
         "description": "Filter series by completion percentage",
-        "sql": "SELECT ComicID, ComicName, ComicYear, Have, Total, ComicImage, CASE WHEN Total > 0 THEN CAST(Have AS FLOAT) / Total * 100 ELSE 0 END as pct FROM comics WHERE Status != 'Paused' HAVING pct >= ? AND pct <= ? ORDER BY pct DESC LIMIT ?",
+        "sql": (
+            "SELECT ComicID, ComicName, ComicYear, Have, Total, ComicImage, pct "
+            "FROM ("
+            "SELECT ComicID, ComicName, ComicYear, Have, Total, ComicImage, "
+            "CASE WHEN Total > 0 THEN CAST(Have AS FLOAT) / Total * 100 ELSE 0 END AS pct "
+            "FROM comics WHERE Status != 'Paused'"
+            ") AS completion "
+            "WHERE pct >= ? AND pct <= ? ORDER BY pct DESC LIMIT ?"
+        ),
         "params": ["min_pct", "max_pct", "limit"],
         "defaults": {"limit": 20},
     },

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -171,9 +171,7 @@ def delete_comic(ctx, comic_id, delete_directory=False):
                         "symlink, or directory; skipping filesystem removal" % comic_location
                     )
                 else:
-                    logger.fdebug(
-                        "[SERIES-DELETE] Comic Location (%s) successfully %s" % (comic_location, action)
-                    )
+                    logger.fdebug("[SERIES-DELETE] Comic Location (%s) successfully %s" % (comic_location, action))
             else:
                 logger.fdebug("[SERIES-DELETE] Comic Location (%s) does not exist" % comic_location)
 

--- a/tests/unit/test_ai_query_patterns.py
+++ b/tests/unit/test_ai_query_patterns.py
@@ -1,0 +1,67 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Database contract tests for AI query patterns."""
+
+import pytest
+
+import comicarr
+from comicarr import db
+from comicarr.app.ai.query_patterns import execute_pattern
+from comicarr.tables import comics, metadata
+
+
+@pytest.fixture
+def completion_series(tmp_path, monkeypatch):
+    """Create completion-filter fixtures in a real temporary SQLite database."""
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", None, raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    with engine.begin() as connection:
+        connection.execute(
+            comics.insert(),
+            [
+                {"ComicID": "zero", "ComicName": "Zero Total", "Have": 9, "Total": 0, "Status": "Active"},
+                {"ComicID": "lower", "ComicName": "Lower Boundary", "Have": 1, "Total": 4, "Status": "Active"},
+                {"ComicID": "middle", "ComicName": "Middle", "Have": 1, "Total": 2, "Status": "Active"},
+                {"ComicID": "upper", "ComicName": "Upper Boundary", "Have": 3, "Total": 4, "Status": "Active"},
+                {"ComicID": "above", "ComicName": "Above Range", "Have": 9, "Total": 10, "Status": "Active"},
+                {"ComicID": "paused", "ComicName": "Paused", "Have": 7, "Total": 10, "Status": "Paused"},
+                {"ComicID": "paused-zero", "ComicName": "Paused Zero", "Have": 0, "Total": 0, "Status": "Paused"},
+            ],
+        )
+
+    yield
+    db.shutdown_engine()
+
+
+def test_completion_filter_includes_boundaries_orders_and_excludes_paused(completion_series):
+    rows = execute_pattern("completion_filter", {"min_pct": 25, "max_pct": 75, "limit": 20})
+
+    assert [(row["ComicID"], row["pct"]) for row in rows] == [
+        ("upper", 75.0),
+        ("middle", 50.0),
+        ("lower", 25.0),
+    ]
+
+
+def test_completion_filter_treats_zero_total_as_zero_percent(completion_series):
+    rows = execute_pattern("completion_filter", {"min_pct": 0, "max_pct": 0, "limit": 20})
+
+    assert [(row["ComicID"], row["pct"]) for row in rows] == [("zero", 0)]
+
+
+def test_completion_filter_applies_validated_limit_after_percentage_ordering(completion_series):
+    rows = execute_pattern("completion_filter", {"min_pct": 0, "max_pct": 100, "limit": 2})
+
+    assert [row["ComicID"] for row in rows] == ["above", "upper"]


### PR DESCRIPTION
## Summary

AI library questions that filter series by completion percentage no longer fail on SQLite with a non-aggregate HAVING error. Percentage computation now occurs in a derived table, preserving inclusive bounds, descending completion order, paused-series exclusion, zero-total handling, and the validated result limit.

## Testing

- Added proof-first contract tests using a real temporary SQLite database.
- AI unit suite: 131 passed.
- Combined Wave 1 backend suite: 895 passed.
- Ruff lint and format checks passed.

## Post-Deploy Monitoring & Validation

- **Window/owner:** Maintainers should exercise completion-percentage questions after deploy and watch AI query logs for 24 hours.
- **Healthy signals:** Completion filters return ordered series within both requested boundaries, with no query-execution error.
- **Watch:** Search logs for HAVING clause on a non-aggregate query, [AI-CHAT] Query execution error, and completion_filter.
- **Failure trigger:** Any SQL error, missing boundary result, paused-series result, or incorrect limit is a rollback signal.
- **Mitigation:** Revert this PR to restore the prior query while disabling completion-filter routing until a corrected query is deployed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
