### PR TITLE
fix: make config writes transactional

### DIFF
--- a/.changeset/persist-config-transactions.md
+++ b/.changeset/persist-config-transactions.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Persist config changes through a shared transaction boundary, encrypt secrets before disk writes, preserve private file permissions, and report storage failures without committing runtime config state.

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -171,9 +171,7 @@ def delete_comic(ctx, comic_id, delete_directory=False):
                         "symlink, or directory; skipping filesystem removal" % comic_location
                     )
                 else:
-                    logger.fdebug(
-                        "[SERIES-DELETE] Comic Location (%s) successfully %s" % (comic_location, action)
-                    )
+                    logger.fdebug("[SERIES-DELETE] Comic Location (%s) successfully %s" % (comic_location, action))
             else:
                 logger.fdebug("[SERIES-DELETE] Comic Location (%s) does not exist" % comic_location)
 

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -854,7 +854,6 @@ def updateComicLocation():
             logger.info(
                 "There are no series in your watchlist to Update the locations. Not updating anything at this time."
             )
-        comicarr.CONFIG.LOCMOVE = False
         comicarr.CONFIG.writeconfig(values={"locmove": False})
     else:
         logger.info("No new ComicLocation path specified - not updating. Set NEWCOMD_DIR in config.ini")

--- a/comicarr/app/system/router.py
+++ b/comicarr/app/system/router.py
@@ -127,7 +127,12 @@ async def setup(request: Request, ctx: AppContext = Depends(get_context)):
             return system_service.initial_setup(ctx, username, password, setup_token)
 
     result = await asyncio.to_thread(_run_setup)
-    status_code = 200 if result["success"] else 400
+    if result["success"]:
+        status_code = 200
+    elif result.get("error") == system_service.SETUP_PERSISTENCE_ERROR:
+        status_code = 500
+    else:
+        status_code = 400
     return JSONResponse(status_code=status_code, content=result)
 
 
@@ -184,6 +189,9 @@ async def update_config(request: Request, ctx: AppContext = Depends(get_context)
     """Update configuration key-values."""
     body = await request.json()
     result = await asyncio.to_thread(system_service.update_config, ctx, body)
+    if not result["success"]:
+        status_code = 500 if result.get("error") == system_service.CONFIG_PERSISTENCE_ERROR else 400
+        return JSONResponse(status_code=status_code, content=result)
     return result
 
 

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -36,6 +36,9 @@ from comicarr.tables import comics, jobhistory, storyarcs
 # Shared rate limiter instance (same object used by CherryPy and FastAPI)
 _rate_limiter = LoginRateLimiter()
 
+SETUP_PERSISTENCE_ERROR = "Failed to persist initial credentials"
+CONFIG_PERSISTENCE_ERROR = "Failed to persist configuration"
+
 
 def _secret_is_configured(value):
     """Return True when a config secret has a meaningful stored value."""
@@ -102,10 +105,10 @@ def _migrate_password(ctx, plaintext_password):
     from comicarr import encrypted
 
     new_hash = encrypted.hash_password(plaintext_password)
-    if ctx.config:
-        ctx.config.process_kwargs({"http_password": new_hash})
-        ctx.config.writeconfig()
-    logger.info("[AUTH] Password migrated to bcrypt")
+    if ctx.config and ctx.config.apply_transaction({"http_password": new_hash}, configure=False):
+        logger.info("[AUTH] Password migrated to bcrypt")
+    else:
+        logger.error("[AUTH] Failed to persist bcrypt password migration")
 
 
 def announce_setup_token(setup_token):
@@ -142,16 +145,21 @@ def initial_setup(ctx, username, password, setup_token):
     if len(password) < 8:
         return {"success": False, "error": "Password must be at least 8 characters"}
 
-    hashed_password = encrypted.hash_password(password)
-    ctx.config.process_kwargs(
-        {
-            "http_username": username,
-            "http_password": hashed_password,
-            "authentication": 2,
-        }
-    )
-    ctx.config.writeconfig()
-    ctx.config.configure(update=True, startup=False)
+    try:
+        hashed_password = encrypted.hash_password(password)
+        persisted = ctx.config.apply_transaction(
+            {
+                "http_username": username,
+                "http_password": hashed_password,
+                "authentication": 2,
+            }
+        )
+    except Exception as e:
+        logger.error("[AUTH-SETUP] Failed to persist initial credentials: %s" % e)
+        persisted = False
+
+    if not persisted:
+        return {"success": False, "error": SETUP_PERSISTENCE_ERROR}
 
     logger.info("[AUTH-SETUP] Initial credentials configured for user: %s" % username)
 
@@ -473,13 +481,17 @@ def update_config(ctx, key_values):
     if not filtered:
         return {"success": False, "error": "No valid config keys provided"}
 
-    # Apply scheduler change first (idempotent), then write config
     interval_keys = {"SEARCH_INTERVAL", "RSS_CHECK_INTERVAL", "DOWNLOAD_SCAN_INTERVAL", "DBUPDATE_INTERVAL"}
     interval_changed = any(k in interval_keys for k in filtered)
 
-    ctx.config.process_kwargs(filtered)
-    ctx.config.writeconfig()
-    ctx.config.configure(update=True, startup=False)
+    try:
+        persisted = ctx.config.apply_transaction(filtered)
+    except Exception as e:
+        logger.error("[CONFIG] Failed to persist configuration update: %s" % e)
+        persisted = False
+
+    if not persisted:
+        return {"success": False, "error": CONFIG_PERSISTENCE_ERROR}
 
     if interval_changed:
         _reconfigure_schedulers(ctx)
@@ -498,22 +510,10 @@ def regenerate_api_key(ctx):
         return {"success": False, "error": "Config not loaded"}
 
     new_api_key = secrets.token_hex(16)
-    old_api_key = getattr(ctx.config, "API_KEY", None)
-    wrote_to_disk = False
     try:
-        ctx.config.process_kwargs({"api_key": new_api_key})
-        if ctx.config.writeconfig() is False:
+        if ctx.config.apply_transaction({"api_key": new_api_key}) is False:
             raise OSError("config write failed")
-        wrote_to_disk = True
-        ctx.config.configure(update=True, startup=False)
     except Exception as e:
-        try:
-            ctx.config.process_kwargs({"api_key": old_api_key})
-            if wrote_to_disk:
-                ctx.config.writeconfig()
-                ctx.config.configure(update=True, startup=False)
-        except Exception as rollback_error:
-            logger.error("[API-KEY] Failed to restore previous API key after regeneration failure: %s" % rollback_error)
         logger.error("[API-KEY] Failed to persist regenerated API key: %s" % e)
         return {"success": False, "error": "Failed to persist new API key"}
 
@@ -534,9 +534,7 @@ def update_providers(ctx, provider_data):
     if provider_type not in ("newznab", "torznab"):
         return {"success": False, "error": "Invalid provider type"}
 
-    # Delegate to config's provider handling
-    ctx.config.process_kwargs({provider_type: providers})
-    ctx.config.writeconfig()
+    ctx.config.writeconfig_values({provider_type: providers})
     ctx.config.configure(update=True, startup=False)
 
     return {"success": True}
@@ -735,8 +733,7 @@ def upgrade_dynamic():
         + str(len(dynamic_storylist))
         + " entries within the db."
     )
-    comicarr.CONFIG.DYNAMIC_UPDATE = 4
-    comicarr.CONFIG.writeconfig()
+    comicarr.CONFIG.writeconfig(values={"dynamic_update": 4})
     return
 
 

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -1197,9 +1197,7 @@ class Config(object):
         """Apply, encrypt, and persist config values as one recoverable update."""
         with _CONFIG_TRANSACTION_LOCK:
             if getattr(self, "_config_write_halted", False):
-                logger.error(
-                    "[CONFIG] Refusing config write: a previous transactional rollback was incomplete"
-                )
+                logger.error("[CONFIG] Refusing config write: a previous transactional rollback was incomplete")
                 return False
 
             try:
