### PR TITLE
fix: handle EventBus queue overflow

### DIFF
--- a/.changeset/calm-events-flow.md
+++ b/.changeset/calm-events-flow.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Keep server-sent event streams responsive under burst traffic by replacing stale queued updates without emitting event-loop errors.

--- a/comicarr/app/core/events.py
+++ b/comicarr/app/core/events.py
@@ -17,7 +17,15 @@ to safely enqueue events from non-async threads.
 
 import asyncio
 import threading
+import time
 from dataclasses import dataclass
+
+from comicarr import logger
+
+# Rate-limit overflow diagnostics so bursts do not flood logs.
+_OVERFLOW_LOG_INTERVAL_SEC = 5.0
+_last_overflow_log = 0.0
+_overflow_log_lock = threading.Lock()
 
 
 @dataclass
@@ -52,6 +60,18 @@ class EventBus:
             self._subscribers.pop(sub_id, None)
 
     @staticmethod
+    def _log_overflow_drop(event):
+        """Emit a rate-limited debug line when oldest events are dropped."""
+        global _last_overflow_log
+        now = time.monotonic()
+        with _overflow_log_lock:
+            if now - _last_overflow_log < _OVERFLOW_LOG_INTERVAL_SEC:
+                return
+            _last_overflow_log = now
+        event_type = getattr(event, "event_type", "?")
+        logger.fdebug("[EventBus] Dropped oldest subscriber event to retain newest type=%s" % event_type)
+
+    @staticmethod
     def _enqueue_latest(q, event):
         """Enqueue on the event-loop thread, retaining the newest event."""
         try:
@@ -68,7 +88,9 @@ class EventBus:
         try:
             q.put_nowait(event)
         except asyncio.QueueFull:
-            pass
+            return
+
+        EventBus._log_overflow_drop(event)
 
     def publish_sync(self, event_type, payload):
         """Thread-safe publish from background threads into async queues.

--- a/comicarr/app/core/events.py
+++ b/comicarr/app/core/events.py
@@ -51,6 +51,25 @@ class EventBus:
         with self._lock:
             self._subscribers.pop(sub_id, None)
 
+    @staticmethod
+    def _enqueue_latest(q, event):
+        """Enqueue on the event-loop thread, retaining the newest event."""
+        try:
+            q.put_nowait(event)
+            return
+        except asyncio.QueueFull:
+            pass
+
+        try:
+            q.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+
+        try:
+            q.put_nowait(event)
+        except asyncio.QueueFull:
+            pass
+
     def publish_sync(self, event_type, payload):
         """Thread-safe publish from background threads into async queues.
 
@@ -66,9 +85,7 @@ class EventBus:
 
         for q in snapshot:
             try:
-                self._loop.call_soon_threadsafe(q.put_nowait, event)
-            except asyncio.QueueFull:
-                pass  # Slow consumer — drop oldest would be better but skip for now
+                self._loop.call_soon_threadsafe(self._enqueue_latest, q, event)
             except RuntimeError:
                 pass  # Event loop closed during shutdown
 

