### PR TITLE
fix: restore activity history and library scans

### DIFF
--- a/.changeset/fresh-activity-tables.md
+++ b/.changeset/fresh-activity-tables.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix scheduled updates for manga libraries, rebuild Activity with searchable sortable paginated tables, show accurate live queue counts and relative activity times, and add a dashboard library-scan action.

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -1302,6 +1302,7 @@ def _ensure_columns(engine, table_name, required_columns):
 
 def dbcheck():
     from comicarr.db import get_engine
+    from comicarr.tables import ddl_info_status_updated
     from comicarr.tables import metadata as sa_metadata
 
     engine = get_engine()
@@ -1602,6 +1603,9 @@ def dbcheck():
         ("packinfo", "TEXT"),
     ]
     _ensure_columns(engine, "ddl_info", ddl_cols)
+    # create_all does not add indexes to existing tables. Create this only
+    # after legacy schemas have the indexed updated_date column.
+    ddl_info_status_updated.create(engine, checkfirst=True)
 
     # -- Provider_searches Table --
     _ensure_columns(engine, "provider_searches", [("id", "INTEGER"), ("hits", "INTEGER DEFAULT 0")])

--- a/comicarr/app/core/database.py
+++ b/comicarr/app/core/database.py
@@ -40,7 +40,7 @@ def get_dialect():
 
 def paginated_query(stmt, limit=None, offset=None):
     """Execute a statement with optional pagination. Returns dict with results/total/has_more."""
-    count_stmt = select(func.count()).select_from(stmt.subquery())
+    count_stmt = select(func.count()).select_from(stmt.order_by(None).subquery())
     with db.get_engine().connect() as conn:
         total = conn.execute(count_stmt).scalar() or 0
 

--- a/comicarr/app/dashboard/service.py
+++ b/comicarr/app/dashboard/service.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 
 import comicarr
 from comicarr import db, logger
+from comicarr.app.downloads import queries as dl_queries
 
 
 def get_dashboard_data(ctx):
@@ -30,6 +31,10 @@ def get_dashboard_data(ctx):
         "stats": {},
         "ai_activity": [],
         "ai_configured": False,
+        "scan_targets": {
+            "comic": isinstance(getattr(comicarr.CONFIG, "COMIC_DIR", None), str) and bool(comicarr.CONFIG.COMIC_DIR),
+            "manga": isinstance(getattr(comicarr.CONFIG, "MANGA_DIR", None), str) and bool(comicarr.CONFIG.MANGA_DIR),
+        },
     }
 
     # Recently downloaded: last 10 from snatched, sorted by DateAdded DESC
@@ -75,6 +80,12 @@ def get_dashboard_data(ctx):
                 "total_expected": total_expected,
                 "completion_pct": round(total_issues / total_expected * 100, 1) if total_expected > 0 else 0,
             }