@@ -1228,9 +1226,7 @@ class Config(object):
                     self.configure(update=True, startup=False)
                 return True
             except BaseException as e:
-                durable_write_happened = self._durable_write_changed(
-                    config_path, file_existed, file_contents
-                )
+                durable_write_happened = self._durable_write_changed(config_path, file_existed, file_contents)
                 runtime_ok = False
                 file_ok = False
                 try:
@@ -1409,9 +1405,7 @@ class Config(object):
         """Serialize every parser mutation and atomic config-file replacement."""
         with _CONFIG_TRANSACTION_LOCK:
             if getattr(self, "_config_write_halted", False):
-                logger.error(
-                    "[CONFIG] Refusing config write: a previous transactional rollback was incomplete"
-                )
+                logger.error("[CONFIG] Refusing config write: a previous transactional rollback was incomplete")
                 return False
             return self._writeconfig(values=values, startup=startup)
 
@@ -1423,9 +1417,7 @@ class Config(object):
         """
         with _CONFIG_TRANSACTION_LOCK:
             if getattr(self, "_config_write_halted", False):
-                logger.error(
-                    "[CONFIG] Refusing config write: a previous transactional rollback was incomplete"
-                )
+                logger.error("[CONFIG] Refusing config write: a previous transactional rollback was incomplete")
                 return False
 
             runtime_snapshot = self._snapshot_runtime_state()
@@ -1441,8 +1433,7 @@ class Config(object):
                     self._restore_transaction_state(runtime_snapshot, parser_defaults, parser_sections)
                 except Exception as rollback_error:
                     logger.error(
-                        "[CONFIG] Failed to restore runtime state after writeconfig_values failure: %s"
-                        % rollback_error
+                        "[CONFIG] Failed to restore runtime state after writeconfig_values failure: %s" % rollback_error
                     )
                 logger.error("[CONFIG] writeconfig_values failed: %s" % e)
                 return False

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -19,12 +19,16 @@
 
 import codecs
 import configparser
+import copy
 import errno
 import glob
 import json
 import os
 import re
 import shutil
+import stat
+import tempfile
+import threading
 from collections import OrderedDict
 from operator import itemgetter
 from pathlib import Path
@@ -33,6 +37,9 @@ import comicarr
 from comicarr import db, encrypted, filechecker, helpers, logger, maintenance
 
 config = configparser.ConfigParser()
+_CONFIG_TRANSACTION_LOCK = threading.RLock()
+_CONFIG_TEMP_PREFIX = ".comicarr-config-"
+_CONFIG_TEMP_SUFFIX = ".tmp"
 
 _CONFIG_DEFINITIONS = OrderedDict(
     {
@@ -1186,7 +1193,203 @@ class Config(object):
             else:
                 pass
 
+    def apply_transaction(self, values, configure=True):
+        """Apply, encrypt, and persist config values as one recoverable update."""
+        with _CONFIG_TRANSACTION_LOCK:
+            try:
+                config_path = self._config_write_target()
+            except (OSError, RuntimeError) as e:
+                logger.error("[CONFIG] Refusing unsafe config write target: %s" % e)
+                return False
+
+            runtime_snapshot = self._snapshot_runtime_state()
+            parser_defaults = copy.deepcopy(config._defaults)
+            parser_sections = copy.deepcopy(config._sections)
+            file_existed = config_path.is_file()
+            file_contents = config_path.read_bytes() if file_existed else None
+            file_mode = config_path.stat().st_mode if file_existed else None
+
+            try:
+                self.process_kwargs(values)
+                self._encrypt_config_for_write()
+                if self.writeconfig() is False:
+                    raise OSError("config write failed")
+                if configure:
+                    # configure() still owns legacy filesystem and queue side effects.
+                    # Running it after the durable write prevents those effects on write
+                    # failure; config state can be rolled back if configure itself fails,
+                    # but already-completed external effects are not reversible here.
+                    self.configure(update=True, startup=False)
+                return True
+            except BaseException as e:
+                try:
+                    self._restore_transaction_state(runtime_snapshot, parser_defaults, parser_sections)
+                except Exception as rollback_error:
+                    logger.error("[CONFIG] Failed to restore runtime state after update failure: %s" % rollback_error)
+                try:
+                    self._restore_config_file(config_path, file_existed, file_contents, file_mode)
+                except Exception as rollback_error:
+                    logger.error(
+                        "[CONFIG] Failed to restore configuration file after update failure: %s" % rollback_error
+                    )
+                logger.error("[CONFIG] Transactional update failed: %s" % e)
+                if isinstance(e, (KeyboardInterrupt, GeneratorExit)):
+                    raise
+                return False
+
+    def _snapshot_runtime_state(self):
+        """Copy mutable runtime state while retaining references to opaque helpers."""
+        snapshot = {}
+        for key, value in self.__dict__.items():
+            try:
+                snapshot[key] = copy.deepcopy(value)
+            except Exception:
+                snapshot[key] = value
+        return snapshot
+
+    def _encrypt_config_for_write(self):
+        """Encrypt every configured secret in the parser without changing runtime values."""
+        configured_secrets = []
+        for attr_name, (section, ini_key) in ENCRYPTED_CONFIG_ITEMS.items():
+            value = getattr(self, attr_name, None)
+            if isinstance(value, (tuple, list)):
+                value = value[0] if value else None
+            if value not in (None, "", "None"):
+                configured_secrets.append((section, ini_key))
+
+        if not configured_secrets:
+            return
+
+        self.ENCRYPT_PASSWORDS = True
+        if not config.has_section("General"):
+            config.add_section("General")
+        config.set("General", "encrypt_passwords", "True")
+        self.encrypt_items(mode="encrypt")
+
+        for section, ini_key in configured_secrets:
+            encrypted_value = config.get(section, ini_key, raw=True, fallback=None)
+            if not encrypted_value or not encrypted_value.startswith("gAAAAA"):
+                raise ValueError("Unable to encrypt configured secret: %s.%s" % (section, ini_key))
+
+    def _restore_transaction_state(self, runtime_snapshot, parser_defaults, parser_sections):
+        """Restore the Config object and shared parser to their pre-update state."""
+        self.__dict__.clear()
+        self.__dict__.update(runtime_snapshot)
+
+        config.clear()
+        config._defaults.clear()
+        config._defaults.update(copy.deepcopy(parser_defaults))
+        for section, options in parser_sections.items():
+            config.add_section(section)
+            for option, value in options.items():
+                config.set(section, option, value)
+
+    def _restore_config_file(self, config_path, file_existed, file_contents, file_mode):
+        """Restore the last durable config only when the transaction changed it."""
+        if file_existed:
+            current_contents = config_path.read_bytes() if config_path.is_file() else None
+            if current_contents == file_contents:
+                return
+            self._atomic_replace_file(
+                config_path,
+                stat.S_IMODE(file_mode),
+                lambda rollback_file: rollback_file.write(file_contents),
+                binary=True,
+            )
+        elif config_path.exists():
+            config_path.unlink()
+
+    def _config_write_target(self):
+        """Resolve a configured symlink target without replacing the link itself."""
+        configured_path = Path(self._config_file).absolute()
+        if configured_path.is_symlink():
+            target_path = configured_path.resolve(strict=False)
+            if target_path.exists() and not target_path.is_file():
+                raise OSError("config symlink target is not a regular file")
+            return target_path
+        if configured_path.exists() and not configured_path.is_file():
+            raise OSError("config path is not a regular file")
+        return configured_path
+
+    @staticmethod
+    def _apply_file_mode(file_descriptor, temp_path, mode):
+        """Apply POSIX permissions with a safe Windows fallback."""
+        fchmod = getattr(os, "fchmod", None)
+        if callable(fchmod):
+            try:
+                fchmod(file_descriptor, mode)
+                return
+            except (AttributeError, NotImplementedError):
+                pass
+            except OSError:
+                if os.name != "nt":
+                    raise
+
+        chmod = getattr(os, "chmod", None)
+        if callable(chmod):
+            try:
+                chmod(temp_path, mode)
+                return
+            except (AttributeError, NotImplementedError):
+                pass
+            except OSError:
+                if os.name != "nt":
+                    raise
+
+        if os.name != "nt":
+            raise OSError("platform cannot apply config file permissions")
+
+    @classmethod
+    def _atomic_replace_file(cls, target_path, mode, write_content, binary=False):
+        """Write through an exclusive same-directory temp and atomically replace."""
+        temp_fd = None
+        temp_path = None
+        try:
+            temp_fd, temp_name = tempfile.mkstemp(
+                prefix=_CONFIG_TEMP_PREFIX,
+                suffix=_CONFIG_TEMP_SUFFIX,
+                dir=str(target_path.parent),
+            )
+            temp_path = Path(temp_name)
+            cls._apply_file_mode(temp_fd, temp_path, mode)
+            open_mode = "wb" if binary else "w"
+            open_kwargs = {} if binary else {"encoding": "utf8"}
+            with os.fdopen(temp_fd, mode=open_mode, **open_kwargs) as temp_file:
+                temp_fd = None
+                write_content(temp_file)
+                temp_file.flush()
+                os.fsync(temp_file.fileno())
+            os.replace(temp_path, target_path)
+            temp_path = None
+        finally:
+            if temp_fd is not None:
+                os.close(temp_fd)
+            if temp_path is not None:
+                try:
+                    temp_path.unlink()
+                except FileNotFoundError:
+                    pass
+                except OSError as cleanup_error:
+                    logger.warn("Unable to remove config temp file %s: %s" % (temp_path, cleanup_error))
+
     def writeconfig(self, values=None, startup=False):
+        """Serialize every parser mutation and atomic config-file replacement."""
+        with _CONFIG_TRANSACTION_LOCK:
+            return self._writeconfig(values=values, startup=startup)
+
+    def writeconfig_values(self, values, startup=False):
+        """Process values before provider sequencing under the shared write lock."""
+        with _CONFIG_TRANSACTION_LOCK:
+            self.process_kwargs(values)
+            return self._writeconfig(startup=startup)
+
+    def _writeconfig(self, values=None, startup=False):
+        try:
+            config_path = self._config_write_target()
+        except (OSError, RuntimeError) as e:
+            logger.warn("Refusing unsafe configuration write target: %s" % e)
+            return False
+
         logger.fdebug("Writing configuration to file")
         config.set("Newznab", "extra_newznabs", ", ".join(self.write_extras(self.EXTRA_NEWZNABS)))
         tmp_torz = self.write_extras(self.EXTRA_TORZNABS)
@@ -1218,17 +1421,18 @@ class Config(object):
         if values is not None:
             self.process_kwargs(values)
 
-        # Atomic write: write to temp file then rename to prevent config loss on crash
+        # Atomic write: restrict the temporary file before making it visible.
+        target_mode = 0o600
         try:
-            tmp_path = self._config_file + ".tmp"
-            with codecs.open(tmp_path, encoding="utf8", mode="w") as configfile:
-                config.write(configfile)
-                configfile.flush()
-                os.fsync(configfile.fileno())
-            os.replace(tmp_path, self._config_file)
+            target_mode = stat.S_IMODE(config_path.stat().st_mode)
+        except FileNotFoundError:
+            pass
+
+        try:
+            self._atomic_replace_file(config_path, target_mode, config.write)
             logger.fdebug("Configuration written to disk.")
             return True
-        except OSError as e:
+        except Exception as e:
             logger.warn("Error writing configuration file: %s", e)
             return False
 
@@ -1308,6 +1512,14 @@ class Config(object):
         if new_encrypted > 0:
             self.WRITE_THE_CONFIG = True
 
+    def _normalize_git_token_auth(self):
+        """Keep the requests Basic-auth token tuple flat across reconfiguration."""
+        token = self.GIT_TOKEN
+        while isinstance(token, (tuple, list)) and token:
+            token = token[0]
+        if token:
+            self.GIT_TOKEN = (token, "x-oauth-basic")
+
     def configure(self, update=False, startup=False):
 
         if all([self.CLEAR_PROVIDER_TABLE is True, startup is True]):
@@ -1322,7 +1534,7 @@ class Config(object):
         self.ENABLE_PUBLIC = False
 
         if self.GIT_TOKEN:
-            self.GIT_TOKEN = (self.GIT_TOKEN, "x-oauth-basic")
+            self._normalize_git_token_auth()
             # logger.info('git_token set to %s' % (self.GIT_TOKEN,))
 
         try:

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -1196,6 +1196,12 @@ class Config(object):
     def apply_transaction(self, values, configure=True):
         """Apply, encrypt, and persist config values as one recoverable update."""
         with _CONFIG_TRANSACTION_LOCK:
+            if getattr(self, "_config_write_halted", False):
+                logger.error(
+                    "[CONFIG] Refusing config write: a previous transactional rollback was incomplete"
+                )
+                return False
+
             try:
                 config_path = self._config_write_target()
             except (OSError, RuntimeError) as e:
@@ -1222,15 +1228,30 @@ class Config(object):
                     self.configure(update=True, startup=False)
                 return True
             except BaseException as e:
+                durable_write_happened = self._durable_write_changed(
+                    config_path, file_existed, file_contents
+                )
+                runtime_ok = False
+                file_ok = False
                 try:
                     self._restore_transaction_state(runtime_snapshot, parser_defaults, parser_sections)
+                    runtime_ok = True
                 except Exception as rollback_error:
                     logger.error("[CONFIG] Failed to restore runtime state after update failure: %s" % rollback_error)
                 try:
                     self._restore_config_file(config_path, file_existed, file_contents, file_mode)
+                    file_ok = True
                 except Exception as rollback_error:
                     logger.error(
                         "[CONFIG] Failed to restore configuration file after update failure: %s" % rollback_error
+                    )
+                if durable_write_happened and not (runtime_ok and file_ok):
+                    self._config_write_halted = True
+                    logger.error(
+                        "[CONFIG] CRITICAL: transactional rollback incomplete "
+                        "(runtime_restored=%s, file_restored=%s). "
+                        "Further config writes are refused until the process restarts or config is repaired."
+                        % (runtime_ok, file_ok)
                     )
                 logger.error("[CONFIG] Transactional update failed: %s" % e)
                 if isinstance(e, (KeyboardInterrupt, GeneratorExit)):
@@ -1246,6 +1267,18 @@ class Config(object):
             except Exception:
                 snapshot[key] = value
         return snapshot
+
+    @staticmethod
+    def _durable_write_changed(config_path, file_existed, file_contents):
+        """Return True when the on-disk config differs from the pre-transaction snapshot."""
+        try:
+            if file_existed:
+                current_contents = config_path.read_bytes() if config_path.is_file() else None
+                return current_contents != file_contents
+            return config_path.exists()
+        except Exception:
+            # If we cannot inspect disk state, assume a durable write may have landed.
+            return True
 
     def _encrypt_config_for_write(self):
         """Encrypt every configured secret in the parser without changing runtime values."""
@@ -1370,24 +1403,55 @@ class Config(object):
                 except FileNotFoundError:
                     pass
                 except OSError as cleanup_error:
-                    logger.warn("Unable to remove config temp file %s: %s" % (temp_path, cleanup_error))
+                    logger.warn("[CONFIG] Unable to remove config temp file %s: %s" % (temp_path, cleanup_error))
 
     def writeconfig(self, values=None, startup=False):
         """Serialize every parser mutation and atomic config-file replacement."""
         with _CONFIG_TRANSACTION_LOCK:
+            if getattr(self, "_config_write_halted", False):
+                logger.error(
+                    "[CONFIG] Refusing config write: a previous transactional rollback was incomplete"
+                )
+                return False
             return self._writeconfig(values=values, startup=startup)
 
     def writeconfig_values(self, values, startup=False):
-        """Process values before provider sequencing under the shared write lock."""
+        """Process values before provider sequencing under the shared write lock.
+
+        Runtime and parser state are restored when the durable write fails so
+        callers do not keep dirty in-memory values after a failed persist.
+        """
         with _CONFIG_TRANSACTION_LOCK:
-            self.process_kwargs(values)
-            return self._writeconfig(startup=startup)
+            if getattr(self, "_config_write_halted", False):
+                logger.error(
+                    "[CONFIG] Refusing config write: a previous transactional rollback was incomplete"
+                )
+                return False
+
+            runtime_snapshot = self._snapshot_runtime_state()
+            parser_defaults = copy.deepcopy(config._defaults)
+            parser_sections = copy.deepcopy(config._sections)
+            try:
+                self.process_kwargs(values)
+                if self._writeconfig(startup=startup) is False:
+                    raise OSError("config write failed")
+                return True
+            except Exception as e:
+                try:
+                    self._restore_transaction_state(runtime_snapshot, parser_defaults, parser_sections)
+                except Exception as rollback_error:
+                    logger.error(
+                        "[CONFIG] Failed to restore runtime state after writeconfig_values failure: %s"
+                        % rollback_error
+                    )
+                logger.error("[CONFIG] writeconfig_values failed: %s" % e)
+                return False
 
     def _writeconfig(self, values=None, startup=False):
         try:
             config_path = self._config_write_target()
         except (OSError, RuntimeError) as e:
-            logger.warn("Refusing unsafe configuration write target: %s" % e)
+            logger.warn("[CONFIG] Refusing unsafe configuration write target: %s" % e)
             return False
 
         logger.fdebug("Writing configuration to file")

--- a/comicarr/locg.py
+++ b/comicarr/locg.py
@@ -185,8 +185,8 @@ def locg(pulldate=None, weeknumber=None, year=None):
 
         logger.info("[PULL-LIST] Successfully populated pull-list into Comicarr for week %s of %s" % (weeknumber, year))
         # set the last poll date/time here so that we don't start overwriting stuff too much...
-        comicarr.CONFIG.PULL_REFRESH = todaydate.strftime("%Y-%m-%d %H:%M:%S")
-        comicarr.CONFIG.writeconfig(values={"pull_refresh": comicarr.CONFIG.PULL_REFRESH})
+        pull_refresh = todaydate.strftime("%Y-%m-%d %H:%M:%S")
+        comicarr.CONFIG.writeconfig(values={"pull_refresh": pull_refresh})
 
         return {"status": "success", "count": len(data), "weeknumber": weeknumber, "year": year}
 

--- a/comicarr/weeklypull.py
+++ b/comicarr/weeklypull.py
@@ -1656,11 +1656,11 @@ def mass_publishers(publishers, weeknumber, year):
     if publishers is None:
         stmt = select(weekly).where((weekly.c.weeknumber == weeknumber) & (weekly.c.year == year))
         watchlist = db.select_all(stmt)
-        comicarr.CONFIG.MASS_PUBLISHERS = []
+        mass_publishers = []
     else:
         for pb in publishers:
             pub_listing.append(pb)
-        comicarr.CONFIG.MASS_PUBLISHERS = json.loads(json.dumps(pub_listing))
+        mass_publishers = json.loads(json.dumps(pub_listing))
         stmt = select(weekly).where(
             (weekly.c.weeknumber == weeknumber) & (weekly.c.year == year) & (weekly.c.PUBLISHER.in_(publishers))
         )
@@ -1668,7 +1668,7 @@ def mass_publishers(publishers, weeknumber, year):
 
     comicarr.CONFIG.writeconfig(
         values={
-            "mass_publishers": json.dumps(comicarr.CONFIG.MASS_PUBLISHERS),
+            "mass_publishers": json.dumps(mass_publishers),
             "auto_mass_add": comicarr.CONFIG.AUTO_MASS_ADD,
         }
     )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -38,11 +38,14 @@ export class ApiError extends Error {
   isRetryable: boolean;
 
   constructor(status: number, originalMessage?: string) {
-    const userMessage =
+    const defaultMessage =
       HTTP_ERROR_MESSAGES[status] ||
       `An unexpected error occurred (${status}). Please try again.`;
+    // Prefer server-provided detail when present so settings/setup toasts are specific.
+    const userMessage =
+      originalMessage && originalMessage.trim() ? originalMessage : defaultMessage;
 
-    super(originalMessage || userMessage);
+    super(userMessage);
     this.name = "ApiError";
     this.status = status;
     this.userMessage = userMessage;
@@ -346,7 +349,21 @@ export async function apiRequest<T = unknown>(
     const response = await fetch(url, options);
 
     if (!response.ok) {
-      throw new ApiError(response.status);
+      let detail: string | undefined;
+      try {
+        const errBody = (await response.json()) as {
+          error?: unknown;
+          detail?: unknown;
+        };
+        if (typeof errBody?.error === "string" && errBody.error.trim()) {
+          detail = errBody.error;
+        } else if (typeof errBody?.detail === "string" && errBody.detail.trim()) {
+          detail = errBody.detail;
+        }
+      } catch {
+        // Non-JSON error bodies fall back to status-based messages.
+      }
+      throw new ApiError(response.status, detail);
     }
 
     const data = await response.json();

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -43,7 +43,9 @@ export class ApiError extends Error {
       `An unexpected error occurred (${status}). Please try again.`;
     // Prefer server-provided detail when present so settings/setup toasts are specific.
     const userMessage =
-      originalMessage && originalMessage.trim() ? originalMessage : defaultMessage;
+      originalMessage && originalMessage.trim()
+        ? originalMessage
+        : defaultMessage;
 
     super(userMessage);
     this.name = "ApiError";
@@ -357,7 +359,10 @@ export async function apiRequest<T = unknown>(
         };
         if (typeof errBody?.error === "string" && errBody.error.trim()) {
           detail = errBody.error;
-        } else if (typeof errBody?.detail === "string" && errBody.detail.trim()) {
+        } else if (
+          typeof errBody?.detail === "string" &&
+          errBody.detail.trim()
+        ) {
           detail = errBody.detail;
         }
       } catch {

--- a/frontend/tests/unit/lib/api.test.ts
+++ b/frontend/tests/unit/lib/api.test.ts
@@ -166,6 +166,31 @@ describe("API Client", () => {
       await expect(apiRequest("GET", "/api/series")).rejects.toThrow(ApiError);
     });
 
+    it("should prefer body.error from non-OK JSON responses", async () => {
+      server.use(
+        http.put("/api/config", () => {
+          return HttpResponse.json(
+            { success: false, error: "Failed to persist configuration" },
+            { status: 500 },
+          );
+        }),
+      );
+
+      try {
+        await apiRequest("PUT", "/api/config", { comic_dir: "/x" });
+        throw new Error("expected apiRequest to reject");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiError);
+        expect((error as ApiError).message).toBe(
+          "Failed to persist configuration",
+        );
+        expect((error as ApiError).userMessage).toBe(
+          "Failed to persist configuration",
+        );
+        expect((error as ApiError).status).toBe(500);
+      }
+    });
+
     it("should include credentials for cookie-based auth", async () => {
       let capturedCredentials: RequestCredentials | undefined;
       server.use(

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -4,7 +4,14 @@ Tests for comicarr.app.system domain — Phase 1.
 Covers: auth login/logout, SSE streaming, config endpoints, JWT cookies.
 """
 
