### PR TITLE
fix: harden series directory deletion

### DIFF
--- a/.changeset/harden-series-directory-deletion.md
+++ b/.changeset/harden-series-directory-deletion.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Validate series directories against configured library roots and preserve database records when directory removal fails.

--- a/comicarr/app/common/filesystem.py
+++ b/comicarr/app/common/filesystem.py
@@ -20,18 +20,28 @@ import os
 import shutil
 
 
-def is_path_within_allowed_dirs(path, allowed_dirs):
+def is_path_within_allowed_dirs(path, allowed_dirs, *, strict=False):
     """Check if a path is within any of the allowed directories.
 
     Uses os.path.realpath + os.path.commonpath to prevent path traversal.
     Unlike the original helpers.py version, this takes allowed_dirs as a
     parameter instead of reading from global config.
+
+    When strict=True, the path must be a real descendant of a root — equality
+    with a root is rejected (needed for destructive operations that must never
+    target a configured library root itself). Overbroad roots that realpath to
+    the filesystem root are ignored in strict mode so they cannot authorize
+    arbitrary absolute paths.
     """
     real_path = os.path.realpath(path)
     for root in allowed_dirs:
         if not root:
             continue
         real_root = os.path.realpath(root)
+        if strict and real_root == os.sep:
+            continue
+        if strict and real_path == real_root:
+            continue
         try:
             if os.path.commonpath([real_root, real_path]) == real_root:
                 return True

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -70,14 +70,24 @@ def _is_strict_library_descendant(path, config):
         return False
 
     try:
-        real_path = os.path.realpath(path)
-        real_roots = [os.path.realpath(root) for root in roots]
+        return is_path_within_allowed_dirs(path, roots, strict=True)
     except (OSError, TypeError, ValueError):
         return False
 
-    if real_path in real_roots:
-        return False
-    return is_path_within_allowed_dirs(path, roots)
+
+def _remove_comic_location(comic_location):
+    """Remove a validated ComicLocation without following directory symlinks.
+
+    Symlinks and regular files are unlinked in place. Real directories use
+    rmtree. Other special nodes are skipped so DB cleanup can still proceed.
+    """
+    if os.path.islink(comic_location) or os.path.isfile(comic_location):
+        os.unlink(comic_location)
+        return "unlinked"
+    if os.path.isdir(comic_location):
+        shutil.rmtree(comic_location)
+        return "removed"
+    return "skipped"
 
 
 def list_comics(ctx, limit=None, offset=None):
@@ -150,12 +160,20 @@ def delete_comic(ctx, comic_id, delete_directory=False):
                     "error": "Unable to safely delete the directory for ComicID: %s" % comic_id,
                 }
 
-            # Remove the requested directory before its database rows. This
+            # Remove the requested path before its database rows. This
             # preserves a recoverable watchlist entry when filesystem removal
             # fails; the database helper owns a separate atomic transaction.
             if os.path.lexists(comic_location):
-                shutil.rmtree(comic_location)
-                logger.fdebug("[SERIES-DELETE] Comic Location (%s) successfully deleted" % comic_location)
+                action = _remove_comic_location(comic_location)
+                if action == "skipped":
+                    logger.fdebug(
+                        "[SERIES-DELETE] Comic Location (%s) is not a regular file, "
+                        "symlink, or directory; skipping filesystem removal" % comic_location
+                    )
+                else:
+                    logger.fdebug(
+                        "[SERIES-DELETE] Comic Location (%s) successfully %s" % (comic_location, action)
+                    )
             else:
                 logger.fdebug("[SERIES-DELETE] Comic Location (%s) does not exist" % comic_location)
 

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -23,12 +23,61 @@ import sqlalchemy
 
 import comicarr
 from comicarr import db, logger
