### PR TITLE
ci: add pre-commit hooks and pin ruff in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,9 @@
 
 - [ ] Tests pass locally (`pytest tests/unit -v`)
 - [ ] Frontend builds (`cd frontend && npm run build`)
-- [ ] Linting passes (`ruff check comicarr/`)
+- [ ] Backend lint/format (`ruff check comicarr/` and `ruff format --check comicarr/`)
+- [ ] Frontend lint/format (`cd frontend && npm run lint && npm run format:check`)
+- [ ] Or one-shot: `npm run lint` (from repo root; requires `uv` + `frontend/node_modules`)
 - [ ] Manually tested (describe what you tested):
 
 ## Screenshots

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      # Pin to match uv.lock / ruff-pre-commit rev so local hooks and CI agree.
       - name: Install linting tools
-        run: pip install ruff
+        run: pip install "ruff==0.15.7"
 
       - name: Run ruff linter
         run: ruff check comicarr/ --output-format=github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+# Local gates that mirror CI lint/format checks.
+# Install once after cloning: uv sync --extra dev && pre-commit install
+# Frontend hooks need frontend deps: cd frontend && npm ci
+#
+# Keep the ruff pre-commit rev aligned with the ruff version in uv.lock.
+
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.7
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^comicarr/
+      - id: ruff-format
+        files: ^comicarr/
+
+  - repo: local
+    hooks:
+      - id: frontend-prettier
+        name: prettier (frontend)
+        language: system
+        entry: python scripts/pre-commit/run_frontend_hook.py prettier
+        files: >-
+          ^frontend/(src/.*\.(ts|tsx|js|jsx|css|json)|tests/e2e/.*\.(ts|tsx|js|jsx|mjs)|playwright\.config\.ts)$
+        pass_filenames: true
+      - id: frontend-eslint
+        name: eslint (frontend)
+        language: system
+        entry: python scripts/pre-commit/run_frontend_hook.py eslint
+        files: ^frontend/.*\.(ts|tsx|js|jsx|mjs)$
+        exclude: ^frontend/(dist|node_modules)/
+        pass_filenames: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,12 @@ Agent-oriented project guide for Comicarr. Prefer retrieval-led reasoning: consu
 | Format check | `ruff format --check comicarr/` |
 | Format fix | `ruff format comicarr/` |
 | Lint frontend | `cd frontend && npm run lint` |
+| Format frontend | `cd frontend && npm run format` / `format:check` |
 | Typecheck | `cd frontend && npm run typecheck` |
+| Lint all (CI parity) | `npm run lint` |
+| Lint fix all | `npm run lint:fix` |
+| Install git hooks | `pre-commit install` (after `uv sync --extra dev`) |
+| Run hooks on tree | `pre-commit run --all-files` |
 
 When using Vite (`npm run dev`) with a separate backend process, the proxy targets `http://localhost:8090`. Override with `VITE_API_PROXY_TARGET` if needed.
 
@@ -51,13 +56,14 @@ Domain packages under `comicarr/app/`: `series`, `search`, `downloads`, `system`
 
 ## Style & anti-patterns
 
-- **Formatting**: `ruff format` enforced in CI; do not use Black
-- **Lint**: `ruff check comicarr/`
+- **Formatting**: `ruff format` enforced in CI and pre-commit; do not use Black
+- **Lint**: `ruff check comicarr/`; frontend ESLint + Prettier enforced in CI and pre-commit
 - **Type hints**: do not mass-add to large legacy modules (`search.py`, `postprocessor.py`); new `comicarr/app/**` code may use annotations like neighboring files
 - Always `except Exception as e` — never bare `except:`
 - GPL license header on new Python files
 - Frontend: `npm` only (not bun)
 - Do not manually bump versions — Changesets automation
+- **Before finishing a change**: run `npm run lint` (or `npm run lint:fix` then re-check). Do not skip with `--no-verify`
 
 ## Common patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,12 @@ Comicarr is built on the foundation of Mylar3 with a completely rebuilt React 19
 | Format check | `ruff format --check comicarr/` |
 | Format fix | `ruff format comicarr/` |
 | Lint frontend | `cd frontend && npm run lint` |