+
+        try:
+            result["stats"].setdefault("queue_count", dl_queries.count_active_ddl_items())
+        except Exception as e:
+            logger.error("[DASHBOARD] Error fetching active queue count: %s" % e)
+            result["stats"].setdefault("queue_count", 0)
 
         # Manga-specific stats
         manga_stats = db.DBConnection().selectone(

--- a/comicarr/app/downloads/queries.py
+++ b/comicarr/app/downloads/queries.py
@@ -13,7 +13,7 @@ Downloads domain queries — snatched history, DDL queue, nzblog, failed.
 Uses SQLAlchemy Core via the existing db module.
 """
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, or_, select
 
 from comicarr import db
 from comicarr.app.core.database import paginated_query as _paginated_query
@@ -28,9 +28,50 @@ from comicarr.tables import snatched as t_snatched
 # ---------------------------------------------------------------------------
 
 
-def get_history(limit=None, offset=None):
-    """Get download history ordered by date, optionally paginated."""
-    stmt = select(t_snatched).order_by(t_snatched.c.DateAdded.desc())
+def _apply_activity_filters(stmt, status_column, search=None, status=None, search_columns=()):
+    if search:
+        pattern = "%%%s%%" % search.strip().lower()
+        stmt = stmt.where(or_(*[column.ilike(pattern) for column in search_columns]))
+    if status:
+        stmt = stmt.where(func.lower(func.coalesce(status_column, "")) == status.strip().lower())
+    return stmt
+
+
+def _apply_activity_sort(stmt, sort, order, allowed_columns, default_column, tie_breaker):
+    sort_column = allowed_columns.get(sort, default_column)
+    direction = sort_column.asc() if str(order).lower() == "asc" else sort_column.desc()
+    return stmt.order_by(direction, tie_breaker.desc())
+
+
+def get_history(limit=None, offset=None, search=None, status=None, sort=None, order="desc"):
+    """Get searchable, sortable download history, optionally paginated."""
+    stmt = _apply_activity_filters(
+        select(t_snatched),
+        t_snatched.c.Status,
+        search=search,
+        status=status,
+        search_columns=(
+            t_snatched.c.ComicName,
+            t_snatched.c.Issue_Number,
+            t_snatched.c.Provider,
+            t_snatched.c.Status,
+            t_snatched.c.FolderName,
+        ),
+    )
+    stmt = _apply_activity_sort(
+        stmt,
+        sort,
+        order,
+        {
+            "series": t_snatched.c.ComicName,
+            "issue": t_snatched.c.Issue_Number,
+            "provider": t_snatched.c.Provider,
+            "status": t_snatched.c.Status,
+            "date": t_snatched.c.DateAdded,
+        },
+        t_snatched.c.DateAdded,
+        t_snatched.c.IssueID,
+    )
     if limit is not None:
         return _paginated_query(stmt, limit=limit, offset=offset)
     return db.select_all(stmt)
@@ -48,10 +89,55 @@ def clear_history(status_type=None):
 # DDL queue
 # ---------------------------------------------------------------------------
 
+ACTIVE_DDL_STATUSES = ("Queued", "Downloading", "Failed")
 
-def get_ddl_queue():
-    """Get all DDL queue items ordered by submit date."""
-    stmt = select(t_ddl_info).order_by(t_ddl_info.c.submit_date.desc())
+
+def active_ddl_condition():
+    """Return the shared predicate for queue rows that still need attention."""
+    return or_(
+        t_ddl_info.c.status.is_(None),
+        t_ddl_info.c.status.in_(ACTIVE_DDL_STATUSES),
+    )
+
+
+def count_active_ddl_items():
+    stmt = select(func.count().label("queue_count")).select_from(t_ddl_info).where(active_ddl_condition())
+    row = db.select_one(stmt)
+    return (row or {}).get("queue_count", 0) or 0
+
+
+def get_ddl_queue(limit=None, offset=None, search=None, status=None, sort=None, order="desc"):
+    """Get active DDL queue items with search, sorting, and pagination."""
+    stmt = select(t_ddl_info).where(active_ddl_condition())
+    stmt = _apply_activity_filters(
+        stmt,
+        t_ddl_info.c.status,
+        search=search,
+        status=status,
+        search_columns=(
+            t_ddl_info.c.series,
+            t_ddl_info.c.filename,
+            t_ddl_info.c.site,
+            t_ddl_info.c.status,
+        ),
+    )
+    stmt = _apply_activity_sort(
+        stmt,
+        sort,
+        order,
+        {
+            "series": t_ddl_info.c.series,
+            "file": t_ddl_info.c.filename,
+            "site": t_ddl_info.c.site,
+            "status": t_ddl_info.c.status,
+            "updated": t_ddl_info.c.updated_date,
+            "submitted": t_ddl_info.c.submit_date,
+        },
+        t_ddl_info.c.updated_date,
+        t_ddl_info.c.ID,
+    )
+    if limit is not None:
+        return _paginated_query(stmt, limit=limit, offset=offset)
     return db.select_all(stmt)
 
 

--- a/comicarr/app/downloads/router.py
+++ b/comicarr/app/downloads/router.py
@@ -31,11 +31,22 @@ router = APIRouter(prefix="/api/downloads", tags=["downloads"])
 
 @router.get("/history", dependencies=[Depends(require_session)])
 def get_history(
-    limit: int = Query(None),
-    offset: int = Query(0),
+    limit: int | None = Query(None, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    q: str = Query(None, max_length=200),
+    status: str = Query(None, max_length=50),
+    sort: str = Query("date"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
 ):
-    """Get download history with optional pagination."""
-    return dl_service.get_history(limit=limit, offset=offset)
+    """Get searchable, sortable download history."""
+    return dl_service.get_history(
+        limit=limit,
+        offset=offset,
+        search=q,
+        status=status,
+        sort=sort,
+        order=order,
+    )
 
 
 @router.delete("/history", dependencies=[Depends(require_session)])
@@ -115,9 +126,23 @@ def process_issue(
 
 
 @router.get("/queue", dependencies=[Depends(require_session)])
-def get_ddl_queue():
-    """Get current DDL download queue."""
-    return dl_service.get_ddl_queue()
+def get_ddl_queue(
+    limit: int | None = Query(None, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    q: str = Query(None, max_length=200),
+    status: str = Query(None, max_length=50),
+    sort: str = Query("updated"),
+    order: str = Query("desc", pattern="^(asc|desc)$"),
+):
+    """Get the searchable, sortable active DDL download queue."""
+    return dl_service.get_ddl_queue(
+        limit=limit,
+        offset=offset,
+        search=q,
+        status=status,
+        sort=sort,
+        order=order,
+    )
 
 
 @router.post("/{item_id}/requeue", dependencies=[Depends(require_session)])

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -44,20 +44,38 @@ _DDL_JOURNAL_REQUEUE_CAP = 3
 # ---------------------------------------------------------------------------
 
 
-def get_history(limit=None, offset=None):
-    """Get download history, optionally paginated."""
+def _paginated_activity_response(key, query, **options):
+    paginated = query(**options)
+    return {
+        key: paginated["results"],
+        "pagination": {
+            "total": paginated["total"],
+            "limit": paginated["limit"],
+            "offset": paginated["offset"],
+            "has_more": paginated["has_more"],
+        },
+    }
+
+
+def get_history(limit=None, offset=None, search=None, status=None, sort=None, order="desc"):
+    """Get searchable, sortable download history, optionally paginated."""
     if limit is not None:
-        paginated = dl_queries.get_history(limit=limit, offset=offset)
-        return {
-            "history": paginated["results"],
-            "pagination": {
-                "total": paginated["total"],
-                "limit": paginated["limit"],
-                "offset": paginated["offset"],
-                "has_more": paginated["has_more"],
-            },
-        }
-    return dl_queries.get_history()
+        return _paginated_activity_response(
+            "history",
+            dl_queries.get_history,
+            limit=limit,
+            offset=offset,
+            search=search,
+            status=status,
+            sort=sort,
+            order=order,
+        )
+    return dl_queries.get_history(
+        search=search,
+        status=status,
+        sort=sort,
+        order=order,
+    )
 
 
 def clear_history(status_type=None):
@@ -147,9 +165,25 @@ def process_issue(comicid, folder, issueid=None):
 # ---------------------------------------------------------------------------
 
 
-def get_ddl_queue():
-    """Get current DDL download queue."""
-    return dl_queries.get_ddl_queue()
+def get_ddl_queue(limit=None, offset=None, search=None, status=None, sort=None, order="desc"):
+    """Get the active DDL download queue."""
+    if limit is not None:
+        return _paginated_activity_response(
+            "queue",
+            dl_queries.get_ddl_queue,
+            limit=limit,
+            offset=offset,
+            search=search,
+            status=status,
+            sort=sort,
+            order=order,
+        )
+    return dl_queries.get_ddl_queue(
+        search=search,
+        status=status,
+        sort=sort,
+        order=order,
+    )
 
 
 def delete_ddl_item(item_id):

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -691,6 +691,8 @@ def manga_library_scan(ctx):
     manga_dir = getattr(comicarr.CONFIG, "MANGA_DIR", None) if comicarr.CONFIG else None
     if not manga_dir:
         return {"success": False, "error": "Manga directory not configured"}
+    if not os.path.isdir(manga_dir):
+        return {"success": False, "error": "Manga directory not found: %s" % manga_dir}
 
     try:
         logger.info("[MANGA-SCAN] Starting manga library scan for: %s" % manga_dir)
@@ -721,6 +723,8 @@ def comic_library_scan(ctx):
     comic_dir = getattr(comicarr.CONFIG, "COMIC_DIR", None) if comicarr.CONFIG else None
     if not comic_dir:
         return {"success": False, "error": "Comic directory not configured"}
+    if not os.path.isdir(comic_dir):
+        return {"success": False, "error": "Comic directory not found: %s" % comic_dir}
 
     try:
         logger.info("[COMIC-SCAN] Starting comic library scan for: %s" % comic_dir)

--- a/comicarr/tables.py
+++ b/comicarr/tables.py
@@ -706,6 +706,7 @@ Index("failed_issueid", failed.c.IssueID)
 Index("upcoming_issuedate", upcoming.c.IssueDate)
 Index("upcoming_issueid", upcoming.c.IssueID)
 Index("pipeline_journal_stage", pipeline_journal.c.stage)
+ddl_info_status_updated = Index("ddl_info_status_updated", ddl_info.c.status, ddl_info.c.updated_date)
 
 # Case-insensitive indexes (SQLite uses COLLATE NOCASE on column definition;
 # PostgreSQL functional indexes are created separately in db.py)

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -2997,6 +2997,14 @@ def watchlist_updater(calledfrom=None, sched=False):
     prev_failed_updates = []
     popthecheck = []
     for row in list_rows:
+        try:
+            comicvine_id = int(row["ComicID"])
+        except (TypeError, ValueError):
+            logger.fdebug(
+                "[BACKFILL-UPDATE] Skipping non-ComicVine series id %s during ComicVine update" % row["ComicID"]
+            )
+            continue
+
         if row["ComicName"] is None and comicarr.CONFIG.ANNUALS_ON:
             logger.fdebug("Popping the check for: %s" % row["ComicID"])
             popthecheck.append(
@@ -3007,7 +3015,7 @@ def watchlist_updater(calledfrom=None, sched=False):
             ["ComicID" not in row["ComicName"], row["Status"] != "Loading", row["ComicName"] is not None]
         ):
             prev_failed_updates.append(
-                {"comicid": int(row["ComicID"]), "comicname": row["ComicName"], "seriesyear": row["ComicYear"]}
+                {"comicid": comicvine_id, "comicname": row["ComicName"], "seriesyear": row["ComicYear"]}
             )
         else:
             try:
@@ -3015,10 +3023,10 @@ def watchlist_updater(calledfrom=None, sched=False):
             except Exception:
                 # if the lastupdated date is NULL, but the other values filled in partially - this will make sure to get the ID so it can be refeshed properly
                 prev_failed_updates.append(
-                    {"comicid": int(row["ComicID"]), "comicname": row["ComicName"], "seriesyear": row["ComicYear"]}
+                    {"comicid": comicvine_id, "comicname": row["ComicName"], "seriesyear": row["ComicYear"]}
                 )
             else:
-                library[int(row["ComicID"])] = {
+                library[comicvine_id] = {
                     "comicid": row["ComicID"],
                     "status": row["Status"],
                     "comicname": row["ComicName"],

--- a/frontend/src/components/data-table/DataTable.tsx
+++ b/frontend/src/components/data-table/DataTable.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import {
   flexRender,
   type Row,
@@ -62,9 +62,8 @@ export function DataTable<TData>({
             table.getRowModel().rows.map((row) => {
               const colSpan = table.getAllColumns().length;
               return (
-                <>
+                <Fragment key={row.id}>
                   <TableRow
-                    key={row.id}
                     data-state={row.getIsSelected() && "selected"}
                     className={cn(
                       "border-b border-border/50",
@@ -86,7 +85,7 @@ export function DataTable<TData>({
                   {renderSubRow &&
                     row.getIsExpanded() &&
                     renderSubRow(row, colSpan)}
-                </>
+                </Fragment>
               );
             })
           ) : (

--- a/frontend/src/components/ui/RelativeTime.tsx
+++ b/frontend/src/components/ui/RelativeTime.tsx
@@ -1,0 +1,23 @@
+import { format, formatDistanceToNowStrict } from "date-fns";
+
+function parseDate(value: string): Date | null {
+  if (!value) return null;
+  const normalized = value.includes("T") ? value : value.replace(" ", "T");
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export default function RelativeTime({ value }: { value?: string | null }) {
+  const date = parseDate(value || "");
+  if (!date) return <span className="text-muted-foreground">—</span>;
+
+  return (
+    <time
+      dateTime={date.toISOString()}
+      title={format(date, "PPpp")}
+      className="font-mono text-[11px] text-muted-foreground whitespace-nowrap"
+    >
+      {formatDistanceToNowStrict(date, { addSuffix: true })}
+    </time>
+  );
+}

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/api";
+import type { PaginationMeta } from "@/types";
 
 export interface HistoryItem {
   IssueID: string;
@@ -15,12 +16,7 @@ export interface HistoryItem {
 
 interface HistoryResponse {
   history: HistoryItem[];
-  pagination: {
-    total: number;
-    limit: number;
-    offset: number;
-    has_more: boolean;
-  };
+  pagination: PaginationMeta;
 }
 
 export interface QueueItem {
@@ -39,22 +35,52 @@ export interface QueueItem {
   submit_date: string;
 }
 
-export function useDownloadHistory(limit: number, offset: number) {
+interface QueueResponse {
+  queue: QueueItem[];
+  pagination: PaginationMeta;
+}
+
+interface ActivityQuery {
+  limit: number;
+  offset: number;
+  q?: string;
+  status?: string;
+  sort: string;
+  order: "asc" | "desc";
+}
+
+function activityUrl(path: string, query: ActivityQuery): string {
+  const params = new URLSearchParams({
+    limit: String(query.limit),
+    offset: String(query.offset),
+    sort: query.sort,
+    order: query.order,
+  });
+  if (query.q?.trim()) params.set("q", query.q.trim());
+  if (query.status?.trim()) params.set("status", query.status.trim());
+  return `${path}?${params.toString()}`;
+}
+
+export function useDownloadHistory(query: ActivityQuery) {
   return useQuery<HistoryResponse>({
-    queryKey: ["downloads", "history", limit, offset],
+    queryKey: ["downloads", "history", query],
     queryFn: () =>
       apiRequest<HistoryResponse>(
         "GET",
-        `/api/downloads/history?limit=${limit}&offset=${offset}`,
+        activityUrl("/api/downloads/history", query),
       ),
     staleTime: 30 * 1000, // 30 seconds
   });
 }
 
-export function useDownloadQueue() {
-  return useQuery<QueueItem[]>({
-    queryKey: ["downloads", "queue"],
-    queryFn: () => apiRequest<QueueItem[]>("GET", "/api/downloads/queue"),
+export function useDownloadQueue(query: ActivityQuery) {
+  return useQuery<QueueResponse>({
+    queryKey: ["downloads", "queue", query],
+    queryFn: () =>
+      apiRequest<QueueResponse>(
+        "GET",
+        activityUrl("/api/downloads/queue", query),
+      ),
     staleTime: 10 * 1000, // 10 seconds — queue data is transient
     refetchInterval: 15 * 1000, // Poll every 15 seconds
   });

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -26,6 +26,7 @@ interface DashboardStats {
   total_issues: number;
   total_expected: number;
   completion_pct: number;
+  queue_count: number;
 }
 
 interface DashboardAiActivity {
@@ -43,6 +44,10 @@ export interface DashboardData {
   stats: DashboardStats;
   ai_activity: DashboardAiActivity[];
   ai_configured: boolean;
+  scan_targets: {
+    comic: boolean;
+    manga: boolean;
+  };
 }
 
 export function useDashboard() {

--- a/frontend/src/hooks/useImport.ts
+++ b/frontend/src/hooks/useImport.ts
@@ -175,6 +175,9 @@ export function useMangaScan(): UseMutationResult<
 > {
   const queryClient = useQueryClient();
   return useMutation({
+    onMutate: () => {
+      queryClient.removeQueries({ queryKey: ["mangaScanProgress"] });
+    },
     mutationFn: () =>
       apiRequest<MangaScanResponse>("POST", "/api/import/manga/scan"),
     onSuccess: () => {
@@ -238,6 +241,9 @@ export function useComicScan(): UseMutationResult<
 > {
   const queryClient = useQueryClient();
   return useMutation({
+    onMutate: () => {
+      queryClient.removeQueries({ queryKey: ["comicScanProgress"] });
+    },
     mutationFn: () =>
       apiRequest<ComicScanResponse>("POST", "/api/import/comic/scan"),
     onSuccess: () => {

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -1,33 +1,56 @@
-import { useState } from "react";
-import { useSearchParams, Link } from "react-router-dom";
+import { useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+  type SortingState,
+  type Table as TanstackTable,
+  type Updater,
+} from "@tanstack/react-table";
+import { RefreshCw } from "lucide-react";
 import {
   useDownloadHistory,
   useDownloadQueue,
   type HistoryItem,
   type QueueItem,
 } from "@/hooks/useActivity";
+import { useDebounce } from "@/hooks/use-debounce";
+import { DataTable } from "@/components/data-table/DataTable";
+import { DataTableServerPagination } from "@/components/data-table/DataTableServerPagination";
+import { DataTableSortHeader } from "@/components/data-table/DataTableSortHeader";
 import { Skeleton } from "@/components/ui/skeleton";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 import EmptyState from "@/components/ui/EmptyState";
+import FilterField from "@/components/ui/FilterField";
+import RelativeTime from "@/components/ui/RelativeTime";
 import PageHeader, { Tab, TabRow } from "@/components/layout/PageHeader";
+import type { PaginationMeta } from "@/types";
 
 type ActivityView = "queue" | "history";
+const PAGE_SIZE = 25;
 
 function StatusPill({ status }: { status: string }) {
-  const s = (status || "").toLowerCase();
+  const normalized = (status || "").toLowerCase();
   let color = "var(--muted-foreground)";
   if (
-    s.includes("down") ||
-    s.includes("snatch") ||
-    s === "active" ||
-    s === "completed" ||
-    s === "done"
-  )
+    normalized.includes("down") ||
+    normalized.includes("snatch") ||
+    normalized === "active" ||
+    normalized === "completed" ||
+    normalized === "done"
+  ) {
     color = "var(--status-active)";
-  else if (s.includes("queue") || s.includes("pend") || s === "wanted")
+  } else if (
+    normalized.includes("queue") ||
+    normalized.includes("pend") ||
+    normalized === "wanted"
+  ) {
     color = "var(--status-paused)";
-  else if (s.includes("fail") || s.includes("error"))
+  } else if (normalized.includes("fail") || normalized.includes("error")) {
     color = "var(--status-error)";
+  }
+
   return (
     <span
       className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase"
@@ -44,12 +67,16 @@ function StatusPill({ status }: { status: string }) {
 
 export default function ActivityPage() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const viewParam = searchParams.get("view");
   const currentView: ActivityView =
-    viewParam === "history" ? "history" : "queue";
+    searchParams.get("view") === "history" ? "history" : "queue";
 
   const setView = (view: ActivityView) => {
-    setSearchParams({ view });
+    setSearchParams((current) => {
+      const next = new URLSearchParams(current);
+      if (view === "history") next.set("view", "history");
+      else next.delete("view");
+      return next;
+    });
   };
 
   return (
@@ -57,9 +84,7 @@ export default function ActivityPage() {
       <PageHeader
         title="Activity"
         meta={
-          currentView === "queue"
-            ? "live download queue"
-            : "completed downloads"
+          currentView === "queue" ? "live download queue" : "download history"
         }
       />
 
@@ -76,243 +101,412 @@ export default function ActivityPage() {
         />
       </TabRow>
 
-      <div className="px-5 py-4">
-        {currentView === "queue" ? <QueueView /> : <HistoryView />}
-      </div>
+      {currentView === "queue" ? <QueueView /> : <HistoryView />}
     </div>
   );
 }
 
-function DenseTable({
-  headers,
-  gridTemplate,
-  children,
+function ActivityToolbar({
+  value,
+  onChange,
+  label,
+  placeholder,
+  isRefreshing,
+  onRefresh,
 }: {
-  headers: string[];
-  gridTemplate: string;
-  children: React.ReactNode;
+  value: string;
+  onChange: (value: string) => void;
+  label: string;
+  placeholder: string;
+  isRefreshing: boolean;
+  onRefresh: () => void;
 }) {
   return (
-    <div
-      className="rounded-[6px] border overflow-x-auto"
-      style={{ borderColor: "var(--border)" }}
-    >
-      <div
-        className="grid px-4 py-2 border-b font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground"
-        style={{
-          borderColor: "var(--border)",
-          background: "var(--card)",
-          gridTemplateColumns: gridTemplate,
-        }}
-      >
-        {headers.map((h, i) => (
-          <div key={`${h}-${i}`}>{h}</div>
-        ))}
+    <div className="px-5 py-2.5 border-b border-border flex items-center gap-3">
+      <div className="flex-1 max-w-lg">
+        <FilterField
+          placeholder={placeholder}
+          aria-label={label}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          shortcut="/"
+        />
       </div>
-      {children}
+      <button
+        type="button"
+        onClick={onRefresh}
+        disabled={isRefreshing}
+        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-[5px] border font-mono text-[11px] text-muted-foreground disabled:opacity-60"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <RefreshCw
+          className={`w-3 h-3 ${isRefreshing ? "animate-spin" : ""}`}
+        />
+        refresh
+      </button>
     </div>
   );
 }
 
-function QueueView() {
-  const { data: queue, isLoading, error, refetch } = useDownloadQueue();
-
-  if (isLoading) {
-    return (
-      <div className="space-y-2">
-        {[0, 1, 2].map((i) => (
-          <Skeleton key={i} className="h-10" />
-        ))}
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <ErrorDisplay
-        error={error}
-        title="Unable to load download queue"
-        onRetry={() => refetch()}
-      />
-    );
-  }
-
-  if (!queue || queue.length === 0) {
-    return (
-      <EmptyState
-        variant="custom"
-        eyebrow="QUEUE · EMPTY"
-        title="No active downloads"
-        description="Downloads will appear here while items are being processed."
-      />
-    );
-  }
-
-  const gridTpl = "1.5fr 2fr 100px 110px 110px";
-
+function LoadingRows() {
   return (
-    <DenseTable
-      headers={["series", "file", "site", "status", "updated"]}
-      gridTemplate={gridTpl}
-    >
-      {queue.map((item: QueueItem) => (
-        <div
-          key={item.ID}
-          className="grid items-center px-4 py-2 text-[12px] border-b last:border-b-0"
-          style={{
-            borderColor: "var(--border-soft, var(--border))",
-            gridTemplateColumns: gridTpl,
-          }}
-        >
-          <div className="font-medium truncate">
-            {item.comicid ? (
-              <Link
-                to={`/library/${item.comicid}`}
-                className="hover:text-[var(--primary)]"
-              >
-                {item.series}
-                {item.year && (
-                  <span className="text-muted-foreground"> ({item.year})</span>
-                )}
-              </Link>
-            ) : (
-              <>
-                {item.series}
-                {item.year && (
-                  <span className="text-muted-foreground"> ({item.year})</span>
-                )}
-              </>
-            )}
-          </div>
-          <div className="font-mono text-[11px] text-muted-foreground truncate">
-            {item.filename || "—"}
-          </div>
-          <div className="text-muted-foreground truncate">
-            {item.site || "—"}
-          </div>
-          <StatusPill status={item.status} />
-          <div className="font-mono text-[11px] text-muted-foreground">
-            {item.updated_date || "—"}
-          </div>
-        </div>
+    <div className="px-5 py-4 space-y-2">
+      {[0, 1, 2].map((index) => (
+        <Skeleton key={index} className="h-11" />
       ))}
-    </DenseTable>
+    </div>
   );
 }
 
-function HistoryView() {
+function useActivityTableState(defaultSortId: string) {
   const [page, setPage] = useState(0);
-  const limit = 50;
-  const offset = page * limit;
-  const { data, isLoading, error, refetch } = useDownloadHistory(limit, offset);
-  const history = data?.history || [];
-  const pagination = data?.pagination;
+  const [search, setSearchState] = useState("");
+  const debouncedSearch = useDebounce(search, 400);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: defaultSortId, desc: true },
+  ]);
+  const activeSort = sorting[0] ?? { id: defaultSortId, desc: true };
 
-  if (isLoading) {
-    return (
-      <div className="space-y-2">
-        {[0, 1, 2].map((i) => (
-          <Skeleton key={i} className="h-10" />
-        ))}
-      </div>
+  const setSearch = (value: string) => {
+    setSearchState(value);
+    setPage(0);
+  };
+  const handleSortingChange = (updater: Updater<SortingState>) => {
+    setSorting((current) =>
+      typeof updater === "function" ? updater(current) : updater,
     );
-  }
+    setPage(0);
+  };
 
-  if (error) {
-    return (
-      <ErrorDisplay
-        error={error}
-        title="Unable to load download history"
-        onRetry={() => refetch()}
-      />
-    );
-  }
+  return {
+    page,
+    setPage,
+    search,
+    setSearch,
+    debouncedSearch,
+    sorting,
+    activeSort,
+    handleSortingChange,
+  };
+}
 
-  if (history.length === 0) {
-    return (
-      <EmptyState
-        variant="custom"
-        eyebrow="HISTORY · EMPTY"
-        title="No download history"
-        description="Completed downloads will appear here."
-      />
-    );
-  }
-
-  const gridTpl = "2fr 80px 160px 120px 120px";
-
+function ActivityTableView<TData>({
+  table,
+  rows,
+  pagination,
+  search,
+  onSearchChange,
+  filterLabel,
+  filterPlaceholder,
+  isLoading,
+  isFetching,
+  error,
+  errorTitle,
+  emptyEyebrow,
+  emptyTitle,
+  emptyDescription,
+  filteredTitle,
+  onRefresh,
+  onNextPage,
+  onPrevPage,
+}: {
+  table: TanstackTable<TData>;
+  rows: TData[];
+  pagination?: PaginationMeta;
+  search: string;
+  onSearchChange: (value: string) => void;
+  filterLabel: string;
+  filterPlaceholder: string;
+  isLoading: boolean;
+  isFetching: boolean;
+  error: Error | null;
+  errorTitle: string;
+  emptyEyebrow: string;
+  emptyTitle: string;
+  emptyDescription: string;
+  filteredTitle: string;
+  onRefresh: () => void;
+  onNextPage: () => void;
+  onPrevPage: () => void;
+}) {
   return (
-    <div className="space-y-3">
-      <div className="font-mono text-[11px] text-muted-foreground">
-        {pagination?.total || history.length} entries
-      </div>
-      <DenseTable
-        headers={["comic", "issue", "provider", "status", "date"]}
-        gridTemplate={gridTpl}
-      >
-        {history.map((item: HistoryItem, index: number) => (
-          <div
-            key={`${item.IssueID}-${item.Status}-${index}`}
-            className="grid items-center px-4 py-2 text-[12px] border-b last:border-b-0"
-            style={{
-              borderColor: "var(--border-soft, var(--border))",
-              gridTemplateColumns: gridTpl,
-            }}
-          >
-            <div className="font-medium truncate">
-              {item.ComicID ? (
-                <Link
-                  to={`/library/${item.ComicID}`}
-                  className="hover:text-[var(--primary)]"
-                >
-                  {item.ComicName}
-                </Link>
-              ) : (
-                item.ComicName
-              )}
-            </div>
-            <div className="font-mono text-[11px] text-muted-foreground">
-              {item.Issue_Number ? `#${item.Issue_Number}` : "—"}
-            </div>
-            <div className="text-muted-foreground truncate">
-              {item.Provider || "—"}
-            </div>
-            <StatusPill status={item.Status} />
-            <div className="font-mono text-[11px] text-muted-foreground">
-              {item.DateAdded || "—"}
-            </div>
-          </div>
-        ))}
-      </DenseTable>
-
-      {pagination && pagination.total > limit && (
-        <div
-          className="flex items-center justify-between pt-3 border-t font-mono text-[11px] text-muted-foreground"
-          style={{ borderColor: "var(--border)" }}
-        >
-          <button
-            type="button"
-            className="px-2.5 py-1 rounded border disabled:opacity-50"
-            style={{ borderColor: "var(--border)" }}
-            onClick={() => setPage((p) => Math.max(0, p - 1))}
-            disabled={page === 0}
-          >
-            ← prev
-          </button>
-          <span>
-            page {page + 1} / {Math.ceil(pagination.total / limit)}
-          </span>
-          <button
-            type="button"
-            className="px-2.5 py-1 rounded border disabled:opacity-50"
-            style={{ borderColor: "var(--border)" }}
-            onClick={() => setPage((p) => p + 1)}
-            disabled={!pagination.has_more}
-          >
-            next →
-          </button>
+    <>
+      <ActivityToolbar
+        value={search}
+        onChange={onSearchChange}
+        label={filterLabel}
+        placeholder={filterPlaceholder}
+        isRefreshing={isFetching}
+        onRefresh={onRefresh}
+      />
+      {isLoading && <LoadingRows />}
+      {error && (
+        <div className="px-5 py-4">
+          <ErrorDisplay error={error} title={errorTitle} onRetry={onRefresh} />
         </div>
       )}
-    </div>
+      {!isLoading && !error && rows.length === 0 && (
+        <div className="px-5 py-4">
+          <EmptyState
+            variant="custom"
+            eyebrow={
+              search ? `${emptyEyebrow} · FILTERED` : `${emptyEyebrow} · EMPTY`
+            }
+            title={search ? filteredTitle : emptyTitle}
+            description={search ? "Try a different filter." : emptyDescription}
+          />
+        </div>
+      )}
+      {!isLoading &&
+        !error &&
+        pagination &&
+        (rows.length > 0 || pagination.offset > 0) && (
+          <div className="overflow-hidden border-b border-border">
+            {rows.length > 0 && <DataTable table={table} />}
+            <DataTableServerPagination
+              pagination={pagination}
+              onNextPage={onNextPage}
+              onPrevPage={onPrevPage}
+            />
+          </div>
+        )}
+    </>
+  );
+}
+
+const queueColumnHelper = createColumnHelper<QueueItem>();
+
+function QueueView() {
+  const {
+    page,
+    setPage,
+    search,
+    setSearch,
+    debouncedSearch,
+    sorting,
+    activeSort,
+    handleSortingChange,
+  } = useActivityTableState("updated");
+  const { data, isLoading, isFetching, error, refetch } = useDownloadQueue({
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+    q: debouncedSearch,
+    sort: activeSort.id,
+    order: activeSort.desc ? "desc" : "asc",
+  });
+  const queue = data?.queue ?? [];
+
+  const columns = useMemo(
+    () => [
+      queueColumnHelper.accessor("series", {
+        header: ({ column }) => (
+          <DataTableSortHeader column={column} title="Series" />
+        ),
+        cell: ({ row }) => {
+          const content = (
+            <>
+              {row.original.series || "—"}
+              {row.original.year && (
+                <span className="text-muted-foreground">
+                  {" "}
+                  ({row.original.year})
+                </span>
+              )}
+            </>
+          );
+          return row.original.comicid ? (
+            <Link
+              to={`/library/${row.original.comicid}`}
+              className="font-medium hover:text-[var(--primary)]"
+            >
+              {content}
+            </Link>
+          ) : (
+            <span className="font-medium">{content}</span>
+          );
+        },
+      }),
+      queueColumnHelper.accessor("filename", {
+        id: "file",
+        header: ({ column }) => (
+          <DataTableSortHeader column={column} title="File" />
+        ),
+        cell: ({ getValue }) => (
+          <span className="font-mono text-[11px] text-muted-foreground">
+            {getValue() || "—"}
+          </span>
+        ),
+      }),
+      queueColumnHelper.accessor("site", {
+        header: ({ column }) => (
+          <DataTableSortHeader column={column} title="Site" />
+        ),
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground">{getValue() || "—"}</span>
+        ),
+      }),
+      queueColumnHelper.accessor("status", {
+        header: ({ column }) => (
+          <DataTableSortHeader column={column} title="Status" />
+        ),
+        cell: ({ getValue }) => <StatusPill status={getValue()} />,
+      }),
+      queueColumnHelper.accessor("updated_date", {
+        id: "updated",
+        header: ({ column }) => (
+          <DataTableSortHeader column={column} title="Updated" />
+        ),
+        cell: ({ getValue }) => <RelativeTime value={getValue()} />,
+      }),
+    ],
+    [],
+  );
+
+  const table = useReactTable({
+    data: queue,
+    columns,
+    state: { sorting },
+    onSortingChange: handleSortingChange,
+    getCoreRowModel: getCoreRowModel(),
+    manualSorting: true,
+    enableSortingRemoval: false,
+    getRowId: (row) => row.ID,
+  });
+
+  return (
+    <ActivityTableView
+      table={table}
+      rows={queue}
+      pagination={data?.pagination}
+      search={search}
+      onSearchChange={setSearch}
+      filterLabel="Filter queue activity"
+      filterPlaceholder="Filter by series, file, site, or status…"
+      isLoading={isLoading}
+      isFetching={isFetching}
+      error={error}
+      errorTitle="Unable to load download queue"
+      emptyEyebrow="QUEUE"
+      emptyTitle="No active downloads"
+      emptyDescription="Queued, downloading, and failed items will appear here."
+      filteredTitle="No matching queue items"
+      onRefresh={() => void refetch()}
+      onNextPage={() => setPage((current) => current + 1)}
+      onPrevPage={() => setPage((current) => Math.max(0, current - 1))}
+    />
+  );
+}
+
+const historyColumnHelper = createColumnHelper<HistoryItem>();
+
+function HistoryView() {
+  const {
+    page,
+    setPage,
+    search,
+    setSearch,
+    debouncedSearch,
+    sorting,
+    activeSort,
+    handleSortingChange,
+  } = useActivityTableState("date");
+  const { data, isLoading, isFetching, error, refetch } = useDownloadHistory({
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+    q: debouncedSearch,
+    sort: activeSort.id,
+    order: activeSort.desc ? "desc" : "asc",
+  });
+  const history = data?.history ?? [];
+
+  const columns = useMemo(
+    () => [
+      historyColumnHelper.accessor("ComicName", {
+        id: "series",
+        header: ({ column }) => (
+          <DataTableSortHeader column={column} title="Series" />
+        ),
+        cell: ({ row }) =>
+          row.original.ComicID ? (
+            <Link
+              to={`/library/${row.original.ComicID}`}
+              className="font-medium hover:text-[var(--primary)]"
+            >
+              {row.original.ComicName || "—"}
+            </Link>
+          ) : (
+            <span className="font-medium">{row.original.ComicName || "—"}</span>
+          ),
+      }),
+      historyColumnHelper.accessor("Issue_Number", {
+        id: "issue",
+        header: ({ column }) => (
+          <DataTableSortHeader column={column} title="Issue" />
+        ),
+        cell: ({ getValue }) => (
+          <span className="font-mono text-[11px] text-muted-foreground">
+            {getValue() ? `#${getValue()}` : "—"}
+          </span>
+        ),
+      }),
+      historyColumnHelper.accessor("Provider", {
+        id: "provider",
+        header: ({ column }) => (
+          <DataTableSortHeader column={column} title="Provider" />
+        ),
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground">{getValue() || "—"}</span>
+        ),
+      }),
+      historyColumnHelper.accessor("Status", {
+        id: "status",
+        header: ({ column }) => (
+          <DataTableSortHeader column={column} title="Status" />
+        ),
+        cell: ({ getValue }) => <StatusPill status={getValue()} />,
+      }),
+      historyColumnHelper.accessor("DateAdded", {
+        id: "date",
+        header: ({ column }) => (
+          <DataTableSortHeader column={column} title="Date" />
+        ),
+        cell: ({ getValue }) => <RelativeTime value={getValue()} />,
+      }),
+    ],
+    [],
+  );
+
+  const table = useReactTable({
+    data: history,
+    columns,
+    state: { sorting },
+    onSortingChange: handleSortingChange,
+    getCoreRowModel: getCoreRowModel(),
+    manualSorting: true,
+    enableSortingRemoval: false,
+    getRowId: (row, index) => `${row.IssueID}-${row.Status}-${index}`,
+  });
+
+  return (
+    <ActivityTableView
+      table={table}
+      rows={history}
+      pagination={data?.pagination}
+      search={search}
+      onSearchChange={setSearch}
+      filterLabel="Filter download history"
+      filterPlaceholder="Filter by series, issue, provider, status, or file…"
+      isLoading={isLoading}
+      isFetching={isFetching}
+      error={error}
+      errorTitle="Unable to load download history"
+      emptyEyebrow="HISTORY"
+      emptyTitle="No download history"
+      emptyDescription="Download events will appear here."
+      filteredTitle="No matching history"
+      onRefresh={() => void refetch()}
+      onNextPage={() => setPage((current) => current + 1)}
+      onPrevPage={() => setPage((current) => Math.max(0, current - 1))}
+    />
   );
 }

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -254,22 +254,28 @@ function ActivityTableView<TData>({
             }
             title={search ? filteredTitle : emptyTitle}
             description={search ? "Try a different filter." : emptyDescription}
+            action={
+              pagination && pagination.offset > 0
+                ? {
+                    label: "Previous",
+                    onClick: onPrevPage,
+                    variant: "outline",
+                  }
+                : undefined
+            }
           />
         </div>
       )}
-      {!isLoading &&
-        !error &&
-        pagination &&
-        (rows.length > 0 || pagination.offset > 0) && (
-          <div className="overflow-hidden border-b border-border">
-            {rows.length > 0 && <DataTable table={table} />}
-            <DataTableServerPagination
-              pagination={pagination}
-              onNextPage={onNextPage}
-              onPrevPage={onPrevPage}
-            />
-          </div>
-        )}
+      {!isLoading && !error && pagination && rows.length > 0 && (
+        <div className="overflow-hidden border-b border-border">
+          <DataTable table={table} />
+          <DataTableServerPagination
+            pagination={pagination}
+            onNextPage={onNextPage}
+            onPrevPage={onPrevPage}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,16 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { RefreshCw } from "lucide-react";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
+import RelativeTime from "@/components/ui/RelativeTime";
+import { useToast } from "@/components/ui/toast";
 import { useDashboard } from "@/hooks/useDashboard";
+import {
+  useComicScan,
+  useComicScanProgress,
+  useMangaScan,
+  useMangaScanProgress,
+} from "@/hooks/useImport";
 
 function Kpi({
   label,
@@ -25,6 +35,61 @@ function Kpi({
 
 export default function DashboardPage() {
   const { data, isLoading, error } = useDashboard();
+  const comicScan = useComicScan();
+  const mangaScan = useMangaScan();
+  const [comicScanning, setComicScanning] = useState(false);
+  const [mangaScanning, setMangaScanning] = useState(false);
+  const { data: comicScanProgress, error: comicProgressError } =
+    useComicScanProgress(comicScanning);
+  const { data: mangaScanProgress, error: mangaProgressError } =
+    useMangaScanProgress(mangaScanning);
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    if (
+      !comicScanning ||
+      !["completed", "error"].includes(comicScanProgress?.status || "")
+    )
+      return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Sync the dashboard action with server scan state
+    setComicScanning(false);
+    if (comicScanProgress?.status === "error") {
+      addToast({ type: "error", message: "Comic library scan failed." });
+    }
+  }, [comicScanning, comicScanProgress?.status, addToast]);
+
+  useEffect(() => {
+    if (
+      !mangaScanning ||
+      !["completed", "error"].includes(mangaScanProgress?.status || "")
+    )
+      return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Sync the dashboard action with server scan state
+    setMangaScanning(false);
+    if (mangaScanProgress?.status === "error") {
+      addToast({ type: "error", message: "Manga library scan failed." });
+    }
+  }, [mangaScanning, mangaScanProgress?.status, addToast]);
+
+  useEffect(() => {
+    if (!comicScanning || !comicProgressError) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Release a dashboard action whose progress request failed
+    setComicScanning(false);
+    addToast({
+      type: "error",
+      message: "Unable to monitor comic library scan.",
+    });
+  }, [comicScanning, comicProgressError, addToast]);
+
+  useEffect(() => {
+    if (!mangaScanning || !mangaProgressError) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Release a dashboard action whose progress request failed
+    setMangaScanning(false);
+    addToast({
+      type: "error",
+      message: "Unable to monitor manga library scan.",
+    });
+  }, [mangaScanning, mangaProgressError, addToast]);
 
   if (error) {
     return (
@@ -45,14 +110,62 @@ export default function DashboardPage() {
   const activeSeries = stats?.total_series ?? 0;
   const totalIssues = stats?.total_issues ?? 0;
   const completion = stats?.completion_pct ?? 0;
-  const queueCount = downloads.filter((d) =>
-    /snatch|queue|wanted/i.test(d.Status),
-  ).length;
+  const queueCount = stats?.queue_count ?? 0;
+  const scanPending =
+    comicScan.isPending ||
+    mangaScan.isPending ||
+    comicScanning ||
+    mangaScanning;
+  const canScan = Boolean(
+    data?.scan_targets?.comic || data?.scan_targets?.manga,
+  );
+
+  const handleLibraryScan = async () => {
+    const scans: { type: "comic" | "manga"; request: Promise<unknown> }[] = [];
+    if (data?.scan_targets?.comic) {
+      scans.push({ type: "comic", request: comicScan.mutateAsync() });
+    }
+    if (data?.scan_targets?.manga) {
+      scans.push({ type: "manga", request: mangaScan.mutateAsync() });
+    }
+
+    if (scans.length === 0) {
+      addToast({
+        type: "error",
+        message:
+          "Configure a comic or manga library directory before scanning.",
+      });
+      return;
+    }
+
+    const results = await Promise.allSettled(scans.map((scan) => scan.request));
+    results.forEach((result, index) => {
+      if (result.status !== "fulfilled") return;
+      if (scans[index].type === "comic") setComicScanning(true);
+      else setMangaScanning(true);
+    });
+    const started = results.filter(
+      (result) => result.status === "fulfilled",
+    ).length;
+    if (started === scans.length) {
+      addToast({
+        type: "success",
+        message: `${started === 2 ? "Comic and manga library scans" : "Library scan"} started.`,
+      });
+    } else if (started > 0) {
+      addToast({
+        type: "error",
+        message: "One library scan started, but another failed to start.",
+      });
+    } else {
+      addToast({ type: "error", message: "Failed to start library scans." });
+    }
+  };
 
   return (
     <div className="h-full flex flex-col page-transition">
       {/* Page header */}
-      <div className="px-5 py-4 border-b border-border flex items-center gap-3">
+      <div className="px-5 py-4 border-b border-border flex items-center justify-between gap-3">
         <div>
           <div className="text-[18px] font-semibold tracking-tight">
             Dashboard
@@ -63,6 +176,23 @@ export default function DashboardPage() {
               : `${activeSeries} series · ${totalIssues} issues · ${queueCount} in queue`}
           </div>
         </div>
+        <button
+          type="button"
+          onClick={() => void handleLibraryScan()}
+          disabled={!canScan || scanPending}
+          title={
+            canScan
+              ? "Scan configured comic and manga libraries"
+              : "Configure a library directory first"
+          }
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[5px] border text-[12px] font-medium disabled:opacity-50"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <RefreshCw
+            className={`w-3.5 h-3.5 ${scanPending ? "animate-spin" : ""}`}
+          />
+          {scanPending ? "Scanning…" : "Scan libraries"}
+        </button>
       </div>
 
       {/* KPI strip */}
@@ -88,13 +218,21 @@ export default function DashboardPage() {
       <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] border-b border-border min-h-[320px]">
         {/* Queue & recent activity */}
         <section className="px-5 py-4 lg:border-r lg:border-border">
-          <div className="flex items-center gap-2.5 mb-3">
-            <div className="text-[13px] font-semibold">
-              Queue & recent activity
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <div className="flex items-center gap-2.5">
+              <div className="text-[13px] font-semibold">
+                Queue & recent activity
+              </div>
+              <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
+                {downloads.length} events
+              </div>
             </div>
-            <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
-              {downloads.length} events
-            </div>
+            <Link
+              to="/activity?view=history"
+              className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
+            >
+              view all →
+            </Link>
           </div>
 
           {isLoading && (
@@ -124,16 +262,14 @@ export default function DashboardPage() {
                   key={`${d.ComicID}-${d.IssueID}-${i}`}
                   className="grid items-center gap-2 py-1.5"
                   style={{
-                    gridTemplateColumns: "60px 90px 1fr 140px 60px 20px",
+                    gridTemplateColumns: "120px 90px minmax(180px, 1fr) 140px",
                     borderTop:
                       i > 0
                         ? "1px solid var(--border-soft, var(--border))"
                         : "none",
                   }}
                 >
-                  <span className="text-[var(--text-muted)]">
-                    {d.DateAdded?.slice(11, 16) || "—"}
-                  </span>
+                  <RelativeTime value={d.DateAdded} />
                   <span className="uppercase truncate" style={{ color }}>
                     {action}
                   </span>
@@ -157,10 +293,6 @@ export default function DashboardPage() {
                   </div>
                   <span className="text-muted-foreground truncate">
                     {d.Provider || "—"}
-                  </span>
-                  <span className="text-[var(--text-muted)] text-right">—</span>
-                  <span className="text-[var(--text-muted)] text-right">
-                    ···
                   </span>
                 </div>
               );

--- a/frontend/tests/components/RelativeTime.test.tsx
+++ b/frontend/tests/components/RelativeTime.test.tsx
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import RelativeTime from "@/components/ui/RelativeTime";
+
+describe("RelativeTime", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders a relative value with the absolute time available", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T09:00:00"));
+
+    render(<RelativeTime value="2026-07-10 08:00:00" />);
+
+    const time = screen.getByText("1 hour ago");
+    expect(time.getAttribute("datetime")).toContain("2026-07-10T");
+    expect(time.getAttribute("title")).toBeTruthy();
+  });
+
+  it("renders a fallback for invalid timestamps", () => {
+    render(<RelativeTime value="not-a-date" />);
+
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+});

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -172,9 +172,11 @@ export const handlers = [
         total_issues: 250,
         total_expected: 500,
         completion_pct: 50.0,
+        queue_count: 2,
       },
       ai_activity: [],
       ai_configured: false,
+      scan_targets: { comic: true, manga: true },
     });
   }),
 
@@ -207,10 +209,7 @@ export const handlers = [
     if (comic) {
       return HttpResponse.json({ comic, issues: mockIssues });
     }
-    return HttpResponse.json(
-      { error: "Comic not found" },
-      { status: 404 },
-    );
+    return HttpResponse.json({ error: "Comic not found" }, { status: 404 });
   }),
 
   http.delete("/api/series/:comicId", () => {
@@ -301,7 +300,10 @@ export const handlers = [
   }),
 
   http.put("/api/config", () => {
-    return HttpResponse.json({ success: true, message: "Configuration updated" });
+    return HttpResponse.json({
+      success: true,
+      message: "Configuration updated",
+    });
   }),
 
   // -------------------------------------------------------------------------
@@ -399,10 +401,7 @@ export function createErrorHandler(
   errorMessage: string,
 ) {
   return http[method](path, () => {
-    return HttpResponse.json(
-      { error: errorMessage },
-      { status: 500 },
-    );
+    return HttpResponse.json({ error: errorMessage }, { status: 500 });
   });
 }
 

--- a/frontend/tests/pages/ActivityPage.test.tsx
+++ b/frontend/tests/pages/ActivityPage.test.tsx
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/server";
+import { render, screen, waitFor } from "../test-utils";
+import ActivityPage from "@/pages/ActivityPage";
+
+const queueItem = {
+  ID: "queue-1",
+  series: "Absolute Flash",
+  year: "2026",
+  filename: "Absolute Flash 013.cbz",
+  size: "10 MB",
+  issueid: "issue-13",
+  comicid: "comic-1",
+  link: "",
+  status: "Downloading",
+  remote_filesize: "10 MB",
+  updated_date: "2026-07-10 08:40",
+  site: "DDL(GetComics)",
+  submit_date: "2026-07-10 08:35",
+};
+
+describe("ActivityPage", () => {
+  it("filters, sorts, and paginates the live queue through the API", async () => {
+    const requests: URL[] = [];
+    server.use(
+      http.get("/api/downloads/queue", ({ request }) => {
+        const url = new URL(request.url);
+        requests.push(url);
+        const offset = Number(url.searchParams.get("offset") || 0);
+        return HttpResponse.json({
+          queue: offset === 0 ? [queueItem] : [],
+          pagination: {
+            total: offset === 0 ? 30 : 20,
+            limit: 25,
+            offset,
+            has_more: offset === 0,
+          },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<ActivityPage />, { route: "/activity", useMemoryRouter: true });
+
+    await screen.findByText("Absolute Flash");
+    await user.type(
+      screen.getByRole("textbox", { name: "Filter queue activity" }),
+      "flash",
+    );
+    await waitFor(() => {
+      expect(
+        requests.some((url) => url.searchParams.get("q") === "flash"),
+      ).toBe(true);
+    });
+
+    await user.click(screen.getByRole("button", { name: /Updated/ }));
+    await waitFor(() => {
+      expect(
+        requests.some(
+          (url) =>
+            url.searchParams.get("sort") === "updated" &&
+            url.searchParams.get("order") === "asc",
+        ),
+      ).toBe(true);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => {
+      expect(
+        requests.some((url) => url.searchParams.get("offset") === "25"),
+      ).toBe(true);
+    });
+    await user.click(screen.getByRole("button", { name: "Previous" }));
+    await waitFor(() => {
+      expect(requests.at(-1)?.searchParams.get("offset")).toBe("0");
+    });
+  });
+
+  it("uses the shared table for history with newest-first defaults", async () => {
+    let historyRequest: URL | undefined;
+    server.use(
+      http.get("/api/downloads/history", ({ request }) => {
+        historyRequest = new URL(request.url);
+        return HttpResponse.json({
+          history: [
+            {
+              IssueID: "issue-13",
+              ComicName: "Absolute Flash",
+              Issue_Number: "13",
+              Size: 0,
+              DateAdded: "2026-07-10 08:40:00",
+              Status: "Post-Processed",
+              FolderName: "",
+              ComicID: "comic-1",
+              Provider: "NZBGeek",
+            },
+          ],
+          pagination: { total: 1, limit: 25, offset: 0, has_more: false },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<ActivityPage />, {
+      route: "/activity?view=history",
+      useMemoryRouter: true,
+    });
+
+    await screen.findByText("Absolute Flash");
+    expect(historyRequest?.searchParams.get("sort")).toBe("date");
+    expect(historyRequest?.searchParams.get("order")).toBe("desc");
+    expect(screen.getByRole("button", { name: /Date/ })).toBeTruthy();
+    await user.type(
+      screen.getByRole("textbox", { name: "Filter download history" }),
+      "nzb",
+    );
+    await waitFor(() => {
+      expect(historyRequest?.searchParams.get("q")).toBe("nzb");
+    });
+  });
+});

--- a/frontend/tests/pages/ActivityPage.test.tsx
+++ b/frontend/tests/pages/ActivityPage.test.tsx
@@ -72,6 +72,11 @@ describe("ActivityPage", () => {
         requests.some((url) => url.searchParams.get("offset") === "25"),
       ).toBe(true);
     });
+    expect(await screen.findByText("No matching queue items")).toBeTruthy();
+    expect(screen.queryByText(/Showing \d+ to \d+ of/)).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Previous" }).hasAttribute("disabled"),
+    ).toBe(false);
     await user.click(screen.getByRole("button", { name: "Previous" }));
     await waitFor(() => {
       expect(requests.at(-1)?.searchParams.get("offset")).toBe("0");

--- a/frontend/tests/pages/DashboardPage.test.tsx
+++ b/frontend/tests/pages/DashboardPage.test.tsx
@@ -7,9 +7,10 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { server } from "../mocks/server";
 import { http, HttpResponse } from "msw";
-import { render, screen } from "../test-utils";
+import { createTestQueryClient, render, screen } from "../test-utils";
 import DashboardPage from "@/pages/DashboardPage";
 
 describe("DashboardPage", () => {
@@ -53,6 +54,86 @@ describe("DashboardPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Spider-Man #1")).toBeTruthy();
     });
+    expect(screen.getByText(/ago$/)).toBeTruthy();
+    expect(screen.getByRole("link", { name: "view all →" })).toBeTruthy();
+  });
+
+  it("starts scans for each configured library from the dashboard", async () => {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(["comicScanProgress"], {
+      status: "completed",
+      progress: {},
+    });
+    queryClient.setQueryData(["mangaScanProgress"], {
+      status: "completed",
+      progress: {},
+    });
+    let comicScans = 0;
+    let mangaScans = 0;
+    server.use(
+      http.post("/api/import/comic/scan", () => {
+        comicScans += 1;
+        return HttpResponse.json({ success: true, message: "started" });
+      }),
+      http.post("/api/import/manga/scan", () => {
+        mangaScans += 1;
+        return HttpResponse.json({ success: true, message: "started" });
+      }),
+      http.get("/api/import/comic/progress", () =>
+        HttpResponse.json({ status: "scanning", progress: {} }),
+      ),
+      http.get("/api/import/manga/progress", () =>
+        HttpResponse.json({ status: "scanning", progress: {} }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    render(<DashboardPage />, { queryClient });
+    const scanButton = await screen.findByRole("button", {
+      name: "Scan libraries",
+    });
+    await waitFor(() =>
+      expect(scanButton.hasAttribute("disabled")).toBe(false),
+    );
+    await user.click(scanButton);
+
+    await waitFor(() => {
+      expect(comicScans).toBe(1);
+      expect(mangaScans).toBe(1);
+    });
+    expect(
+      screen
+        .getByRole("button", { name: "Scanning…" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  it("reports a partial library scan startup failure", async () => {
+    server.use(
+      http.post("/api/import/comic/scan", () =>
+        HttpResponse.json({ success: true, message: "started" }),
+      ),
+      http.post("/api/import/manga/scan", () =>
+        HttpResponse.json({ detail: "busy" }, { status: 409 }),
+      ),
+      http.get("/api/import/comic/progress", () =>
+        HttpResponse.json({ status: "completed", progress: {} }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    render(<DashboardPage />);
+    await user.click(
+      await screen.findByRole("button", { name: "Scan libraries" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "One library scan started, but another failed to start.",
+        ),
+      ).toBeTruthy();
+    });
   });
 
   it("renders this-week upcoming list", async () => {
@@ -91,6 +172,11 @@ describe("DashboardPage", () => {
       expect(screen.getByText("no recent activity")).toBeTruthy();
       expect(screen.getByText("nothing upcoming this week")).toBeTruthy();
     });
+    expect(
+      screen
+        .getByRole("button", { name: "Scan libraries" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
   });
 
   it("renders command hint card", async () => {

--- a/tests/unit/test_dashboard_service.py
+++ b/tests/unit/test_dashboard_service.py
@@ -14,6 +14,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _default_queue_count(monkeypatch):
+    monkeypatch.setattr("comicarr.app.dashboard.service.dl_queries.count_active_ddl_items", lambda: 0)
+
+
 class _FakeDBConnection:
     """Minimal DB stub for testing dashboard queries."""
 
@@ -43,9 +48,16 @@ class TestGetDashboardData:
     def test_returns_recently_downloaded(self, mock_comicarr, mock_db):
         mock_comicarr.AI_CLIENT = None
         recent = [
-            {"ComicName": "Spider-Man", "Issue_Number": "1", "DateAdded": "2026-04-01",
-             "Status": "Snatched", "Provider": "nzb", "ComicID": "100", "IssueID": "200",
-             "ComicImage": "http://img/1.jpg"},
+            {
+                "ComicName": "Spider-Man",
+                "Issue_Number": "1",
+                "DateAdded": "2026-04-01",
+                "Status": "Snatched",
+                "Provider": "nzb",
+                "ComicID": "100",
+                "IssueID": "200",
+                "ComicImage": "http://img/1.jpg",
+            },
         ]
         fake_db = _FakeDBConnection(select_results={"snatched": recent, "futureupcoming": []})
         mock_db.DBConnection.return_value = fake_db
@@ -62,8 +74,14 @@ class TestGetDashboardData:
     def test_returns_upcoming_releases(self, mock_comicarr, mock_db):
         mock_comicarr.AI_CLIENT = None
         upcoming = [
-            {"ComicName": "Batman", "IssueNumber": "5", "IssueDate": "2026-04-06",
-             "Publisher": "DC Comics", "ComicID": "300", "Status": "Wanted"},
+            {
+                "ComicName": "Batman",
+                "IssueNumber": "5",
+                "IssueDate": "2026-04-06",
+                "Publisher": "DC Comics",
+                "ComicID": "300",
+                "Status": "Wanted",
+            },
         ]
         fake_db = _FakeDBConnection(select_results={"futureupcoming": upcoming, "snatched": []})
         mock_db.DBConnection.return_value = fake_db
@@ -97,12 +115,62 @@ class TestGetDashboardData:
 
     @patch("comicarr.app.dashboard.service.db")
     @patch("comicarr.app.dashboard.service.comicarr")
+    def test_returns_active_queue_count(self, mock_comicarr, mock_db, monkeypatch):
+        mock_comicarr.AI_CLIENT = None
+        mock_comicarr.CONFIG.COMIC_DIR = "/comics"
+        mock_comicarr.CONFIG.MANGA_DIR = "/manga"
+        monkeypatch.setattr(
+            "comicarr.app.dashboard.service.dl_queries.count_active_ddl_items",
+            lambda: 3,
+        )
+        fake_db = _FakeDBConnection(
+            select_results={"snatched": [], "futureupcoming": []},
+            selectone_result={"total_series": 1, "total_issues": 1, "total_expected": 1},
+        )
+        mock_db.DBConnection.return_value = fake_db
+
+        from comicarr.app.dashboard.service import get_dashboard_data
+
+        result = get_dashboard_data(None)
+
+        assert result["stats"]["queue_count"] == 3
+        assert result["scan_targets"] == {"comic": True, "manga": True}
+
+    @patch("comicarr.app.dashboard.service.db")
+    @patch("comicarr.app.dashboard.service.comicarr")
+    def test_queue_count_failure_preserves_other_stats(self, mock_comicarr, mock_db, monkeypatch):
+        mock_comicarr.AI_CLIENT = None
+        monkeypatch.setattr(
+            "comicarr.app.dashboard.service.dl_queries.count_active_ddl_items",
+            MagicMock(side_effect=RuntimeError("count failed")),
+        )
+        fake_db = _FakeDBConnection(
+            select_results={"snatched": [], "futureupcoming": []},
+            selectone_result={"total_series": 1, "total_issues": 1, "total_expected": 1},
+        )
+        mock_db.DBConnection.return_value = fake_db
+
+        from comicarr.app.dashboard.service import get_dashboard_data
+
+        result = get_dashboard_data(None)
+
+        assert result["stats"]["queue_count"] == 0
+        assert result["stats"]["total_series"] == 1
+        assert result["stats"]["total_issues"] == 1
+
+    @patch("comicarr.app.dashboard.service.db")
+    @patch("comicarr.app.dashboard.service.comicarr")
     def test_returns_ai_activity_when_configured(self, mock_comicarr, mock_db):
         mock_comicarr.AI_CLIENT = MagicMock()
         activity = [
-            {"timestamp": "2026-04-05T12:00:00", "feature_type": "search",
-             "action_description": "Expanded search query", "prompt_tokens": 100,
-             "completion_tokens": 50, "success": True},
+            {
+                "timestamp": "2026-04-05T12:00:00",
+                "feature_type": "search",
+                "action_description": "Expanded search query",
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "success": True,
+            },
         ]
         fake_db = _FakeDBConnection(
             select_results={"snatched": [], "futureupcoming": [], "ai_activity_log": activity},
@@ -149,7 +217,7 @@ class TestGetDashboardData:
 
         assert result["recently_downloaded"] == []
         assert result["upcoming_releases"] == []
-        assert result["stats"] == {}
+        assert result["stats"] == {"queue_count": 0}
         assert result["ai_activity"] == []
         assert result["ai_configured"] is False
 

--- a/tests/unit/test_download_activity_queries.py
+++ b/tests/unit/test_download_activity_queries.py
@@ -7,12 +7,11 @@
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 
-from inspect import getsource
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from sqlalchemy import insert
+from sqlalchemy import create_engine, event, insert, text
 from sqlalchemy import inspect as sa_inspect
 
 import comicarr
@@ -209,9 +208,46 @@ def test_unpaginated_service_preserves_filters_and_array_shape(monkeypatch):
     queue.assert_called_once_with(search="flash", status="failed", sort=None, order="desc")
 
 
-def test_activity_index_is_created_after_legacy_ddl_columns():
-    source = getsource(comicarr.dbcheck)
-
-    assert source.index('_ensure_columns(engine, "ddl_info", ddl_cols)') < source.index(
-        "ddl_info_status_updated.create(engine, checkfirst=True)"
+def test_legacy_ddl_schema_migration_adds_column_before_activity_index(tmp_path, monkeypatch):
+    """A pre-activity database gets the indexed column before the index is built."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'legacy-activity.db'}")
+    monkeypatch.setattr(comicarr.db, "_engine", engine)
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(DYNAMIC_UPDATE=4, OLDCONFIG_VERSION=None),
     )