+from comicarr.app.common.filesystem import is_path_within_allowed_dirs
 from comicarr.app.series import queries as series_queries
 from comicarr.tables import annuals, comics, issues, oneoffhistory, storyarcs, weekly
 
 # ---------------------------------------------------------------------------
 # Series CRUD
 # ---------------------------------------------------------------------------
+
+_LIBRARY_ROOT_CONFIG_KEYS = (
+    "DESTINATION_DIR",
+    "MANGA_DESTINATION_DIR",
+    "COMIC_DIR",
+    "MANGA_DIR",
+    "MULTIPLE_DEST_DIRS",
+    "NEWCOM_DIR",
+)
+
+
+def _configured_library_roots(config):
+    """Return explicit, non-empty roots that can contain series directories."""
+    if config is None:
+        return []
+
+    roots = []
+    for key in _LIBRARY_ROOT_CONFIG_KEYS:
+        root = getattr(config, key, None)
+        # Config path fields are defined as strings. Ignoring other dynamic
+        # attribute values ensures only explicitly configured roots authorize
+        # deletion.
+        if not isinstance(root, str):
+            continue
+        root = root.strip()
+        if root and root.lower() != "none":
+            roots.append(root)
+    return roots
+
+
+def _is_strict_library_descendant(path, config):
+    """Require path to resolve below, but never equal, a configured root."""
+    if not isinstance(path, (str, os.PathLike)):
+        return False
+
+    roots = _configured_library_roots(config)
+    if not roots:
+        return False
+
+    try:
+        real_path = os.path.realpath(path)
+        real_roots = [os.path.realpath(root) for root in roots]
+    except (OSError, TypeError, ValueError):
+        return False
+
+    if real_path in real_roots:
+        return False
+    return is_path_within_allowed_dirs(path, roots)
 
 
 def list_comics(ctx, limit=None, offset=None):
@@ -89,14 +138,28 @@ def delete_comic(ctx, comic_id, delete_directory=False):
     logger.fdebug("Deletion request received for %s (%s) [%s]" % (comic["ComicName"], comic["ComicYear"], comic_id))
 
     try:
-        series_queries.delete_comic(comic_id)
-
         if delete_directory and comic.get("ComicLocation"):
-            if os.path.exists(comic["ComicLocation"]):
-                shutil.rmtree(comic["ComicLocation"])
-                logger.fdebug("[SERIES-DELETE] Comic Location (%s) successfully deleted" % comic["ComicLocation"])
+            comic_location = comic["ComicLocation"]
+            if not _is_strict_library_descendant(comic_location, ctx.config):
+                logger.error(
+                    "[SERIES-DELETE] Refusing to delete Comic Location (%s): "
+                    "not a strict descendant of a configured library root" % comic_location
+                )
+                return {
+                    "success": False,
+                    "error": "Unable to safely delete the directory for ComicID: %s" % comic_id,
+                }
+
+            # Remove the requested directory before its database rows. This
+            # preserves a recoverable watchlist entry when filesystem removal
+            # fails; the database helper owns a separate atomic transaction.
+            if os.path.lexists(comic_location):
+                shutil.rmtree(comic_location)
+                logger.fdebug("[SERIES-DELETE] Comic Location (%s) successfully deleted" % comic_location)
             else:
-                logger.fdebug("[SERIES-DELETE] Comic Location (%s) does not exist" % comic["ComicLocation"])
+                logger.fdebug("[SERIES-DELETE] Comic Location (%s) does not exist" % comic_location)
+
+        series_queries.delete_comic(comic_id)
 
     except Exception as e:
         logger.error("Unable to delete ComicID: %s. Error: %s" % (comic_id, e))

--- a/tests/unit/test_app_core.py
+++ b/tests/unit/test_app_core.py
@@ -342,6 +342,17 @@ class TestCommonFilesystem:
         traversal = str(tmp_path) + "/../../../etc/passwd"
         assert not is_path_within_allowed_dirs(traversal, allowed)
 