-from unittest.mock import MagicMock, call, patch
+import configparser
+import json
+import os
+import stat
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 import comicarr
 
@@ -17,6 +24,7 @@ from comicarr.app.core.security import (
     create_session_token,
     validate_jwt_token,
 )
+from comicarr.app.system import router as system_router
 from comicarr.app.system import service as system_service
 
 
@@ -48,6 +56,20 @@ def _make_test_ctx(**overrides):
             setattr(config, key.upper(), value)
 
     config.process_kwargs.side_effect = process_kwargs
+
+    def apply_transaction(values, configure=True):
+        previous = {key.upper(): getattr(config, key.upper(), None) for key in values}
+        try:
+            config.process_kwargs(values)
+            if configure:
+                config.configure(update=True, startup=False)
+            return True
+        except Exception:
+            for key, value in previous.items():
+                setattr(config, key, value)
+            return False
+
+    config.apply_transaction.side_effect = apply_transaction
 
     defaults = {
         "config": config,
@@ -116,6 +138,17 @@ class TestVerifyLogin:
 
         result = system_service.verify_login(ctx, "admin", "pass", "127.0.0.1")
         assert result["success"] is False
+
+    @patch("comicarr.encrypted")
+    def test_password_migration_uses_shared_transaction_without_configure(self, mock_encrypted):
+        """Login hash migration does not mutate the parser outside the transaction lock."""
+        ctx = _make_test_ctx()
+        mock_encrypted.hash_password.return_value = "$2b$12$migrated"
+
+        system_service._migrate_password(ctx, "legacy-password")
+
+        ctx.config.apply_transaction.assert_called_once_with({"http_password": "$2b$12$migrated"}, configure=False)
+        ctx.config.writeconfig.assert_not_called()
 
 
 # =============================================================================
@@ -213,8 +246,54 @@ class TestInitialSetup:
         # this is harmless in tests, just let it run
         result = system_service.initial_setup(ctx, "admin", "password123", None)
         assert result["success"] is True
-        ctx.config.process_kwargs.assert_called_once()
-        ctx.config.writeconfig.assert_called_once()
+        ctx.config.apply_transaction.assert_called_once_with(
+            {
+                "http_username": "admin",
+                "http_password": "$2b$12$hashed",
+                "authentication": 2,
+            }
+        )
+
+    @patch("comicarr.encrypted")
+    def test_setup_persistence_failure_preserves_setup_state(self, mock_encrypted, monkeypatch):
+        """Failed setup writes must leave credentials, tokens, and signals unchanged."""
+        ctx = _make_test_ctx(setup_token="setup-token")
+        ctx.config.HTTP_USERNAME = None
+        ctx.config.HTTP_PASSWORD = None
+        ctx.config.apply_transaction.side_effect = None
+        ctx.config.apply_transaction.return_value = False
+        mock_encrypted.hash_password.return_value = "$2b$12$hashed"
+        monkeypatch.setattr(comicarr, "SETUP_TOKEN", "setup-token")
+        monkeypatch.setattr(comicarr, "SIGNAL", None)
+
+        result = system_service.initial_setup(ctx, "admin", "password123", "setup-token")
+
+        assert result == {"success": False, "error": "Failed to persist initial credentials"}
+        assert ctx.config.HTTP_USERNAME is None
+        assert ctx.config.HTTP_PASSWORD is None
+        assert ctx.setup_token == "setup-token"
+        assert comicarr.SETUP_TOKEN == "setup-token"
+        assert ctx.signal is None
+        assert comicarr.SIGNAL is None
+
+    @patch("comicarr.encrypted")
+    def test_setup_hash_failure_preserves_setup_state(self, mock_encrypted, monkeypatch):
+        """Password hashing failures use the controlled setup persistence contract."""
+        ctx = _make_test_ctx(setup_token="setup-token")
+        ctx.config.HTTP_USERNAME = None
+        ctx.config.HTTP_PASSWORD = None
+        mock_encrypted.hash_password.side_effect = RuntimeError("hash failed")
+        monkeypatch.setattr(comicarr, "SETUP_TOKEN", "setup-token")
+        monkeypatch.setattr(comicarr, "SIGNAL", None)
+
+        result = system_service.initial_setup(ctx, "admin", "password123", "setup-token")
+
+        assert result == {"success": False, "error": "Failed to persist initial credentials"}
+        ctx.config.apply_transaction.assert_not_called()
+        assert ctx.setup_token == "setup-token"
+        assert comicarr.SETUP_TOKEN == "setup-token"
+        assert ctx.signal is None
+        assert comicarr.SIGNAL is None
 
     def test_setup_rejects_short_password(self):
         """Setup rejects passwords shorter than 8 characters."""
@@ -411,8 +490,8 @@ class TestConfigService:
         ctx = _make_test_ctx()
         result = system_service.update_config(ctx, {"comic_dir": "/new/path"})
         assert result["success"] is True
-        ctx.config.process_kwargs.assert_called_once()
-        args = ctx.config.process_kwargs.call_args[0][0]
+        ctx.config.apply_transaction.assert_called_once()
+        args = ctx.config.apply_transaction.call_args[0][0]
         assert "COMIC_DIR" in args
 
     def test_update_config_accepts_uppercase_keys(self):
@@ -439,9 +518,42 @@ class TestConfigService:
             },
         )
         assert result["success"] is True
