### PR TITLE
fix: migrate legacy SQLite unique constraints

### DIFF
--- a/.changeset/migrate-sqlite-upsert-constraints.md
+++ b/.changeset/migrate-sqlite-upsert-constraints.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Repair atomic upserts on legacy SQLite databases with an isolated safety snapshot and transactional unique indexes that preserve historical null or empty-key rows.

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -1690,9 +1690,7 @@ def _build_upsert_unique_constraints():
     for table_name, constraint_name in _UPSERT_UNIQUE_CONSTRAINT_NAMES.items():
         key_cols = UPSERT_KEYS.get(table_name)
         if not key_cols:
-            raise RuntimeError(
-                "[UNIQUE-MIGRATION] UPSERT_KEYS has no entry for allowlisted table %s" % table_name
-            )
+            raise RuntimeError("[UNIQUE-MIGRATION] UPSERT_KEYS has no entry for allowlisted table %s" % table_name)
         constraints[table_name] = (list(key_cols), constraint_name)
     return constraints
 
@@ -1926,10 +1924,7 @@ def _mysql_dedup_valid_keys(conn, table_name, key_cols):
 
 
 def _add_unique_constraint_sql(quoted_table, quoted_constraint, quoted_keys):
-    return (
-        f"ALTER TABLE {quoted_table} ADD CONSTRAINT {quoted_constraint} "
-        f"UNIQUE ({', '.join(quoted_keys)})"
-    )
+    return f"ALTER TABLE {quoted_table} ADD CONSTRAINT {quoted_constraint} UNIQUE ({', '.join(quoted_keys)})"
 
 
 def _backup_sqlite_unique_migration(engine, backup_func=None):

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -20,6 +20,7 @@
 
 import csv
 import datetime
+import hashlib
 import itertools
 import json
 import locale
@@ -42,7 +43,7 @@ import requests
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy import inspect, text
-from sqlalchemy.exc import OperationalError, ProgrammingError
+from sqlalchemy.exc import OperationalError, ProgrammingError, SQLAlchemyError
 
 import comicarr.config
 from comicarr import (
@@ -1651,85 +1652,281 @@ def dbcheck():
         helpers.upgrade_dynamic()
 
 
-def _migrate_unique_constraints(engine):
-    """Add UNIQUE constraints to tables that need them for atomic upserts.
+_UPSERT_UNIQUE_CONSTRAINTS = {
+    "issues": (["IssueID"], "uq_issues_issueid"),
+    "annuals": (["IssueID"], "uq_annuals_issueid"),
+    "storyarcs": (["IssueArcID"], "uq_storyarcs_issuearcid"),
+    "readlist": (["IssueID"], "uq_readlist_issueid"),
+    "failed": (["ID", "Provider", "NZBName"], "uq_failed_id_provider_nzbname"),
+    "upcoming": (["ComicID", "IssueNumber"], "uq_upcoming_comicid_issuenum"),
+    "nzblog": (["IssueID", "PROVIDER"], "uq_nzblog_issueid_provider"),
+    "importresults": (["impID"], "uq_importresults_impid"),
+    "jobhistory": (["JobName"], "uq_jobhistory_jobname"),
+    "snatched": (["IssueID", "Status", "Provider"], "uq_snatched_issue_status_provider"),
+    "oneoffhistory": (["ComicID", "IssueID"], "uq_oneoffhistory_comicid_issueid"),
+    "weekly": (["ComicID", "IssueID"], "uq_weekly_comicid_issueid"),
+}
 
-    For SQLite, this requires table recreation (cannot ALTER TABLE ADD CONSTRAINT).
-    For PostgreSQL/MySQL, uses ALTER TABLE ADD CONSTRAINT directly.
 
-    Only runs once — skips if constraints already exist.
-    """
-    from comicarr.db import get_dialect
+def _index_has_partial_predicate(index):
+    dialect_options = index.get("dialect_options") or {}
+    if any(name.endswith("_where") and value is not None for name, value in dialect_options.items()):
+        return True
+    return any(index.get(name) is not None for name in ("filter_definition", "predicate", "where"))
 
-    dialect = get_dialect()
 
-    # Tables needing UNIQUE constraints and their key columns
-    # Tables that already have them (comics, rssdb, ref32p, ddl_info, exceptions_log,
-    # tmp_searches, notifs, provider_searches, mylar_info) are skipped.
-    constraint_map = {
-        "issues": (["IssueID"], "uq_issues_issueid"),
-        "annuals": (["IssueID"], "uq_annuals_issueid"),
-        "storyarcs": (["IssueArcID"], "uq_storyarcs_issuearcid"),
-        "readlist": (["IssueID"], "uq_readlist_issueid"),
-        "failed": (["ID", "Provider", "NZBName"], "uq_failed_id_provider_nzbname"),
-        "upcoming": (["ComicID", "IssueNumber"], "uq_upcoming_comicid_issuenum"),
-        "nzblog": (["IssueID", "PROVIDER"], "uq_nzblog_issueid_provider"),
-        "importresults": (["impID"], "uq_importresults_impid"),
-        "jobhistory": (["JobName"], "uq_jobhistory_jobname"),
-        "snatched": (["IssueID", "Status", "Provider"], "uq_snatched_issue_status_provider"),
-        "oneoffhistory": (["ComicID", "IssueID"], "uq_oneoffhistory_comicid_issueid"),
-        "weekly": (["ComicID", "IssueID"], "uq_weekly_comicid_issueid"),
-    }
-
+def _has_unique_enforcement(engine, table_name, key_cols):
+    """Return whether a table has a unique constraint or index on ``key_cols``."""
     inspector = inspect(engine)
+    expected_columns = tuple(sorted(key_cols))
+    constraints = inspector.get_unique_constraints(table_name)
+    constraint_columns = {tuple(sorted(constraint.get("column_names") or [])) for constraint in constraints}
+    if expected_columns in constraint_columns:
+        return True
 
-    for table_name, (key_cols, constraint_name) in constraint_map.items():
-        # Check if constraint already exists
-        try:
-            existing_uq = inspector.get_unique_constraints(table_name)
-            existing_uq_names = {u.get("name") for u in existing_uq}
-            if constraint_name in existing_uq_names:
-                continue
-            # Also check if columns already have unique constraints by column set
-            existing_col_sets = {tuple(sorted(u.get("column_names", []))) for u in existing_uq}
-            if tuple(sorted(key_cols)) in existing_col_sets:
-                continue
-        except Exception:
+    for index in inspector.get_indexes(table_name):
+        index_columns = tuple(sorted(index.get("column_names") or []))
+        if not index.get("unique") or index_columns != expected_columns:
+            continue
+        if engine.dialect.name != "sqlite":
+            if not _index_has_partial_predicate(index):
+                return True
             continue
 
-        logger.info("Adding UNIQUE constraint %s on %s(%s)", constraint_name, table_name, ", ".join(key_cols))
+        sqlite_where = (index.get("dialect_options") or {}).get("sqlite_where")
+        if sqlite_where is None:
+            if not _index_has_partial_predicate(index):
+                return True
+        elif _sqlite_valid_key_predicate_matches(sqlite_where, key_cols):
+            return True
 
-        # Deduplicate first — keep row with highest rowid
-        null_checks = " AND ".join(f"{k} IS NOT NULL AND {k} != ''" for k in key_cols)
-        dedup_sql = (
-            f"DELETE FROM {table_name} WHERE rowid NOT IN ("
-            f"SELECT MAX(rowid) FROM {table_name} WHERE {null_checks} GROUP BY {', '.join(key_cols)}"
-            f") AND {null_checks}"
-        )
+    return False
+
+
+def _valid_key_predicate(columns):
+    return " AND ".join(f"{column} IS NOT NULL AND {column} != ''" for column in columns)
+
+
+def _canonical_sqlite_predicate(predicate):
+    predicate_sql = re.sub(r'["`\[\]]', "", str(predicate))
+    predicate_sql = predicate_sql.replace("<>", "!=")
+    predicate_sql = re.sub(r"[()]", "", predicate_sql)
+    predicate_sql = re.sub(r"\s*!=\s*", " != ", predicate_sql)
+    return re.sub(r"\s+", " ", predicate_sql).strip().casefold()
+
+
+def _sqlite_valid_key_predicate_matches(predicate, key_cols):
+    expected_predicate = _valid_key_predicate(key_cols)
+    return _canonical_sqlite_predicate(predicate) == _canonical_sqlite_predicate(expected_predicate)
+
+
+def _sqlite_unique_index_sql(engine, table_name, key_cols, constraint_name):
+    """Build a safely quoted partial UNIQUE index for valid legacy keys."""
+    quote = engine.dialect.identifier_preparer.quote_identifier
+    quoted_columns = [quote(column) for column in key_cols]
+    valid_key_predicate = _valid_key_predicate(quoted_columns)
+    return (
+        f"CREATE UNIQUE INDEX {quote(constraint_name)} ON {quote(table_name)} "
+        f"({', '.join(quoted_columns)}) WHERE {valid_key_predicate}"
+    )
+
+
+def _sqlite_database_path(engine):
+    database = engine.url.database
+    database_name = str(database).casefold() if database else ""
+    if not database or database_name == ":memory:":
+        return None
+
+    uri = engine.url.query.get("uri")
+    uri_values = uri if isinstance(uri, (tuple, list)) else (uri,)
+    uri_mode_enabled = any(
+        value is not None and str(value).casefold() in {"1", "true", "yes", "on"} for value in uri_values
+    )
+    if not uri_mode_enabled:
+        return os.path.abspath(os.path.expanduser(str(database)))
+
+    if database_name.startswith("file:"):
+        mode = engine.url.query.get("mode")
+        mode_values = mode if isinstance(mode, (tuple, list)) else (mode,)
+        if any(value is not None and str(value).casefold() == "memory" for value in mode_values):
+            return None
+
+        if database_name.startswith("file::memory:"):
+            return None
+
+    with engine.connect() as conn:
+        for _sequence, schema_name, database_path in conn.exec_driver_sql("PRAGMA database_list"):
+            if schema_name == "main" and database_path:
+                return os.path.abspath(os.path.expanduser(database_path))
+    return os.path.abspath(os.path.expanduser(str(database)))
+
+
+def _backup_sqlite_unique_migration(engine, backup_func=None):
+    """Create the mandatory WAL-safe backup for a destructive SQLite migration."""
+    source_path = _sqlite_database_path(engine)
+    if source_path is None:
+        return
+
+    data_dir = getattr(comicarr, "DATA_DIR", None) or os.path.dirname(source_path)
+    backup_dir = os.path.join(data_dir, "backups", "migrations")
+    config = getattr(comicarr, "CONFIG", None)
+    retention = getattr(config, "BACKUP_RETENTION", 4) if config is not None else 4
+    retention = retention or 4
+    backup = backup_func or maintenance.auto_backup_db
+
+    try:
+        backup_succeeded = backup(source_path, backup_dir, retention)
+    except Exception as e:
+        message = "SQLite unique-constraint backup failed before migration"
+        logger.error("%s: %s", message, e)
+        raise RuntimeError(message) from e
+
+    if not backup_succeeded:
+        message = "SQLite unique-constraint backup failed; migration was not started"
+        logger.error(message)
+        raise RuntimeError(message)
+
+
+def _pending_unique_constraints(engine):
+    pending = []
+    inspector = inspect(engine)
+    for table_name, (key_cols, constraint_name) in _UPSERT_UNIQUE_CONSTRAINTS.items():
         try:
-            with engine.begin() as conn:
-                conn.execute(text(dedup_sql))
-        except (OperationalError, ProgrammingError) as e:
-            logger.warn("Dedup on %s failed (non-fatal): %s", table_name, e)
+            if not inspector.has_table(table_name):
+                continue
+            if not _has_unique_enforcement(engine, table_name, key_cols):
+                pending.append((table_name, key_cols, constraint_name))
+        except SQLAlchemyError as e:
+            logger.warn("Could not inspect UNIQUE enforcement for %s: %s", table_name, e)
+    return pending
+
+
+def _bounded_alternate_index_name(engine, constraint_name, table_name, key_cols, attempt):
+    max_length = max(int(getattr(engine.dialect, "max_identifier_length", 128) or 128), 1)
+    identity = f"{table_name}|{','.join(key_cols)}|{attempt}"
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:12]
+    suffix = f"_ca_{digest}"
+    if len(suffix) >= max_length:
+        return digest[:max_length]
+    return f"{constraint_name[: max_length - len(suffix)]}{suffix}"
+
+
+def _sqlite_available_index_name(engine, constraint_name, table_name, key_cols):
+    with engine.connect() as conn:
+        existing_names = {
+            str(name).casefold()
+            for name in conn.execute(
+                text("SELECT name FROM sqlite_master WHERE type = 'index' AND name IS NOT NULL")
+            ).scalars()
+        }
+
+    max_length = max(int(getattr(engine.dialect, "max_identifier_length", 128) or 128), 1)
+    if len(constraint_name) <= max_length and constraint_name.casefold() not in existing_names:
+        return constraint_name
+
+    for attempt in range(100):
+        candidate = _bounded_alternate_index_name(engine, constraint_name, table_name, key_cols, attempt)
+        if candidate.casefold() not in existing_names:
+            return candidate
+    raise RuntimeError(f"Could not allocate a unique index name for {table_name}")
+
+
+def _migrate_unique_constraints(engine, backup_func=None):
+    """Install the unique enforcement required by atomic upserts.
+
+    Legacy SQLite databases receive partial unique indexes so duplicate null or
+    empty keys remain valid. File-backed databases are backed up once after
+    preflight and before the first deduplication. Each table's deterministic
+    deduplication and index creation share one transaction, ensuring a failed
+    DDL statement restores the rows deleted by that attempt.
+    """
+    dialect = engine.dialect.name
+
+    # Tables that already have enforcement (comics, rssdb, ref32p, ddl_info,
+    # exceptions_log, tmp_searches, notifs, provider_searches, mylar_info) are
+    # intentionally outside _UPSERT_UNIQUE_CONSTRAINTS.
+    pending_constraints = _pending_unique_constraints(engine)
+    if not pending_constraints:
+        return
+
+    if dialect == "sqlite":
+        _backup_sqlite_unique_migration(engine, backup_func)
+
+    for table_name, key_cols, constraint_name in pending_constraints:
+        try:
+            if _has_unique_enforcement(engine, table_name, key_cols):
+                continue
+        except SQLAlchemyError as e:
+            logger.warn("Could not recheck UNIQUE enforcement for %s: %s", table_name, e)
+            continue
+
+        quote = engine.dialect.identifier_preparer.quote_identifier
+        quoted_table = quote(table_name)
+        quoted_keys = [quote(column) for column in key_cols]
+        valid_key_predicate = _valid_key_predicate(quoted_keys)
+        dedup_sql = (
+            f"DELETE FROM {quoted_table} WHERE rowid NOT IN ("
+            f"SELECT MAX(rowid) FROM {quoted_table} WHERE {valid_key_predicate} "
+            f"GROUP BY {', '.join(quoted_keys)}"
+            f") AND {valid_key_predicate}"
+        )
 
         if dialect == "sqlite":