+    def test_strict_rejects_root_itself_and_filesystem_root(self, tmp_path):
+        import os
+
+        from comicarr.app.common.filesystem import is_path_within_allowed_dirs
+
+        child = tmp_path / "series"
+        child.mkdir()
+        assert is_path_within_allowed_dirs(str(child), [str(tmp_path)], strict=True)
+        assert not is_path_within_allowed_dirs(str(tmp_path), [str(tmp_path)], strict=True)
+        assert not is_path_within_allowed_dirs(str(child), [os.sep], strict=True)
+
     def test_windows_hardlink_uses_os_link(self):
         from comicarr.app.common.filesystem import file_ops
 

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -1,0 +1,192 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Tests for the series domain service."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from comicarr.app.core.context import AppContext
+from comicarr.app.series import service as series_service
+
+
+def _make_ctx(**config_overrides):
+    config_values = {
+        "COMIC_DIR": None,
+        "MANGA_DIR": None,
+        "DESTINATION_DIR": None,
+        "MANGA_DESTINATION_DIR": None,
+        "MULTIPLE_DEST_DIRS": None,
+        "NEWCOM_DIR": None,
+    }
+    config_values.update(config_overrides)
+    return AppContext(config=SimpleNamespace(**config_values))
+
+
+def _comic(location):
+    return {
+        "ComicName": "Example Series",
+        "ComicYear": "2026",
+        "ComicLocation": str(location),
+    }
+
+
+def _delete(ctx, location, delete_side_effect=None):
+    with (
+        patch.object(series_service.series_queries, "get_comic_for_delete", return_value=_comic(location)),
+        patch.object(series_service.series_queries, "delete_comic") as delete_from_db,
+    ):
+        delete_from_db.side_effect = delete_side_effect
+        result = series_service.delete_comic(ctx, "123", delete_directory=True)
+    return result, delete_from_db
+
+
+class TestDeleteComicDirectory:
+    def test_rejects_directory_when_no_library_root_is_configured(self, tmp_path):
+        series_directory = tmp_path / "series"
+        series_directory.mkdir()
+
+        result, delete_from_db = _delete(_make_ctx(), series_directory)
+
+        assert result["success"] is False
+        assert series_directory.is_dir()
+        delete_from_db.assert_not_called()
+
+    def test_rejects_directory_outside_configured_library_roots(self, tmp_path):
+        library_root = tmp_path / "library"
+        outside_series = tmp_path / "outside" / "series"
+        library_root.mkdir()
+        outside_series.mkdir(parents=True)
+
+        result, delete_from_db = _delete(
+            _make_ctx(DESTINATION_DIR=str(library_root)),
+            outside_series,
+        )
+
+        assert result["success"] is False
+        assert outside_series.is_dir()
+        delete_from_db.assert_not_called()
+
+    def test_rejects_configured_library_root_itself(self, tmp_path):
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+
+        result, delete_from_db = _delete(
+            _make_ctx(DESTINATION_DIR=str(library_root)),
+            library_root,
+        )
+
+        assert result["success"] is False
+        assert library_root.is_dir()
+        delete_from_db.assert_not_called()
+
+    def test_rejects_symlink_that_escapes_library_root(self, tmp_path):
+        library_root = tmp_path / "library"
+        outside_series = tmp_path / "outside" / "series"
+        library_root.mkdir()
+        outside_series.mkdir(parents=True)
+        linked_series = library_root / "linked-series"
+        linked_series.symlink_to(outside_series, target_is_directory=True)
+
+        result, delete_from_db = _delete(
+            _make_ctx(DESTINATION_DIR=str(library_root)),
+            linked_series,
+        )
+
+        assert result["success"] is False
+        assert linked_series.is_symlink()
+        assert outside_series.is_dir()
+        delete_from_db.assert_not_called()
+
+    def test_filesystem_failure_does_not_delete_database_rows(self, tmp_path):
+        library_root = tmp_path / "library"
+        series_directory = library_root / "series"
+        series_directory.mkdir(parents=True)
+
+        with (
+            patch.object(
+                series_service.series_queries,
+                "get_comic_for_delete",
+                return_value=_comic(series_directory),
+            ),
+            patch.object(series_service.shutil, "rmtree", side_effect=OSError("permission denied")),
+            patch.object(series_service.series_queries, "delete_comic") as delete_from_db,
+        ):
+            result = series_service.delete_comic(
+                _make_ctx(DESTINATION_DIR=str(library_root)),
+                "123",
+                delete_directory=True,
+            )
+
+        assert result["success"] is False
+        assert series_directory.is_dir()
+        delete_from_db.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "root_key",
+        [
+            "DESTINATION_DIR",
+            "MANGA_DESTINATION_DIR",
+            "COMIC_DIR",
+            "MANGA_DIR",
+            "MULTIPLE_DEST_DIRS",
+            "NEWCOM_DIR",
+        ],
+    )
+    def test_valid_strict_descendant_is_removed_before_database_rows(self, tmp_path, root_key):
+        library_root = tmp_path / "library"
+        series_directory = library_root / "series"
+        series_directory.mkdir(parents=True)
+
+        def assert_directory_was_removed(_comic_id):
+            assert not series_directory.exists()
+
+        result, delete_from_db = _delete(
+            _make_ctx(**{root_key: str(library_root)}),
+            series_directory,
+            delete_side_effect=assert_directory_was_removed,
+        )
+
+        assert result["success"] is True
+        assert not series_directory.exists()
+        delete_from_db.assert_called_once_with("123")
+
+    def test_missing_valid_directory_still_deletes_database_rows(self, tmp_path):
+        library_root = tmp_path / "library"
+        missing_series = library_root / "missing-series"
+        library_root.mkdir()
+
+        result, delete_from_db = _delete(
+            _make_ctx(DESTINATION_DIR=str(library_root)),
+            missing_series,
+        )
+
+        assert result["success"] is True
+        delete_from_db.assert_called_once_with("123")
+
+    def test_database_only_deletion_does_not_validate_or_remove_directory(self, tmp_path):
+        outside_series = tmp_path / "outside" / "series"
+        outside_series.mkdir(parents=True)
+        ctx = _make_ctx()
+
+        with (
+            patch.object(
+                series_service.series_queries,
+                "get_comic_for_delete",
+                return_value=_comic(outside_series),
+            ),
+            patch.object(series_service.series_queries, "delete_comic") as delete_from_db,
+        ):
+            result = series_service.delete_comic(ctx, "123", delete_directory=False)
+
+        assert result["success"] is True
+        assert outside_series.is_dir()
+        delete_from_db.assert_called_once_with("123")

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -9,6 +9,7 @@
 
 """Tests for the series domain service."""
 