-        args = ctx.config.process_kwargs.call_args[0][0]
+        args = ctx.config.apply_transaction.call_args[0][0]
         assert "COMIC_DIR" in args
         assert "API_KEY" not in args
+
+    def test_update_config_reports_persistence_failure_without_side_effects(self, monkeypatch):
+        """Failed durable writes must not reconfigure schedulers or replace the global config."""
+        ctx = _make_test_ctx()
+        previous_global = object()
+        monkeypatch.setattr(comicarr, "CONFIG", previous_global)
+        ctx.config.apply_transaction.side_effect = None
+        ctx.config.apply_transaction.return_value = False
+
+        with patch.object(system_service, "_reconfigure_schedulers") as reconfigure:
+            result = system_service.update_config(ctx, {"search_interval": 720})
+
+        assert result == {"success": False, "error": "Failed to persist configuration"}
+        reconfigure.assert_not_called()
+        assert comicarr.CONFIG is previous_global
+
+    def test_update_config_reconfigures_scheduler_after_persistence(self):
+        """Scheduler changes happen only after the transactional write succeeds."""
+        ctx = _make_test_ctx()
+        events = []
+
+        def persist(values):
+            events.append("persist")
+            return True
+
+        ctx.config.apply_transaction.side_effect = persist
+        with patch.object(
+            system_service, "_reconfigure_schedulers", side_effect=lambda _ctx: events.append("scheduler")
+        ):
+            result = system_service.update_config(ctx, {"search_interval": 720})
+
+        assert result == {"success": True}
+        assert events == ["persist", "scheduler"]
 
     @patch("comicarr.app.system.service.secrets.token_hex", return_value="a" * 32)
     def test_regenerate_api_key_persists_new_key(self, mock_token_hex):
