### PR TITLE
fix: deduplicate database migrations across batches

### DIFF
--- a/.changeset/deduplicate-database-migrations.md
+++ b/.changeset/deduplicate-database-migrations.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Deduplicate legacy database rows across migration batches and report target constraint conflicts as failed migrations.

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -171,9 +171,7 @@ def delete_comic(ctx, comic_id, delete_directory=False):
                         "symlink, or directory; skipping filesystem removal" % comic_location
                     )
                 else:
-                    logger.fdebug(
-                        "[SERIES-DELETE] Comic Location (%s) successfully %s" % (comic_location, action)
-                    )
+                    logger.fdebug("[SERIES-DELETE] Comic Location (%s) successfully %s" % (comic_location, action))
             else:
                 logger.fdebug("[SERIES-DELETE] Comic Location (%s) does not exist" % comic_location)
 

--- a/comicarr/db_migrate.py
+++ b/comicarr/db_migrate.py
@@ -28,9 +28,9 @@ import logging
 import os
 import re
 
-from sqlalchemy import create_engine, inspect, text
+from sqlalchemy import create_engine, func, inspect, select, text
 from sqlalchemy.engine import make_url
-from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy.exc import IntegrityError, OperationalError, ProgrammingError
 
 from comicarr.tables import UPSERT_KEYS, metadata
 
@@ -158,6 +158,23 @@ def _clean_row(row_dict, table_name, int_columns, text_columns):
     return cleaned, conversions
 
 
+def _quote_identifier(identifier):
+    """Quote a SQLite identifier used in migration-only source queries."""
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _stable_source_order(source_inspector, table_name):
+    """Return a deterministic order for paginating a legacy SQLite table."""
+    primary_key = source_inspector.get_pk_constraint(table_name) or {}
+    primary_key_columns = primary_key.get("constrained_columns") or []
+    if primary_key_columns:
+        return ", ".join(_quote_identifier(column) for column in primary_key_columns)
+
+    # Ordinary legacy SQLite tables always expose a unique rowid. WITHOUT ROWID
+    # tables require a primary key, so they take the branch above.
+    return "rowid"
+
+
 def validate(source_url, target_url):
     """Dry-run validation: report type mismatches, duplicates, and row counts."""
     print("\n=== Validation Mode ===")
@@ -281,10 +298,14 @@ def migrate(source_url, target_url, batch_size=5000):
 
         # Get target column names to filter source data
         target_cols = {c.name for c in table_obj.columns}
+        table_identifier = _quote_identifier(table_name)
+        table_migrated = 0
+        table_cleaned = 0
+        table_deduped = 0
 
         try:
             with source_engine.connect() as source_conn:
-                count_result = source_conn.execute(text(f"SELECT COUNT(*) FROM {table_name}"))
+                count_result = source_conn.execute(text(f"SELECT COUNT(*) FROM {table_identifier}"))
                 row_count = count_result.scalar()
 
                 if row_count == 0:
@@ -293,31 +314,31 @@ def migrate(source_url, target_url, batch_size=5000):
 
                 # Read and insert in batches
                 offset = 0
-                table_migrated = 0
-                table_cleaned = 0
-                table_deduped = 0
+                seen_keys = set()
+                upsert_keys = UPSERT_KEYS.get(table_name)
+                source_order = _stable_source_order(source_inspector, table_name)
 
                 while offset < row_count:
                     rows = source_conn.execute(
-                        text(f"SELECT * FROM {table_name} LIMIT :limit OFFSET :offset"),
+                        text(f"SELECT * FROM {table_identifier} ORDER BY {source_order} LIMIT :limit OFFSET :offset"),
                         {"limit": batch_size, "offset": offset},
                     )
 
                     batch = []
-                    seen_keys = set()
+                    batch_cleaned = 0
                     for row in rows:
                         row_dict = dict(row._mapping)
                         # Filter to only columns that exist in the target schema
                         row_dict = {k: v for k, v in row_dict.items() if k in target_cols}
                         cleaned, conversions = _clean_row(row_dict, table_name, int_cols, text_cols)
                         table_cleaned += len(conversions)