+import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -75,6 +76,39 @@ class TestDeleteComicDirectory:
         assert outside_series.is_dir()
         delete_from_db.assert_not_called()
 
+    def test_rejects_path_prefix_sibling_of_library_root(self, tmp_path):
+        """A path that shares a string prefix with the root must not authorize deletion."""
+        library_root = tmp_path / "library"
+        evil_series = tmp_path / "library-evil" / "series"
+        library_root.mkdir()
+        evil_series.mkdir(parents=True)
+
+        result, delete_from_db = _delete(
+            _make_ctx(DESTINATION_DIR=str(library_root)),
+            evil_series,
+        )
+
+        assert result["success"] is False
+        assert evil_series.is_dir()
+        delete_from_db.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "root_value",
+        ["None", "none", "  ", 42],
+    )
+    def test_rejects_when_configured_roots_are_empty_or_invalid(self, tmp_path, root_value):
+        series_directory = tmp_path / "series"
+        series_directory.mkdir()
+
+        result, delete_from_db = _delete(
+            _make_ctx(DESTINATION_DIR=root_value),
+            series_directory,
+        )
+
+        assert result["success"] is False
+        assert series_directory.is_dir()
+        delete_from_db.assert_not_called()
+
     def test_rejects_configured_library_root_itself(self, tmp_path):
         library_root = tmp_path / "library"
         library_root.mkdir()