@@ -452,8 +564,8 @@ class TestConfigService:
         assert result == {"success": True, "api_key": "a" * 32}
         assert ctx.config.API_KEY == "a" * 32
         mock_token_hex.assert_called_once_with(16)
-        ctx.config.process_kwargs.assert_called_once_with({"api_key": "a" * 32})
-        ctx.config.writeconfig.assert_called_once_with()
+        ctx.config.apply_transaction.assert_called_once_with({"api_key": "a" * 32})
+        ctx.config.writeconfig.assert_not_called()
         ctx.config.configure.assert_called_once_with(update=True, startup=False)
 
     def test_regenerate_api_key_rejects_missing_config(self):
@@ -474,32 +586,24 @@ class TestConfigService:
         assert result == {"success": False, "error": "Failed to persist new API key"}
         assert ctx.config.API_KEY == "configured-api-key"
         mock_token_hex.assert_called_once_with(16)
-        assert ctx.config.process_kwargs.call_args_list == [
-            call({"api_key": "a" * 32}),
-            call({"api_key": "configured-api-key"}),
-        ]
-        assert ctx.config.writeconfig.call_count == 2
-        assert ctx.config.configure.call_args_list == [
-            call(update=True, startup=False),
-            call(update=True, startup=False),
-        ]
+        ctx.config.apply_transaction.assert_called_once_with({"api_key": "a" * 32})
+        ctx.config.writeconfig.assert_not_called()
+        ctx.config.configure.assert_called_once_with(update=True, startup=False)
 
     @patch("comicarr.app.system.service.secrets.token_hex", return_value="a" * 32)
-    def test_regenerate_api_key_reports_silent_write_failure(self, mock_token_hex):
-        """regenerate_api_key fails when writeconfig reports an unsuccessful write."""
+    def test_regenerate_api_key_reports_transaction_failure(self, mock_token_hex):
+        """regenerate_api_key fails when the transactional write is unsuccessful."""
         ctx = _make_test_ctx()