-            # SQLite cannot ALTER TABLE ADD CONSTRAINT — must recreate table
-            # Skip for now; the constraint exists in tables.py for new databases.
-            # Existing SQLite databases will use the non-atomic upsert fallback
-            # until the user runs the migration tool.
-            logger.info(
-                "SQLite: UNIQUE constraint %s defined in schema for new databases. "
-                "Existing database will use legacy upsert until migration.",
-                constraint_name,
-            )
-        else:
-            # PostgreSQL / MySQL: add constraint directly
-            cols = ", ".join(key_cols)
+            index_name = _sqlite_available_index_name(engine, constraint_name, table_name, key_cols)
+            index_sql = _sqlite_unique_index_sql(engine, table_name, key_cols, index_name)
             try:
                 with engine.begin() as conn:
-                    conn.execute(text(f"ALTER TABLE {table_name} ADD CONSTRAINT {constraint_name} UNIQUE ({cols})"))
+                    conn.execute(text(dedup_sql))
+                    conn.execute(text(index_sql))
+            except SQLAlchemyError as e:
+                logger.warn(
+                    "Could not add SQLite UNIQUE index %s on %s; changes rolled back: %s",
+                    index_name,
+                    table_name,
+                    e,
+                )
+                continue
+        else:
+            index_name = constraint_name
+            # Keep the legacy non-SQLite sequence: rowid deduplication is
+            # best-effort, then the database-native constraint is attempted.
+            try:
+                with engine.begin() as conn:
+                    conn.execute(text(dedup_sql))
+            except (OperationalError, ProgrammingError) as e:
+                logger.warn("Dedup on %s failed (non-fatal): %s", table_name, e)
+
+            try:
+                with engine.begin() as conn:
+                    conn.execute(
+                        text(
+                            f"ALTER TABLE {quoted_table} ADD CONSTRAINT {quote(constraint_name)} "
+                            f"UNIQUE ({', '.join(quoted_keys)})"
+                        )
+                    )
             except (OperationalError, ProgrammingError) as e:
                 logger.warn("Could not add constraint %s: %s", constraint_name, e)
+                continue
+
+        try:
+            constraint_installed = _has_unique_enforcement(engine, table_name, key_cols)
+        except SQLAlchemyError as e:
+            logger.warn("Could not verify UNIQUE enforcement for %s: %s", table_name, e)
+            continue
+
+        if constraint_installed:
+            logger.info(
+                "Added UNIQUE enforcement %s on %s(%s)",
+                index_name,
+                table_name,
+                ", ".join(key_cols),
+            )
+        else:
+            logger.warn(
+                "UNIQUE enforcement %s on %s was not installed",
+                constraint_name,
+                table_name,
+            )
 
     # if to_the_rss_update is True:
     #    comicarr.MAINTENANCE = True

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -20,6 +20,7 @@
 
 import csv
 import datetime
+import glob
 import hashlib
 import itertools
 import json
@@ -482,6 +483,11 @@ def initialize(config_file):
         logger.info("Checking to see if the database has all tables....")
         try:
             dbcheck()
+        except RuntimeError as e:
+            # Unique-constraint backup/migration aborts must fail closed — do not
+            # soft-catch them as a generic "Cannot connect to the database".
+            logger.error("[UNIQUE-MIGRATION] Refusing startup after migration abort: %s" % e)
+            raise
         except Exception as e:
             logger.error("Cannot connect to the database: %s" % e)
         else:
@@ -1652,20 +1658,46 @@ def dbcheck():
         helpers.upgrade_dynamic()
 
 