+    monkeypatch.setattr(comicarr, "_migrate_unique_constraints", lambda _engine: None)
+
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE ddl_info (ID TEXT, status TEXT)"))
+
+    statements = []
+
+    def capture_sql(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement.lower())
+
+    event.listen(engine, "before_cursor_execute", capture_sql)
+    try:
+        comicarr.dbcheck()
+    finally:
+        event.remove(engine, "before_cursor_execute", capture_sql)
+
+    ddl_columns = {column["name"] for column in sa_inspect(engine).get_columns("ddl_info")}
+    ddl_indexes = {index["name"] for index in sa_inspect(engine).get_indexes("ddl_info")}
+    assert "updated_date" in ddl_columns
+    assert "ddl_info_status_updated" in ddl_indexes
+
+    column_add = next(
+        index
+        for index, statement in enumerate(statements)
+        if "alter table ddl_info add column updated_date" in statement
+    )
+    index_create = next(
+        index for index, statement in enumerate(statements) if "create index ddl_info_status_updated" in statement
+    )
+    assert column_add < index_create
+
+    engine.dispose()
+    monkeypatch.setattr(comicarr.db, "_engine", None)

--- a/tests/unit/test_download_activity_queries.py
+++ b/tests/unit/test_download_activity_queries.py
@@ -1,0 +1,217 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+from inspect import getsource
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import insert
+from sqlalchemy import inspect as sa_inspect
+
+import comicarr
+from comicarr import db
+from comicarr.app.downloads import queries, router, service
+from comicarr.tables import ddl_info, metadata, snatched
+
+
+@pytest.fixture
+def activity_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+def test_queue_excludes_completed_rows_and_supports_search_sort_pagination(activity_db):
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(ddl_info),
+            [
+                {
+                    "ID": "queued-old",
+                    "series": "Saga",
+                    "status": "Queued",
+                    "updated_date": "2026-07-09 09:00",
+                },
+                {
+                    "ID": "queued-new",
+                    "series": "Saga Deluxe",
+                    "status": "Downloading",
+                    "updated_date": "2026-07-10 09:00",
+                },
+                {
+                    "ID": "failed",
+                    "series": "Saga Failure",
+                    "status": "Failed",
+                    "updated_date": "2026-07-09 12:00",
+                },
+                {
+                    "ID": "completed",
+                    "series": "Saga Archive",
+                    "status": "Completed",
+                    "updated_date": "2026-07-10 10:00",
+                },
+                {
+                    "ID": "done",
+                    "series": "Finished Series",
+                    "status": "Done",
+                    "updated_date": "2026-07-10 11:00",
+                },
+                {
+                    "ID": "unknown",
+                    "series": "Unknown Series",
+                    "status": None,
+                    "updated_date": "2026-07-10 12:00",
+                },
+            ],
+        )
+
+    result = queries.get_ddl_queue(
+        limit=1,
+        offset=0,
+        search="saga",
+        sort="updated",
+        order="desc",
+    )
+
+    assert result["total"] == 3
+    assert result["has_more"] is True
+    assert [row["ID"] for row in result["results"]] == ["queued-new"]
+    assert queries.count_active_ddl_items() == 4
+    assert "ddl_info_status_updated" in {index["name"] for index in sa_inspect(activity_db).get_indexes("ddl_info")}
+
+    queued_only = queries.get_ddl_queue(limit=10, offset=0, status="queued")
+    assert queued_only["total"] == 1
+    assert queued_only["results"][0]["ID"] == "queued-old"
+
+
+def test_history_supports_filtering_and_oldest_first_sort(activity_db):
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(snatched),
+            [
+                {
+                    "IssueID": "1",
+                    "ComicName": "Batman",
+                    "Issue_Number": "1",
+                    "DateAdded": "2026-07-10 09:00:00",
+                    "Status": "Snatched",
+                    "Provider": "NZBGeek",
+                },
+                {
+                    "IssueID": "2",
+                    "ComicName": "Batman",
+                    "Issue_Number": "2",
+                    "DateAdded": "2026-07-09 09:00:00",
+                    "Status": "Post-Processed",
+                    "Provider": "NZBGeek",
+                },
+                {
+                    "IssueID": "3",
+                    "ComicName": "Superman",
+                    "Issue_Number": "1",
+                    "DateAdded": "2026-07-08 09:00:00",
+                    "Status": "Snatched",
+                    "Provider": "NZBGeek",
+                },
+            ],
+        )
+
+    result = queries.get_history(
+        limit=10,
+        offset=0,
+        search="batman",
+        sort="date",
+        order="asc",
+    )
+
+    assert result["total"] == 2
+    assert [row["IssueID"] for row in result["results"]] == ["2", "1"]
+
+    processed = queries.get_history(limit=10, offset=0, status="post-processed")
+    assert processed["total"] == 1
+    assert processed["results"][0]["IssueID"] == "2"
+
+
+def test_activity_routes_forward_query_controls(monkeypatch):
+    history = MagicMock(return_value={"history": [], "pagination": {}})
+    queue = MagicMock(return_value={"queue": [], "pagination": {}})
+    monkeypatch.setattr(router.dl_service, "get_history", history)
+    monkeypatch.setattr(router.dl_service, "get_ddl_queue", queue)
+
+    router.get_history(
+        limit=25,
+        offset=50,
+        q="flash",
+        status="snatched",
+        sort="date",
+        order="asc",
+    )
+    router.get_ddl_queue(
+        limit=25,
+        offset=25,
+        q="flash",
+        status="queued",
+        sort="updated",
+        order="desc",
+    )
+
+    history.assert_called_once_with(
+        limit=25,
+        offset=50,
+        search="flash",
+        status="snatched",
+        sort="date",
+        order="asc",
+    )
+    queue.assert_called_once_with(
+        limit=25,
+        offset=25,
+        search="flash",
+        status="queued",
+        sort="updated",
+        order="desc",
+    )
+
+
+def test_activity_routes_preserve_unpaginated_compatibility(monkeypatch):
+    history = MagicMock(return_value=[])
+    queue = MagicMock(return_value=[])
+    monkeypatch.setattr(router.dl_service, "get_history", history)
+    monkeypatch.setattr(router.dl_service, "get_ddl_queue", queue)
+
+    assert router.get_history(limit=None, offset=0, q=None, status=None, sort="date", order="desc") == []
+    assert router.get_ddl_queue(limit=None, offset=0, q=None, status=None, sort="updated", order="desc") == []
+    assert history.call_args.kwargs["limit"] is None
+    assert queue.call_args.kwargs["limit"] is None
+
+
+def test_unpaginated_service_preserves_filters_and_array_shape(monkeypatch):
+    history = MagicMock(return_value=[{"IssueID": "1"}])
+    queue = MagicMock(return_value=[{"ID": "queued"}])
+    monkeypatch.setattr(service.dl_queries, "get_history", history)
+    monkeypatch.setattr(service.dl_queries, "get_ddl_queue", queue)
+
+    assert service.get_history(search="flash", status="snatched") == [{"IssueID": "1"}]
+    assert service.get_ddl_queue(search="flash", status="failed") == [{"ID": "queued"}]
+    history.assert_called_once_with(search="flash", status="snatched", sort=None, order="desc")
+    queue.assert_called_once_with(search="flash", status="failed", sort=None, order="desc")
+
+
+def test_activity_index_is_created_after_legacy_ddl_columns():
+    source = getsource(comicarr.dbcheck)
+
+    assert source.index('_ensure_columns(engine, "ddl_info", ddl_cols)') < source.index(
+        "ddl_info_status_updated.create(engine, checkfirst=True)"
+    )