-        ctx.config.writeconfig.return_value = False
+        ctx.config.apply_transaction.side_effect = None
+        ctx.config.apply_transaction.return_value = False
 
         result = system_service.regenerate_api_key(ctx)
 
         assert result == {"success": False, "error": "Failed to persist new API key"}
         assert ctx.config.API_KEY == "configured-api-key"
         mock_token_hex.assert_called_once_with(16)
-        assert ctx.config.process_kwargs.call_args_list == [
-            call({"api_key": "a" * 32}),
-            call({"api_key": "configured-api-key"}),
-        ]
-        ctx.config.writeconfig.assert_called_once_with()
+        ctx.config.apply_transaction.assert_called_once_with({"api_key": "a" * 32})
+        ctx.config.writeconfig.assert_not_called()
         ctx.config.configure.assert_not_called()
 
     def test_update_config_accepts_new_writable_keys(self):
@@ -515,7 +619,7 @@ class TestConfigService:
             },
         )
         assert result["success"] is True
-        args = ctx.config.process_kwargs.call_args[0][0]
+        args = ctx.config.apply_transaction.call_args[0][0]
         assert "COMICVINE_ENABLED" in args
         assert "PREFERRED_QUALITY" in args
 
@@ -540,3 +644,377 @@ class TestConfigService:
         result = system_service.get_version_info(ctx)
         assert result["current_version"] == "0.6.0"
         assert result["install_type"] == "git"