-_UPSERT_UNIQUE_CONSTRAINTS = {
-    "issues": (["IssueID"], "uq_issues_issueid"),
-    "annuals": (["IssueID"], "uq_annuals_issueid"),
-    "storyarcs": (["IssueArcID"], "uq_storyarcs_issuearcid"),
-    "readlist": (["IssueID"], "uq_readlist_issueid"),
-    "failed": (["ID", "Provider", "NZBName"], "uq_failed_id_provider_nzbname"),
-    "upcoming": (["ComicID", "IssueNumber"], "uq_upcoming_comicid_issuenum"),
-    "nzblog": (["IssueID", "PROVIDER"], "uq_nzblog_issueid_provider"),
-    "importresults": (["impID"], "uq_importresults_impid"),
-    "jobhistory": (["JobName"], "uq_jobhistory_jobname"),
-    "snatched": (["IssueID", "Status", "Provider"], "uq_snatched_issue_status_provider"),
-    "oneoffhistory": (["ComicID", "IssueID"], "uq_oneoffhistory_comicid_issueid"),
-    "weekly": (["ComicID", "IssueID"], "uq_weekly_comicid_issueid"),
+# Explicit allowlist of legacy tables that need migration-time UNIQUE enforcement.
+# Key columns are derived from tables.UPSERT_KEYS so constraint targets stay aligned
+# with atomic upserts. Tables that already ship with enforcement (comics, rssdb,
+# ref32p, ddl_info, exceptions_log, tmp_searches, notifs, provider_searches,
+# mylar_info, ...) are intentionally excluded.
+_UPSERT_UNIQUE_CONSTRAINT_NAMES = {
+    "issues": "uq_issues_issueid",
+    "annuals": "uq_annuals_issueid",
+    "storyarcs": "uq_storyarcs_issuearcid",
+    "readlist": "uq_readlist_issueid",
+    "failed": "uq_failed_id_provider_nzbname",
+    "upcoming": "uq_upcoming_comicid_issuenum",
+    "nzblog": "uq_nzblog_issueid_provider",
+    "importresults": "uq_importresults_impid",
+    "jobhistory": "uq_jobhistory_jobname",
+    "snatched": "uq_snatched_issue_status_provider",
+    "oneoffhistory": "uq_oneoffhistory_comicid_issueid",
+    "weekly": "uq_weekly_comicid_issueid",
 }
+
+# Fixed-name pre-dedup snapshot; excluded from auto_backup_db timestamp rotation.
+_PRE_UNIQUE_MIGRATION_BACKUP = "comicarr.db.pre-unique-migration.bak"
+
+
+def _build_upsert_unique_constraints():
+    """Map allowlisted tables to (key_cols from UPSERT_KEYS, constraint name)."""
+    from comicarr.tables import UPSERT_KEYS
+
+    constraints = {}
+    for table_name, constraint_name in _UPSERT_UNIQUE_CONSTRAINT_NAMES.items():
+        key_cols = UPSERT_KEYS.get(table_name)
+        if not key_cols:
+            raise RuntimeError(
+                "[UNIQUE-MIGRATION] UPSERT_KEYS has no entry for allowlisted table %s" % table_name
+            )
+        constraints[table_name] = (list(key_cols), constraint_name)
+    return constraints
+
+
+_UPSERT_UNIQUE_CONSTRAINTS = _build_upsert_unique_constraints()
 
 
 def _index_has_partial_predicate(index):
@@ -1761,14 +1793,178 @@ def _sqlite_database_path(engine):
     return os.path.abspath(os.path.expanduser(str(database)))
 
 
+def _row_identity_column(dialect):
+    """Return the dialect-native physical row identity used for deduplication."""
+    if dialect == "sqlite":
+        return "rowid"
+    if dialect == "postgresql":
+        return "ctid"
+    return None
+
+
+# Library tables where MAX(rowid) can discard an older complete copy in favor of
+# a newer refresh stub. Prefer Location / completion Status over pure LWW.
+_LIBRARY_QUALITY_DEDUP_TABLES = frozenset({"issues", "annuals", "readlist", "storyarcs"})
+
+
+def _status_rank_sql(quoted_status_column):
+    """Higher is better — prefer completed/on-disk states over Wanted stubs."""
+    return (
+        f"CASE {quoted_status_column} "
+        f"WHEN 'Downloaded' THEN 50 "
+        f"WHEN 'Archived' THEN 50 "
+        f"WHEN 'Snatched' THEN 40 "
+        f"WHEN 'Failed' THEN 20 "
+        f"WHEN 'Wanted' THEN 10 "
+        f"WHEN 'Skipped' THEN 10 "
+        f"ELSE 15 END"
+    )
+
+
+def _library_quality_order_sql(quote, column_names, row_identity):
+    """ORDER BY clause for library-quality survivor selection (DESC ranks first)."""
+    columns = {name.casefold() for name in column_names}
+    order_parts = []
+    if "location" in columns:
+        loc = quote("Location")
+        order_parts.append(f"CASE WHEN {loc} IS NOT NULL AND {loc} != '' THEN 1 ELSE 0 END DESC")
+    if "status" in columns:
+        order_parts.append(f"{_status_rank_sql(quote('Status'))} DESC")
+    # Final tie-breaker: highest physical row id (legacy LWW).
+    order_parts.append(f"{row_identity} DESC")
+    return ", ".join(order_parts)
+
+
+def _dedup_delete_sql(
+    dialect,
+    quoted_table,
+    quoted_keys,
+    valid_key_predicate,
+    table_name=None,
+    column_names=None,
+    quote=None,
+):
+    """Build DELETE that keeps one row per valid key group.
+
+    Default is MAX(rowid/ctid). For library tables with Status/Location columns,
+    prefer non-empty Location and stronger Status, then row identity.
+    """
+    row_identity = _row_identity_column(dialect)
+    if row_identity is None:
+        return None
+
+    use_quality = (
+        table_name in _LIBRARY_QUALITY_DEDUP_TABLES
+        and column_names is not None
+        and quote is not None
+        and ({name.casefold() for name in column_names} & {"location", "status"})
+    )
+    if not use_quality:
+        group_by = ", ".join(quoted_keys)
+        return (
+            f"DELETE FROM {quoted_table} WHERE {row_identity} NOT IN ("
+            f"SELECT MAX({row_identity}) FROM {quoted_table} WHERE {valid_key_predicate} "
+            f"GROUP BY {group_by}"
+            f") AND {valid_key_predicate}"
+        )
+
+    partition = ", ".join(quoted_keys)
+    order_by = _library_quality_order_sql(quote, column_names, row_identity)
+    # Delete every non-winner (rn > 1) among valid-key rows.
+    return (
+        f"DELETE FROM {quoted_table} WHERE {row_identity} IN ("
+        f"SELECT {row_identity} FROM ("
+        f"SELECT {row_identity}, ROW_NUMBER() OVER ("
+        f"PARTITION BY {partition} ORDER BY {order_by}"
+        f") AS _comicarr_rn FROM {quoted_table} WHERE {valid_key_predicate}"
+        f") AS _comicarr_ranked WHERE _comicarr_rn > 1"
+        f")"
+    )
+
+
+def _mysql_dedup_valid_keys(conn, table_name, key_cols):
+    """Remove duplicate valid-key rows on MySQL/MariaDB primary-less tables.
+
+    Legacy Comicarr tables often lack a primary key, so MySQL has no rowid/ctid.
+    For each valid key group with count C > 1, DELETE ... LIMIT C-1 keeps one
+    arbitrary survivor. Must run in the same connection/transaction as ADD CONSTRAINT
+    where the engine allows (MySQL DDL may still implicitly commit).
+    """
+    quote = conn.dialect.identifier_preparer.quote_identifier
+    quoted_table = quote(table_name)
+    quoted_keys = [quote(column) for column in key_cols]
+    valid_key_predicate = _valid_key_predicate(quoted_keys)
+    group_by = ", ".join(quoted_keys)
+
+    dup_rows = (
+        conn.execute(
+            text(
+                f"SELECT {group_by}, COUNT(*) AS _comicarr_cnt FROM {quoted_table} "
+                f"WHERE {valid_key_predicate} "
+                f"GROUP BY {group_by} HAVING COUNT(*) > 1"
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    for row in dup_rows:
+        cnt = int(row["_comicarr_cnt"])
+        if cnt < 2:
+            continue
+        predicates = []
+        params = {}
+        for index, column in enumerate(key_cols):
+            param = f"k{index}"
+            predicates.append(f"{quote(column)} = :{param}")
+            params[param] = row[column]
+        where_clause = " AND ".join(predicates) + " AND " + valid_key_predicate
+        conn.execute(
+            text(f"DELETE FROM {quoted_table} WHERE {where_clause} LIMIT {cnt - 1}"),
+            params,
+        )
+
+
+def _add_unique_constraint_sql(quoted_table, quoted_constraint, quoted_keys):
+    return (
+        f"ALTER TABLE {quoted_table} ADD CONSTRAINT {quoted_constraint} "
+        f"UNIQUE ({', '.join(quoted_keys)})"
+    )
+
+
 def _backup_sqlite_unique_migration(engine, backup_func=None):
-    """Create the mandatory WAL-safe backup for a destructive SQLite migration."""
+    """Create the mandatory WAL-safe backup for a destructive SQLite migration.
+
+    Backups are co-located with the live database file under
+    ``<db-dir>/backups/migrations/``. A fixed-name pin
+    (``comicarr.db.pre-unique-migration.bak``) is written once and preserved
+    across retention rotation of timestamped backups.
+    """
     source_path = _sqlite_database_path(engine)
     if source_path is None:
         return
 
-    data_dir = getattr(comicarr, "DATA_DIR", None) or os.path.dirname(source_path)
-    backup_dir = os.path.join(data_dir, "backups", "migrations")
+    # Prefer the live DB directory over DATA_DIR when they differ (e.g. custom DB path).
+    backup_dir = os.path.join(os.path.dirname(source_path), "backups", "migrations")
+    pin_path = os.path.join(backup_dir, _PRE_UNIQUE_MIGRATION_BACKUP)
+    abs_source = os.path.abspath(source_path)
+    abs_backup_dir = os.path.abspath(backup_dir)
+    abs_pin = os.path.abspath(pin_path)
+
+    logger.info(
+        "[UNIQUE-MIGRATION] Pre-migration backup source=%s dest_dir=%s pin=%s",
+        abs_source,
+        abs_backup_dir,
+        abs_pin,
+    )
+
+    if os.path.isfile(pin_path):
+        logger.info(
+            "[UNIQUE-MIGRATION] Reusing existing pre-unique-migration pin backup at %s",
+            abs_pin,
+        )
+        return
+
     config = getattr(comicarr, "CONFIG", None)
     retention = getattr(config, "BACKUP_RETENTION", 4) if config is not None else 4
     retention = retention or 4
@@ -1778,13 +1974,30 @@ def _backup_sqlite_unique_migration(engine, backup_func=None):
         backup_succeeded = backup(source_path, backup_dir, retention)
     except Exception as e:
         message = "SQLite unique-constraint backup failed before migration"
-        logger.error("%s: %s", message, e)
+        logger.error("[UNIQUE-MIGRATION] %s: %s", message, e)
         raise RuntimeError(message) from e
 
     if not backup_succeeded:
         message = "SQLite unique-constraint backup failed; migration was not started"
-        logger.error(message)
+        logger.error("[UNIQUE-MIGRATION] %s", message)
         raise RuntimeError(message)
+
+    # Pin the first successful pre-dedup snapshot under a fixed name so later
+    # timestamped rotation cannot remove the migration restore point.
+    if not os.path.isfile(pin_path):
+        timestamped = sorted(
+            path
+            for path in glob.glob(os.path.join(backup_dir, "comicarr.db.*.bak"))
+            if re.match(r"^comicarr\.db\.\d{8}_\d{6}\.bak$", os.path.basename(path))
+        )
+        if timestamped:
+            try:
+                shutil.copy2(timestamped[-1], pin_path)
+                logger.info("[UNIQUE-MIGRATION] Wrote pre-unique-migration pin backup to %s", abs_pin)
+            except OSError as e:
+                message = "SQLite unique-constraint pin backup failed before migration"
+                logger.error("[UNIQUE-MIGRATION] %s: %s", message, e)
+                raise RuntimeError(message) from e
 
 
 def _pending_unique_constraints(engine):
@@ -1797,8 +2010,27 @@ def _pending_unique_constraints(engine):
             if not _has_unique_enforcement(engine, table_name, key_cols):
                 pending.append((table_name, key_cols, constraint_name))
         except SQLAlchemyError as e:
-            logger.warn("Could not inspect UNIQUE enforcement for %s: %s", table_name, e)
+            logger.warn("[UNIQUE-MIGRATION] Could not inspect UNIQUE enforcement for %s: %s", table_name, e)
     return pending
+
+
+def _remaining_unenforced_tables(engine, pending_constraints):
+    """Return allowlisted table names from ``pending_constraints`` still lacking enforcement."""
+    remaining = []
+    for table_name, key_cols, _constraint_name in pending_constraints:
+        try:
+            if not inspect(engine).has_table(table_name):
+                continue
+            if not _has_unique_enforcement(engine, table_name, key_cols):
+                remaining.append(table_name)
+        except SQLAlchemyError as e:
+            logger.warn(
+                "[UNIQUE-MIGRATION] Could not verify UNIQUE enforcement for %s after migration: %s",
+                table_name,
+                e,
+            )
+            remaining.append(table_name)
+    return remaining
 
 
 def _bounded_alternate_index_name(engine, constraint_name, table_name, key_cols, attempt):
@@ -1839,6 +2071,9 @@ def _migrate_unique_constraints(engine, backup_func=None):
     preflight and before the first deduplication. Each table's deterministic
     deduplication and index creation share one transaction, ensuring a failed
     DDL statement restores the rows deleted by that attempt.
+
+    After the per-table loop, any still-pending tables cause a RuntimeError so
+    startup fails closed rather than soft-succeeding without enforcement.
     """
     dialect = engine.dialect.name
 
@@ -1857,19 +2092,32 @@ def _migrate_unique_constraints(engine, backup_func=None):
             if _has_unique_enforcement(engine, table_name, key_cols):
                 continue
         except SQLAlchemyError as e:
-            logger.warn("Could not recheck UNIQUE enforcement for %s: %s", table_name, e)
-            continue
+            # Recheck failure must not skip the table — only confirmed enforcement skips work.
+            logger.warn(
+                "[UNIQUE-MIGRATION] Could not recheck UNIQUE enforcement for %s; proceeding with migration: %s",
+                table_name,
+                e,
+            )
 
         quote = engine.dialect.identifier_preparer.quote_identifier
         quoted_table = quote(table_name)
         quoted_keys = [quote(column) for column in key_cols]
         valid_key_predicate = _valid_key_predicate(quoted_keys)
-        dedup_sql = (
-            f"DELETE FROM {quoted_table} WHERE rowid NOT IN ("
-            f"SELECT MAX(rowid) FROM {quoted_table} WHERE {valid_key_predicate} "
-            f"GROUP BY {', '.join(quoted_keys)}"
-            f") AND {valid_key_predicate}"
+        try:
+            column_names = [col["name"] for col in inspect(engine).get_columns(table_name)]
+        except SQLAlchemyError:
+            column_names = []
+        dedup_sql = _dedup_delete_sql(
+            dialect,
+            quoted_table,
+            quoted_keys,
+            valid_key_predicate,
+            table_name=table_name,
+            column_names=column_names,
+            quote=quote,
         )
+        constraint_sql = _add_unique_constraint_sql(quoted_table, quote(constraint_name), quoted_keys)
+        index_name = constraint_name
 
         if dialect == "sqlite":
             index_name = _sqlite_available_index_name(engine, constraint_name, table_name, key_cols)
@@ -1880,57 +2128,71 @@ def _migrate_unique_constraints(engine, backup_func=None):
                     conn.execute(text(index_sql))
             except SQLAlchemyError as e:
                 logger.warn(
-                    "Could not add SQLite UNIQUE index %s on %s; changes rolled back: %s",
+                    "[UNIQUE-MIGRATION] Could not add SQLite UNIQUE index %s on %s; changes rolled back: %s",
                     index_name,
                     table_name,
                     e,
                 )
                 continue
-        else:
-            index_name = constraint_name
-            # Keep the legacy non-SQLite sequence: rowid deduplication is
-            # best-effort, then the database-native constraint is attempted.
+        elif dialect == "postgresql":
             try:
                 with engine.begin() as conn:
                     conn.execute(text(dedup_sql))
-            except (OperationalError, ProgrammingError) as e:
-                logger.warn("Dedup on %s failed (non-fatal): %s", table_name, e)
-
+                    conn.execute(text(constraint_sql))
+            except SQLAlchemyError as e:
+                logger.warn(
+                    "[UNIQUE-MIGRATION] Could not add PostgreSQL UNIQUE constraint %s on %s; changes rolled back: %s",
+                    constraint_name,
+                    table_name,
+                    e,
+                )
+                continue
+        elif dialect == "mysql":
             try:
                 with engine.begin() as conn:
-                    conn.execute(
-                        text(
-                            f"ALTER TABLE {quoted_table} ADD CONSTRAINT {quote(constraint_name)} "
-                            f"UNIQUE ({', '.join(quoted_keys)})"
-                        )
-                    )
-            except (OperationalError, ProgrammingError) as e:
-                logger.warn("Could not add constraint %s: %s", constraint_name, e)
+                    _mysql_dedup_valid_keys(conn, table_name, key_cols)
+                    conn.execute(text(constraint_sql))
+            except SQLAlchemyError as e:
+                logger.warn(
+                    "[UNIQUE-MIGRATION] Could not add MySQL UNIQUE constraint %s on %s; changes rolled back: %s",
+                    constraint_name,
+                    table_name,
+                    e,
+                )
                 continue
+        else:
+            logger.warn(
+                "[UNIQUE-MIGRATION] Unsupported dialect %s for unique-constraint migration on %s",
+                dialect,
+                table_name,
+            )
+            continue
 
         try:
             constraint_installed = _has_unique_enforcement(engine, table_name, key_cols)
         except SQLAlchemyError as e:
-            logger.warn("Could not verify UNIQUE enforcement for %s: %s", table_name, e)
+            logger.warn("[UNIQUE-MIGRATION] Could not verify UNIQUE enforcement for %s: %s", table_name, e)
             continue
 
         if constraint_installed:
             logger.info(
-                "Added UNIQUE enforcement %s on %s(%s)",
+                "[UNIQUE-MIGRATION] Added UNIQUE enforcement %s on %s(%s)",
                 index_name,
                 table_name,
                 ", ".join(key_cols),
             )
         else:
             logger.warn(
-                "UNIQUE enforcement %s on %s was not installed",
+                "[UNIQUE-MIGRATION] UNIQUE enforcement %s on %s was not installed",
                 constraint_name,
                 table_name,
             )
 
-    # if to_the_rss_update is True:
-    #    comicarr.MAINTENANCE = True
-    #    comicarr.MAINTENANCE_DB_TOTAL = 1 # set this to 1 to kick it.
+    remaining = _remaining_unenforced_tables(engine, pending_constraints)
+    if remaining:
+        message = "Unique-constraint migration incomplete for: %s" % ", ".join(remaining)
+        logger.error("[UNIQUE-MIGRATION] %s", message)
+        raise RuntimeError(message)
 
 
 def halt():

--- a/comicarr/db.py
+++ b/comicarr/db.py
@@ -34,7 +34,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 import sqlalchemy
-from sqlalchemy import create_engine, event, func, text
+from sqlalchemy import and_, create_engine, event, func, literal_column, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import OperationalError
 
@@ -265,10 +265,24 @@ def _build_upsert_stmt(table_name: str, value_dict: dict, key_dict: dict):
             from sqlalchemy.dialects.postgresql import insert as dialect_insert
 
         stmt = dialect_insert(table).values(**all_values)
-        stmt = stmt.on_conflict_do_update(
-            index_elements=upsert_keys,
-            set_=value_dict,
-        )
+        conflict_options = {
+            "index_elements": upsert_keys,
+            "set_": value_dict,
+        }
+        if dialect == "sqlite":
+            # Legacy SQLite databases use partial unique indexes so historical
+            # null/empty keys remain valid. Use the identical literal predicate
+            # here so SQLite can infer those indexes as the conflict target.
+            conflict_options["index_where"] = and_(
+                *(
+                    and_(
+                        table.c[key].is_not(None),
+                        table.c[key] != literal_column("''"),
+                    )
+                    for key in upsert_keys
+                )
+            )
+        stmt = stmt.on_conflict_do_update(**conflict_options)
     elif dialect == "mysql":
         from sqlalchemy.dialects.mysql import insert as dialect_insert
 

--- a/comicarr/maintenance.py
+++ b/comicarr/maintenance.py
@@ -85,8 +85,14 @@ def auto_backup_db(source_path, dest_dir, retention=4):
         if src_conn:
             src_conn.close()
 
-    # Rotate old backups — keep only `retention` most recent
-    existing = sorted(glob.glob(os.path.join(dest_dir, "comicarr.db.*.bak")))
+    # Rotate only timestamped comicarr.db.YYYYMMDD_HHMMSS.bak files. Fixed-name
+    # pins (e.g. comicarr.db.pre-unique-migration.bak) are never pruned here.
+    timestamped_backup = re.compile(r"^comicarr\.db\.\d{8}_\d{6}\.bak$")
+    existing = sorted(
+        path
+        for path in glob.glob(os.path.join(dest_dir, "comicarr.db.*.bak"))
+        if timestamped_backup.match(os.path.basename(path))
+    )
     while len(existing) > retention:
         oldest = existing.pop(0)
         try:

--- a/tests/unit/test_unique_constraint_migration.py
+++ b/tests/unit/test_unique_constraint_migration.py
@@ -21,7 +21,7 @@ from sqlalchemy.exc import IntegrityError, OperationalError
 
 import comicarr
 from comicarr import db
-from comicarr.tables import metadata
+from comicarr.tables import UPSERT_KEYS, metadata
 
 EXPECTED_CONSTRAINTS = {
     "issues": (["IssueID"], "uq_issues_issueid"),
@@ -157,6 +157,16 @@ def test_legacy_sqlite_migration_repairs_real_single_and_composite_upserts(legac
         conn.execute(text("INSERT INTO issues VALUES ('', 'empty-c', 'Wanted')"))
 
 
+def test_upsert_unique_constraint_map_matches_upsert_keys_allowlist():
+    """Lock migration key columns to tables.UPSERT_KEYS for the allowlisted tables."""
+    assert comicarr._UPSERT_UNIQUE_CONSTRAINTS == EXPECTED_CONSTRAINTS
+    assert set(comicarr._UPSERT_UNIQUE_CONSTRAINT_NAMES) == set(EXPECTED_CONSTRAINTS)
+    for table_name, (key_columns, constraint_name) in EXPECTED_CONSTRAINTS.items():
+        assert comicarr._UPSERT_UNIQUE_CONSTRAINT_NAMES[table_name] == constraint_name
+        assert list(UPSERT_KEYS[table_name]) == key_columns
+        assert comicarr._UPSERT_UNIQUE_CONSTRAINTS[table_name][0] == list(UPSERT_KEYS[table_name])
+
+
 def test_sqlite_migration_covers_every_declared_legacy_upsert_table_and_is_idempotent(legacy_engine):
     assert comicarr._UPSERT_UNIQUE_CONSTRAINTS == EXPECTED_CONSTRAINTS
     with legacy_engine.begin() as conn:
@@ -287,7 +297,8 @@ def test_sqlite_migration_rolls_back_deduplication_on_forced_ddl_failure(legacy_
 
     event.listen(legacy_engine, "before_cursor_execute", fail_index_creation)
     try:
-        _run_migration(legacy_engine)
+        with pytest.raises(RuntimeError, match="Unique-constraint migration incomplete"):
+            _run_migration(legacy_engine)
     finally:
         event.remove(legacy_engine, "before_cursor_execute", fail_index_creation)
 
@@ -308,24 +319,20 @@ def test_sqlite_migration_backs_up_before_delete_and_only_once(legacy_engine):
         )
 
     backup_calls = []
+    source_path = os.path.abspath(legacy_engine.url.database)
+    expected_backup_dir = os.path.join(os.path.dirname(source_path), "backups", "migrations")
 
-    def backup_before_delete(source_path, dest_dir, retention):
+    def backup_before_delete(source, dest_dir, retention):
         with legacy_engine.connect() as conn:
             assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'")) == 2
-        backup_calls.append((source_path, dest_dir, retention))
+        backup_calls.append((source, dest_dir, retention))
         return True
 
     with patch.object(comicarr.maintenance, "auto_backup_db", side_effect=backup_before_delete) as backup:
         comicarr._migrate_unique_constraints(legacy_engine)
         comicarr._migrate_unique_constraints(legacy_engine)
 
-    assert backup_calls == [
-        (
-            os.path.abspath(legacy_engine.url.database),
-            os.path.join(comicarr.DATA_DIR, "backups", "migrations"),
-            7,
-        )
-    ]
+    assert backup_calls == [(source_path, expected_backup_dir, 7)]
     backup.assert_called_once_with(*backup_calls[0])
 
 
@@ -343,7 +350,8 @@ def test_migration_backup_survives_same_second_normal_backup(legacy_engine):
     fixed_timestamp = "20260710_010203"
     source_path = os.path.abspath(legacy_engine.url.database)
     normal_backup_dir = Path(comicarr.DATA_DIR) / "backups"
-    migration_backup_dir = normal_backup_dir / "migrations"
+    migration_backup_dir = Path(os.path.dirname(source_path)) / "backups" / "migrations"
+    pin_backup = migration_backup_dir / comicarr._PRE_UNIQUE_MIGRATION_BACKUP
     with patch.object(comicarr.maintenance.time, "strftime", return_value=fixed_timestamp):
         _run_migration(legacy_engine, comicarr.maintenance.auto_backup_db)
         assert comicarr.maintenance.auto_backup_db(source_path, str(normal_backup_dir), 7)
@@ -352,12 +360,52 @@ def test_migration_backup_survives_same_second_normal_backup(legacy_engine):
     normal_backup = normal_backup_dir / f"comicarr.db.{fixed_timestamp}.bak"
     assert migration_backup != normal_backup
     assert migration_backup.is_file()
+    assert pin_backup.is_file()
     assert normal_backup.is_file()
 
     with sqlite3.connect(migration_backup) as conn:
         assert conn.execute("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'").fetchone()[0] == 2
+    with sqlite3.connect(pin_backup) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'").fetchone()[0] == 2
     with sqlite3.connect(normal_backup) as conn:
         assert conn.execute("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'").fetchone()[0] == 1
+
+
+def test_pre_unique_migration_pin_is_reused_and_not_rotated(legacy_engine, tmp_path):
+    """Pin is written once; retention rotation must not delete it."""
+    with legacy_engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name)"),
+            [
+                {"id": "issue-1", "name": "old"},
+                {"id": "issue-1", "name": "newest"},
+            ],
+        )
+
+    source_path = os.path.abspath(legacy_engine.url.database)
+    migration_backup_dir = Path(os.path.dirname(source_path)) / "backups" / "migrations"
+    pin_path = migration_backup_dir / comicarr._PRE_UNIQUE_MIGRATION_BACKUP
+
+    with patch.object(comicarr.maintenance.time, "strftime", return_value="20260710_010203"):
+        _run_migration(legacy_engine, comicarr.maintenance.auto_backup_db)
+
+    assert pin_path.is_file()
+    pin_stat = pin_path.stat()
+
+    # Simulate many subsequent rotating backups in the same dir; pin must remain.
+    for index in range(8):
+        with patch.object(comicarr.maintenance.time, "strftime", return_value=f"20260710_02020{index}"):
+            assert comicarr.maintenance.auto_backup_db(source_path, str(migration_backup_dir), 2)
+
+    assert pin_path.is_file()
+    assert pin_path.stat().st_mtime == pin_stat.st_mtime
+    assert pin_path.stat().st_size == pin_stat.st_size
+
+    # Second migration with pin present must not re-backup (pending already cleared).
+    backup = MagicMock(return_value=True)
+    comicarr._migrate_unique_constraints(legacy_engine, backup_func=backup)
+    backup.assert_not_called()
 
 
 def test_sqlite_migration_backup_failure_prevents_all_changes(legacy_engine):
@@ -433,7 +481,7 @@ def test_sqlite_memory_like_paths_without_uri_mode_are_backed_up(tmp_path, monke
     monkeypatch.chdir(tmp_path)
     engine = create_engine(database_url)
     monkeypatch.setattr(db, "_engine", engine)
-    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path / "other-data-dir"))
     monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(BACKUP_RETENTION=7))
     with engine.begin() as conn:
         _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
@@ -448,9 +496,10 @@ def test_sqlite_memory_like_paths_without_uri_mode_are_backed_up(tmp_path, monke
     backup = MagicMock(return_value=True)
     comicarr._migrate_unique_constraints(engine, backup_func=backup)
 
+    source_path = str(tmp_path / database_name)
     backup.assert_called_once_with(
-        str(tmp_path / database_name),
-        str(tmp_path / "backups" / "migrations"),
+        source_path,
+        os.path.join(os.path.dirname(source_path), "backups", "migrations"),
         7,
     )
     with engine.connect() as conn:
@@ -498,3 +547,116 @@ def test_non_sqlite_full_unique_index_is_enforcement():
 
     with patch.object(comicarr, "inspect", return_value=inspector):
         assert comicarr._has_unique_enforcement(engine, "issues", ["IssueID"])
+
+
+def test_dedup_sql_uses_dialect_native_row_identity():
+    quoted_table = '"issues"'
+    quoted_keys = ['"IssueID"']
+    predicate = '"IssueID" IS NOT NULL AND "IssueID" != \'\''
+    # Without quality columns / table context, keep MAX(rowid|ctid).
+    sqlite_sql = comicarr._dedup_delete_sql("sqlite", quoted_table, quoted_keys, predicate)
+    pg_sql = comicarr._dedup_delete_sql("postgresql", quoted_table, quoted_keys, predicate)
+    mysql_sql = comicarr._dedup_delete_sql("mysql", quoted_table, quoted_keys, predicate)
+
+    assert "MAX(rowid)" in sqlite_sql
+    assert "MAX(ctid)" in pg_sql
+    assert "rowid" not in pg_sql
+    assert mysql_sql is None
+
+
+def test_dedup_sql_library_tables_use_status_location_ranking():
+    quote = lambda name: f'"{name}"'
+    quoted_table = quote("issues")
+    quoted_keys = [quote("IssueID")]
+    predicate = '"IssueID" IS NOT NULL AND "IssueID" != \'\''
+    sql = comicarr._dedup_delete_sql(
+        "sqlite",
+        quoted_table,
+        quoted_keys,
+        predicate,
+        table_name="issues",
+        column_names=["IssueID", "Status", "Location", "ComicName"],
+        quote=quote,
+    )
+    assert "ROW_NUMBER()" in sql
+    assert "Downloaded" in sql
+    assert "Location" in sql
+    assert "MAX(rowid)" not in sql
+
+
+def test_library_quality_dedup_keeps_older_downloaded_with_location(legacy_engine):
+    """Prefer complete library row over a newer Wanted refresh stub."""
+    with legacy_engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName", "Status", "Location"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name, :status, :location)"),
+            [
+                {
+                    "id": "issue-1",
+                    "name": "complete",
+                    "status": "Downloaded",
+                    "location": "/library/issue-1.cbz",
+                },
+                {
+                    "id": "issue-1",
+                    "name": "stub",
+                    "status": "Wanted",
+                    "location": "",
+                },
+            ],
+        )
+
+    _run_migration(legacy_engine)
+
+    with legacy_engine.connect() as conn:
+        rows = conn.execute(
+            text("SELECT ComicName, Status, Location FROM issues WHERE IssueID = 'issue-1'")
+        ).all()
+        assert len(rows) == 1
+        assert rows[0] == ("complete", "Downloaded", "/library/issue-1.cbz")
+
+
+def test_recheck_inspect_error_still_attempts_migration(legacy_engine):
+    with legacy_engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name)"),
+            [
+                {"id": "issue-1", "name": "old"},
+                {"id": "issue-1", "name": "newest"},
+            ],
+        )
+
+    pending = comicarr._pending_unique_constraints(legacy_engine)
+    assert pending
+    real_has_enforcement = comicarr._has_unique_enforcement
+    calls = {"n": 0}
+
+    def recheck_then_real(engine, table_name, key_cols):
+        calls["n"] += 1
+        # First call is the per-table recheck inside the migration loop.
+        if calls["n"] == 1:
+            raise OperationalError("recheck", {}, Exception("inspect failed"))
+        return real_has_enforcement(engine, table_name, key_cols)
+
+    with (
+        patch.object(comicarr, "_pending_unique_constraints", return_value=pending),
+        patch.object(comicarr, "_has_unique_enforcement", side_effect=recheck_then_real),
+    ):
+        _run_migration(legacy_engine)
+
+    with legacy_engine.connect() as conn:
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'")) == 1
+    assert tuple(["IssueID"]) in _unique_column_sets(legacy_engine, "issues")
+
+
+def test_initialize_source_rethrows_runtime_error_from_dbcheck():
+    """Guard the initialize() fail-closed branch for unique-migration RuntimeError."""
+    import inspect as py_inspect
+
+    source = py_inspect.getsource(comicarr.initialize)
+    marker = "Checking to see if the database has all tables"
+    dbcheck_branch = source[source.index(marker) : source.index(marker) + 500]
+    assert "except RuntimeError as e:" in dbcheck_branch
+    assert "[UNIQUE-MIGRATION] Refusing startup after migration abort" in dbcheck_branch
+    assert dbcheck_branch.index("except RuntimeError as e:") < dbcheck_branch.index("except Exception as e:")

--- a/tests/unit/test_unique_constraint_migration.py
+++ b/tests/unit/test_unique_constraint_migration.py
@@ -1,0 +1,500 @@
+# Copyright (C) 2012–2024 Mylar3 contributors
+# Copyright (C) 2025–2026 Comicarr contributors
+#
+# This file is part of Comicarr.
+# Originally based on Mylar3 (https://github.com/mylar3/mylar3).
+#
+# Comicarr is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+import os
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, event, inspect, text
+from sqlalchemy.exc import IntegrityError, OperationalError
+
+import comicarr
+from comicarr import db
+from comicarr.tables import metadata
+
+EXPECTED_CONSTRAINTS = {
+    "issues": (["IssueID"], "uq_issues_issueid"),
+    "annuals": (["IssueID"], "uq_annuals_issueid"),
+    "storyarcs": (["IssueArcID"], "uq_storyarcs_issuearcid"),
+    "readlist": (["IssueID"], "uq_readlist_issueid"),
+    "failed": (["ID", "Provider", "NZBName"], "uq_failed_id_provider_nzbname"),
+    "upcoming": (["ComicID", "IssueNumber"], "uq_upcoming_comicid_issuenum"),
+    "nzblog": (["IssueID", "PROVIDER"], "uq_nzblog_issueid_provider"),
+    "importresults": (["impID"], "uq_importresults_impid"),
+    "jobhistory": (["JobName"], "uq_jobhistory_jobname"),
+    "snatched": (["IssueID", "Status", "Provider"], "uq_snatched_issue_status_provider"),
+    "oneoffhistory": (["ComicID", "IssueID"], "uq_oneoffhistory_comicid_issueid"),
+    "weekly": (["ComicID", "IssueID"], "uq_weekly_comicid_issueid"),
+}
+
+
+@pytest.fixture
+def legacy_engine(tmp_path, monkeypatch):
+    engine = create_engine(f"sqlite:///{tmp_path / 'legacy.db'}")
+    monkeypatch.setattr(db, "_engine", engine)
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(BACKUP_RETENTION=7))
+    monkeypatch.setattr(comicarr, "LOG_LEVEL", 0, raising=False)
+    yield engine
+    engine.dispose()
+    monkeypatch.setattr(db, "_engine", None)
+
+
+def _successful_backup(_source_path, _dest_dir, _retention):
+    return True
+
+
+def _run_migration(engine, backup_func=_successful_backup):
+    comicarr._migrate_unique_constraints(engine, backup_func=backup_func)
+
+
+def _create_legacy_table(conn, table_name, columns):
+    preparer = conn.dialect.identifier_preparer
+    table_sql = preparer.quote_identifier(table_name)
+    columns_sql = ", ".join(f"{preparer.quote_identifier(column)} TEXT" for column in columns)
+    conn.execute(text(f"CREATE TABLE {table_sql} ({columns_sql})"))
+
+
+def _unique_column_sets(engine, table_name):
+    inspector = inspect(engine)
+    constraints = {
+        tuple(sorted(constraint.get("column_names") or []))
+        for constraint in inspector.get_unique_constraints(table_name)
+    }
+    indexes = {
+        tuple(sorted(index.get("column_names") or []))
+        for index in inspector.get_indexes(table_name)
+        if index.get("unique")
+    }
+    return constraints | indexes
+
+
+def test_legacy_sqlite_migration_repairs_real_single_and_composite_upserts(legacy_engine):
+    with legacy_engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName", "Status"])
+        _create_legacy_table(conn, "failed", ["ID", "Provider", "NZBName", "Status"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name, :status)"),
+            [
+                {"id": "issue-1", "name": "old", "status": "Wanted"},
+                {"id": "issue-1", "name": "newest", "status": "Snatched"},
+                {"id": None, "name": "null-a", "status": "Wanted"},
+                {"id": None, "name": "null-b", "status": "Wanted"},
+                {"id": "", "name": "empty-a", "status": "Wanted"},
+                {"id": "", "name": "empty-b", "status": "Wanted"},
+            ],
+        )
+        conn.execute(
+            text("INSERT INTO failed VALUES (:id, :provider, :name, :status)"),
+            [
+                {"id": "failure-1", "provider": "provider", "name": "release", "status": "old"},
+                {"id": "failure-1", "provider": "provider", "name": "release", "status": "newest"},
+                {"id": "", "provider": "provider", "name": "release", "status": "empty-a"},
+                {"id": "", "provider": "provider", "name": "release", "status": "empty-b"},
+            ],
+        )
+
+    with pytest.raises(OperationalError, match="ON CONFLICT clause does not match"):
+        db.upsert("issues", {"ComicName": "before", "Status": "Wanted"}, {"IssueID": "issue-1"})
+
+    _run_migration(legacy_engine)
+
+    with legacy_engine.connect() as conn:
+        issue_rows = conn.execute(text("SELECT ComicName FROM issues WHERE IssueID = 'issue-1'")).scalars().all()
+        failed_rows = (
+            conn.execute(
+                text(
+                    "SELECT Status FROM failed WHERE ID = 'failure-1' AND Provider = 'provider' AND NZBName = 'release'"
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert issue_rows == ["newest"]
+        assert failed_rows == ["newest"]
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID IS NULL")) == 2
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = ''")) == 2
+        assert conn.scalar(text("SELECT COUNT(*) FROM failed WHERE ID = ''")) == 2
+
+    db.upsert("issues", {"ComicName": "updated", "Status": "Downloaded"}, {"IssueID": "issue-1"})
+    db.upsert(
+        "failed",
+        {"Status": "Retrying"},
+        {"ID": "failure-1", "Provider": "provider", "NZBName": "release"},
+    )
+    db.upsert("issues", {"ComicName": "empty-upsert", "Status": "Wanted"}, {"IssueID": ""})
+    db.upsert("issues", {"ComicName": "null-upsert", "Status": "Wanted"}, {"IssueID": None})
+
+    with legacy_engine.connect() as conn:
+        assert conn.scalar(text("SELECT ComicName FROM issues WHERE IssueID = 'issue-1'")) == "updated"
+        assert (
+            conn.scalar(
+                text(
+                    "SELECT Status FROM failed WHERE ID = 'failure-1' AND Provider = 'provider' AND NZBName = 'release'"
+                )
+            )
+            == "Retrying"
+        )
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = ''")) == 3
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID IS NULL")) == 3
+
+    with pytest.raises(IntegrityError):
+        with legacy_engine.begin() as conn:
+            conn.execute(text("INSERT INTO issues VALUES ('issue-1', 'duplicate', 'Wanted')"))
+
+    with legacy_engine.begin() as conn:
+        conn.execute(text("INSERT INTO issues VALUES ('', 'empty-c', 'Wanted')"))
+
+
+def test_sqlite_migration_covers_every_declared_legacy_upsert_table_and_is_idempotent(legacy_engine):
+    assert comicarr._UPSERT_UNIQUE_CONSTRAINTS == EXPECTED_CONSTRAINTS
+    with legacy_engine.begin() as conn:
+        for table_name, (key_columns, _constraint_name) in EXPECTED_CONSTRAINTS.items():
+            _create_legacy_table(conn, table_name, key_columns)
+
+    _run_migration(legacy_engine)
+    _run_migration(legacy_engine)
+
+    inspector = inspect(legacy_engine)
+    for table_name, (key_columns, constraint_name) in EXPECTED_CONSTRAINTS.items():
+        assert tuple(sorted(key_columns)) in _unique_column_sets(legacy_engine, table_name)
+        matching_indexes = [
+            index
+            for index in inspector.get_indexes(table_name)
+            if index.get("unique") and tuple(sorted(index.get("column_names") or [])) == tuple(sorted(key_columns))
+        ]
+        assert [index["name"] for index in matching_indexes] == [constraint_name]
+
+
+def test_sqlite_migration_recognizes_existing_table_unique_constraint(legacy_engine):
+    with legacy_engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE issues (IssueID TEXT, ComicName TEXT, CONSTRAINT legacy_issues_unique UNIQUE (IssueID))")
+        )
+
+    _run_migration(legacy_engine)
+
+    inspector = inspect(legacy_engine)
+    assert tuple(["IssueID"]) in _unique_column_sets(legacy_engine, "issues")
+    assert not any(index["name"] == "uq_issues_issueid" for index in inspector.get_indexes("issues"))
+
+
+def test_sqlite_upsert_remains_compatible_with_new_full_unique_constraints(legacy_engine):
+    metadata.create_all(legacy_engine)
+
+    db.upsert("issues", {"ComicName": "first", "Status": "Wanted"}, {"IssueID": "issue-1"})
+    db.upsert("issues", {"ComicName": "updated", "Status": "Downloaded"}, {"IssueID": "issue-1"})
+    db.upsert("issues", {"ComicName": "empty-first", "Status": "Wanted"}, {"IssueID": ""})
+    db.upsert("issues", {"ComicName": "empty-updated", "Status": "Downloaded"}, {"IssueID": ""})
+    db.upsert("issues", {"ComicName": "null-first", "Status": "Wanted"}, {"IssueID": None})
+    db.upsert("issues", {"ComicName": "null-second", "Status": "Wanted"}, {"IssueID": None})
+
+    with legacy_engine.connect() as conn:
+        assert conn.scalar(text("SELECT ComicName FROM issues WHERE IssueID = 'issue-1'")) == "updated"
+        assert conn.scalar(text("SELECT ComicName FROM issues WHERE IssueID = ''")) == "empty-updated"
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = ''")) == 1
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID IS NULL")) == 2
+
+
+@pytest.mark.parametrize(
+    "legacy_predicate",
+    [
+        "IssueID IS NOT NULL AND IssueID != '' AND ComicName IS NOT NULL",
+        "IssueID != '' AND IssueID IS NOT NULL",
+    ],
+)
+def test_sqlite_migration_does_not_mistake_incompatible_partial_index_for_enforcement(legacy_engine, legacy_predicate):
+    with legacy_engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName", "Status"])
+        conn.execute(
+            text(f"CREATE UNIQUE INDEX legacy_narrow_issues_index ON issues (IssueID) WHERE {legacy_predicate}")
+        )
+
+    with pytest.raises(OperationalError, match="ON CONFLICT clause does not match"):
+        db.upsert("issues", {"ComicName": "before", "Status": "Wanted"}, {"IssueID": "issue-1"})
+
+    _run_migration(legacy_engine)
+
+    indexes = inspect(legacy_engine).get_indexes("issues")
+    assert any(index["name"] == "uq_issues_issueid" and index.get("unique") for index in indexes)
+    db.upsert("issues", {"ComicName": "after", "Status": "Downloaded"}, {"IssueID": "issue-1"})
+    with legacy_engine.connect() as conn:
+        assert conn.scalar(text("SELECT ComicName FROM issues WHERE IssueID = 'issue-1'")) == "after"
+
+
+@pytest.mark.parametrize("occupied_index_name", ["uq_issues_issueid", "UQ_ISSUES_ISSUEID"])
+def test_sqlite_migration_uses_alternate_name_when_canonical_index_name_is_taken(
+    legacy_engine, monkeypatch, occupied_index_name
+):
+    monkeypatch.setattr(legacy_engine.dialect, "max_identifier_length", 30)
+    with legacy_engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
+        quoted_index_name = conn.dialect.identifier_preparer.quote_identifier(occupied_index_name)
+        conn.execute(text(f"CREATE INDEX {quoted_index_name} ON issues (ComicName)"))
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name)"),
+            [
+                {"id": "issue-1", "name": "old"},
+                {"id": "issue-1", "name": "newest"},
+            ],
+        )
+
+    _run_migration(legacy_engine)
+
+    with legacy_engine.connect() as conn:
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'")) == 1
+    unique_indexes = [index for index in inspect(legacy_engine).get_indexes("issues") if index.get("unique")]
+    assert len(unique_indexes) == 1
+    assert unique_indexes[0]["name"] == comicarr._bounded_alternate_index_name(
+        legacy_engine,
+        "uq_issues_issueid",
+        "issues",
+        ["IssueID"],
+        0,
+    )
+    assert len(unique_indexes[0]["name"]) <= legacy_engine.dialect.max_identifier_length
+
+    db.upsert("issues", {"ComicName": "updated"}, {"IssueID": "issue-1"})
+    with legacy_engine.connect() as conn:
+        assert conn.scalar(text("SELECT ComicName FROM issues WHERE IssueID = 'issue-1'")) == "updated"
+
+
+def test_sqlite_migration_rolls_back_deduplication_on_forced_ddl_failure(legacy_engine):
+    with legacy_engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name)"),
+            [
+                {"id": "issue-1", "name": "old"},
+                {"id": "issue-1", "name": "newest"},
+            ],
+        )
+
+    def fail_index_creation(_conn, _cursor, statement, parameters, _context, _executemany):
+        if statement.lstrip().startswith("CREATE UNIQUE INDEX"):
+            raise OperationalError(statement, parameters, sqlite3.OperationalError("injected failure"))
+
+    event.listen(legacy_engine, "before_cursor_execute", fail_index_creation)
+    try:
+        _run_migration(legacy_engine)
+    finally:
+        event.remove(legacy_engine, "before_cursor_execute", fail_index_creation)
+
+    with legacy_engine.connect() as conn:
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'")) == 2
+    assert tuple(["IssueID"]) not in _unique_column_sets(legacy_engine, "issues")
+
+
+def test_sqlite_migration_backs_up_before_delete_and_only_once(legacy_engine):
+    with legacy_engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name)"),
+            [
+                {"id": "issue-1", "name": "old"},
+                {"id": "issue-1", "name": "newest"},
+            ],
+        )
+
+    backup_calls = []
+
+    def backup_before_delete(source_path, dest_dir, retention):
+        with legacy_engine.connect() as conn:
+            assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'")) == 2
+        backup_calls.append((source_path, dest_dir, retention))
+        return True
+
+    with patch.object(comicarr.maintenance, "auto_backup_db", side_effect=backup_before_delete) as backup:
+        comicarr._migrate_unique_constraints(legacy_engine)
+        comicarr._migrate_unique_constraints(legacy_engine)
+
+    assert backup_calls == [
+        (
+            os.path.abspath(legacy_engine.url.database),
+            os.path.join(comicarr.DATA_DIR, "backups", "migrations"),
+            7,
+        )
+    ]
+    backup.assert_called_once_with(*backup_calls[0])
+
+
+def test_migration_backup_survives_same_second_normal_backup(legacy_engine):
+    with legacy_engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name)"),
+            [
+                {"id": "issue-1", "name": "old"},
+                {"id": "issue-1", "name": "newest"},
+            ],
+        )
+
+    fixed_timestamp = "20260710_010203"
+    source_path = os.path.abspath(legacy_engine.url.database)
+    normal_backup_dir = Path(comicarr.DATA_DIR) / "backups"
+    migration_backup_dir = normal_backup_dir / "migrations"
+    with patch.object(comicarr.maintenance.time, "strftime", return_value=fixed_timestamp):
+        _run_migration(legacy_engine, comicarr.maintenance.auto_backup_db)
+        assert comicarr.maintenance.auto_backup_db(source_path, str(normal_backup_dir), 7)
+
+    migration_backup = migration_backup_dir / f"comicarr.db.{fixed_timestamp}.bak"
+    normal_backup = normal_backup_dir / f"comicarr.db.{fixed_timestamp}.bak"
+    assert migration_backup != normal_backup
+    assert migration_backup.is_file()
+    assert normal_backup.is_file()
+
+    with sqlite3.connect(migration_backup) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'").fetchone()[0] == 2
+    with sqlite3.connect(normal_backup) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'").fetchone()[0] == 1
+
+
+def test_sqlite_migration_backup_failure_prevents_all_changes(legacy_engine):
+    with legacy_engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name)"),
+            [
+                {"id": "issue-1", "name": "old"},
+                {"id": "issue-1", "name": "newest"},
+            ],
+        )
+
+    with pytest.raises(RuntimeError, match="backup"):
+        _run_migration(legacy_engine, lambda *_args: False)
+
+    with legacy_engine.connect() as conn:
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'")) == 2
+    assert tuple(["IssueID"]) not in _unique_column_sets(legacy_engine, "issues")
+
+
+def test_sqlite_in_memory_migration_does_not_attempt_durable_backup(monkeypatch):
+    engine = create_engine("sqlite://")
+    monkeypatch.setattr(db, "_engine", engine)
+    with engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name)"),
+            [
+                {"id": "issue-1", "name": "old"},
+                {"id": "issue-1", "name": "newest"},
+            ],
+        )
+
+    comicarr._migrate_unique_constraints(engine)
+
+    with engine.connect() as conn:
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'")) == 1
+    engine.dispose()
+
+
+def test_sqlite_named_memory_uri_migration_does_not_attempt_filesystem_backup(monkeypatch):
+    engine = create_engine("sqlite:///file:comicarr_unique_migration?mode=memory&cache=shared&uri=true")
+    monkeypatch.setattr(db, "_engine", engine)
+    with engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name)"),
+            [
+                {"id": "issue-1", "name": "old"},
+                {"id": "issue-1", "name": "newest"},
+            ],
+        )
+
+    with patch.object(comicarr.maintenance, "auto_backup_db", return_value=True) as backup:
+        comicarr._migrate_unique_constraints(engine)
+
+    backup.assert_not_called()
+    with engine.connect() as conn:
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'")) == 1
+    engine.dispose()
+
+
+@pytest.mark.parametrize(
+    ("database_url", "database_name"),
+    [
+        ("sqlite:///foo.db?mode=memory", "foo.db"),
+        ("sqlite:///file::memory:", "file::memory:"),
+        ("sqlite:///foo.db?mode=memory&uri=true", "foo.db?mode=memory"),
+    ],
+)
+def test_sqlite_memory_like_paths_without_uri_mode_are_backed_up(tmp_path, monkeypatch, database_url, database_name):
+    monkeypatch.chdir(tmp_path)
+    engine = create_engine(database_url)
+    monkeypatch.setattr(db, "_engine", engine)
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(BACKUP_RETENTION=7))
+    with engine.begin() as conn:
+        _create_legacy_table(conn, "issues", ["IssueID", "ComicName"])
+        conn.execute(
+            text("INSERT INTO issues VALUES (:id, :name)"),
+            [
+                {"id": "issue-1", "name": "old"},
+                {"id": "issue-1", "name": "newest"},
+            ],
+        )
+
+    backup = MagicMock(return_value=True)
+    comicarr._migrate_unique_constraints(engine, backup_func=backup)
+
+    backup.assert_called_once_with(
+        str(tmp_path / database_name),
+        str(tmp_path / "backups" / "migrations"),
+        7,
+    )
+    with engine.connect() as conn:
+        assert conn.scalar(text("SELECT COUNT(*) FROM issues WHERE IssueID = 'issue-1'")) == 1
+    engine.dispose()
+
+
+@pytest.mark.parametrize(
+    ("dialect_name", "dialect_options", "filter_definition"),
+    [
+        ("postgresql", {"postgresql_where": "IssueID IS NOT NULL"}, None),
+        ("other", {}, "IssueID IS NOT NULL"),
+    ],
+)
+def test_non_sqlite_partial_unique_indexes_are_not_full_enforcement(dialect_name, dialect_options, filter_definition):
+    engine = SimpleNamespace(dialect=SimpleNamespace(name=dialect_name))
+    inspector = MagicMock()
+    inspector.get_unique_constraints.return_value = []
+    inspector.get_indexes.return_value = [
+        {
+            "name": "partial_issues",
+            "column_names": ["IssueID"],
+            "unique": True,
+            "dialect_options": dialect_options,
+            "filter_definition": filter_definition,
+        }
+    ]
+
+    with patch.object(comicarr, "inspect", return_value=inspector):
+        assert not comicarr._has_unique_enforcement(engine, "issues", ["IssueID"])
+
+
+def test_non_sqlite_full_unique_index_is_enforcement():
+    engine = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+    inspector = MagicMock()
+    inspector.get_unique_constraints.return_value = []
+    inspector.get_indexes.return_value = [
+        {
+            "name": "full_issues",
+            "column_names": ["IssueID"],
+            "unique": True,
+            "dialect_options": {"postgresql_where": None},
+        }
+    ]
+
+    with patch.object(comicarr, "inspect", return_value=inspector):
+        assert comicarr._has_unique_enforcement(engine, "issues", ["IssueID"])


### PR DESCRIPTION
## Summary

Legacy SQLite databases now receive the unique enforcement required by Comicarr's atomic `ON CONFLICT` upserts. Startup preflights the affected tables, creates a mandatory WAL-safe pre-migration snapshot under `backups/migrations`, deterministically removes duplicate valid keys, and creates matching partial unique indexes in the same per-table transaction.

The partial indexes preserve historical rows with `NULL` or empty key components. SQLite upserts now use the identical conflict predicate; fresh full constraints and migrated partial indexes are both supported. Existing compatible enforcement is recognized, incompatible/partial indexes are rejected correctly, and case-insensitive index-name collisions receive deterministic alternate names.

## Testing

- Added proof-first legacy fixtures for single/composite constraints, duplicate retention, NULL/empty semantics, real upserts/direct conflicts, all 12 affected tables, idempotency, failed-DDL rollback, mandatory backup ordering/failure, same-second backup separation, index-name collisions, non-SQL partial indexes, and file-backed versus named-memory SQLite URLs.
- Full backend suite before the final URL guard: 906 passed; final migration suite: 20 passed.
- Ruff lint and format checks passed.
- Startup help and lockfile checks passed.

## Backup and Recovery

- A file-backed SQLite migration will not delete duplicate rows unless its WAL-safe snapshot succeeds.
- Migration snapshots use `DATA_DIR/backups/migrations`, separate from ordinary startup-backup naming and retention collisions.
- If backup or index creation fails, that migration is aborted or its per-table deduplication is rolled back.

## Post-Deploy Monitoring & Validation

- **Window/owner:** Maintainers should review the first startup after deployment, especially on long-lived SQLite installations.
- **Healthy signals:** One migration backup appears before deduplication, each pending table logs installed UNIQUE enforcement, startup completes, and subsequent issue/history upserts succeed.
- **Watch:** `unique-constraint backup failed`, `Could not add SQLite UNIQUE index`, `UNIQUE enforcement ... was not installed`, long SQLite write/schema locks, and repeated migration attempts on every restart.
- **Failure trigger:** No pre-migration snapshot, missing enforcement after startup, repeated `ON CONFLICT clause does not match`, or unexpected duplicate loss requires stopping writes and inspecting the backup.
- **Mitigation:** Stop Comicarr, preserve the live database/WAL files, restore the migration snapshot from `backups/migrations`, resolve the reported index collision or disk/permission failure, then retry startup.

## Known Limitation

The first migration can hold SQLite write/schema locks while scanning and indexing large legacy tables. Each table is isolated in its own transaction to bound rollback scope.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migrations for legacy SQLite databases, restoring reliable upsert behavior.
  * Preserved historical records with missing or empty key values while enforcing uniqueness for valid keys.
  * Added safer migration handling with pre-change backups and rollback protection if an update fails.
  * Improved compatibility with existing unique constraints and indexes across supported database systems.
  * Ensured repeated migrations complete safely without creating duplicate constraints or indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->