+| Format frontend | `cd frontend && npm run format` / `format:check` |
 | Typecheck | `cd frontend && npm run typecheck` |
+| Lint all (CI parity) | `npm run lint` |
+| Lint fix all | `npm run lint:fix` |
+| Install git hooks | `pre-commit install` (after `uv sync --extra dev`) |
+| Run hooks on tree | `pre-commit run --all-files` |
 | Add dependency | `uv add <package>` |
 | Add dev dep | `uv add --optional dev <package>` |
 
@@ -87,10 +92,11 @@ Conventional PR titles keep history readable, but they do not control releases. 
 - **Do NOT mass-add type hints** to large legacy modules (`search.py`, `postprocessor.py`, etc.)
 - **New code under `comicarr/app/`** may use annotations matching neighboring files
 - **Do NOT use bare `except:` clauses** - Always catch `Exception as e`
-- **Do NOT use Black or other external formatters** - Use `ruff format` only (enforced by CI)
+- **Do NOT use Black or other external formatters** - Use `ruff format` only (enforced by CI and pre-commit)
 - **Do NOT use `bun` for frontend** - Use `npm` commands only
 - **Do NOT omit GPL license header** from new Python files
 - **Do NOT manually bump versions** - Changesets release automation handles this
+- **Do NOT finish without linting** - Run `npm run lint` (or `npm run lint:fix` then re-check) before considering work done; do not bypass hooks with `--no-verify`
 
 ## Common Patterns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,16 +21,38 @@ cd comicarr
 uv sync --extra dev
 
 # Activate virtual environment
-source .venv/bin/activate
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
 
 # Install frontend dependencies (lockfile-respecting; matches CI)
 cd frontend
 npm ci
 cd ..
 