+                        batch_cleaned += len(conversions)
 
                         # Deduplicate rows that would violate UNIQUE constraints
-                        upsert_keys = UPSERT_KEYS.get(table_name)
                         if upsert_keys:
                             key_vals = tuple(cleaned.get(k) for k in upsert_keys)
-                            if any(v is None or v == "" for v in key_vals):
-                                batch.append(cleaned)  # Allow NULL keys
+                            if any(v is None for v in key_vals):
+                                batch.append(cleaned)  # UNIQUE constraints allow NULL keys
                             elif key_vals in seen_keys:
                                 table_deduped += 1
                                 continue  # Skip duplicate
@@ -331,11 +352,12 @@ def migrate(source_url, target_url, batch_size=5000):
                         with target_engine.begin() as target_conn:
                             target_conn.execute(table_obj.insert(), batch)
                         table_migrated += len(batch)
+                        total_migrated += len(batch)
+
+                    total_cleaned += batch_cleaned
 
                     offset += batch_size
 
-                total_migrated += table_migrated
-                total_cleaned += table_cleaned
                 total_deduped[table_name] = table_deduped
                 parts = []
                 if table_cleaned:
@@ -345,13 +367,14 @@ def migrate(source_url, target_url, batch_size=5000):
                 status = f"({', '.join(parts)})" if parts else ""
                 print(f"  {table_name:25s}  {table_migrated:>8,d} rows migrated  {status}")
 
-        except (OperationalError, ProgrammingError) as e:
+        except (IntegrityError, OperationalError, ProgrammingError) as e:
             failed_tables.append((table_name, str(e)))
             print(f"  FAIL  {table_name}: {e}")
 
     # --- Post-migration verification ---
     print("\n=== Verification ===")
     verify_ok = True
+    failed_table_names = {name for name, _ in failed_tables}
     for table_name in ALL_TABLES:
         if table_name not in source_tables:
             continue
@@ -359,13 +382,17 @@ def migrate(source_url, target_url, batch_size=5000):
         if table_obj is None:
             continue
 
+        table_identifier = _quote_identifier(table_name)
         with source_engine.connect() as conn:
-            src_count = conn.execute(text(f"SELECT COUNT(*) FROM {table_name}")).scalar()
+            src_count = conn.execute(text(f"SELECT COUNT(*) FROM {table_identifier}")).scalar()
         with target_engine.connect() as conn:
-            tgt_count = conn.execute(text(f"SELECT COUNT(*) FROM {table_name}")).scalar()
+            tgt_count = conn.execute(select(func.count()).select_from(table_obj)).scalar()
 
         deduped = total_deduped.get(table_name, 0)
-        if src_count == tgt_count:
+        if table_name in failed_table_names:
+            match = "FAILED"
+            verify_ok = False
+        elif src_count == tgt_count:
             match = "OK"
         elif deduped and src_count == tgt_count + deduped:
             match = f"OK ({deduped} deduped)"

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -1,3 +1,12 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
 from sqlalchemy import create_engine, text
 
 from comicarr.db_migrate import migrate
@@ -166,3 +175,20 @@ def test_migrate_reports_target_integrity_conflicts(tmp_path, capsys):
     assert "Failed tables: 1" in output
     assert "Verification: FAILED" in output
     assert "Migration completed with issues" in output
