### PR TITLE
fix: show live app version in UI chrome badges

### DIFF
--- a/.changeset/fix-app-version-display.md
+++ b/.changeset/fix-app-version-display.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Show the real app version in the sidebar, login screen, and onboarding welcome step instead of a hardcoded 0.15 / v0.15.1 badge.

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -4,6 +4,7 @@ import Logo from "@/components/Logo";
 import type { LucideIcon } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTheme } from "@/contexts/ThemeContext";
+import { APP_VERSION } from "@/lib/version";
 import {
   Sidebar,
   SidebarContent,
@@ -129,7 +130,7 @@ export default function AppSidebar() {
             <Logo className="h-4 w-auto text-foreground" />
           </Link>
           <span className="group-data-[collapsible=icon]:hidden font-mono text-[10px] text-[var(--text-muted)] px-1.5 py-0.5 border border-sidebar-border rounded-sm">
-            0.15
+            {APP_VERSION}
           </span>
         </div>
       </SidebarHeader>

--- a/frontend/src/components/onboarding/OnboardingDialog.tsx
+++ b/frontend/src/components/onboarding/OnboardingDialog.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/hooks/useMigration";
 import { Kbd } from "@/components/ui/kbd";
 import Logo from "@/components/Logo";
+import { formatAppVersion } from "@/lib/version";
 
 type Step = "welcome" | "migrate" | "fresh" | "running" | "done";
 
@@ -249,7 +250,7 @@ function WelcomeStep({
 }) {
   return (
     <div className="flex flex-col gap-4">
-      <MonoLabel>Welcome · v0.15.1</MonoLabel>
+      <MonoLabel>Welcome · {formatAppVersion()}</MonoLabel>
       <div className="text-[20px] font-semibold tracking-tight">
         Let's get your library set up.
       </div>

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -1,0 +1,14 @@
+import { version } from "../../package.json";
+
+/**
+ * App release version for UI chrome (sidebar, login, onboarding).
+ *
+ * Sourced from frontend/package.json. Changesets keeps this in sync with the
+ * root package and pyproject versions on release.
+ */
+export const APP_VERSION: string = version;
+
+/** Format for badges, e.g. `v0.18.5`. */
+export function formatAppVersion(withPrefix = true): string {
+  return withPrefix ? `v${APP_VERSION}` : APP_VERSION;
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -13,6 +13,7 @@ import { checkHealth, checkSetup, setupCredentials } from "@/lib/api";
 import { Kbd } from "@/components/ui/kbd";
 import GridShader from "@/components/login/GridShader";
 import Logo from "@/components/Logo";
+import { formatAppVersion } from "@/lib/version";
 
 function MonoLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -393,7 +394,7 @@ export default function LoginPage() {
         <div className="flex items-center gap-2 mb-6">
           <Logo className="h-4 w-auto text-foreground" />
           <span className="ml-auto font-mono text-[10px] text-muted-foreground px-1.5 py-0.5 border border-border rounded-sm">
-            v0.15.1
+            {formatAppVersion()}
           </span>
         </div>
 

--- a/frontend/tests/unit/lib/version.test.ts
+++ b/frontend/tests/unit/lib/version.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import packageJson from "../../../package.json";
+import { APP_VERSION, formatAppVersion } from "@/lib/version";
+
+describe("version", () => {
+  it("matches frontend package.json", () => {
+    expect(APP_VERSION).toBe(packageJson.version);
+    expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("formats with and without v prefix", () => {
+    expect(formatAppVersion()).toBe(`v${packageJson.version}`);
+    expect(formatAppVersion(true)).toBe(`v${packageJson.version}`);
+    expect(formatAppVersion(false)).toBe(packageJson.version);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces hardcoded version badges (`0.15` / `v0.15.1`) in the sidebar header, login screen, and onboarding welcome step
- Reads the release version from `frontend/package.json` (kept in sync by Changesets with root package + pyproject)
- Adds a small shared helper (`APP_VERSION` / `formatAppVersion`) and unit coverage

## Test plan
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run test:run -- tests/unit/lib/version.test.ts tests/pages/LoginPage.test.tsx`
- [ ] Confirm sidebar badge shows current release (e.g. `0.18.5`) after frontend rebuild/refresh
- [ ] Confirm login page badge shows `v0.18.5`
- [ ] Confirm onboarding welcome step shows `Welcome · v0.18.5` when triggered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - App version displays now stay synchronized with the current release across the sidebar, login screen, and onboarding welcome screen.
  - Version formatting is consistent, including optional `v` prefixes.

- **Tests**
  - Added coverage to verify the displayed version matches the application release and follows the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->