+
+
+class _JsonRequest:
+    def __init__(self, body):
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+
+class TestConfigRouter:
+    @pytest.mark.asyncio
+    async def test_setup_returns_server_error_when_persistence_fails(self):
+        """The setup endpoint distinguishes storage failure from invalid input."""
+        ctx = _make_test_ctx(setup_token="setup-token")
+        failure = {"success": False, "error": "Failed to persist initial credentials"}
+        request = _JsonRequest(
+            {
+                "username": "admin",
+                "password": "password123",
+                "setup_token": "setup-token",
+            }
+        )
+
+        with patch.object(system_router.system_service, "initial_setup", return_value=failure):
+            response = await system_router.setup(request, ctx)
+
+        assert response.status_code == 500
+        assert json.loads(response.body) == failure
+
+    @pytest.mark.asyncio
+    async def test_update_config_returns_server_error_when_persistence_fails(self):
+        """The settings endpoint must not report HTTP success for a failed write."""
+        ctx = _make_test_ctx()
+        failure = {"success": False, "error": "Failed to persist configuration"}
+
+        with patch.object(system_router.system_service, "update_config", return_value=failure):
+            response = await system_router.update_config(_JsonRequest({"comic_dir": "/new/path"}), ctx)
+
+        assert response.status_code == 500
+        assert json.loads(response.body) == failure
+
+
+def _make_real_config(tmp_path, monkeypatch):
+    """Build a real Config with an isolated parser and no configure side effects."""
+    from comicarr import config as config_module
+    from comicarr import encrypted as encrypted_module
+
+    config_path = tmp_path / "config.ini"
+    config_path.write_text("")
+    secure_dir = tmp_path / "secure"
+    secure_dir.mkdir()
+
+    monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
+    encrypted_module._fernet_instance = None
+
+    cfg = config_module.Config(str(config_path))
+    cfg.config_vals()
+    cfg.SECURE_DIR = str(secure_dir)
+    config_module.config.set("General", "secure_dir", str(secure_dir))
+    cfg.provider_sequence = MagicMock()
+    monkeypatch.setattr(comicarr, "CONFIG", cfg)
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    return cfg, config_path, config_module
+
+
+def _symlink_or_skip(link_path, target_path):
+    try:
+        link_path.symlink_to(target_path)
+    except (OSError, NotImplementedError) as e:
+        pytest.skip("symlinks unavailable: %s" % e)
+
+
+class TestConfigTransactions:
+    def test_locked_value_write_processes_before_provider_sequence(self, tmp_path, monkeypatch):
+        """Provider payloads are applied before sequencing without releasing the write lock."""
+        cfg, _config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        events = []
+        original_process = cfg.process_kwargs
+
+        def tracked_process(values):
+            events.append("process")
+            original_process(values)
+
+        def tracked_atomic_replace(_target, _mode, _write_content, binary=False):
+            assert binary is False
+            events.append("write")
+
+        cfg.process_kwargs = tracked_process
+        cfg.provider_sequence = MagicMock(side_effect=lambda: events.append("provider_sequence"))
+        cfg._atomic_replace_file = tracked_atomic_replace
+
+        assert cfg.writeconfig_values({"COMIC_DIR": "/ordered/library"}) is True
+
+        assert cfg.COMIC_DIR == "/ordered/library"
+        assert events == ["process", "provider_sequence", "write"]
+
+    def test_transaction_encrypts_disk_secret_and_keeps_runtime_decrypted(self, tmp_path, monkeypatch):
+        """A successful settings write persists ciphertext before configure runs."""
+        cfg, config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        events = []
+        original_write = cfg.writeconfig
+
+        def tracked_write():
+            events.append("write")
+            return original_write()
+
+        cfg.writeconfig = MagicMock(side_effect=tracked_write)
+        cfg.configure = MagicMock(side_effect=lambda **_kwargs: events.append("configure"))
+        secret = "transaction-test-secret"
+
+        assert cfg.apply_transaction({"AI_API_KEY": secret}) is True
+
+        persisted = configparser.ConfigParser()
+        persisted.read(config_path)
+        persisted_secret = persisted.get("AI", "ai_api_key")
+        assert persisted_secret.startswith("gAAAAA")
+        assert secret not in config_path.read_text()
+        assert cfg.AI_API_KEY == secret
+        assert cfg.ENCRYPT_PASSWORDS is True
+        assert events == ["write", "configure"]
+        cfg.writeconfig.assert_called_once_with()
+
+    def test_transaction_preserves_existing_config_file_mode(self, tmp_path, monkeypatch):
+        """Atomic replacement retains the permissions of an existing config file."""
+        cfg, config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        os.chmod(config_path, 0o640)
+        cfg.configure = MagicMock()
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is True
+
+        assert stat.S_IMODE(config_path.stat().st_mode) == 0o640
+
+    def test_transaction_creates_new_config_file_with_private_mode(self, tmp_path, monkeypatch):
+        """A first durable config write creates config.ini with mode 0600."""
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        config_path.unlink()
+        cfg.configure = MagicMock()
+        replaced_modes = []
+        real_replace = os.replace
+
+        def checked_replace(source, destination):
+            if config_module.Path(destination) == config_path:
+                replaced_modes.append(stat.S_IMODE(os.stat(source).st_mode))
+            real_replace(source, destination)
+
+        monkeypatch.setattr(config_module.os, "replace", checked_replace)
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is True
+
+        assert replaced_modes == [0o600]
+        assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+
+    def test_normal_write_ignores_hostile_predictable_temp_symlink(self, tmp_path, monkeypatch):
+        """A pre-created legacy .tmp symlink cannot redirect config output."""
+        cfg, config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        victim = tmp_path / "victim.txt"
+        victim.write_text("untouched")
+        predictable_temp = tmp_path / "config.ini.tmp"
+        _symlink_or_skip(predictable_temp, victim)
+        cfg.configure = MagicMock()
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is True
+
+        assert victim.read_text() == "untouched"
+        assert predictable_temp.is_symlink()
+        assert config_path.is_file()
+
+    def test_rollback_ignores_hostile_predictable_temp_symlink(self, tmp_path, monkeypatch):
+        """A pre-created legacy .rollback symlink cannot redirect rollback output."""
+        cfg, config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.process_kwargs({"COMIC_DIR": "/old/library"})
+        assert cfg.writeconfig() is True
+        victim = tmp_path / "victim.txt"
+        victim.write_text("untouched")
+        predictable_rollback = tmp_path / "config.ini.rollback"
+        _symlink_or_skip(predictable_rollback, victim)
+        cfg.configure = MagicMock(side_effect=RuntimeError("configure failed"))
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is False
+
+        assert victim.read_text() == "untouched"
+        assert predictable_rollback.is_symlink()
+        assert config_path.is_file()
+
+    def test_transaction_preserves_config_symlink_identity(self, tmp_path, monkeypatch):
+        """Atomic updates replace a symlink's target without replacing the link itself."""
+        cfg, config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.process_kwargs({"COMIC_DIR": "/old/library"})
+        assert cfg.writeconfig() is True
+        target_path = tmp_path / "real-config.ini"
+        config_path.replace(target_path)
+        _symlink_or_skip(config_path, target_path)
+        cfg.configure = MagicMock()
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is True
+
+        assert config_path.is_symlink()
+        persisted = configparser.ConfigParser()
+        persisted.read(target_path)
+        assert persisted.get("Import", "comic_dir") == "/new/library"
+
+    def test_unique_temp_is_cleaned_after_replace_failure(self, tmp_path, monkeypatch):
+        """A failed replace removes only the exclusive temp created for that write."""
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        replacement_sources = []
+        real_replace = os.replace
+
+        def failing_replace(source, destination):
+            if config_module.Path(destination) == config_path:
+                replacement_sources.append(config_module.Path(source))
+                raise OSError("replace failed")
+            real_replace(source, destination)
+
+        monkeypatch.setattr(config_module.os, "replace", failing_replace)
+
+        assert cfg.writeconfig(values={"COMIC_DIR": "/new/library"}) is False
+
+        assert len(replacement_sources) == 1
+        created_temp = replacement_sources[0]
+        assert created_temp.name.startswith(".comicarr-config-")
+        assert len(created_temp.name) <= 64
+        assert not created_temp.exists()
+
+    @pytest.mark.parametrize("fchmod_behavior", ["missing", "not-implemented"])
+    def test_config_write_falls_back_when_fchmod_unavailable(self, tmp_path, monkeypatch, fchmod_behavior):
+        """Platforms without fchmod still persist through a chmod fallback."""
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        config_path.unlink()
+        cfg.configure = MagicMock()
+        if fchmod_behavior == "missing":
+            monkeypatch.setattr(config_module.os, "fchmod", None)
+        else:
+            monkeypatch.setattr(
+                config_module.os,
+                "fchmod",
+                MagicMock(side_effect=NotImplementedError),
+            )
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is True
+        assert config_path.is_file()
+        if os.name != "nt":
+            assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+
+    def test_transaction_restores_parser_runtime_and_file_after_write_failure(self, tmp_path, monkeypatch):
+        """A failed atomic write rolls every staged config representation back."""
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.process_kwargs({"COMIC_DIR": "/old/library"})
+        original_file = config_path.read_bytes()
+        writer = MagicMock(return_value=False)
+        configure = MagicMock()
+        cfg.writeconfig = writer
+        cfg.configure = configure
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is False
+
+        assert cfg.COMIC_DIR == "/old/library"
+        assert config_module.config.get("Import", "comic_dir") == "/old/library"
+        assert config_path.read_bytes() == original_file
+        writer.assert_called_once_with()
+        configure.assert_not_called()
+
+    def test_transaction_does_not_write_when_secret_encryption_fails(self, tmp_path, monkeypatch):
+        """Plaintext secrets never reach the writer when encryption cannot complete."""
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        writer = MagicMock(return_value=True)
+        cfg.writeconfig = writer
+        cfg.configure = MagicMock()
+        cfg.encrypt_items = MagicMock()
+
+        assert cfg.apply_transaction({"AI_API_KEY": "unpersisted-test-secret"}) is False
+
+        assert cfg.AI_API_KEY is None
+        assert config_module.config.get("AI", "ai_api_key") == "None"
+        assert "unpersisted-test-secret" not in config_path.read_text()
+        writer.assert_not_called()
+        cfg.configure.assert_not_called()
+
+    def test_unrelated_transaction_keeps_git_auth_tuple_flat(self, tmp_path, monkeypatch):
+        """Repeated configure normalization keeps requests auth as a two-string tuple."""
+        cfg, _config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.GIT_TOKEN = ("git-token", "x-oauth-basic")
+        cfg.configure = MagicMock(side_effect=lambda **_kwargs: cfg._normalize_git_token_auth())
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is True
+
+        assert cfg.GIT_TOKEN == ("git-token", "x-oauth-basic")
+        assert all(isinstance(part, str) for part in cfg.GIT_TOKEN)
+
+    def test_transaction_restores_durable_file_when_configure_fails(self, tmp_path, monkeypatch):
+        """A post-write configure failure restores the last durable configuration."""
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.process_kwargs({"COMIC_DIR": "/old/library"})
+        assert cfg.writeconfig() is True
+        original_file = config_path.read_bytes()
+        original_write = cfg.writeconfig
+        writer = MagicMock(side_effect=original_write)
+        cfg.writeconfig = writer
+        cfg.configure = MagicMock(side_effect=RuntimeError("configure failed"))
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is False
+
+        assert cfg.COMIC_DIR == "/old/library"
+        assert config_module.config.get("Import", "comic_dir") == "/old/library"
+        assert config_path.read_bytes() == original_file
+        writer.assert_called_once_with()
+
+    def test_transaction_restores_state_when_configure_raises_system_exit(self, tmp_path, monkeypatch):
+        """SystemExit from legacy configure cannot bypass transactional rollback."""
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.process_kwargs({"COMIC_DIR": "/old/library"})
+        assert cfg.writeconfig() is True
+        original_file = config_path.read_bytes()
+        cfg.configure = MagicMock(side_effect=SystemExit(1))
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is False
+
+        assert cfg.COMIC_DIR == "/old/library"
+        assert config_module.config.get("Import", "comic_dir") == "/old/library"
+        assert config_path.read_bytes() == original_file
+
+    def test_direct_writer_waits_for_failed_transaction_rollback(self, tmp_path, monkeypatch):
+        """A concurrent direct writer cannot be erased by another transaction's rollback."""
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.process_kwargs({"COMIC_DIR": "/old/library", "DESTINATION_DIR": "/old/destination"})
+        assert cfg.writeconfig() is True
+
+        configure_entered = threading.Event()
+        release_configure = threading.Event()
+        direct_writer_started = threading.Event()
+        direct_writer_done = threading.Event()
+        results = {}
+
+        def failing_configure(**_kwargs):
+            configure_entered.set()
+            assert release_configure.wait(timeout=2)
+            raise RuntimeError("configure failed")
+
+        def transactional_writer():
+            results["transaction"] = cfg.apply_transaction({"COMIC_DIR": "/transaction/library"})
+
+        def direct_writer():
+            direct_writer_started.set()
+            results["direct"] = cfg.writeconfig(values={"DESTINATION_DIR": "/direct/destination"})
+            direct_writer_done.set()
+
+        cfg.configure = failing_configure
+        transaction_thread = threading.Thread(target=transactional_writer)
+        direct_thread = threading.Thread(target=direct_writer)
+        transaction_thread.start()
+        assert configure_entered.wait(timeout=2)
+        direct_thread.start()
+
+        try:
+            assert direct_writer_started.wait(timeout=2)
+            direct_writer_was_blocked = not direct_writer_done.wait(timeout=0.1)
+        finally:
+            release_configure.set()
+            transaction_thread.join(timeout=2)
+            direct_thread.join(timeout=2)
+
+        assert direct_writer_was_blocked
+        assert not transaction_thread.is_alive()
+        assert not direct_thread.is_alive()
+        assert results == {"transaction": False, "direct": True}
+        assert cfg.COMIC_DIR == "/old/library"
+        assert cfg.DESTINATION_DIR == "/direct/destination"
+        assert config_module.config.get("Import", "comic_dir") == "/old/library"
+        assert config_module.config.get("General", "destination_dir") == "/direct/destination"
+
+        persisted = configparser.ConfigParser()
+        persisted.read(config_path)
+        assert persisted.get("Import", "comic_dir") == "/old/library"
+        assert persisted.get("General", "destination_dir") == "/direct/destination"

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -150,6 +150,36 @@ class TestVerifyLogin:
         ctx.config.apply_transaction.assert_called_once_with({"http_password": "$2b$12$migrated"}, configure=False)
         ctx.config.writeconfig.assert_not_called()
 