+    # Per-table verification must mark the failed table FAILED (not only MISMATCH).
+    assert "source=       3  target=       3  FAILED" in output
+
+    # Prior successful batches stay committed; conflict row must not overwrite target seed.
+    target_engine = create_engine(_sqlite_url(target_path))
+    with target_engine.connect() as conn:
+        rows = {
+            row["ComicID"]: row["ComicName"]
+            for row in conn.execute(text("SELECT ComicID, ComicName FROM comics")).mappings()
+        }
+    target_engine.dispose()
+
+    assert rows == {
+        "first": "migrated before conflict",
+        "second": "also migrated before conflict",
+        "existing": "target row",
+    }

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -1,0 +1,168 @@
+from sqlalchemy import create_engine, text
+
+from comicarr.db_migrate import migrate
+from comicarr.tables import comics, metadata
+
+
+def _sqlite_url(path):
+    return f"sqlite:///{path}"
+
+
+def _create_legacy_comics_database(path, rows):
+    engine = create_engine(_sqlite_url(path))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE comics (ComicID TEXT, ComicName TEXT)"))
+        conn.execute(
+            text("INSERT INTO comics (ComicID, ComicName) VALUES (:comic_id, :comic_name)"),
+            [{"comic_id": comic_id, "comic_name": comic_name} for comic_id, comic_name in rows],
+        )
+    engine.dispose()
+
+
+def _create_legacy_snatched_database(path, rows):
+    engine = create_engine(_sqlite_url(path))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE snatched (IssueID TEXT, Status TEXT, Provider TEXT, ComicName TEXT)"))
+        conn.execute(
+            text(
+                "INSERT INTO snatched (IssueID, Status, Provider, ComicName) "
+                "VALUES (:issue_id, :status, :provider, :comic_name)"
+            ),
+            [
+                {
+                    "issue_id": issue_id,
+                    "status": status,
+                    "provider": provider,
+                    "comic_name": comic_name,
+                }
+                for issue_id, status, provider, comic_name in rows
+            ],
+        )
+    engine.dispose()
+
+
+def test_migrate_deduplicates_unique_keys_across_batches(tmp_path, capsys):
+    source_path = tmp_path / "source.db"
+    target_path = tmp_path / "target.db"
+    _create_legacy_comics_database(
+        source_path,
+        [
+            ("duplicate", "first row wins"),
+            ("", "first empty key wins"),
+            (None, "first null key remains allowed"),
+            ("other", "other row"),
+            ("duplicate", "later row is removed"),
+            ("", "later empty key is removed"),
+            (None, "second null key remains allowed"),
+        ],
+    )
+
+    result = migrate(_sqlite_url(source_path), _sqlite_url(target_path), batch_size=2)
+
+    output = capsys.readouterr().out
+    assert result is True
+    assert "5 rows migrated  (2 deduped)" in output
+    assert "source=       7  target=       5  OK (2 deduped)" in output
+    assert "Total rows migrated: 5" in output
+    assert "Verification: PASSED" in output
+
+    target_engine = create_engine(_sqlite_url(target_path))
+    with target_engine.connect() as conn:
+        rows = conn.execute(text("SELECT ComicID, ComicName FROM comics ORDER BY rowid")).mappings().all()
+    target_engine.dispose()
+
+    assert rows == [
+        {"ComicID": "duplicate", "ComicName": "first row wins"},
+        {"ComicID": "", "ComicName": "first empty key wins"},
+        {"ComicID": None, "ComicName": "first null key remains allowed"},
+        {"ComicID": "other", "ComicName": "other row"},
+        {"ComicID": None, "ComicName": "second null key remains allowed"},
+    ]
+
+
+def test_migrate_deduplicates_composite_keys_with_empty_components(tmp_path, capsys):
+    source_path = tmp_path / "source.db"
+    target_path = tmp_path / "target.db"
+    _create_legacy_snatched_database(
+        source_path,
+        [
+            ("issue-a", "", "provider", "first empty component wins"),
+            (None, "Wanted", "provider", "first null component remains allowed"),
+            ("other", "Wanted", "provider", "other row"),
+            ("issue-a", "", "provider", "later empty component is removed"),
+            (None, "Wanted", "provider", "second null component remains allowed"),
+        ],
+    )
+
+    result = migrate(_sqlite_url(source_path), _sqlite_url(target_path), batch_size=2)
+
+    output = capsys.readouterr().out
+    assert result is True
+    assert "4 rows migrated  (1 deduped)" in output
+    assert "source=       5  target=       4  OK (1 deduped)" in output
+    assert "Verification: PASSED" in output
+
+    target_engine = create_engine(_sqlite_url(target_path))
+    with target_engine.connect() as conn:
+        rows = (
+            conn.execute(text("SELECT IssueID, Status, Provider, ComicName FROM snatched ORDER BY rowid"))
+            .mappings()
+            .all()
+        )
+    target_engine.dispose()
+
+    assert rows == [
+        {
+            "IssueID": "issue-a",
+            "Status": "",
+            "Provider": "provider",
+            "ComicName": "first empty component wins",
+        },
+        {
+            "IssueID": None,
+            "Status": "Wanted",
+            "Provider": "provider",
+            "ComicName": "first null component remains allowed",
+        },
+        {
+            "IssueID": "other",
+            "Status": "Wanted",
+            "Provider": "provider",
+            "ComicName": "other row",
+        },
+        {
+            "IssueID": None,
+            "Status": "Wanted",
+            "Provider": "provider",
+            "ComicName": "second null component remains allowed",
+        },
+    ]
+
+
+def test_migrate_reports_target_integrity_conflicts(tmp_path, capsys):
+    source_path = tmp_path / "source.db"
+    target_path = tmp_path / "target.db"
+    _create_legacy_comics_database(
+        source_path,
+        [
+            ("first", "migrated before conflict"),
+            ("second", "also migrated before conflict"),
+            ("existing", "source row conflicts with target"),
+        ],
+    )
+
+    target_engine = create_engine(_sqlite_url(target_path))
+    metadata.create_all(target_engine)
+    with target_engine.begin() as conn:
+        conn.execute(comics.insert().values(ComicID="existing", ComicName="target row"))
+    target_engine.dispose()
+
+    result = migrate(_sqlite_url(source_path), _sqlite_url(target_path), batch_size=2)
+
+    output = capsys.readouterr().out
+    assert result is False
+    assert "FAIL  comics:" in output
+    assert "Total rows migrated: 2" in output
+    assert "Failed tables: 1" in output
+    assert "Verification: FAILED" in output
+    assert "Migration completed with issues" in output


