### PR TITLE
fix: harden remote artifact boundaries

### DIFF
--- a/.changeset/harden-remote-artifacts.md
+++ b/.changeset/harden-remote-artifacts.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Keep provider downloads inside Comicarr's configured directories, publish completed files atomically, and reject remote ZIP archives that would expand beyond safe resource limits.

--- a/comicarr/app/common/remote_artifacts.py
+++ b/comicarr/app/common/remote_artifacts.py
@@ -1,0 +1,523 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Safety boundaries for filenames and archives received from remote services."""
+
+import logging
+import os
+import re
+import shutil
+import stat
+import tempfile
+import unicodedata
+import zipfile
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+MAX_ZIP_MEMBERS = 10_000
+MAX_ZIP_UNCOMPRESSED_BYTES = 20 * 1024 * 1024 * 1024
+MAX_ZIP_COMPRESSION_RATIO = 200
+ZIP_RATIO_CHECK_MIN_BYTES = 1024 * 1024
+ZIP_DISK_RESERVE_BYTES = 256 * 1024 * 1024
+FILE_STAGING_PREFIX = ".comicarr-part-"
+ZIP_STAGING_PREFIX = ".comicarr-extract-"
+ZIP_BACKUP_PREFIX = ".comicarr-backup-"
+
+_INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+_LOGGER = logging.getLogger(__name__)
+_WINDOWS_RESERVED_NAMES = {
+    "AUX",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "COM¹",
+    "COM²",
+    "COM³",
+    "CON",
+    "CONIN$",
+    "CONOUT$",
+    "CLOCK$",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9",
+    "LPT¹",
+    "LPT²",
+    "LPT³",
+    "NUL",
+    "PRN",
+}
+
+
+class RemoteArtifactError(ValueError):
+    """Raised when a remote filename or archive cannot be handled safely."""
+
+
+def safe_remote_filename(filename):
+    """Normalize an untrusted filename to one portable path component.
+
+    Path separators and platform-invalid characters are replaced rather than
+    discarding the surrounding title, while valid Unicode is preserved.
+    """
+    if filename is None:
+        raise RemoteArtifactError("Remote filename is missing")
+    if isinstance(filename, bytes):
+        filename = filename.decode("utf-8", errors="replace")
+
+    normalized = unicodedata.normalize("NFC", str(filename)).strip()
+    normalized = _INVALID_FILENAME_CHARS.sub("-", normalized).strip(" .")
+    if not normalized or not any(character not in ".- " for character in normalized):
+        raise RemoteArtifactError("Remote filename is empty after normalization")
+    if normalized.split(".", 1)[0].rstrip(" .").upper() in _WINDOWS_RESERVED_NAMES:
+        normalized = "_" + normalized
+    return normalized
+
+
+def ensure_path_within_directory(directory, path):
+    """Return a resolved path only when it is strictly inside ``directory``."""
+    root = Path(directory).expanduser().resolve()
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    candidate = candidate.resolve()
+    try:
+        contained = os.path.commonpath([str(root), str(candidate)]) == str(root)
+    except ValueError as e:
+        raise RemoteArtifactError("Remote artifact path is on a different volume") from e
+    if not contained or candidate == root:
+        raise RemoteArtifactError("Remote artifact path escapes its destination")
+    return candidate
+
+
+def resolve_remote_artifact_path(directory, filename):
+    """Normalize ``filename`` and resolve it strictly inside ``directory``."""
+    return ensure_path_within_directory(directory, safe_remote_filename(filename))
+
+
+def _permission_mode(value, fallback, allowed_mask=0o777):
+    """Parse an octal mode and remove bits disallowed for the artifact type.
+
+    Remote files never receive privilege-bearing special bits. Directories may
+    retain setgid and sticky bits for shared-library collaboration, but setuid
+    is not meaningful or safe for this boundary.
+    """
+    if value is None or isinstance(value, bool):
+        return fallback
+    if isinstance(value, int):
+        if 0 <= value <= 0o777:
+            return value & allowed_mask
+        if value <= 999 and re.fullmatch(r"[0-7]{3}", str(value)):
+            return int(str(value), 8) & allowed_mask
+        if 0 <= value <= 0o7777:
+            return value & allowed_mask
+        return fallback
+
+    mode_text = str(value).strip().lower()
+    if mode_text.startswith("0o"):
+        mode_text = mode_text[2:]
+    if not re.fullmatch(r"[0-7]{1,4}", mode_text):
+        return fallback
+    mode = int(mode_text, 8)
+    return mode & allowed_mask if 0 <= mode <= 0o7777 else fallback
+
+
+def _configured_permission(config, attribute, fallback, allowed_mask=0o777):
+    return _permission_mode(getattr(config, attribute, None), fallback, allowed_mask=allowed_mask)
+
+
+def _ownership_supported():
+    return all(hasattr(os, attribute) for attribute in ("chown", "getuid", "getgid"))
+
+
+def _unset_identity(value):
+    return value is None or str(value).strip().lower() in {"", "none"}
+
+
+def _resolve_identity(value, identity_type):
+    if isinstance(value, int):
+        if value < 0:
+            raise RemoteArtifactError("Configured %s cannot be negative" % identity_type)
+        return value
+
+    identity = str(value).strip()
+    if identity.isdigit():
+        return int(identity)
+    try:
+        if identity_type == "owner":
+            import pwd
+
+            return pwd.getpwnam(identity).pw_uid
+        import grp
+
+        return grp.getgrnam(identity).gr_gid
+    except (ImportError, KeyError) as e:
+        raise RemoteArtifactError("Configured %s does not exist: %s" % (identity_type, identity)) from e
+
+
+def _configured_ownership(config):
+    if not _ownership_supported():
+        return None
+    configured_group = getattr(config, "CHGROUP", None)
+    if _unset_identity(configured_group):
+        return None
+    configured_owner = getattr(config, "CHOWNER", None)
+    owner = os.getuid() if _unset_identity(configured_owner) else _resolve_identity(configured_owner, "owner")
+    group = _resolve_identity(configured_group, "group")
+    return owner, group
+
+
+def _new_artifact_policy():
+    import comicarr
+
+    config = getattr(comicarr, "CONFIG", None)
+    if bool(getattr(config, "ENFORCE_PERMS", False)):
+        return (
+            _configured_permission(config, "CHMOD_FILE", 0o600),
+            _configured_permission(config, "CHMOD_DIR", 0o700, allowed_mask=0o3777),
+            _configured_ownership(config),
+        )
+
+    captured_umask = _permission_mode(getattr(comicarr, "UMASK", None), None)
+    if captured_umask is None:
+        return 0o600, 0o700, None
+    return 0o666 & ~captured_umask, 0o777 & ~captured_umask, None
+
+
+def _stat_ownership(stat_result):
+    if not _ownership_supported():
+        return None
+    return stat_result.st_uid, stat_result.st_gid
+
+
+def _apply_ownership(path, ownership):
+    if ownership is not None:
+        os.chown(path, ownership[0], ownership[1])
+
+
+def _apply_artifact_metadata(path, mode, ownership):
+    _apply_ownership(path, ownership)
+    os.chmod(path, mode)
+
+
+def _replacement_file_metadata(destination):
+    if destination.is_symlink():
+        raise RemoteArtifactError("Remote artifact destination is a symbolic link")
+    if destination.exists():
+        existing_stat = destination.stat()
+        return stat.S_IMODE(existing_stat.st_mode), _stat_ownership(existing_stat)
+    file_mode, _, ownership = _new_artifact_policy()
+    return file_mode, ownership
+
+
+def write_chunks_atomically(destination, chunks):
+    """Write byte chunks beside ``destination`` and atomically publish on success."""
+    destination = Path(destination)
+    file_mode, ownership = _replacement_file_metadata(destination)
+    file_descriptor, temporary_name = tempfile.mkstemp(
+        prefix=FILE_STAGING_PREFIX,
+        suffix=".part",
+        dir=destination.parent,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(file_descriptor, "wb") as output:
+            for chunk in chunks:
+                if chunk:
+                    output.write(chunk)
+            output.flush()
+            os.fsync(output.fileno())
+        _apply_artifact_metadata(temporary_path, file_mode, ownership)
+        os.replace(temporary_path, destination)
+    except Exception as e:
+        try:
+            temporary_path.unlink(missing_ok=True)
+        except Exception as cleanup_error:
+            _LOGGER.warning(
+                "Unable to clean up failed download staging file %s after %s: %s",
+                temporary_path,
+                e,
+                cleanup_error,
+            )
+        raise
+
+
+def _portable_zip_component(component):
+    if component != component.rstrip(" ."):
+        raise RemoteArtifactError("Archive contains a non-portable member name")
+    component = unicodedata.normalize("NFC", component)
+    if not component or _INVALID_FILENAME_CHARS.search(component):
+        raise RemoteArtifactError("Archive contains a non-portable member name")
+    device_basename = component.split(".", 1)[0].rstrip(" .").upper()
+    if device_basename in _WINDOWS_RESERVED_NAMES:
+        raise RemoteArtifactError("Archive contains a non-portable member name")
+    return component
+
+
+def _portable_collision_key(relative_parts):
+    return tuple(unicodedata.normalize("NFC", part.casefold()) for part in relative_parts)
+
+
+def _validated_zip_members(zip_file, destination, existing_size=0):
+    members = zip_file.infolist()
+    if len(members) > MAX_ZIP_MEMBERS:
+        raise RemoteArtifactError("Archive contains too many members")
+
+    total_uncompressed = 0
+    total_compressed = 0
+    normalized_targets = set()
+    portable_prefixes = {}
+    validated = []
+    destination = Path(destination).resolve()
+
+    for member in members:
+        raw_name = member.filename.replace("\\", "/")
+        posix_path = PurePosixPath(raw_name)
+        windows_path = PureWindowsPath(raw_name)
+        if (
+            not raw_name
+            or posix_path.is_absolute()
+            or windows_path.is_absolute()
+            or windows_path.drive
+            or ".." in posix_path.parts
+        ):
+            raise RemoteArtifactError("Archive contains an invalid member name")
+
+        raw_relative_parts = tuple(part for part in posix_path.parts if part not in {"", "."})
+        relative_parts = tuple(_portable_zip_component(part) for part in raw_relative_parts)
+        if not relative_parts:
+            raise RemoteArtifactError("Archive contains an empty member name")
+        for prefix_length in range(1, len(relative_parts) + 1):
+            canonical_prefix = _portable_collision_key(relative_parts[:prefix_length])
+            raw_prefix = raw_relative_parts[:prefix_length]
+            previous_prefix = portable_prefixes.get(canonical_prefix)
+            if previous_prefix is not None and previous_prefix != raw_prefix:
+                raise RemoteArtifactError("Archive contains duplicate portable member paths")
+            portable_prefixes[canonical_prefix] = raw_prefix
+        target = destination.joinpath(*relative_parts).resolve()
+        try:
+            contained = os.path.commonpath([str(destination), str(target)]) == str(destination)
+        except ValueError as e:
+            raise RemoteArtifactError("Archive member is on a different volume") from e
+        if not contained or target == destination:
+            raise RemoteArtifactError("Archive member resolves outside its destination")
+        current_path = destination
+        for relative_part in relative_parts:
+            current_path = current_path / relative_part
+            if current_path.is_symlink():
+                raise RemoteArtifactError("Archive member collides with an existing symbolic link")
+
+        target_key = _portable_collision_key(relative_parts)
+        if target_key in normalized_targets:
+            raise RemoteArtifactError("Archive contains duplicate member paths")
+        normalized_targets.add(target_key)
+
+        member_mode = (member.external_attr >> 16) & 0o170000
+        if member_mode == stat.S_IFLNK:
+            raise RemoteArtifactError("Archive contains a symbolic link")
+        if member.flag_bits & 0x1:
+            raise RemoteArtifactError("Encrypted archives are not supported")
+
+        total_uncompressed += member.file_size
+        total_compressed += member.compress_size
+        if total_uncompressed > MAX_ZIP_UNCOMPRESSED_BYTES:
+            raise RemoteArtifactError("Archive expands beyond the configured size limit")
+        if member.file_size >= ZIP_RATIO_CHECK_MIN_BYTES and (
+            member.compress_size == 0 or member.file_size / member.compress_size > MAX_ZIP_COMPRESSION_RATIO
+        ):
+            raise RemoteArtifactError("Archive member has a suspicious compression ratio")
+
+        validated.append((member, relative_parts))
+
+    if total_uncompressed >= ZIP_RATIO_CHECK_MIN_BYTES and (
+        total_compressed == 0 or total_uncompressed / total_compressed > MAX_ZIP_COMPRESSION_RATIO
+    ):
+        raise RemoteArtifactError("Archive has a suspicious aggregate compression ratio")
+
+    free_bytes = shutil.disk_usage(destination.parent).free
+    available_bytes = max(0, free_bytes - ZIP_DISK_RESERVE_BYTES)
+    if total_uncompressed + existing_size > available_bytes:
+        raise RemoteArtifactError("Archive requires more free disk space than is available")
+    return validated
+
+
+def _make_directories(path, mode, ownership):
+    path = Path(path)
+    missing = []
+    current = path
+    while not current.exists():
+        missing.append(current)
+        if current.parent == current:
+            break
+        current = current.parent
+    path.mkdir(parents=True, exist_ok=True)
+    for directory in reversed(missing):
+        _apply_artifact_metadata(directory, mode, ownership)
+
+
+def _extract_zip_member(
+    zip_file,
+    member,
+    destination,
+    file_mode=0o600,
+    directory_mode=0o700,
+    ownership=None,
+):
+    if member.is_dir():
+        _make_directories(destination, directory_mode, ownership)
+        return
+
+    destination_existed = destination.exists()
+    _make_directories(destination.parent, directory_mode, ownership)
+    bytes_written = 0
+    with zip_file.open(member, "r") as source, destination.open("wb") as output:
+        while True:
+            chunk = source.read(1024 * 1024)
+            if not chunk:
+                break
+            bytes_written += len(chunk)
+            if bytes_written > member.file_size:
+                raise RemoteArtifactError("Archive member expanded beyond its declared size")
+            output.write(chunk)
+    if bytes_written != member.file_size:
+        raise RemoteArtifactError("Archive member size does not match its metadata")
+    if not destination_existed:
+        _apply_artifact_metadata(destination, file_mode, ownership)
+
+
+def _remove_path(path):
+    path = Path(path)
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+    elif path.exists():
+        shutil.rmtree(path)
+
+
+def _directory_size(path):
+    total_size = 0
+    for root, directories, filenames in os.walk(path, followlinks=False):
+        for name in directories + filenames:
+            candidate = Path(root) / name
+            try:
+                total_size += candidate.lstat().st_size
+            except FileNotFoundError:
+                continue
+    return total_size
+
+
+def _preserve_tree_metadata(source, destination):
+    if not _ownership_supported():
+        return
+
+    source = Path(source)
+    destination = Path(destination)
+    source_paths = [source]
+    for root, directories, filenames in os.walk(source, followlinks=False):
+        source_root = Path(root)
+        source_paths.extend(source_root / name for name in directories + filenames)
+
+    for source_path in source_paths:
+        if source_path.is_symlink():
+            continue
+        source_stat = source_path.stat()
+        relative_path = source_path.relative_to(source)
+        destination_path = destination / relative_path
+        _apply_artifact_metadata(
+            destination_path,
+            stat.S_IMODE(source_stat.st_mode),
+            _stat_ownership(source_stat),
+        )
+
+
+def extract_zip_atomically(archive_path, destination):
+    """Validate and overlay a ZIP in staging before publishing the result.
+
+    Existing extraction directories are copied into staging first so successful
+    retries retain the legacy merge behavior without exposing partial output.
+    """
+    archive_path = Path(archive_path)
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging_path = Path(
+        tempfile.mkdtemp(
+            prefix=ZIP_STAGING_PREFIX,
+            dir=destination.parent,
+        )
+    )
+    backup_path = None
+
+    try:
+        destination_exists = os.path.lexists(destination)
+        if destination_exists and (destination.is_symlink() or not destination.is_dir()):
+            raise RemoteArtifactError("Archive destination is not a directory")
+        existing_size = _directory_size(destination) if destination_exists else 0
+        file_mode, directory_mode, new_ownership = _new_artifact_policy()
+        root_mode = stat.S_IMODE(destination.stat().st_mode) if destination_exists else directory_mode
+        root_ownership = _stat_ownership(destination.stat()) if destination_exists else new_ownership
+        with zipfile.ZipFile(archive_path, "r") as zip_file:
+            members = _validated_zip_members(zip_file, destination, existing_size=existing_size)
+            if destination_exists:
+                shutil.copytree(destination, staging_path, dirs_exist_ok=True, symlinks=True)
+            for member, relative_parts in members:
+                _extract_zip_member(
+                    zip_file,
+                    member,
+                    staging_path.joinpath(*relative_parts),
+                    file_mode=file_mode,
+                    directory_mode=directory_mode,
+                    ownership=new_ownership,
+                )
+        if destination_exists:
+            _preserve_tree_metadata(destination, staging_path)
+        _apply_artifact_metadata(staging_path, root_mode, root_ownership)
+
+        if destination_exists:
+            backup_path = Path(
+                tempfile.mkdtemp(
+                    prefix=ZIP_BACKUP_PREFIX,
+                    dir=destination.parent,
+                )
+            )
+            backup_path.rmdir()
+            os.replace(destination, backup_path)
+        try:
+            os.replace(staging_path, destination)
+        except Exception as e:
+            _LOGGER.debug("Unable to publish extraction staging directory %s: %s", staging_path, e)
+            if backup_path is not None:
+                os.replace(backup_path, destination)
+                backup_path = None
+            raise
+    except Exception as e:
+        try:
+            _remove_path(staging_path)
+        except Exception as cleanup_error:
+            _LOGGER.warning(
+                "Unable to clean up failed extraction staging directory %s after %s: %s",
+                staging_path,
+                e,
+                cleanup_error,
+            )
+        raise
+    else:
+        if backup_path is not None:
+            try:
+                _remove_path(backup_path)
+            except Exception as e:
+                _LOGGER.warning("Unable to remove replaced extraction backup %s: %s", backup_path, e)
+    return destination

--- a/comicarr/downloaders/mediafire.py
+++ b/comicarr/downloaders/mediafire.py
@@ -21,11 +21,17 @@
 
 import os
 import re
+from email.message import Message
 
 import requests
 
 import comicarr
 from comicarr import db, helpers, logger
+from comicarr.app.common.remote_artifacts import (
+    resolve_remote_artifact_path,
+    safe_remote_filename,
+    write_chunks_atomically,
+)
 
 
 class MediaFire(object):
@@ -59,12 +65,22 @@ class MediaFire(object):
                 # link no longer valid
                 return {"success": False, "filename": None, "path": None, "link_type_failure": "GC-Media"}
 
-        m = re.search('filename="(.*)"', t.headers["Content-Disposition"])
-        filename = m.groups()[0]
-        filename = filename.encode("iso8859").decode("utf-8")
+        content_disposition = Message()
+        content_disposition["Content-Disposition"] = t.headers["Content-Disposition"]
+        filename = content_disposition.get_filename()
+        if filename is None:
+            return {"success": False, "filename": None, "path": None, "link_type_failure": "GC-Media"}
+        try:
+            filename = filename.encode("iso8859").decode("utf-8")
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            pass
 
         file, ext = os.path.splitext(filename)
-        filename = "%s[__%s__]%s" % (file, issueid, ext)
+        try:
+            filename = safe_remote_filename("%s[__%s__]%s" % (file, issueid, ext))
+        except ValueError as e:
+            logger.warn("[MediaFire] Refusing unsafe remote filename: %s" % e)
+            return {"success": False, "filename": None, "path": None, "link_type_failure": "GC-Media"}
 
         try:
             filesize = int(t.headers["Content-Length"])
@@ -88,7 +104,14 @@ class MediaFire(object):
         return self.mediafire_dl(url, id, fileinfo, issueid)
 
     def mediafire_dl(self, url, id, fileinfo, issueid):
-        filepath = os.path.join(self.dl_location, fileinfo["filename"])
+        try:
+            filename = safe_remote_filename(fileinfo["filename"])
+            filepath = resolve_remote_artifact_path(self.dl_location, filename)
+        except ValueError as e:
+            logger.warn("[MediaFire] Refusing unsafe download path: %s" % e)
+            return {"success": False, "filename": None, "path": None, "link_type_failure": "GC-Media"}
+        fileinfo = dict(fileinfo)
+        fileinfo["filename"] = filename
 
         db.upsert(
             "ddl_info",
@@ -102,11 +125,7 @@ class MediaFire(object):
             response = self.session.get(url, verify=True, headers=self.headers, stream=True, timeout=(30, 30))
 
             logger.fdebug("[MediaFire] now writing....")
-            with open(filepath, "wb") as f:
-                for chunk in response.iter_content(chunk_size=4096):
-                    if chunk:
-                        f.write(chunk)
-                        f.flush()
+            write_chunks_atomically(filepath, response.iter_content(chunk_size=4096))
 
         except Exception as e:
             logger.fdebug("[MediaFire][ERROR] %s" % e)
@@ -117,7 +136,7 @@ class MediaFire(object):
         try:
             filesize = os.stat(filepath).st_size
         except FileNotFoundError:
-            return {"success": false, "filenme": None, "path": None}
+            return {"success": False, "filename": None, "path": None}
         else:
             logger.fdebug("[MediaFire] download completed - downloaded %s / %s" % (filesize, fileinfo["filesize"]))
 

--- a/comicarr/getcomics.py
+++ b/comicarr/getcomics.py
@@ -28,7 +28,6 @@ import sys
 import time
 import traceback
 import urllib.parse
-import zipfile
 from operator import itemgetter
 
 import requests
@@ -36,6 +35,13 @@ from bs4 import BeautifulSoup
 
 import comicarr
 from comicarr import db, helpers, logger, search_filer
+from comicarr.app.common.remote_artifacts import (
+    ensure_path_within_directory,
+    extract_zip_atomically,
+    resolve_remote_artifact_path,
+    safe_remote_filename,
+    write_chunks_atomically,
+)
 
 
 class GC(object):
@@ -1179,7 +1185,7 @@ class GC(object):
 
                 if filename is not None:
                     file, ext = os.path.splitext(filename)
-                    filename = "%s[__%s__]%s" % (file, issueid, ext)
+                    filename = safe_remote_filename("%s[__%s__]%s" % (file, issueid, ext))
 
                 logger.fdebug("filename: %s" % filename)
 
@@ -1195,6 +1201,7 @@ class GC(object):
                             filename = os.path.basename(urllib.parse.unquote(t.url))
                             if "GetComics.INFO" in filename:
                                 filename = re.sub("GetComics.INFO", "", filename, re.I).strip()
+                            filename = safe_remote_filename(filename)
                             try:
                                 remote_filesize = int(t.headers["Content-length"])
                                 logger.fdebug("remote filesize: %s" % remote_filesize)
@@ -1246,7 +1253,7 @@ class GC(object):
                         )
                         return {"success": False, "filename": filename, "path": None, "link_type": link_type}
 
-                dst_path = os.path.join(comicarr.CONFIG.DDL_LOCATION, filename)
+                dst_path = resolve_remote_artifact_path(comicarr.CONFIG.DDL_LOCATION, filename)
 
                 t.headers["Accept-encoding"] = "gzip"
                 if resume is not None:
@@ -1258,23 +1265,9 @@ class GC(object):
 
                 else:
                     if os.path.exists(dst_path):
-                        logger.fdebug("%s already exists - resume not enabled - let us hammer thine" % dst_path)
-                        try:
-                            os.remove(dst_path)
-                        except Exception as e:
-                            file, ext = os.path.splitext(filename)
-                            filename = "%s.1%s" % (file, ext)
-                            dst_path = os.path.join(comicarr.CONFIG.DDL_LOCATION, filename)
-                            logger.warn(
-                                "[ERROR: %s] Unable to remove already existing file."
-                                " Creating tmp file @%s so it can download." % (e, filename)
-                            )
+                        logger.fdebug("%s already exists - replacing it after the download completes" % dst_path)
 
-                    with open(dst_path, "wb") as f:
-                        for chunk in t.iter_content(chunk_size=1024):
-                            if chunk:
-                                f.write(chunk)
-                                f.flush()
+                    write_chunks_atomically(dst_path, t.iter_content(chunk_size=1024))
 
         except requests.exceptions.Timeout as e:
             logger.error("[ERROR] download has timed out due to inactivity...: %s", e)
@@ -1290,14 +1283,24 @@ class GC(object):
             return self.zip_zip(id, dst_path, filename)
 
     def zip_zip(self, id, dst_path, filename):
+        try:
+            dst_path = ensure_path_within_directory(comicarr.CONFIG.DDL_LOCATION, dst_path)
+        except ValueError as e:
+            logger.warn("[ERROR: %s] Refusing archive outside the DDL download directory." % e)
+            return {"success": False, "filename": filename, "path": None}
+
         if os.path.isfile(dst_path):
-            if dst_path.endswith(".zip"):
-                new_path = os.path.join(comicarr.CONFIG.DDL_LOCATION, re.sub(".zip", "", filename).strip())
+            if str(dst_path).lower().endswith(".zip"):
+                try:
+                    archive_name = safe_remote_filename(filename)
+                    extraction_name = os.path.splitext(archive_name)[0]
+                    new_path = resolve_remote_artifact_path(comicarr.CONFIG.DDL_LOCATION, extraction_name)
+                except ValueError as e:
+                    logger.warn("[ERROR: %s] Refusing unsafe archive filename." % e)
+                    return {"success": False, "filename": filename, "path": None}
                 logger.info("Zip file detected. Unzipping into new modified path location: %s" % new_path)
                 try:
-                    zip_f = zipfile.ZipFile(dst_path, "r")
-                    zip_f.extractall(new_path)
-                    zip_f.close()
+                    extract_zip_atomically(dst_path, new_path)
                 except Exception as e:
                     logger.warn("[ERROR: %s] Unable to extract zip file: %s" % (e, new_path))
                     return {"success": False, "filename": filename, "path": None}
@@ -1308,8 +1311,8 @@ class GC(object):
                         logger.warn("[ERROR: %s] Unable to remove zip file from %s after extraction." % (e, dst_path))
                     filename = None
             else:
-                new_path = dst_path
-            return {"success": True, "filename": filename, "path": new_path}
+                new_path = str(dst_path)
+            return {"success": True, "filename": filename, "path": str(new_path)}
 
         comicarr.DDL_LOCK.release()
         return {"success": False, "filename": filename, "path": None}

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -56,6 +56,11 @@ from comicarr import (
     search_filer,
     updater,
 )
+from comicarr.app.common.remote_artifacts import (
+    resolve_remote_artifact_path,
+    safe_remote_filename,
+    write_chunks_atomically,
+)
 from comicarr.downloaders import external_server as exs
 from comicarr.tables import (
     annuals,
@@ -2910,11 +2915,11 @@ def nzbname_create(provider, title=None, info=None):
 
     elif any([provider == "32P", provider == "WWT", provider == "DEM", "DDL" in provider]):
         # filesafe the name cause people are idiots when they post sometimes.
-        nzbname = re.sub(r"\s{2,}", " ", helpers.filesafe(title)).strip()
+        nzbname = re.sub(r"\s{2,}", " ", safe_remote_filename(title)).strip()
         # let's change all space to decimals for simplicity
         nzbname = re.sub(" ", ".", nzbname)
         # gotta replace & or escape it
-        nzbname = re.sub(r"\&amp;|(amp;)|amp;|\&", "and", title)
+        nzbname = re.sub(r"\&amp;|(amp;)|amp;|\&", "and", nzbname)
         nzbname = re.sub(r"[\,\:\?\']", "", nzbname)
         if nzbname.lower().endswith(".torrent"):
             nzbname = re.sub(".torrent", "", nzbname)
@@ -2943,8 +2948,18 @@ def nzbname_create(provider, title=None, info=None):
     if nzbname is None:
         return None
     else:
+        try:
+            nzbname = safe_remote_filename(nzbname)
+        except ValueError as e:
+            logger.warn("[SEARCHER] Refusing unsafe remote artifact name: %s" % e)
+            return None
         logger.fdebug("nzbname used for post-processing: %s" % nzbname)
         return nzbname
+
+
+def _nzb_cache_path(cache_dir, nzbname):
+    """Return the cache path as a legacy-compatible string for client APIs."""
+    return str(resolve_remote_artifact_path(cache_dir, nzbname))
 
 
 def searcher(
@@ -3265,13 +3280,8 @@ def searcher(
             # save the nzb grabbed, so we can bypass all the 'send-url' crap.
             if not nzbname.endswith(".nzb"):
                 nzbname = nzbname + ".nzb"
-            nzbpath = os.path.join(comicarr.CONFIG.CACHE_DIR, nzbname)
-
-            with open(nzbpath, "wb") as f:
-                for chunk in r.iter_content(chunk_size=1024):
-                    if chunk:  # filter out keep-alive new chunks
-                        f.write(chunk)
-                        f.flush()
+            nzbpath = _nzb_cache_path(comicarr.CONFIG.CACHE_DIR, nzbname)
+            write_chunks_atomically(nzbpath, r.iter_content(chunk_size=1024))
 
     # blackhole
     sent_to = None

--- a/tests/unit/test_remote_artifact_security.py
+++ b/tests/unit/test_remote_artifact_security.py
@@ -1,0 +1,608 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+import os
+import stat
+import xmlrpc.client
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import comicarr
+from comicarr import getcomics, search
+from comicarr.app.common import remote_artifacts
+from comicarr.downloaders import mediafire
+
+
+def _assert_within(root, path):
+    assert os.path.commonpath([os.path.realpath(root), os.path.realpath(path)]) == os.path.realpath(root)
+
+
+@pytest.mark.parametrize("provider", ["DDL(GetComics)", "Newznab"])
+def test_nzbname_create_keeps_remote_title_inside_cache(tmp_path, provider):
+    cache_dir = tmp_path / "cache"
+    generated_name = search.nzbname_create(provider, "../../outside")
+
+    _assert_within(cache_dir, cache_dir / f"{generated_name}.nzb")
+    assert "/" not in generated_name
+    assert "\\" not in generated_name
+
+
+def test_search_cache_path_remains_xmlrpc_compatible_string(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    nzb_path = search._nzb_cache_path(cache_dir, "issue.nzb")
+    marshalled = xmlrpc.client.dumps((nzb_path,))
+
+    assert isinstance(nzb_path, str)
+    assert "<string>" in marshalled
+
+
+def test_mediafire_content_disposition_cannot_escape_download_directory(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(DDL_LOCATION=str(tmp_path)))
+    downloader = mediafire.MediaFire()
+    downloader.dl_location = str(tmp_path)
+    response = SimpleNamespace(
+        headers={
+            "Content-Disposition": 'attachment; filename="../../outside.cbz"',
+            "Content-Length": "12",
+        }
+    )
+    downloader.session.get = MagicMock(return_value=response)
+    monkeypatch.setattr(mediafire.db, "upsert", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        downloader,
+        "mediafire_dl",
+        lambda url, download_id, fileinfo, issueid: {
+            "success": True,
+            "filename": fileinfo["filename"],
+            "path": os.path.join(downloader.dl_location, fileinfo["filename"]),
+        },
+    )
+
+    result = downloader.ddl_download("https://example.invalid/file", "download-1", "issue-1")
+
+    _assert_within(tmp_path, result["path"])
+    assert "/" not in result["filename"]
+    assert "\\" not in result["filename"]
+
+
+def test_mediafire_download_publishes_sanitized_filename_atomically(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(DDL_LOCATION=str(tmp_path)))
+    downloader = mediafire.MediaFire()
+    downloader.session.get = MagicMock(
+        return_value=SimpleNamespace(iter_content=lambda chunk_size: iter([b"comic-data"]))
+    )
+    monkeypatch.setattr(mediafire.db, "upsert", lambda *args, **kwargs: None)
+
+    result = downloader.mediafire_dl(
+        "https://example.invalid/file",
+        "download-1",
+        {"filename": "../../outside.cbz", "filesize": len(b"comic-data")},
+        "issue-1",
+    )
+
+    assert result["success"] is True
+    _assert_within(tmp_path, result["path"])
+    assert os.path.exists(result["path"])
+    with open(result["path"], "rb") as downloaded_file:
+        assert downloaded_file.read() == b"comic-data"
+    assert list(tmp_path.glob("*.part")) == []
+
+
+def test_zip_extraction_rejects_suspicious_expansion_ratio(tmp_path, monkeypatch):
+    archive = tmp_path / "bomb.zip"
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+        zip_file.writestr("payload.bin", b"0" * (2 * 1024 * 1024))
+
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(DDL_LOCATION=str(tmp_path)))
+    downloader = getcomics.GC.__new__(getcomics.GC)
+
+    result = downloader.zip_zip("download-1", str(archive), archive.name)
+
+    assert result == {"success": False, "filename": archive.name, "path": None}
+    assert archive.exists()
+    assert not (tmp_path / "bomb").exists()
+
+
+def test_remote_filename_preserves_unicode_while_normalizing_separators():
+    assert remote_artifacts.safe_remote_filename("Monstress/藍藍.cbz") == "Monstress-藍藍.cbz"
+    with pytest.raises(remote_artifacts.RemoteArtifactError):
+        remote_artifacts.safe_remote_filename("../../")
+
+
+def test_remote_path_rejects_existing_symlink_that_escapes_root(tmp_path):
+    download_root = tmp_path / "downloads"
+    download_root.mkdir()
+    outside = tmp_path / "outside.cbz"
+    outside.write_bytes(b"outside")
+    (download_root / "issue.cbz").symlink_to(outside)
+
+    with pytest.raises(remote_artifacts.RemoteArtifactError, match="escapes"):
+        remote_artifacts.resolve_remote_artifact_path(download_root, "issue.cbz")
+
+
+def test_atomic_chunk_write_keeps_existing_file_on_stream_failure(tmp_path):
+    destination = tmp_path / "issue.cbz"
+    destination.write_bytes(b"existing")
+
+    def failing_chunks():
+        yield b"partial"
+        raise OSError("connection reset")
+
+    with pytest.raises(OSError, match="connection reset"):
+        remote_artifacts.write_chunks_atomically(destination, failing_chunks())
+
+    assert destination.read_bytes() == b"existing"
+    assert list(tmp_path.glob("*.part")) == []
+
+
+def test_atomic_chunk_write_preserves_existing_file_mode(tmp_path, monkeypatch):
+    destination = tmp_path / "issue.cbz"
+    destination.write_bytes(b"existing")
+    destination.chmod(0o664)
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(ENFORCE_PERMS=True, CHMOD_FILE="0600"))
+
+    remote_artifacts.write_chunks_atomically(destination, [b"replacement"])
+
+    assert destination.read_bytes() == b"replacement"
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o664
+
+
+@pytest.mark.parametrize("configured_mode", ["0664", "0o664", 0o664, 664])
+def test_atomic_chunk_write_applies_configured_mode_to_new_file(tmp_path, monkeypatch, configured_mode):
+    destination = tmp_path / "issue.cbz"
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(ENFORCE_PERMS=True, CHMOD_FILE=configured_mode),
+    )
+
+    remote_artifacts.write_chunks_atomically(destination, [b"new"])
+
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o664
+
+
+def test_default_permission_policy_uses_captured_umask_without_mutating_it(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(ENFORCE_PERMS=False, CHMOD_FILE="0660", CHMOD_DIR="0777"),
+    )
+    monkeypatch.setattr(comicarr, "UMASK", 0o022)
+    monkeypatch.setattr(remote_artifacts.os, "umask", lambda value: pytest.fail("must not mutate process umask"))
+
+    file_destination = tmp_path / "issue.cbz"
+    remote_artifacts.write_chunks_atomically(file_destination, [b"comic"])
+    archive = tmp_path / "default-modes.zip"
+    extraction_destination = tmp_path / "default-modes"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("pages/001.jpg", b"page")
+    remote_artifacts.extract_zip_atomically(archive, extraction_destination)
+
+    assert stat.S_IMODE(file_destination.stat().st_mode) == 0o644
+    assert stat.S_IMODE(extraction_destination.stat().st_mode) == 0o755
+    assert stat.S_IMODE((extraction_destination / "pages").stat().st_mode) == 0o755
+    assert stat.S_IMODE((extraction_destination / "pages" / "001.jpg").stat().st_mode) == 0o644
+
+
+@pytest.mark.skipif(not all(hasattr(os, name) for name in ("chown", "getuid", "getgid")), reason="POSIX ownership")
+def test_atomic_replacement_reapplies_existing_ownership(tmp_path, monkeypatch):
+    destination = tmp_path / "issue.cbz"
+    destination.write_bytes(b"existing")
+    expected_ownership = (destination.stat().st_uid, destination.stat().st_gid)
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(ENFORCE_PERMS=False))
+    monkeypatch.setattr(comicarr, "UMASK", 0o022)
+    original_chown = os.chown
+    ownership_calls = []
+
+    def record_chown(path, uid, gid, **kwargs):
+        ownership_calls.append((os.fspath(path), uid, gid))
+        return original_chown(path, uid, gid, **kwargs)
+
+    monkeypatch.setattr(remote_artifacts.os, "chown", record_chown)
+
+    remote_artifacts.write_chunks_atomically(destination, [b"replacement"])
+
+    assert expected_ownership in [(uid, gid) for _, uid, gid in ownership_calls]
+    assert (destination.stat().st_uid, destination.stat().st_gid) == expected_ownership
+
+
+@pytest.mark.skipif(not all(hasattr(os, name) for name in ("chown", "getuid", "getgid")), reason="POSIX ownership")
+def test_atomic_replacement_ownership_failure_keeps_original(tmp_path, monkeypatch):
+    destination = tmp_path / "issue.cbz"
+    destination.write_bytes(b"existing")
+    original_stat = destination.stat()
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(ENFORCE_PERMS=False))
+    monkeypatch.setattr(comicarr, "UMASK", 0o022)
+    monkeypatch.setattr(
+        remote_artifacts.os,
+        "chown",
+        lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError("ownership denied")),
+    )
+
+    with pytest.raises(PermissionError, match="ownership denied"):
+        remote_artifacts.write_chunks_atomically(destination, [b"replacement"])
+
+    assert destination.read_bytes() == b"existing"
+    assert (destination.stat().st_uid, destination.stat().st_gid) == (original_stat.st_uid, original_stat.st_gid)
+
+
+def test_zip_extraction_accepts_normal_comic_archive(tmp_path):
+    archive = tmp_path / "Monstress 藍.zip"
+    destination = tmp_path / "Monstress 藍"
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+        zip_file.writestr("pages/001.jpg", b"page-one")
+        zip_file.writestr("ComicInfo.xml", b"<ComicInfo />")
+
+    result = remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert result == destination
+    assert (destination / "pages" / "001.jpg").read_bytes() == b"page-one"
+    assert (destination / "ComicInfo.xml").read_bytes() == b"<ComicInfo />"
+
+
+@pytest.mark.parametrize(
+    "member_name",
+    [
+        "CON.txt",
+        "COM¹.log",
+        "LPT².cbz",
+        "CONIN$.txt",
+        "CONOUT$.txt",
+        "CLOCK$.txt",
+        "pages/001.jpg:metadata",
+        "pages/trailing. ",
+    ],
+)
+def test_zip_extraction_rejects_nonportable_component_names(tmp_path, member_name):
+    archive = tmp_path / "nonportable.zip"
+    destination = tmp_path / "nonportable"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr(member_name, b"page")
+
+    with pytest.raises(remote_artifacts.RemoteArtifactError, match="portable"):
+        remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize(
+    "member_names",
+    [
+        ("Page.jpg", "page.jpg"),
+        ("café.jpg", "cafe\u0301.jpg"),
+        ("Page/a.jpg", "page/b.jpg"),
+        ("café/a.jpg", "cafe\u0301/b.jpg"),
+    ],
+)
+def test_zip_extraction_rejects_portable_name_collisions(tmp_path, member_names):
+    archive = tmp_path / "collision.zip"
+    destination = tmp_path / "collision"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        for member_name in member_names:
+            zip_file.writestr(member_name, b"page")
+
+    with pytest.raises(remote_artifacts.RemoteArtifactError, match="duplicate"):
+        remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert not destination.exists()
+
+
+def test_zip_extraction_applies_configured_modes_to_new_tree(tmp_path, monkeypatch):
+    archive = tmp_path / "modes.zip"
+    destination = tmp_path / "modes"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("pages/001.jpg", b"page")
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(ENFORCE_PERMS=True, CHMOD_DIR="0750", CHMOD_FILE="0640"),
+    )
+
+    remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o750
+    assert stat.S_IMODE((destination / "pages").stat().st_mode) == 0o750
+    assert stat.S_IMODE((destination / "pages" / "001.jpg").stat().st_mode) == 0o640
+
+
+@pytest.mark.parametrize(
+    ("configured_directory_mode", "configured_file_mode"),
+    [("2775", "6775"), (0o2775, 0o6775)],
+)
+def test_enforced_modes_preserve_directory_setgid_but_strip_file_special_bits(
+    tmp_path,
+    monkeypatch,
+    configured_directory_mode,
+    configured_file_mode,
+):
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(
+            ENFORCE_PERMS=True,
+            CHMOD_DIR=configured_directory_mode,
+            CHMOD_FILE=configured_file_mode,
+        ),
+    )
+    file_destination = tmp_path / "issue.cbz"
+    remote_artifacts.write_chunks_atomically(file_destination, [b"comic"])
+    archive = tmp_path / "special-modes.zip"
+    extraction_destination = tmp_path / "special-modes"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("pages/001.jpg", b"page")
+
+    remote_artifacts.extract_zip_atomically(archive, extraction_destination)
+
+    assert stat.S_IMODE(extraction_destination.stat().st_mode) == 0o2775
+    assert stat.S_IMODE((extraction_destination / "pages").stat().st_mode) == 0o2775
+    assert stat.S_IMODE(file_destination.stat().st_mode) == 0o775
+    assert stat.S_IMODE((extraction_destination / "pages" / "001.jpg").stat().st_mode) == 0o775
+
+
+def test_new_artifacts_use_secure_modes_when_config_is_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.setattr(comicarr, "UMASK", None)
+    file_destination = tmp_path / "issue.cbz"
+    remote_artifacts.write_chunks_atomically(file_destination, [b"comic"])
+
+    archive = tmp_path / "secure.zip"
+    extraction_destination = tmp_path / "secure"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("pages/001.jpg", b"page")
+    remote_artifacts.extract_zip_atomically(archive, extraction_destination)
+
+    assert stat.S_IMODE(file_destination.stat().st_mode) == 0o600
+    assert stat.S_IMODE(extraction_destination.stat().st_mode) == 0o700
+    assert stat.S_IMODE((extraction_destination / "pages").stat().st_mode) == 0o700
+    assert stat.S_IMODE((extraction_destination / "pages" / "001.jpg").stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(not all(hasattr(os, name) for name in ("chown", "getuid", "getgid")), reason="POSIX ownership")
+def test_enforced_new_artifacts_apply_configured_numeric_ownership(tmp_path, monkeypatch):
+    expected_ownership = (os.getuid(), os.getgid())
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(
+            ENFORCE_PERMS=True,
+            CHMOD_DIR="0750",
+            CHMOD_FILE="0640",
+            CHOWNER=str(expected_ownership[0]),
+            CHGROUP=str(expected_ownership[1]),
+        ),
+    )
+    original_chown = os.chown
+    ownership_calls = []
+
+    def record_chown(path, uid, gid, **kwargs):
+        ownership_calls.append((os.fspath(path), uid, gid))
+        return original_chown(path, uid, gid, **kwargs)
+
+    monkeypatch.setattr(remote_artifacts.os, "chown", record_chown)
+    file_destination = tmp_path / "issue.cbz"
+    remote_artifacts.write_chunks_atomically(file_destination, [b"comic"])
+    archive = tmp_path / "ownership.zip"
+    extraction_destination = tmp_path / "ownership"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("pages/001.jpg", b"page")
+    remote_artifacts.extract_zip_atomically(archive, extraction_destination)
+
+    assert ownership_calls
+    assert all((uid, gid) == expected_ownership for _, uid, gid in ownership_calls)
+    assert (file_destination.stat().st_uid, file_destination.stat().st_gid) == expected_ownership
+    assert (extraction_destination.stat().st_uid, extraction_destination.stat().st_gid) == expected_ownership
+    extracted_file = extraction_destination / "pages" / "001.jpg"
+    assert (extracted_file.stat().st_uid, extracted_file.stat().st_gid) == expected_ownership
+
+
+@pytest.mark.skipif(not all(hasattr(os, name) for name in ("chown", "getuid", "getgid")), reason="POSIX ownership")
+def test_enforced_new_artifacts_resolve_named_owner_and_group(tmp_path, monkeypatch):
+    pwd = pytest.importorskip("pwd")
+    grp = pytest.importorskip("grp")
+    expected_ownership = (os.getuid(), os.getgid())
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(
+            ENFORCE_PERMS=True,
+            CHMOD_FILE="0640",
+            CHOWNER=pwd.getpwuid(expected_ownership[0]).pw_name,
+            CHGROUP=grp.getgrgid(expected_ownership[1]).gr_name,
+        ),
+    )
+    original_chown = os.chown
+    ownership_calls = []
+
+    def record_chown(path, uid, gid, **kwargs):
+        ownership_calls.append((uid, gid))
+        return original_chown(path, uid, gid, **kwargs)
+
+    monkeypatch.setattr(remote_artifacts.os, "chown", record_chown)
+
+    remote_artifacts.write_chunks_atomically(tmp_path / "named-owner.cbz", [b"comic"])
+
+    assert ownership_calls == [expected_ownership]
+
+
+@pytest.mark.skipif(not all(hasattr(os, name) for name in ("chown", "getuid", "getgid")), reason="POSIX ownership")
+def test_zip_swap_reapplies_ownership_to_every_existing_file_and_directory(tmp_path, monkeypatch):
+    archive = tmp_path / "existing-tree.zip"
+    destination = tmp_path / "existing-tree"
+    pages = destination / "pages"
+    pages.mkdir(parents=True)
+    existing_file = pages / "001.jpg"
+    existing_file.write_bytes(b"old")
+    expected_paths = {destination, pages, existing_file}
+    expected_ownership = {
+        path.relative_to(destination): (path.stat().st_uid, path.stat().st_gid) for path in expected_paths
+    }
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("pages/001.jpg", b"new")
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(ENFORCE_PERMS=False))
+    monkeypatch.setattr(comicarr, "UMASK", 0o022)
+    original_chown = os.chown
+    ownership_calls = []
+
+    def record_chown(path, uid, gid, **kwargs):
+        ownership_calls.append((os.fspath(path), uid, gid))
+        return original_chown(path, uid, gid, **kwargs)
+
+    monkeypatch.setattr(remote_artifacts.os, "chown", record_chown)
+
+    remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert len(ownership_calls) >= len(expected_paths)
+    for relative_path, ownership in expected_ownership.items():
+        published_path = destination / relative_path
+        assert (published_path.stat().st_uid, published_path.stat().st_gid) == ownership
+
+
+def test_zip_extraction_preserves_existing_destination_contents(tmp_path):
+    archive = tmp_path / "updated.zip"
+    destination = tmp_path / "updated"
+    destination.mkdir()
+    (destination / "keep.txt").write_text("keep")
+    (destination / "001.jpg").write_bytes(b"old-page")
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("001.jpg", b"new-page")
+
+    remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert (destination / "keep.txt").read_text() == "keep"
+    assert (destination / "001.jpg").read_bytes() == b"new-page"
+
+
+def test_zip_backup_cleanup_failure_does_not_undo_success(tmp_path, monkeypatch, caplog):
+    archive = tmp_path / "updated.zip"
+    destination = tmp_path / "updated"
+    destination.mkdir()
+    (destination / "001.jpg").write_bytes(b"old-page")
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("001.jpg", b"new-page")
+
+    original_remove = remote_artifacts._remove_path
+
+    def fail_backup_cleanup(path):
+        if "backup-" in os.fspath(path):
+            raise OSError("cleanup denied")
+        original_remove(path)
+
+    monkeypatch.setattr(remote_artifacts, "_remove_path", fail_backup_cleanup)
+
+    result = remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert result == destination
+    assert (destination / "001.jpg").read_bytes() == b"new-page"
+    assert "cleanup denied" in caplog.text
+
+
+def test_bounded_staging_names_support_near_limit_destinations(tmp_path):
+    long_filename = "f" * 245
+    file_destination = tmp_path / long_filename
+    remote_artifacts.write_chunks_atomically(file_destination, [b"file"])
+
+    archive = tmp_path / "long.zip"
+    extraction_destination = tmp_path / ("d" * 245)
+    extraction_destination.mkdir()
+    (extraction_destination / "old.txt").write_text("old")
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("new.txt", b"new")
+
+    remote_artifacts.extract_zip_atomically(archive, extraction_destination)
+
+    assert file_destination.read_bytes() == b"file"
+    assert (extraction_destination / "new.txt").read_bytes() == b"new"
+
+
+def test_zip_zip_preserves_string_path_for_non_archive(tmp_path, monkeypatch):
+    comic_file = tmp_path / "issue.cbz"
+    comic_file.write_bytes(b"comic")
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(DDL_LOCATION=str(tmp_path)))
+    downloader = getcomics.GC.__new__(getcomics.GC)
+
+    result = downloader.zip_zip("download-1", str(comic_file), comic_file.name)
+
+    assert result == {"success": True, "filename": comic_file.name, "path": str(comic_file)}
+    assert isinstance(result["path"], str)
+
+
+def test_zip_preflight_enforces_member_count(tmp_path, monkeypatch):
+    archive = tmp_path / "too-many.zip"
+    destination = tmp_path / "too-many"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("001.jpg", b"one")
+        zip_file.writestr("002.jpg", b"two")
+    monkeypatch.setattr(remote_artifacts, "MAX_ZIP_MEMBERS", 1)
+
+    with pytest.raises(remote_artifacts.RemoteArtifactError, match="too many members"):
+        remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert not destination.exists()
+
+
+def test_zip_preflight_enforces_aggregate_uncompressed_size(tmp_path, monkeypatch):
+    archive = tmp_path / "too-large.zip"
+    destination = tmp_path / "too-large"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("001.jpg", b"1" * 16)
+        zip_file.writestr("002.jpg", b"2" * 16)
+    monkeypatch.setattr(remote_artifacts, "MAX_ZIP_UNCOMPRESSED_BYTES", 20)
+
+    with pytest.raises(remote_artifacts.RemoteArtifactError, match="size limit"):
+        remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert not destination.exists()
+
+
+def test_zip_preflight_reserves_available_disk_space(tmp_path, monkeypatch):
+    archive = tmp_path / "no-space.zip"
+    destination = tmp_path / "no-space"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("001.jpg", b"1" * 32)
+    monkeypatch.setattr(
+        remote_artifacts.shutil,
+        "disk_usage",
+        lambda path: SimpleNamespace(free=remote_artifacts.ZIP_DISK_RESERVE_BYTES + 16),
+    )
+
+    with pytest.raises(remote_artifacts.RemoteArtifactError, match="free disk space"):
+        remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert not destination.exists()
+
+
+def test_zip_extraction_cleans_staging_after_member_failure(tmp_path, monkeypatch):
+    archive = tmp_path / "interrupted.zip"
+    destination = tmp_path / "interrupted"
+    with zipfile.ZipFile(archive, "w") as zip_file:
+        zip_file.writestr("001.jpg", b"one")
+        zip_file.writestr("002.jpg", b"two")
+
+    original_extract = remote_artifacts._extract_zip_member
+    calls = 0
+
+    def fail_second_member(zip_file, member, member_destination, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("disk write failed")
+        original_extract(zip_file, member, member_destination, **kwargs)
+
+    monkeypatch.setattr(remote_artifacts, "_extract_zip_member", fail_second_member)
+
+    with pytest.raises(OSError, match="disk write failed"):
+        remote_artifacts.extract_zip_atomically(archive, destination)
+
+    assert not destination.exists()
+    assert list(tmp_path.glob(".comicarr-extract-*")) == []


### PR DESCRIPTION
## Summary

Remote filenames, download paths, and GetComics ZIPs now cross a shared containment boundary before Comicarr writes or extracts them. The change closes cache/DDL path escapes, publishes non-resumed downloads atomically, parses MediaFire filenames safely, and rejects unsafe or unexpectedly expansive archives before extraction.

ZIP extraction now validates every member and canonical path prefix, rejects traversal, symlinks, encryption, portable-name collisions/device aliases, excessive member counts, expanded size, suspicious compression ratios, and insufficient disk headroom. Extraction is staged and atomically overlaid while preserving existing content, modes, ownership, and configured permission policy.

## Testing

- Added proof-first coverage for search and MediaFire path escapes, XML-RPC string compatibility, interrupted writes, symlink containment, Unicode/portable names, archive limits, disk budget, partial cleanup, merge rollback, bounded temp names, UMASK/enforced permissions, ownership preservation, and Windows device/collision aliases.
- Full backend suite: 934 passed.
- Ruff lint and format checks passed.
- Startup help and lockfile checks passed.

## Compatibility Notes

- Archives over 10,000 members, 20 GiB expanded size, or a 200:1 compression ratio are rejected intentionally.
- Resumed downloads still append directly, but only after their destination resolves inside the configured DDL directory.
- Hardlink identity and platform ACL/xattr preservation remain best-effort across atomic inode/directory replacement; mode, uid, and gid are preserved explicitly where the platform supports them.

## Post-Deploy Monitoring & Validation

- **Window/owner:** Maintainers should monitor remote-download and extraction logs through the first 24 hours and at least one GetComics/MediaFire download.
- **Healthy signals:** Downloads remain beneath `CACHE_DIR`/`DDL_LOCATION`, ordinary archives publish once, existing extraction content remains intact, and configured ownership/modes are retained.
- **Watch:** Search logs for `Refusing unsafe`, `non-portable member`, `suspicious compression ratio`, `requires more free disk space`, staging cleanup warnings, and provider download failures.
- **Failure trigger:** A legitimate normal archive is rejected repeatedly, an artifact publishes outside its root, existing content/ownership changes unexpectedly, or hidden staging/backup paths accumulate.
- **Mitigation:** Revert this PR, disable the affected DDL provider temporarily, preserve the rejected archive for inspection, and verify destination/permission configuration before retrying.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