+    @patch("comicarr.encrypted")
+    def test_password_migration_failure_is_logged_and_non_raising(self, mock_encrypted):
+        """Failed bcrypt migration must not raise out of the migration helper."""
+        ctx = _make_test_ctx()
+        mock_encrypted.hash_password.return_value = "$2b$12$migrated"
+        ctx.config.apply_transaction.side_effect = None
+        ctx.config.apply_transaction.return_value = False
+
+        system_service._migrate_password(ctx, "legacy-password")
+
+        ctx.config.apply_transaction.assert_called_once_with({"http_password": "$2b$12$migrated"}, configure=False)
+
+    @patch("comicarr.encrypted")
+    def test_plaintext_login_succeeds_when_password_migration_fails(self, mock_encrypted):
+        """Login still succeeds if hash migration cannot be persisted."""
+        ctx = _make_test_ctx()
+        ctx.config.HTTP_PASSWORD = "legacy-password"
+        mock_encrypted.hash_password.return_value = "$2b$12$migrated"
+        ctx.config.apply_transaction.side_effect = None
+        ctx.config.apply_transaction.return_value = False
+
+        result = system_service.verify_login(ctx, "admin", "legacy-password", "127.0.0.1")
+
+        assert result["success"] is True
+        assert result["username"] == "admin"
+        assert ctx.config.HTTP_PASSWORD == "legacy-password"
+        ctx.config.apply_transaction.assert_called_once_with(
+            {"http_password": "$2b$12$migrated"}, configure=False
+        )
+
 
 # =============================================================================
 # JWT Token Integration Tests
@@ -675,6 +705,25 @@ class TestConfigRouter:
         assert json.loads(response.body) == failure
 
     @pytest.mark.asyncio
+    async def test_setup_returns_bad_request_for_validation_failure(self):
+        """Client-input failures remain HTTP 400, not 500."""
+        ctx = _make_test_ctx(setup_token="setup-token")
+        failure = {"success": False, "error": "Password must be at least 8 characters"}
+        request = _JsonRequest(
+            {
+                "username": "admin",
+                "password": "short",
+                "setup_token": "setup-token",
+            }
+        )
+
+        with patch.object(system_router.system_service, "initial_setup", return_value=failure):
+            response = await system_router.setup(request, ctx)
+
+        assert response.status_code == 400
+        assert json.loads(response.body) == failure
+
+    @pytest.mark.asyncio
     async def test_update_config_returns_server_error_when_persistence_fails(self):
         """The settings endpoint must not report HTTP success for a failed write."""
         ctx = _make_test_ctx()
@@ -684,6 +733,18 @@ class TestConfigRouter:
             response = await system_router.update_config(_JsonRequest({"comic_dir": "/new/path"}), ctx)
 
         assert response.status_code == 500
+        assert json.loads(response.body) == failure
+
+    @pytest.mark.asyncio
+    async def test_update_config_returns_bad_request_for_validation_failure(self):
+        """Invalid settings payloads keep the 400 contract separate from storage errors."""
+        ctx = _make_test_ctx()
+        failure = {"success": False, "error": "No valid config keys provided"}
+
+        with patch.object(system_router.system_service, "update_config", return_value=failure):
+            response = await system_router.update_config(_JsonRequest({"api_key": "hacked"}), ctx)
+
+        assert response.status_code == 400
         assert json.loads(response.body) == failure
 
 
@@ -740,6 +801,42 @@ class TestConfigTransactions:
 
         assert cfg.COMIC_DIR == "/ordered/library"
         assert events == ["process", "provider_sequence", "write"]
+
+    def test_writeconfig_values_restores_runtime_when_write_fails(self, tmp_path, monkeypatch):
+        """Failed value writes must not leave process_kwargs mutations in memory."""
+        cfg, _config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        original_dir = cfg.COMIC_DIR
+
+        def fail_write(*_args, **_kwargs):
+            raise OSError("simulated replace failure")
+
+        cfg._atomic_replace_file = fail_write
+
+        assert cfg.writeconfig_values({"COMIC_DIR": "/should-not-stick"}) is False
+        assert cfg.COMIC_DIR == original_dir
+
+    def test_incomplete_file_restore_halts_further_writes(self, tmp_path, monkeypatch):
+        """After a durable write, failed file restore blocks subsequent config writes."""
+        cfg, config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        original_dir = cfg.COMIC_DIR
+        cfg.configure = MagicMock(side_effect=RuntimeError("configure boom"))
+
+        real_restore_state = cfg._restore_transaction_state
+
+        def restore_state_ok(*args, **kwargs):
+            return real_restore_state(*args, **kwargs)
+
+        def restore_file_fail(*_args, **_kwargs):
+            raise OSError("simulated file restore failure")
+
+        cfg._restore_transaction_state = restore_state_ok
+        cfg._restore_config_file = restore_file_fail
+
+        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is False
+        assert getattr(cfg, "_config_write_halted", False) is True
+        assert cfg.COMIC_DIR == original_dir
+        assert cfg.apply_transaction({"COMIC_DIR": "/another/library"}) is False
+        assert cfg.writeconfig() is False
 
     def test_transaction_encrypts_disk_secret_and_keeps_runtime_decrypted(self, tmp_path, monkeypatch):
         """A successful settings write persists ciphertext before configure runs."""


### PR DESCRIPTION
## Summary

Setup, settings, API-key regeneration, and plaintext-password migration now persist through a serialized, recoverable config transaction. Config values are staged in memory, configured secrets are encrypted before the single durable write, and write/configure failures restore runtime attributes, the shared parser, and the previous file before the API reports failure.

Atomic config replacement now preserves existing private modes, defaults new files to `0600`, uses exclusive same-directory temporary files, preserves legitimate `config.ini` symlink identity, and avoids predictable-temp symlink clobbering. Provider updates retain their legacy serialization contract but share the same write lock and original process-before-sequence ordering.

## Testing

- Added proof-first coverage for setup/settings write failures, token/restart preservation, scheduler ordering, encrypted-on-disk/decrypted-at-runtime secrets, API-key rollback, parser/file restoration, `SystemExit`, concurrent writers, Git-token tuple normalization, file modes, hostile temp symlinks, config symlinks, Windows permission fallbacks, and provider ordering.
- Full backend suite: 912 passed.
- Ruff lint and format checks passed.
- Startup help and lockfile checks passed.

## Scope Note

Legacy Newznab/Torznab payload normalization and embedded provider API-key encryption are unchanged and intentionally outside this PR. This change serializes that existing path without claiming a new provider-storage format.

## Post-Deploy Monitoring & Validation

- **Window/owner:** Maintainers should watch setup, settings saves, API-key rotation, and startup/config logs through the first 24 hours.
- **Healthy signals:** Successful updates survive restart, secrets remain Fernet ciphertext on disk, runtime clients continue using decrypted values, and failed writes leave the prior configuration active.
- **Watch:** Search logs for `Transactional update failed`, `Refusing unsafe config write target`, temp cleanup warnings, provider persistence errors, scheduler reconfiguration errors, and repeated setup retries.
- **Failure trigger:** Plaintext secrets appear in `config.ini`, file mode becomes broader than the prior mode, a failed save changes runtime behavior, or a valid settings update cannot survive restart.
- **Mitigation:** Revert this PR, restore the last known-good config/backup, rotate any potentially exposed credentials, and retry the setting only after filesystem ownership/permissions are corrected.

## Known Limitation

Legacy `configure()` performs some filesystem, queue, and module-global effects that cannot be rolled back with parser/file snapshots. Those effects now run only after durable persistence, and any subsequent configure failure restores the config state and file.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