### PR DESCRIPTION
## Summary

The standalone SQLite-to-PostgreSQL/MySQL migration now tracks unique keys across the entire source table instead of resetting deduplication at every batch boundary. Duplicates split across batches—including empty-string and composite keys—are retained deterministically once, while rows containing `NULL` key components remain allowed by SQL UNIQUE semantics.

Source pagination now has a stable primary-key or SQLite `rowid` order, identifiers are quoted, committed-row/cleaning counters remain accurate across partial failures, and target `IntegrityError` failures are reported as failed tables with failed verification instead of escaping the migration command.

## Testing

- Added proof-first SQLite source/target coverage for cross-batch single, empty-string, composite, and NULL keys; deterministic first-row retention; count reporting; and pre-existing target conflicts.
- Full backend suite: 892 passed.
- Ruff lint and format checks passed.
- Startup help and lockfile checks passed.

## Post-Deploy Monitoring & Validation

- **Window/owner:** Operators should review the complete output of the next database migration before switching Comicarr to the target database.
- **Healthy signals:** Each table reports expected migrated/deduped counts, verification is `PASSED`, and the process exits successfully.
- **Watch:** `FAIL`, `MISMATCH`, `IntegrityError`, unexpectedly high dedupe counts, memory pressure, and long-running OFFSET batches.
- **Failure trigger:** Any failed table, verification mismatch, or target count inconsistent with source minus reported dedupes means the target must not be used.
- **Mitigation:** Discard/recreate the incomplete target database, retain the source SQLite file, inspect the reported table/key collision, and rerun after correcting the source or target state.

## Known Limitations

- Table-wide unique-key tracking uses memory proportional to unique source keys.
- Existing OFFSET pagination may be slower for very large legacy tables.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