--- a/tests/unit/test_series_scan_start.py
+++ b/tests/unit/test_series_scan_start.py
@@ -1,0 +1,36 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import comicarr
+from comicarr.app.series import service
+
+
+@pytest.mark.parametrize(
+    ("scan", "config_key", "path", "error"),
+    [
+        (service.comic_library_scan, "COMIC_DIR", "/missing/comics", "Comic directory not found"),
+        (service.manga_library_scan, "MANGA_DIR", "/missing/manga", "Manga directory not found"),
+    ],
+)
+def test_library_scan_rejects_missing_mount(monkeypatch, scan, config_key, path, error):
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(**{config_key: path}))
+    monkeypatch.setattr(service.os.path, "isdir", MagicMock(return_value=False))
+    thread = MagicMock()
+    monkeypatch.setattr(service.threading, "Thread", thread)
+
+    result = scan(None)
+
+    assert result["success"] is False
+    assert error in result["error"]
+    thread.assert_not_called()

--- a/tests/unit/test_updater_watchlist.py
+++ b/tests/unit/test_updater_watchlist.py
@@ -1,0 +1,106 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import comicarr
+from comicarr import updater
+
+
+def _configure_updater(monkeypatch, *, annuals_on, rows, cv_results):
+    refresh_thread = MagicMock()
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(ANNUALS_ON=annuals_on, BACKFILL_TIMESPAN=15),
+    )
+    monkeypatch.setattr(comicarr, "DB_BACKFILL", False)
+    monkeypatch.setattr(comicarr, "UPDATER_STATUS", "Waiting")
+    monkeypatch.setattr(comicarr, "REFRESH_QUEUE", SimpleNamespace(queue=[]))
+    monkeypatch.setattr(comicarr, "importer", SimpleNamespace(refresh_thread=refresh_thread))
+    monkeypatch.setattr(
+        comicarr,
+        "cv",
+        SimpleNamespace(
+            getComic=lambda **_kwargs: {
+                "count": max(1, len(cv_results)),
+                "totalcount": max(1, len(cv_results)),
+                "results": cv_results,
+            }
+        ),
+    )
+    monkeypatch.setattr(updater.db, "select_one", MagicMock(return_value=None))
+    monkeypatch.setattr(updater.db, "select_all", MagicMock(return_value=rows))
+    monkeypatch.setattr(updater.db, "upsert", MagicMock())
+    monkeypatch.setattr(updater.helpers, "job_management", MagicMock())
+    monkeypatch.setattr(updater.helpers, "utctimestamp", MagicMock(return_value="now"))
+    return refresh_thread
+
+
+def test_watchlist_updater_skips_non_comicvine_series_ids(monkeypatch):
+    refresh_thread = _configure_updater(
+        monkeypatch,
+        annuals_on=False,
+        cv_results=[
+            {
+                "comicid": {"id": 123},
+                "last_updated": "2026-07-10 08:00:00",
+            }
+        ],
+        rows=[
+            {
+                "ComicID": "mal-1",
+                "ComicName": "Manga Series",
+                "Status": "Active",
+                "ComicYear": "2026",
+                "LastUpdated": "2026-07-01 08:00:00",
+                "Total": 10,
+            },
+            {
+                "ComicID": "123",
+                "ComicName": "Comic Series",
+                "Status": "Active",
+                "ComicYear": "2026",
+                "LastUpdated": "2026-07-01 08:00:00",
+                "Total": 10,
+            },
+        ],
+    )
+
+    updater.watchlist_updater()
+
+    refresh_thread.assert_called_once_with([{"comicid": 123, "comicname": "Comic Series", "seriesyear": "2026"}])
+
+
+def test_watchlist_updater_keeps_annual_release_lookup_id_as_text(monkeypatch):
+    refresh_thread = _configure_updater(
+        monkeypatch,
+        annuals_on=True,
+        cv_results=[],
+        rows=[
+            {
+                "ComicID": "456",
+                "ComicName": None,
+                "Status": "Active",
+                "ComicYear": "2026",
+                "LastUpdated": None,
+                "Total": 0,
+                "ReleaseComicID": None,
+            }
+        ],
+    )
+
+    updater.watchlist_updater()
+
+    refresh_thread.assert_called_once_with([{"comicid": 456, "comicname": None, "seriesyear": "2026"}])
+    annual_lookup = updater.db.select_one.call_args.args[0]
+    release_id = next(iter(annual_lookup.compile().params.values()))
+    assert release_id == "456"
+    assert isinstance(release_id, str)