+# Install git pre-commit hooks (lint/format on commit)
+pre-commit install
+
 # Run the application
 python3 Comicarr.py --nolaunch
 ```
+
+### Pre-commit hooks
+
+Hooks run automatically on `git commit` and mirror the CI lint/format checks:
+
+- **Backend**: `ruff` (lint + autofix) and `ruff format` on `comicarr/`
+- **Frontend**: Prettier and ESLint (via `frontend/` lockfile tools)
+
+One-time install: `uv sync --extra dev && pre-commit install` (and `cd frontend && npm ci` for frontend hooks).
+
+Useful commands:
+
+```bash
+pre-commit run --all-files   # run hooks on the whole tree
+npm run lint                 # same checks CI uses (backend + frontend)
+npm run lint:fix             # autofix what can be fixed
+```
+
+If a hook rewrites files, stage the changes and commit again. Avoid `git commit --no-verify` unless you have a deliberate reason — CI will still enforce the same rules.
 
 ### Frontend Development
 
@@ -62,7 +84,7 @@ npm run test:run
 
 ### Python
 
-- **Formatting**: `ruff format comicarr/` is enforced in CI; run it before pushing
+- **Formatting**: `ruff format comicarr/` is enforced in CI and by pre-commit; run it before pushing
 - **Lint**: `ruff check comicarr/`
 - **Type hints**: not required on large legacy modules; allowed in new `comicarr/app/**` code to match neighbors
 - **Always catch specific exceptions** — use `except Exception as e`, never bare `except:`
@@ -76,6 +98,8 @@ npm run test:run
 - Tailwind CSS 4 for styling
 - TanStack Query for data fetching
 - Radix UI for accessible components
+- **Lint**: `cd frontend && npm run lint` (ESLint)
+- **Format**: `cd frontend && npm run format` / `npm run format:check` (Prettier; enforced in CI and pre-commit)
 
 ### Import Ordering
 
@@ -97,8 +121,8 @@ All new Python files must include the GPL v3 license header at the top.
    docs/api-guide
    chore/update-deps
    ```
-2. Make your changes with clear, conventional commit messages
-3. Ensure all tests pass and linting is clean
+2. Make your changes with clear, conventional commit messages (pre-commit hooks will lint/format staged files)
+3. Ensure all tests pass and linting is clean (`npm run lint` from the repo root)
 4. Open a PR — **the title must follow conventional commit format** (CI enforces this):
    ```
    feat: Add manga search provider

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "endOfLine": "auto"
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
     "changeset": "changeset",
     "version-packages": "changeset version && npm run sync-version",
     "sync-version": "node scripts/release/sync-version.mjs",
-    "prepare-github-release": "node scripts/release/prepare-github-release.mjs"
+    "prepare-github-release": "node scripts/release/prepare-github-release.mjs",
+    "lint": "npm run lint:backend && npm run lint:frontend",
+    "lint:backend": "python scripts/run_ruff.py check comicarr/ && python scripts/run_ruff.py format --check comicarr/",
+    "lint:frontend": "npm --prefix frontend run lint && npm --prefix frontend run format:check",
+    "lint:fix": "npm run lint:fix:backend && npm run lint:fix:frontend",
+    "lint:fix:backend": "python scripts/run_ruff.py check comicarr/ --fix && python scripts/run_ruff.py format comicarr/",
+    "lint:fix:frontend": "npm --prefix frontend run format && npm --prefix frontend exec -- eslint . --fix"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "freezegun>=1.4.0",
     "factory-boy>=3.3.0",
     "hypothesis>=6.100.0",
+    "pre-commit>=4.0.0",
     "ruff>=0.15.7",
     "tomli>=2.0; python_version < '3.11'",
 ]

--- a/scripts/pre-commit/run_frontend_hook.py
+++ b/scripts/pre-commit/run_frontend_hook.py
@@ -1,0 +1,80 @@
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Run frontend prettier/eslint from frontend/ with paths relative to that package.
+
+Used by local pre-commit hooks so tooling resolves the frontend lockfile,
+eslint config, and prettier version correctly on Windows and Unix.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        print(
+            "usage: run_frontend_hook.py <prettier|eslint> [files...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    tool = args[0]
+    files = args[1:]
+    root = Path(__file__).resolve().parents[2]
+    frontend = root / "frontend"
+    node_modules = frontend / "node_modules"
+
+    if not node_modules.is_dir():
+        print(
+            "frontend/node_modules missing; run: cd frontend && npm ci",
+            file=sys.stderr,
+        )
+        return 1
+
+    rel_files: list[str] = []
+    frontend_resolved = frontend.resolve()
+    for raw in files:
+        path = Path(raw).resolve()
+        try:
+            rel = path.relative_to(frontend_resolved)
+        except ValueError:
+            continue
+        rel_files.append(rel.as_posix())
+
+    if files and not rel_files:
+        return 0
+
+    if tool == "prettier":
+        cmd = ["npx", "prettier", "--write", "--ignore-unknown", *rel_files]
+    elif tool == "eslint":
+        # Match CI (`npm run lint` → `eslint .`) when no filenames are provided.
+        targets = rel_files if rel_files else ["."]
+        cmd = ["npx", "eslint", "--fix", *targets]
+    else:
+        print(f"unknown tool: {tool}", file=sys.stderr)
+        return 2
+
+    # On Windows, npx is a .cmd shim and requires shell=True.
+    completed = subprocess.run(cmd, cwd=frontend, shell=(sys.platform == "win32"))
+    return int(completed.returncode or 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_ruff.py
+++ b/scripts/run_ruff.py
@@ -1,0 +1,69 @@
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Invoke project ruff from .venv, PATH, or uv.
+
+Used by root package.json lint scripts so they work without requiring
+a globally installed ``uv`` on PATH (common on Windows agent setups).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ruff_command() -> list[str]:
+    win = sys.platform == "win32"
+    venv_ruff = ROOT / ".venv" / ("Scripts" if win else "bin") / ("ruff.exe" if win else "ruff")
+    if venv_ruff.is_file():
+        return [str(venv_ruff)]
+
+    path_ruff = shutil.which("ruff")
+    if path_ruff:
+        return [path_ruff]
+
+    path_uv = shutil.which("uv")
+    if path_uv:
+        return [path_uv, "run", "ruff"]
+
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "uv", "--version"],
+            check=True,
+            capture_output=True,
+        )
+        return [sys.executable, "-m", "uv", "run", "ruff"]
+    except (OSError, subprocess.CalledProcessError):
+        pass
+
+    raise SystemExit(
+        "ruff not found. Install dev deps with: uv sync --extra dev\n"
+        "(or activate .venv so ruff is on PATH)"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    cmd = _ruff_command() + args
+    return int(subprocess.call(cmd) or 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -230,6 +230,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "cfscrape"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -391,6 +400,7 @@ dev = [
     { name = "freezegun" },
     { name = "httpx" },
     { name = "hypothesis" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -429,6 +439,7 @@ requires-dist = [
     { name = "openai", specifier = ">=2.30.0" },
     { name = "packaging", specifier = ">=22.0" },
     { name = "pillow", specifier = ">=12.3.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "psycopg2-binary", marker = "extra == 'postgres'", specifier = ">=2.9" },
     { name = "pycryptodome", specifier = ">=3.19.0" },
     { name = "pyjwt", specifier = ">=2.13.0" },
@@ -619,6 +630,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -632,7 +652,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -698,6 +718,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dc/79/db7edb5e77d6dfbc54d7d9df72828be4318275b2e580549ff45a962f6461/feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228", size = 286579, upload-time = "2025-09-10T13:33:59.486Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/eb/c96d64137e29ae17d83ad2552470bafe3a7a915e85434d9942077d7fd011/feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324", size = 81480, upload-time = "2025-09-10T13:33:58.022Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
 ]
 
 [[package]]
@@ -860,6 +889,15 @@ wheels = [
 ]
 
 [[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1012,6 +1050,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1134,12 +1181,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -1517,6 +1589,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl", hash = "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe", size = 34181, upload-time = "2026-07-08T23:06:49.402Z" },
 ]
 
 [[package]]
@@ -2081,6 +2166,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/65/ec1d92091671e6407d3e7c1f5801413bb7b2b57630a50cae7750456ba0ed/virtualenv-21.6.0.tar.gz", hash = "sha256:e18a4d750f2b64dea73e72ffde3922f3c52365fabdc8157ebd3da20d031c4734", size = 5526111, upload-time = "2026-07-06T22:49:56.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/e7/2fbd0cc1653c53eed8f10670538bb547de2b3e37aacad283faa82a71094b/virtualenv-21.6.0-py3-none-any.whl", hash = "sha256:bce9d097950fef9d81129b333babfb7767072850c2f1acce0ec536708401bfd1", size = 5506216, upload-time = "2026-07-06T22:49:54.941Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

CI was catching backend ruff/format (and sometimes frontend ESLint/Prettier) failures only after PRs were opened, because the repo had no local automation and CI installed unpinned latest ruff. This PR adds pre-commit hooks that mirror those checks, pins CI ruff to the lockfile version, and documents one-shot lint commands for humans and agents.

## Changes

- Add `.pre-commit-config.yaml` with ruff + ruff-format for `comicarr/`, and Prettier/ESLint for `frontend/`
- Add cross-platform frontend hook runner (`scripts/pre-commit/run_frontend_hook.py`) so tools resolve from the frontend lockfile
- Add `pre-commit` to the Python `dev` extra and update `uv.lock`
- Pin CI backend lint to `ruff==0.15.7` (matches `uv.lock` / pre-commit rev)
- Add root `npm run lint` / `npm run lint:fix` helpers (`scripts/run_ruff.py` finds ruff without requiring global `uv` on PATH)
- Set `frontend/.prettierrc.json` `endOfLine: "auto"` to avoid Windows CRLF thrash under pre-commit
- Update CONTRIBUTING, AGENTS/CLAUDE, and the PR template checklists

## Release Impact

- [x] No app release impact; no changeset needed

## Testing

- [x] `pre-commit run --all-files` (ruff, ruff-format, prettier, eslint all passed)
- [x] `npm run lint` (backend + frontend check passed)
- [x] Confirmed ruff-format/prettier hooks rewrite staged violations
- [ ] Manually tested (describe what you tested): N/A — CI/tooling only

## Additional Notes

After pull: `uv sync --extra dev && pre-commit install` (and `cd frontend && npm ci` for frontend hooks).

When bumping ruff later, keep three places aligned: `pyproject.toml`/`uv.lock`, `.pre-commit-config.yaml` `rev`, and the pin in `.github/workflows/ci.yml`.