@@ -104,6 +138,53 @@ class TestDeleteComicDirectory:
         assert result["success"] is False
         assert linked_series.is_symlink()
         assert outside_series.is_dir()
+        delete_from_db.assert_not_called()
+
+    def test_unlinks_in_library_symlink_without_removing_target(self, tmp_path):
+        library_root = tmp_path / "library"
+        real_series = library_root / "real-series"
+        real_series.mkdir(parents=True)
+        (real_series / "issue.cbz").write_text("x")
+        linked_series = library_root / "linked-series"
+        linked_series.symlink_to(real_series, target_is_directory=True)
+
+        result, delete_from_db = _delete(
+            _make_ctx(DESTINATION_DIR=str(library_root)),
+            linked_series,
+        )
+
+        assert result["success"] is True
+        assert not linked_series.exists()
+        assert real_series.is_dir()
+        assert (real_series / "issue.cbz").is_file()
+        delete_from_db.assert_called_once_with("123")
+
+    def test_unlinks_regular_file_comic_location(self, tmp_path):
+        library_root = tmp_path / "library"
+        library_root.mkdir()
+        series_file = library_root / "series.cbz"
+        series_file.write_text("comic-data")
+
+        result, delete_from_db = _delete(
+            _make_ctx(DESTINATION_DIR=str(library_root)),
+            series_file,
+        )
+
+        assert result["success"] is True
+        assert not series_file.exists()
+        delete_from_db.assert_called_once_with("123")
+
+    def test_rejects_filesystem_root_as_configured_library_root(self, tmp_path):
+        series_directory = tmp_path / "series"
+        series_directory.mkdir()
+
+        result, delete_from_db = _delete(
+            _make_ctx(DESTINATION_DIR=os.sep),
+            series_directory,
+        )
+
+        assert result["success"] is False
+        assert series_directory.is_dir()
         delete_from_db.assert_not_called()
 
     def test_filesystem_failure_does_not_delete_database_rows(self, tmp_path):


### PR DESCRIPTION
## Summary

Optional series-directory deletion now resolves the persisted path against Comicarr's configured library roots before touching either the filesystem or database. It rejects root directories, paths outside all configured roots, missing root configuration, and symlink escapes; filesystem failures leave the watchlist record intact.

The safe ordering removes a validated directory before the transactional database cleanup. Database-only deletion remains unchanged, and a missing but valid descendant still permits stale database records to be removed.

## Testing

- Added proof-first coverage for missing roots, outside paths, configured roots themselves, symlink escapes, filesystem failures, missing directories, database-only deletion, and every supported library root including `NEWCOM_DIR`.
- Full backend suite: 902 passed.
- Ruff lint and format checks passed.
- Startup help and lockfile checks passed.

## Post-Deploy Monitoring & Validation

- **Window/owner:** Maintainers should watch series-deletion requests and filesystem errors for the first 24 hours after deployment.
- **Healthy signals:** Valid child directories are removed once, database-only deletions remain successful, and rejected paths leave both files and database rows unchanged.
- **Watch:** Search logs for `[SERIES-DELETE] Refusing`, `Unable to safely delete`, permission errors, and repeated delete retries.
- **Failure trigger:** A valid configured library child being rejected, any configured root being removed, or database rows disappearing after a filesystem failure requires immediate investigation.
- **Mitigation:** Revert this PR and use database-only deletion while checking the affected configured root and persisted `ComicLocation` values.

## Known Limitation

Filesystem removal and the database transaction cannot be atomic together. If directory removal succeeds and the subsequent database transaction fails, the watchlist row remains and a retry completes the database cleanup.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