### PR DESCRIPTION
## Summary

Production activity is reliable and actionable again: manga IDs no longer crash the daily ComicVine updater, Activity shows the newest queue/history records in consistent searchable and sortable tables, and library scans can be started safely from the dashboard.

The dashboard queue count now reflects active DDL work instead of recent history events, while relative timestamps make the event list understandable across days. Existing unpaginated API consumers keep their array response shape; the new table UI opts into bounded pagination explicitly.

## Changes

- Treat non-numeric series IDs as non-ComicVine records during the ComicVine updater while preserving text IDs for annual lookups.
- Add server-side filtering, stable sorting, and pagination for active DDL queue and download history, including failed/stuck rows and an upgrade-safe queue index.
- Rebuild Queue and History with the shared data-table components, 25-row pagination, filter controls, sortable columns, relative dates, refresh actions, and recoverable empty-page navigation.
- Show the true active queue total and simplify dashboard recent activity with relative dates and a History link.
- Add a dashboard scan action that reuses the existing comic/manga scan endpoints, prevents overlapping scans, monitors progress, reports partial failures, clears stale progress, and rejects missing library mounts before spawning work.

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset`
- [ ] No app release impact; no changeset needed

## Testing

- [x] 1,059 backend unit tests pass (`pytest tests/unit -q`)
- [x] 80 frontend tests pass (`npm run test:run`)
- [x] Frontend production build passes (`npm run build`)
- [x] Backend lint/format passes for application code and changed tests
- [x] Frontend lint, typecheck, and format checks pass
- [x] 9 Chromium smoke tests pass, including authenticated navigation to Activity
- [x] Lockfile, CLI startup sanity, and changeset status checks pass

## Post-deploy monitoring and validation

- During the next daily updater run, confirm logs contain no `invalid literal for int()` or `DB Updater ... raised an exception`; non-ComicVine rows may emit a debug-level skip message.
- Confirm `/api/downloads/queue?limit=25&sort=updated&order=desc` excludes completed rows but retains queued, downloading, failed, and legacy null-status rows.
- Verify Activity defaults newest-first and that filter, sort, Previous, and Next work for both Queue and History.
- Confirm the dashboard queue KPI matches the active queue total and recent events show relative timestamps with absolute-time tooltips.
- Trigger configured library scans from the dashboard, verify the button stays disabled until progress reaches a terminal state, and confirm a missing NAS mount returns an immediate error rather than leaving a stuck scan.
- Validation window: 24 hours through the next scheduled DB updater run. Roll back if the updater throws, activity endpoints regress, or a scan remains stuck after progress polling.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rebuilt Activity views with searchable, sortable, paginated tables for download history and the live queue.
  * Added relative timestamps and clearer status displays.
  * Added a Dashboard action to scan configured comic and manga libraries.
  * Dashboard queue counts now reflect active items more accurately.

* **Bug Fixes**
  * Improved scheduled library update handling and compatibility with varied series identifiers.
  * Library scans now stop with a clear error when configured directories are unavailable.
  * New scans no longer show stale progress from previous scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->