--- a/tests/unit/test_app_core.py
+++ b/tests/unit/test_app_core.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from comicarr.app.core.context import AppContext
-from comicarr.app.core.events import EventBus
+from comicarr.app.core.events import AppEvent, EventBus
 from comicarr.app.core.exceptions import (
     AuthError,
     ConfigError,
@@ -112,6 +112,17 @@ class TestEventBus:
         bus.publish_sync("test", {"msg": "hello"})
         assert q.empty()
 
+    def test_publish_ignores_closed_loop_during_shutdown(self):
+        bus = EventBus()
+        loop = MagicMock()
+        loop.call_soon_threadsafe.side_effect = RuntimeError("Event loop is closed")
+        bus.set_loop(loop)
+        bus.subscribe()
+
+        bus.publish_sync("shutdown", {"message": "stopping"})
+
+        loop.call_soon_threadsafe.assert_called_once()
+
     @pytest.mark.asyncio
     async def test_publish_delivers_to_subscriber(self):
         bus = EventBus()
@@ -169,6 +180,33 @@ class TestEventBus:
         assert not q.empty()
         event = q.get_nowait()
         assert event.event_type == "bg_event"
+        bus.unsubscribe(sub_id)
+
+    @pytest.mark.asyncio
+    async def test_publish_replaces_oldest_event_when_subscriber_queue_is_full(self):
+        bus = EventBus()
+        loop = asyncio.get_running_loop()
+        bus.set_loop(loop)
+
+        sub_id, q = bus.subscribe()
+        seed_events = [AppEvent("seed", {"index": index}) for index in range(q.maxsize)]
+        for event in seed_events:
+            q.put_nowait(event)
+
+        loop_errors = []
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+        try:
+            bus.publish_sync("latest", {"index": q.maxsize})
+            await asyncio.sleep(0)
+        finally:
+            loop.set_exception_handler(previous_handler)
+
+        queued_events = [q.get_nowait() for _ in range(q.qsize())]
+        assert loop_errors == []
+        assert len(queued_events) == q.maxsize
+        assert queued_events[0] == seed_events[1]
+        assert queued_events[-1] == AppEvent("latest", {"index": q.maxsize})
         bus.unsubscribe(sub_id)
 
 

--- a/tests/unit/test_app_core.py
+++ b/tests/unit/test_app_core.py
@@ -205,8 +205,37 @@ class TestEventBus:
         queued_events = [q.get_nowait() for _ in range(q.qsize())]
         assert loop_errors == []
         assert len(queued_events) == q.maxsize
-        assert queued_events[0] == seed_events[1]
-        assert queued_events[-1] == AppEvent("latest", {"index": q.maxsize})
+        assert queued_events == seed_events[1:] + [AppEvent("latest", {"index": q.maxsize})]
+        bus.unsubscribe(sub_id)
+
+    @pytest.mark.asyncio
+    async def test_publish_burst_retains_newest_window_when_queue_full(self):
+        bus = EventBus()
+        loop = asyncio.get_running_loop()
+        bus.set_loop(loop)
+
+        sub_id, q = bus.subscribe()
+        seed_events = [AppEvent("seed", {"index": index}) for index in range(q.maxsize)]
+        for event in seed_events:
+            q.put_nowait(event)
+
+        burst_count = 3
+        newest_events = [AppEvent("burst", {"index": q.maxsize + offset}) for offset in range(burst_count)]
+
+        loop_errors = []
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+        try:
+            for event in newest_events:
+                bus.publish_sync(event.event_type, event.payload)
+            await asyncio.sleep(0)
+        finally:
+            loop.set_exception_handler(previous_handler)
+
+        queued_events = [q.get_nowait() for _ in range(q.qsize())]
+        assert loop_errors == []
+        assert len(queued_events) == q.maxsize
+        assert queued_events == seed_events[burst_count:] + newest_events
         bus.unsubscribe(sub_id)
 
 


### PR DESCRIPTION
## Summary

Slow server-sent-event consumers no longer produce unhandled event-loop QueueFull exceptions during bursts. A full subscriber queue now drops its oldest stale update and retains the newest event, while preserving normal background-thread delivery and closed-loop shutdown handling.

## Testing

- Added proof-first overflow coverage that fills the subscriber queue and captures event-loop errors.
- Core application test file: 45 passed.
- Combined Wave 1 backend suite: 895 passed.
- Ruff lint and format checks passed.

## Post-Deploy Monitoring & Validation

- **Window/owner:** Maintainers should watch SSE behavior through one normal high-activity window or the first 24 hours.
- **Healthy signals:** Connected clients continue receiving current events without callback exceptions; reconnect behavior remains unchanged.
- **Watch:** Search logs for QueueFull, Exception in callback, EventBus errors, and unusual /api/events/stream reconnect frequency.
- **Failure trigger:** Repeated callback exceptions, lost current-state updates, or a reconnect spike indicates the overflow policy is not behaving as intended.
- **Mitigation:** Revert this PR and temporarily reduce event publication frequency while investigating the subscriber backlog.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
