### PR TITLE
fix: restore reliable dashboard operations

### DIFF
--- a/.changeset/reliable-dashboard-releases.md
+++ b/.changeset/reliable-dashboard-releases.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Restore current operational dashboard data and add a safe, observable weekly release refresh.

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -161,6 +161,7 @@ IMPORTINBOX_STATUS = "Waiting"
 SEARCH_STATUS = "Waiting"
 RSS_STATUS = "Waiting"
 WEEKLY_STATUS = "Waiting"
+WEEKLY_MANUAL_NEXT_RUN = None
 VERSION_STATUS = "Waiting"
 UPDATER_STATUS = "Waiting"
 FORCE_STATUS = {}
@@ -1572,7 +1573,16 @@ def dbcheck():
     _ensure_columns(engine, "ref32p", [("Updated", "TEXT")])
 
     # -- Jobhistory Table --
-    _ensure_columns(engine, "jobhistory", [("status", "TEXT")])
+    _ensure_columns(
+        engine,
+        "jobhistory",
+        [
+            ("status", "TEXT"),
+            ("last_success_timestamp", "FLOAT"),
+            ("last_failure_timestamp", "FLOAT"),
+            ("last_error", "TEXT"),
+        ],
+    )
 
     # last date — used by db Updater for staggering requests
     jobhistory_existing = {c["name"] for c in inspect(engine).get_columns("jobhistory")}

--- a/comicarr/app/dashboard/service.py
+++ b/comicarr/app/dashboard/service.py
@@ -17,6 +17,14 @@ from datetime import datetime, timedelta
 import comicarr
 from comicarr import db, logger
 from comicarr.app.downloads import queries as dl_queries
+from comicarr.app.storyarcs import service as storyarcs_service
+
+RECENT_ACTIVITY_DAYS = 30
+
+
+def recent_activity_cutoff(now=None):
+    """Return the inclusive cutoff for the dashboard's bounded activity preview."""
+    return (now or datetime.now()) - timedelta(days=RECENT_ACTIVITY_DAYS)
 
 
 def get_dashboard_data(ctx):
@@ -27,8 +35,9 @@ def get_dashboard_data(ctx):
     """
     result = {
         "recently_downloaded": [],
+        "active_queue": [],
         "upcoming_releases": [],
-        "stats": {},
+        "stats": {"queue_count": 0},
         "ai_activity": [],
         "ai_configured": False,
         "scan_targets": {
@@ -37,29 +46,23 @@ def get_dashboard_data(ctx):
         },
     }
 
-    # Recently downloaded: last 10 from snatched, sorted by DateAdded DESC
+    # Recent activity is a bounded preview. Full history retains all rows.
     try:
+        cutoff = recent_activity_cutoff().strftime("%Y-%m-%d %H:%M:%S")
         recent = db.DBConnection().select(
             "SELECT s.ComicName, s.Issue_Number, s.DateAdded, s.Status, s.Provider, "
             "s.ComicID, s.IssueID, c.ComicImage "
             "FROM snatched s LEFT JOIN comics c ON s.ComicID = c.ComicID "
-            "ORDER BY s.DateAdded DESC LIMIT 10"
+            "WHERE s.DateAdded >= ? ORDER BY s.DateAdded DESC LIMIT 10",
+            [cutoff],
         )
         result["recently_downloaded"] = recent or []
     except Exception as e:
         logger.error("[DASHBOARD] Error fetching recent downloads: %s" % e)
 
-    # Upcoming: next 7 days from futureupcoming
+    # Library releases: matching titles from this application current week.
     try:
-        today = datetime.now().strftime("%Y-%m-%d")
-        week_ahead = (datetime.now() + timedelta(days=7)).strftime("%Y-%m-%d")
-        upcoming = db.DBConnection().select(
-            "SELECT ComicName, IssueNumber, IssueDate, Publisher, ComicID, Status "
-            "FROM futureupcoming WHERE IssueDate >= ? AND IssueDate <= ? "
-            "ORDER BY IssueDate ASC LIMIT 20",
-            [today, week_ahead],
-        )
-        result["upcoming_releases"] = upcoming or []
+        result["upcoming_releases"] = storyarcs_service.get_upcoming(include_downloaded=True) or []
     except Exception as e:
         logger.error("[DASHBOARD] Error fetching upcoming: %s" % e)
 
@@ -80,11 +83,6 @@ def get_dashboard_data(ctx):
                 "total_expected": total_expected,
                 "completion_pct": round(total_issues / total_expected * 100, 1) if total_expected > 0 else 0,
             }
-
-        try:
-            result["stats"].setdefault("queue_count", dl_queries.count_active_ddl_items())
-        except Exception as e:
-            logger.error("[DASHBOARD] Error fetching active queue count: %s" % e)
             result["stats"].setdefault("queue_count", 0)
 
         # Manga-specific stats
@@ -115,6 +113,18 @@ def get_dashboard_data(ctx):
             result["stats"]["comic_total"] = comic_stats.get("comic_total", 0) or 0
     except Exception as e:
         logger.error("[DASHBOARD] Error fetching stats: %s" % e)
+
+    # Queue KPI and preview deliberately share the active DDL predicate.
+    try:
+        result["stats"]["queue_count"] = dl_queries.count_active_ddl_items()
+    except Exception as e:
+        logger.error("[DASHBOARD] Error fetching active queue count: %s" % e)
+        result["stats"].setdefault("queue_count", 0)
+
+    try:
+        result["active_queue"] = dl_queries.get_active_ddl_preview(limit=5)
+    except Exception as e:
+        logger.error("[DASHBOARD] Error fetching active queue preview: %s" % e)
 
     # AI activity: last 5 entries (only if AI configured)
     # Check both runtime client and saved config (client requires restart)

--- a/comicarr/app/downloads/queries.py
+++ b/comicarr/app/downloads/queries.py
@@ -106,6 +106,17 @@ def count_active_ddl_items():
     return (row or {}).get("queue_count", 0) or 0
 
 
+def get_active_ddl_preview(limit=5):
+    """Return the newest active queue rows for compact operational summaries."""
+    stmt = (
+        select(t_ddl_info)
+        .where(active_ddl_condition())
+        .order_by(t_ddl_info.c.updated_date.desc(), t_ddl_info.c.ID.desc())
+        .limit(limit)
+    )
+    return db.select_all(stmt)
+
+
 def get_ddl_queue(limit=None, offset=None, search=None, status=None, sort=None, order="desc"):
     """Get active DDL queue items with search, sorting, and pagination."""
     stmt = select(t_ddl_info).where(active_ddl_condition())

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -40,6 +40,30 @@ _LIBRARY_ROOT_CONFIG_KEYS = (
     "NEWCOM_DIR",
 )
 
+# Reserve a scanner before its background thread gets CPU time. The scanners
+# also own process-wide locks while they run; these short-lived locks close the
+# gap between accepting an API request and the worker acquiring that lock.
+_COMIC_SCAN_START_LOCK = threading.Lock()
+_MANGA_SCAN_START_LOCK = threading.Lock()
+
+
+def _start_library_scan(scanner, status_attr, worker, start_lock, scan_label, scan_dir, thread_name):
+    """Reserve and launch a scanner without allowing a second hand-off worker."""
+    with start_lock:
+        if getattr(scanner, status_attr) == "scanning" or scanner._SCAN_LOCK.locked():
+            return {"success": False, "error": "A library scan is already in progress"}
+
+        previous_status = getattr(scanner, status_attr)
+        setattr(scanner, status_attr, "scanning")
+        try:
+            logger.info("[%s-SCAN] Starting %s library scan for: %s" % (scan_label.upper(), scan_label, scan_dir))
+            threading.Thread(target=worker, name=thread_name).start()
+            return {"success": True, "message": "%s scan started for: %s" % (scan_label.capitalize(), scan_dir)}
+        except Exception as e:
+            setattr(scanner, status_attr, previous_status)
+            logger.error("[%s-SCAN] Error: %s" % (scan_label.upper(), e))
+            return {"success": False, "error": "Failed to start %s scan: %s" % (scan_label, str(e))}
+
 
 def _configured_library_roots(config):
     """Return explicit, non-empty roots that can contain series directories."""
@@ -694,13 +718,15 @@ def manga_library_scan(ctx):
     if not os.path.isdir(manga_dir):
         return {"success": False, "error": "Manga directory not found: %s" % manga_dir}
 
-    try:
-        logger.info("[MANGA-SCAN] Starting manga library scan for: %s" % manga_dir)
-        threading.Thread(target=mangasync.mangaScan, name="API-MangaScan").start()
-        return {"success": True, "message": "Manga scan started for: %s" % manga_dir}
-    except Exception as e:
-        logger.error("[MANGA-SCAN] Error: %s" % e)
-        return {"success": False, "error": "Failed to start manga scan: %s" % str(e)}
+    return _start_library_scan(
+        mangasync,
+        "MANGA_SCAN_STATUS",
+        mangasync.mangaScan,
+        _MANGA_SCAN_START_LOCK,
+        "manga",
+        manga_dir,
+        "API-MangaScan",
+    )
 
 
 def manga_scan_confirm(ctx, selected_ids, scan_id):
@@ -726,13 +752,15 @@ def comic_library_scan(ctx):
     if not os.path.isdir(comic_dir):
         return {"success": False, "error": "Comic directory not found: %s" % comic_dir}
 
-    try:
-        logger.info("[COMIC-SCAN] Starting comic library scan for: %s" % comic_dir)
-        threading.Thread(target=comicsync.comicScan, name="API-ComicScan").start()
-        return {"success": True, "message": "Comic scan started for: %s" % comic_dir}
-    except Exception as e:
-        logger.error("[COMIC-SCAN] Error: %s" % e)
-        return {"success": False, "error": "Failed to start comic scan: %s" % str(e)}
+    return _start_library_scan(
+        comicsync,
+        "COMIC_SCAN_STATUS",
+        comicsync.comicScan,
+        _COMIC_SCAN_START_LOCK,
+        "comic",
+        comic_dir,
+        "API-ComicScan",
+    )
 
 
 def comic_scan_confirm(ctx, selected_ids, scan_id):

--- a/comicarr/app/storyarcs/service.py
+++ b/comicarr/app/storyarcs/service.py
@@ -670,17 +670,20 @@ def clear_read_issues():
 # ---------------------------------------------------------------------------
 
 
-def get_upcoming(include_downloaded=False):
-    """Get upcoming issues for the current week."""
-    today = datetime.date.today()
+def get_current_week(today=None):
+    """Return the application current Sunday-based week and year."""
+    today = today or datetime.date.today()
     if today.strftime("%U") == "00":
         weekday = 0 if today.isoweekday() == 7 else today.isoweekday()
         sunday = today - datetime.timedelta(days=weekday)
-        week = sunday.strftime("%U")
-        year = sunday.strftime("%Y")
-    else:
-        week = today.strftime("%U")
-        year = today.strftime("%Y")
+        return sunday.strftime("%U"), sunday.strftime("%Y")
+
+    return today.strftime("%U"), today.strftime("%Y")
+
+
+def get_upcoming(include_downloaded=False):
+    """Get upcoming issues for the current week."""
+    week, year = get_current_week()
 
     return arc_queries.get_upcoming(week, year, include_downloaded=include_downloaded)
 

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -38,12 +38,17 @@ from comicarr.tables import comics, jobhistory, storyarcs
 
 # Shared rate limiter instance (same object used by CherryPy and FastAPI)
 _rate_limiter = LoginRateLimiter()
-_weekly_refresh_lock = threading.Lock()
+_fallback_weekly_refresh_lock = threading.Lock()
 
 WEEKLY_JOB_NAME = "Weekly Pullist"
 
 SETUP_PERSISTENCE_ERROR = "Failed to persist initial credentials"
 CONFIG_PERSISTENCE_ERROR = "Failed to persist configuration"
+
+
+def get_weekly_refresh_lock():
+    """Return the process-wide weekly lock after package initialization."""
+    return getattr(comicarr, "WEEKLY_REFRESH_LOCK", _fallback_weekly_refresh_lock)
 
 
 def _secret_is_configured(value):
@@ -651,7 +656,7 @@ def _get_weekly_job_history():
 
 def request_weekly_refresh(ctx):
     """Queue the existing weekly APScheduler job for an immediate, coalesced run."""
-    with _weekly_refresh_lock:
+    with get_weekly_refresh_lock():
         scheduler = getattr(ctx, "scheduler", None)
         if scheduler is None:
             return {"accepted": False, "state": "unavailable", "error": "Weekly scheduler is unavailable"}
@@ -1082,16 +1087,18 @@ def job_management(
             jstatus = ji["status"]
             if jstatus is None:
                 jstatus = "Waiting"
-            elif jstatus == "Running":
+            elif jstatus == "Running" or (jstatus == "Queued" and "weekly" in ji["JobName"].lower()):
+                was_running = jstatus == "Running"
                 jstatus = "Waiting"
                 recovery_values = {"status": jstatus}
                 if "weekly" in ji["JobName"].lower():
-                    recovery_values.update(
-                        {
-                            "last_failure_timestamp": ji["prev_run_timestamp"],
-                            "last_error": "Previous weekly refresh was interrupted by restart.",
-                        }
-                    )
+                    if was_running:
+                        recovery_values.update(
+                            {
+                                "last_failure_timestamp": ji["prev_run_timestamp"],
+                                "last_error": "Previous weekly refresh was interrupted by restart.",
+                            }
+                        )
                 db.upsert("jobhistory", recovery_values, {"JobName": ji["JobName"]})
             if "update" in ji["JobName"].lower():
                 if comicarr.SCHED_DBUPDATE_LAST is None:

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -25,8 +25,11 @@ import secrets
 import shlex
 import subprocess
 import sys
+import threading
 from collections import namedtuple
 from pathlib import Path
+
+from sqlalchemy import select
 
 import comicarr
 from comicarr import db, logger
@@ -35,6 +38,9 @@ from comicarr.tables import comics, jobhistory, storyarcs
 
 # Shared rate limiter instance (same object used by CherryPy and FastAPI)
 _rate_limiter = LoginRateLimiter()
+_weekly_refresh_lock = threading.Lock()
+
+WEEKLY_JOB_NAME = "Weekly Pullist"
 
 SETUP_PERSISTENCE_ERROR = "Failed to persist initial credentials"
 CONFIG_PERSISTENCE_ERROR = "Failed to persist configuration"
@@ -593,17 +599,110 @@ def get_job_info(ctx):
     if not ctx.scheduler:
         return {"jobs": []}
 
+    weekly_history = _get_weekly_job_history()
     jobs = []
     for job in ctx.scheduler.get_jobs():
-        jobs.append(
-            {
-                "id": job.id,
-                "name": job.name,
-                "next_run_time": str(job.next_run_time) if job.next_run_time else None,
-                "trigger": str(job.trigger),
-            }
-        )
+        job_info = {
+            "id": job.id,
+            "name": job.name,
+            "next_run_time": str(job.next_run_time) if job.next_run_time else None,
+            "trigger": str(job.trigger),
+        }
+        if job.id == "weekly":
+            status = weekly_history.get("status") or getattr(comicarr, "WEEKLY_STATUS", "Waiting")
+            if job.next_run_time is None:
+                status = "Paused"
+            job_info.update(
+                {
+                    "status": status,
+                    "state": _weekly_state(status),
+                    "last_success_timestamp": weekly_history.get("last_success_timestamp"),
+                    "last_failure_timestamp": weekly_history.get("last_failure_timestamp"),
+                    "last_error": weekly_history.get("last_error"),
+                }
+            )
+        jobs.append(job_info)
     return {"jobs": jobs}
+
+
+def _weekly_state(status):
+    """Normalize persisted scheduler status for API consumers."""
+    return (status or "Waiting").strip().lower()
+
+
+def _get_weekly_job_history():
+    """Read durable weekly-job outcome data without making job status unavailable on DB errors."""
+    try:
+        return (
+            db.select_one(
+                select(
+                    jobhistory.c.status,
+                    jobhistory.c.last_success_timestamp,
+                    jobhistory.c.last_failure_timestamp,
+                    jobhistory.c.last_error,
+                ).where(jobhistory.c.JobName == WEEKLY_JOB_NAME)
+            )
+            or {}
+        )
+    except Exception as e:
+        logger.warn("[WEEKLY] Could not read durable refresh status: %s" % e)
+        return {}
+
+
+def request_weekly_refresh(ctx):
+    """Queue the existing weekly APScheduler job for an immediate, coalesced run."""
+    with _weekly_refresh_lock:
+        scheduler = getattr(ctx, "scheduler", None)
+        if scheduler is None:
+            return {"accepted": False, "state": "unavailable", "error": "Weekly scheduler is unavailable"}
+
+        job = scheduler.get_job("weekly")
+        if job is None:
+            return {"accepted": False, "state": "unavailable", "error": "Weekly scheduler job is unavailable"}
+
+        state = _weekly_state(getattr(comicarr, "WEEKLY_STATUS", "Waiting"))
+        if state == "running":
+            return {
+                "accepted": False,
+                "state": "running",
+                "next_run_time": str(job.next_run_time) if job.next_run_time else None,
+            }
+        if job.next_run_time is None:
+            return {"accepted": False, "state": "paused", "error": "Weekly refresh is paused"}
+        if state == "queued":
+            return {
+                "accepted": False,
+                "state": "queued",
+                "next_run_time": str(job.next_run_time),
+            }
+
+        next_run_time = datetime.datetime.utcnow()
+        comicarr.WEEKLY_MANUAL_NEXT_RUN = job.next_run_time
+        job.modify(next_run_time=next_run_time)
+        comicarr.WEEKLY_STATUS = "Queued"
+        ctx.weekly_status = "Queued"
+        try:
+            db.upsert("jobhistory", {"status": "Queued"}, {"JobName": WEEKLY_JOB_NAME})
+        except Exception as e:
+            logger.warn("[WEEKLY] Could not persist refresh request state: %s" % e)
+
+        return {
+            "accepted": True,
+            "state": "queued",
+            "next_run_time": str(next_run_time),
+        }
+
+
+def sanitize_job_error(error):
+    """Keep operational errors useful without persisting credentials or large tracebacks."""
+    message = re.sub(r"\s+", " ", str(error or "")).strip()
+    message = re.sub(
+        r"(?i)(api[ _-]?key|authorization|password|token)\s*[=:]\s*[^\s,;]+",
+        r"\1=[redacted]",
+        message,
+    )
+    message = re.sub(r"(?i)(https?://)[^/@\s]+@", r"\1[redacted]@", message)
+    return message[:500] or "Weekly refresh failed; check server logs for details."
 
 
 def get_startup_diagnostics(ctx):
@@ -954,7 +1053,14 @@ def script_env(mode, vars):
 
 
 def job_management(
-    write=False, job=None, last_run_completed=None, current_run=None, status=None, failure=False, startup=False
+    write=False,
+    job=None,
+    last_run_completed=None,
+    current_run=None,
+    status=None,
+    failure=False,
+    failure_message=None,
+    startup=False,
 ):
     from comicarr.helpers import utctimestamp
 
@@ -965,12 +1071,28 @@ def job_management(
         from sqlalchemy import select
 
         job_info = db.select_all(
-            select(jobhistory.c.JobName, jobhistory.c.status, jobhistory.c.prev_run_timestamp).distinct()
+            select(
+                jobhistory.c.JobName,
+                jobhistory.c.status,
+                jobhistory.c.prev_run_timestamp,
+                jobhistory.c.last_success_timestamp,
+            ).distinct()
         )
         for ji in job_info:
             jstatus = ji["status"]
-            if any([jstatus is None, jstatus == "Running"]):
+            if jstatus is None:
                 jstatus = "Waiting"
+            elif jstatus == "Running":
+                jstatus = "Waiting"
+                recovery_values = {"status": jstatus}
+                if "weekly" in ji["JobName"].lower():
+                    recovery_values.update(
+                        {
+                            "last_failure_timestamp": ji["prev_run_timestamp"],
+                            "last_error": "Previous weekly refresh was interrupted by restart.",
+                        }
+                    )
+                db.upsert("jobhistory", recovery_values, {"JobName": ji["JobName"]})
             if "update" in ji["JobName"].lower():
                 if comicarr.SCHED_DBUPDATE_LAST is None:
                     comicarr.SCHED_DBUPDATE_LAST = ji["prev_run_timestamp"]
@@ -995,7 +1117,7 @@ def job_management(
                 comicarr.RSS_STATUS = jstatus
             elif "weekly" in ji["JobName"].lower():
                 if comicarr.SCHED_WEEKLY_LAST is None:
-                    comicarr.SCHED_WEEKLY_LAST = ji["prev_run_timestamp"]
+                    comicarr.SCHED_WEEKLY_LAST = ji["last_success_timestamp"] or ji["prev_run_timestamp"]
                 if jstatus is None:
                     jstatus = "Waiting"
                 comicarr.WEEKLY_STATUS = jstatus
@@ -1070,7 +1192,8 @@ def job_management(
         elif jobname == "Weekly Pullist":
             prev_run_timestamp = comicarr.SCHED_WEEKLY_LAST
             if "next run" in jobstatus:
-                comicarr.WEEKLY_STATUS = "Waiting"
+                if comicarr.WEEKLY_STATUS not in {"Error", "Running", "Queued"}:
+                    comicarr.WEEKLY_STATUS = "Waiting"
                 if any(ky == "weekly" for ky, vl in comicarr.FORCE_STATUS.items()):
                     comicarr.WEEKLY_STATUS = comicarr.FORCE_STATUS["weekly"]
                     next_the_run = True
@@ -1226,11 +1349,13 @@ def job_management(
                                 comicarr.FORCE_STATUS.pop("weekly")
 
                             if comicarr.WEEKLY_STATUS != "Paused":
-                                if comicarr.CONFIG.ALT_PULL == 2:
-                                    wkt = 4
-                                else:
-                                    wkt = 24
-                                nextrun_stamp = utctimestamp() + (wkt * 60 * 60)
+                                # APScheduler has already advanced the interval trigger
+                                # before the job body runs. Preserve that cadence after a
+                                # manual refresh instead of replacing it with a one-off
+                                # delay that drifts from the configured schedule.
+                                nextrun_date = getattr(jbst, "next_run_time", None)
+                                if nextrun_date is not None:
+                                    nextrun_stamp = nextrun_date.timestamp()
                             else:
                                 comicarr.SCHED.pause_job("weekly")
                             comicarr.SCHED_WEEKLY_LAST = last_run_completed
@@ -1261,9 +1386,13 @@ def job_management(
 
                     if jobstore is not None:
                         if nextrun_stamp is not None:
-                            nextrun_date = datetime.datetime.utcfromtimestamp(nextrun_stamp)
-                            jobstore.modify(next_run_time=nextrun_date)
-                            nextrun_date = nextrun_date.replace(microsecond=0)
+                            if job == "Weekly Pullist":
+                                nextrun_date = getattr(jobstore, "next_run_time", None)
+                            else:
+                                nextrun_date = datetime.datetime.utcfromtimestamp(nextrun_stamp)
+                                jobstore.modify(next_run_time=nextrun_date)
+                            if nextrun_date is not None:
+                                nextrun_date = nextrun_date.replace(microsecond=0)
                     else:
                         # if the rss is enabled after startup, we have to re-set it up...
                         nextrun_stamp = utctimestamp() + (int(comicarr.CONFIG.RSS_CHECKINTERVAL) * 60)
@@ -1283,6 +1412,20 @@ def job_management(
                     "next_run_datetime": nextrun_date,
                     "status": status,
                 }
+                if failure:
+                    updateVals.update(
+                        {
+                            "last_failure_timestamp": last_run_completed,
+                            "last_error": sanitize_job_error(failure_message),
+                        }
+                    )
+                else:
+                    updateVals.update(
+                        {
+                            "last_success_timestamp": last_run_completed,
+                            "last_error": None,
+                        }
+                    )
 
             logger.fdebug("Job update for %s: %s" % (updateCtrl, updateVals))
             db.upsert("jobhistory", updateVals, updateCtrl)

--- a/comicarr/app/weekly/router.py
+++ b/comicarr/app/weekly/router.py
@@ -12,9 +12,12 @@ Weekly pull list router — serves weekly release data for the Weekly page.
 """
 
 from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
 
 from comicarr.app.core.context import AppContext, get_context
 from comicarr.app.core.security import require_session
+from comicarr.app.storyarcs import service as storyarcs_service
+from comicarr.app.system import service as system_service
 
 router = APIRouter(prefix="/api/weekly", tags=["weekly"])
 
@@ -22,14 +25,25 @@ router = APIRouter(prefix="/api/weekly", tags=["weekly"])
 @router.get("", dependencies=[Depends(require_session)])
 @router.get("/", dependencies=[Depends(require_session)])
 def get_weekly(ctx: AppContext = Depends(get_context)):
-    """Return weekly pull list data."""
+    """Return industry releases for the application current Sunday-based week."""
     from comicarr import db, logger
 
     try:
+        week, year = storyarcs_service.get_current_week()
         rows = db.DBConnection().select(
-            "SELECT COMIC, ISSUE, PUBLISHER, SHIPDATE, STATUS, ComicID, IssueID FROM weekly ORDER BY COMIC ASC"
+            "SELECT COMIC, ISSUE, PUBLISHER, SHIPDATE, STATUS, ComicID, IssueID "
+            "FROM weekly WHERE weeknumber = ? AND year = ? ORDER BY COMIC ASC",
+            [str(int(week)), year],
         )
         return rows or []
     except Exception as e:
         logger.error("[WEEKLY] Error fetching weekly data: %s" % e)
         return []
+
+
+@router.post("/refresh", dependencies=[Depends(require_session)])
+def refresh_weekly(ctx: AppContext = Depends(get_context)):
+    """Request an immediate run of the existing, coalesced weekly scheduler job."""
+    result = system_service.request_weekly_refresh(ctx)
+    status_code = 503 if result["state"] == "unavailable" else 202 if result["accepted"] else 200
+    return JSONResponse(status_code=status_code, content=result)

--- a/comicarr/tables.py
+++ b/comicarr/tables.py
@@ -453,6 +453,9 @@ jobhistory = Table(
     Column("successful_completions", Text),
     Column("failed_completions", Text),
     Column("status", Text),
+    Column("last_success_timestamp", Float),
+    Column("last_failure_timestamp", Float),
+    Column("last_error", Text),
     Column("last_date", Text),
     UniqueConstraint("JobName", name="uq_jobhistory_jobname"),
 )

--- a/comicarr/weeklypullit.py
+++ b/comicarr/weeklypullit.py
@@ -48,30 +48,35 @@ class Weekly:
         pass
 
     def run(self):
-        logger.info("[WEEKLY] Checking Weekly Pull-list for new releases/updates")
-        helpers.job_management(write=True, job="Weekly Pullist", current_run=helpers.utctimestamp(), status="Running")
-        comicarr.WEEKLY_STATUS = "Running"
-        try:
-            pull_result = weeklypull.pullit()
-            if isinstance(pull_result, dict) and pull_result.get("status") == "failure":
-                raise RuntimeError("Weekly pull source reported a failure")
-            weeklypull.future_check()
-        except Exception as e:
-            logger.error("[WEEKLY] Pull-list refresh failed: %s" % e)
+        from comicarr.app.system.service import get_weekly_refresh_lock
+
+        with get_weekly_refresh_lock():
+            logger.info("[WEEKLY] Checking Weekly Pull-list for new releases/updates")
+            helpers.job_management(
+                write=True, job="Weekly Pullist", current_run=helpers.utctimestamp(), status="Running"
+            )
+            comicarr.WEEKLY_STATUS = "Running"
+            try:
+                pull_result = weeklypull.pullit()
+                if isinstance(pull_result, dict) and pull_result.get("status") == "failure":
+                    raise RuntimeError("Weekly pull source reported a failure")
+                weeklypull.future_check()
+            except Exception as e:
+                logger.error("[WEEKLY] Pull-list refresh failed: %s" % e)
+                _restore_manual_next_run()
+                helpers.job_management(
+                    write=True,
+                    job="Weekly Pullist",
+                    last_run_completed=helpers.utctimestamp(),
+                    status="Error",
+                    failure=True,
+                    failure_message=e,
+                )
+                comicarr.WEEKLY_STATUS = "Error"
+                return
+
             _restore_manual_next_run()
             helpers.job_management(
-                write=True,
-                job="Weekly Pullist",
-                last_run_completed=helpers.utctimestamp(),
-                status="Error",
-                failure=True,
-                failure_message=e,
+                write=True, job="Weekly Pullist", last_run_completed=helpers.utctimestamp(), status="Waiting"
             )
-            comicarr.WEEKLY_STATUS = "Error"
-            return
-
-        _restore_manual_next_run()
-        helpers.job_management(
-            write=True, job="Weekly Pullist", last_run_completed=helpers.utctimestamp(), status="Waiting"
-        )
-        comicarr.WEEKLY_STATUS = "Waiting"
+            comicarr.WEEKLY_STATUS = "Waiting"

--- a/comicarr/weeklypullit.py
+++ b/comicarr/weeklypullit.py
@@ -18,8 +18,29 @@
 #  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import datetime
+
 import comicarr
 from comicarr import helpers, logger, weeklypull
+
+
+def _restore_manual_next_run():
+    """Restore the recurring schedule displaced by an immediate manual run."""
+    scheduled_run = getattr(comicarr, "WEEKLY_MANUAL_NEXT_RUN", None)
+    comicarr.WEEKLY_MANUAL_NEXT_RUN = None
+    if not isinstance(scheduled_run, datetime.datetime):
+        return
+
+    now = datetime.datetime.now(tz=scheduled_run.tzinfo) if scheduled_run.tzinfo else datetime.datetime.utcnow()
+    if scheduled_run <= now:
+        return
+
+    try:
+        job = comicarr.SCHED.get_job("weekly")
+        if job is not None:
+            job.modify(next_run_time=scheduled_run)
+    except Exception as e:
+        logger.error("[WEEKLY] Could not restore scheduled refresh time: %s" % e)
 
 
 class Weekly:
@@ -30,9 +51,27 @@ class Weekly:
         logger.info("[WEEKLY] Checking Weekly Pull-list for new releases/updates")
         helpers.job_management(write=True, job="Weekly Pullist", current_run=helpers.utctimestamp(), status="Running")
         comicarr.WEEKLY_STATUS = "Running"
-        weeklypull.pullit()
-        weeklypull.future_check()
+        try:
+            pull_result = weeklypull.pullit()
+            if isinstance(pull_result, dict) and pull_result.get("status") == "failure":
+                raise RuntimeError("Weekly pull source reported a failure")
+            weeklypull.future_check()
+        except Exception as e:
+            logger.error("[WEEKLY] Pull-list refresh failed: %s" % e)
+            _restore_manual_next_run()
+            helpers.job_management(
+                write=True,
+                job="Weekly Pullist",
+                last_run_completed=helpers.utctimestamp(),
+                status="Error",
+                failure=True,
+                failure_message=e,
+            )
+            comicarr.WEEKLY_STATUS = "Error"
+            return
+
+        _restore_manual_next_run()
         helpers.job_management(
             write=True, job="Weekly Pullist", last_run_completed=helpers.utctimestamp(), status="Waiting"
         )
-        # comicarr.WEEKLY_STATUS = 'Waiting'
+        comicarr.WEEKLY_STATUS = "Waiting"

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -21,6 +21,16 @@ interface DashboardUpcoming {
   Status: string;
 }
 
+export interface DashboardQueueItem {
+  ID: string;
+  series: string;
+  filename: string;
+  status: string | null;
+  updated_date: string | null;
+  site: string | null;
+  comicid: string | null;
+}
+
 interface DashboardStats {
   total_series: number;
   total_issues: number;
@@ -40,6 +50,7 @@ interface DashboardAiActivity {
 
 export interface DashboardData {
   recently_downloaded: DashboardDownload[];
+  active_queue: DashboardQueueItem[];
   upcoming_releases: DashboardUpcoming[];
   stats: DashboardStats;
   ai_activity: DashboardAiActivity[];

--- a/frontend/src/hooks/useWeekly.ts
+++ b/frontend/src/hooks/useWeekly.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/api";
+
+export interface WeeklyRefreshResult {
+  accepted: boolean;
+  state: "queued" | "running" | "paused";
+  message?: string;
+  error?: string;
+}
+
+export interface ScheduledJob {
+  id: string;
+  name: string;
+  next_run_time: string | null;
+  trigger: string;
+  status?: string | null;
+  last_success_timestamp?: number | null;
+  last_failure_timestamp?: number | null;
+  last_error?: string | null;
+}
+
+interface JobsResponse {
+  jobs: ScheduledJob[];
+}
+
+export function useWeeklyRefresh() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      apiRequest<WeeklyRefreshResult>("POST", "/api/weekly/refresh"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["system", "jobs"] });
+    },
+  });
+}
+
+export function useScheduledJobs(enabled: boolean) {
+  return useQuery<JobsResponse>({
+    queryKey: ["system", "jobs"],
+    queryFn: () => apiRequest<JobsResponse>("GET", "/api/system/jobs"),
+    enabled,
+    staleTime: 0,
+    refetchInterval: (query) => {
+      const weekly = query.state.data?.jobs.find((job) => job.id === "weekly");
+      const status = weekly?.status?.toLowerCase();
+      return status === "running" || status === "queued" ? 2_000 : false;
+    },
+  });
+}

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -446,6 +446,7 @@ function dashboardPayload() {
   const totalExpected = SERIES.reduce((sum, s) => sum + (s.Total || 0), 0);
   return {
     recently_downloaded: recentDownloads(),
+    active_queue: [],
     upcoming_releases: upcomingReleases(),
     stats: {
       total_series: totalSeries,

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -286,93 +286,103 @@ export default function DashboardPage() {
                 </div>
                 <QueueStatus status={item.status} />
                 <span className="text-muted-foreground truncate text-right">
-                  {item.updated_date ? <RelativeTime value={item.updated_date} /> : "—"}
+                  {item.updated_date ? (
+                    <RelativeTime value={item.updated_date} />
+                  ) : (
+                    "—"
+                  )}
                 </span>
               </div>
             ))}
           </div>
 
           <div className="mt-5 pt-4 border-t border-border">
-          <div className="flex items-center justify-between gap-3 mb-3">
-            <div className="flex items-center gap-2.5">
-              <div className="text-[13px] font-semibold">
-                Recent activity
-              </div>
-              <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
-                {downloads.length} event{downloads.length === 1 ? "" : "s"} · 30 days
-              </div>
-            </div>
-            <Link
-              to="/activity?view=history"
-              className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
-            >
-              open history →
-            </Link>
-          </div>
-
-          {isLoading && (
-            <div className="font-mono text-[11px] text-muted-foreground py-4">
-              loading recent activity…
-            </div>
-          )}
-
-          {!isLoading && downloads.length === 0 && (
-            <div className="font-mono text-[11px] text-muted-foreground py-4">
-              no activity in the last 30 days — <Link to="/activity?view=history" className="hover:text-foreground">open full history</Link>
-            </div>
-          )}
-
-          <div className="font-mono text-[11px]">
-            {downloads.slice(0, 5).map((d, i) => {
-              const action = d.Status?.toLowerCase() || "—";
-              const color = action.includes("down")
-                ? "var(--chart-4)"
-                : action.includes("post") || action.includes("import")
-                  ? "var(--status-active)"
-                  : action.includes("snatch") || action.includes("queue")
-                    ? "var(--status-paused)"
-                    : "var(--muted-foreground)";
-              return (
-                <div
-                  key={`${d.ComicID}-${d.IssueID}-${i}`}
-                  className="grid items-center gap-2 py-1.5"
-                  style={{
-                    gridTemplateColumns: "120px 90px minmax(180px, 1fr) 140px",
-                    borderTop:
-                      i > 0
-                        ? "1px solid var(--border-soft, var(--border))"
-                        : "none",
-                  }}
-                >
-                  <RelativeTime value={d.DateAdded} />
-                  <span className="uppercase truncate" style={{ color }}>
-                    {action}
-                  </span>
-                  <div className="flex items-center gap-2 min-w-0">
-                    {d.ComicID && (
-                      <img
-                        src={`/api/metadata/art/${d.ComicID}`}
-                        alt=""
-                        className="w-4 h-6 object-cover rounded-[1px] shrink-0"
-                        onError={(e) => {
-                          e.currentTarget.style.visibility = "hidden";
-                        }}
-                      />
-                    )}
-                    <Link
-                      to={`/library/${d.ComicID}`}
-                      className="font-sans text-foreground truncate hover:text-[var(--primary)]"
-                    >
-                      {d.ComicName} #{d.Issue_Number}
-                    </Link>
-                  </div>
-                  <span className="text-muted-foreground truncate">
-                    {d.Provider || "—"}
-                  </span>
+            <div className="flex items-center justify-between gap-3 mb-3">
+              <div className="flex items-center gap-2.5">
+                <div className="text-[13px] font-semibold">Recent activity</div>
+                <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
+                  {downloads.length} event{downloads.length === 1 ? "" : "s"} ·
+                  30 days
                 </div>
-              );
-            })}
-          </div>
+              </div>
+              <Link
+                to="/activity?view=history"
+                className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
+              >
+                open history →
+              </Link>
+            </div>
+
+            {isLoading && (
+              <div className="font-mono text-[11px] text-muted-foreground py-4">
+                loading recent activity…
+              </div>
+            )}
+
+            {!isLoading && downloads.length === 0 && (
+              <div className="font-mono text-[11px] text-muted-foreground py-4">
+                no activity in the last 30 days —{" "}
+                <Link
+                  to="/activity?view=history"
+                  className="hover:text-foreground"
+                >
+                  open full history
+                </Link>
+              </div>
+            )}
+
+            <div className="font-mono text-[11px]">
+              {downloads.slice(0, 5).map((d, i) => {
+                const action = d.Status?.toLowerCase() || "—";
+                const color = action.includes("down")
+                  ? "var(--chart-4)"
+                  : action.includes("post") || action.includes("import")
+                    ? "var(--status-active)"
+                    : action.includes("snatch") || action.includes("queue")
+                      ? "var(--status-paused)"
+                      : "var(--muted-foreground)";
+                return (
+                  <div
+                    key={`${d.ComicID}-${d.IssueID}-${i}`}
+                    className="grid items-center gap-2 py-1.5"
+                    style={{
+                      gridTemplateColumns:
+                        "120px 90px minmax(180px, 1fr) 140px",
+                      borderTop:
+                        i > 0
+                          ? "1px solid var(--border-soft, var(--border))"
+                          : "none",
+                    }}
+                  >
+                    <RelativeTime value={d.DateAdded} />
+                    <span className="uppercase truncate" style={{ color }}>
+                      {action}
+                    </span>
+                    <div className="flex items-center gap-2 min-w-0">
+                      {d.ComicID && (
+                        <img
+                          src={`/api/metadata/art/${d.ComicID}`}
+                          alt=""
+                          className="w-4 h-6 object-cover rounded-[1px] shrink-0"
+                          onError={(e) => {
+                            e.currentTarget.style.visibility = "hidden";
+                          }}
+                        />
+                      )}
+                      <Link
+                        to={`/library/${d.ComicID}`}
+                        className="font-sans text-foreground truncate hover:text-[var(--primary)]"
+                      >
+                        {d.ComicName} #{d.Issue_Number}
+                      </Link>
+                    </div>
+                    <span className="text-muted-foreground truncate">
+                      {d.Provider || "—"}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         </section>
 
@@ -381,9 +391,9 @@ export default function DashboardPage() {
           <div className="flex items-center justify-between gap-3 mb-3">
             <div className="flex items-center gap-2.5">
               <div className="text-[13px] font-semibold">This week</div>
-            <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
-              {upcoming.length} releases
-            </div>
+              <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
+                {upcoming.length} releases
+              </div>
             </div>
             <Link
               to="/releases?view=mine"

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,7 +4,7 @@ import { RefreshCw } from "lucide-react";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 import RelativeTime from "@/components/ui/RelativeTime";
 import { useToast } from "@/components/ui/toast";
-import { useDashboard } from "@/hooks/useDashboard";
+import { useDashboard, type DashboardQueueItem } from "@/hooks/useDashboard";
 import {
   useComicScan,
   useComicScanProgress,
@@ -30,6 +30,21 @@ function Kpi({
         </div>
       </div>
     </div>
+  );
+}
+
+function QueueStatus({ status }: { status: DashboardQueueItem["status"] }) {
+  const normalized = (status || "queued").toLowerCase();
+  const color = normalized.includes("fail")
+    ? "var(--status-error)"
+    : normalized.includes("download")
+      ? "var(--status-active)"
+      : "var(--status-paused)";
+
+  return (
+    <span className="uppercase truncate" style={{ color }}>
+      {status || "Queued"}
+    </span>
   );
 }
 
@@ -105,6 +120,7 @@ export default function DashboardPage() {
 
   const stats = data?.stats;
   const downloads = data?.recently_downloaded || [];
+  const activeQueue = data?.active_queue || [];
   const upcoming = data?.upcoming_releases || [];
 
   const activeSeries = stats?.total_series ?? 0;
@@ -214,41 +230,100 @@ export default function DashboardPage() {
         <Kpi label="Queue" value={String(queueCount)} borderLeft />
       </div>
 
-      {/* Two-column body */}
+      {/* Operational summaries */}
       <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] border-b border-border min-h-[320px]">
-        {/* Queue & recent activity */}
+        {/* Active queue and recent history */}
         <section className="px-5 py-4 lg:border-r lg:border-border">
           <div className="flex items-center justify-between gap-3 mb-3">
             <div className="flex items-center gap-2.5">
+              <div className="text-[13px] font-semibold">Active queue</div>
+              <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
+                {queueCount} item{queueCount === 1 ? "" : "s"}
+              </div>
+            </div>
+            <Link
+              to="/activity"
+              className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
+            >
+              open queue →
+            </Link>
+          </div>
+
+          {isLoading && (
+            <div className="font-mono text-[11px] text-muted-foreground py-3">
+              loading queue…
+            </div>
+          )}
+
+          {!isLoading && activeQueue.length === 0 && (
+            <div className="font-mono text-[11px] text-muted-foreground py-3">
+              queue is clear
+            </div>
+          )}
+
+          <div className="font-mono text-[11px]">
+            {activeQueue.map((item, index) => (
+              <div
+                key={item.ID}
+                className="grid items-center gap-2 py-1.5"
+                style={{
+                  gridTemplateColumns: "minmax(140px, 1fr) 100px 120px",
+                  borderTop:
+                    index > 0
+                      ? "1px solid var(--border-soft, var(--border))"
+                      : "none",
+                }}
+              >
+                <div className="min-w-0">
+                  <div className="font-sans text-foreground truncate">
+                    {item.series || item.filename || "Unnamed download"}
+                  </div>
+                  {item.filename && item.filename !== item.series && (
+                    <div className="text-muted-foreground truncate">
+                      {item.filename}
+                    </div>
+                  )}
+                </div>
+                <QueueStatus status={item.status} />
+                <span className="text-muted-foreground truncate text-right">
+                  {item.updated_date ? <RelativeTime value={item.updated_date} /> : "—"}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-5 pt-4 border-t border-border">
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <div className="flex items-center gap-2.5">
               <div className="text-[13px] font-semibold">
-                Queue & recent activity
+                Recent activity
               </div>
               <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
-                {downloads.length} events
+                {downloads.length} event{downloads.length === 1 ? "" : "s"} · 30 days
               </div>
             </div>
             <Link
               to="/activity?view=history"
               className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
             >
-              view all →
+              open history →
             </Link>
           </div>
 
           {isLoading && (
             <div className="font-mono text-[11px] text-muted-foreground py-4">
-              loading activity…
+              loading recent activity…
             </div>
           )}
 
           {!isLoading && downloads.length === 0 && (
             <div className="font-mono text-[11px] text-muted-foreground py-4">
-              no recent activity
+              no activity in the last 30 days — <Link to="/activity?view=history" className="hover:text-foreground">open full history</Link>
             </div>
           )}
 
           <div className="font-mono text-[11px]">
-            {downloads.slice(0, 8).map((d, i) => {
+            {downloads.slice(0, 5).map((d, i) => {
               const action = d.Status?.toLowerCase() || "—";
               const color = action.includes("down")
                 ? "var(--chart-4)"
@@ -298,15 +373,24 @@ export default function DashboardPage() {
               );
             })}
           </div>
+          </div>
         </section>
 
         {/* This week */}
         <section className="px-5 py-4">
-          <div className="flex items-center gap-2.5 mb-3">
-            <div className="text-[13px] font-semibold">This week</div>
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <div className="flex items-center gap-2.5">
+              <div className="text-[13px] font-semibold">This week</div>
             <div className="font-mono text-[10px] text-[var(--text-muted)] tracking-wider uppercase">
               {upcoming.length} releases
             </div>
+            </div>
+            <Link
+              to="/releases?view=mine"
+              className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
+            >
+              view mine →
+            </Link>
           </div>
 
           {isLoading && (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -34,12 +34,12 @@ function Kpi({
 }
 
 function QueueStatus({ status }: { status: DashboardQueueItem["status"] }) {
-  const normalized = (status || "queued").toLowerCase();
-  const color = normalized.includes("fail")
-    ? "var(--status-error)"
-    : normalized.includes("download")
-      ? "var(--status-active)"
-      : "var(--status-paused)";
+  const color =
+    status === "Failed"
+      ? "var(--status-error)"
+      : status === "Downloading"
+        ? "var(--status-active)"
+        : "var(--status-paused)";
 
   return (
     <span className="uppercase truncate" style={{ color }}>

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Search, RefreshCw } from "lucide-react";
 import {
@@ -7,11 +7,12 @@ import {
   useBulkQueueIssues,
   useBulkUnqueueIssues,
 } from "@/hooks/useQueue";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/api";
 import { useAiStatus } from "@/hooks/useAiStatus";
 import { AiSuggestions } from "@/components/weekly/AiSuggestions";
 import { useToast } from "@/components/ui/toast";
+import { useScheduledJobs, useWeeklyRefresh } from "@/hooks/useWeekly";
 import { Skeleton } from "@/components/ui/skeleton";
 import UpcomingTable from "@/components/queue/UpcomingTable";
 import BulkActionBar from "@/components/queue/BulkActionBar";
@@ -104,15 +105,83 @@ export default function ReleasesPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const viewParam = searchParams.get("view");
   const currentView: ReleasesView = viewParam === "all" ? "all" : "mine";
+  const weeklyRefresh = useWeeklyRefresh();
+  const queryClient = useQueryClient();
+  const [refreshRequestedAt, setRefreshRequestedAt] = useState<number | null>(null);
+  const refreshRequested = refreshRequestedAt !== null;
+  const { data: jobs } = useScheduledJobs(refreshRequested);
+  const { addToast } = useToast();
+  const weeklyJob = jobs?.jobs.find((job) => job.id === "weekly");
+  const weeklyStatus = weeklyJob?.status?.toLowerCase();
+  const refreshMessage = !refreshRequested
+    ? null
+    : weeklyStatus === "queued"
+      ? "Refresh queued — it will start shortly."
+      : weeklyStatus === "running"
+      ? "Refreshing releases…"
+      : weeklyStatus === "error"
+        ? weeklyJob?.last_error || "Refresh failed. Check the pull source, then retry."
+        : weeklyJob?.last_success_timestamp &&
+            weeklyJob.last_success_timestamp >= refreshRequestedAt
+          ? "Releases refreshed."
+          : "Refresh queued — it will start shortly.";
+
+  useEffect(() => {
+    if (
+      !refreshRequestedAt ||
+      weeklyStatus !== "waiting" ||
+      !weeklyJob?.last_success_timestamp ||
+      weeklyJob.last_success_timestamp < refreshRequestedAt
+    ) {
+      return;
+    }
+    queryClient.invalidateQueries({ queryKey: ["weekly"] });
+    queryClient.invalidateQueries({ queryKey: ["upcoming"] });
+    queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+  }, [
+    queryClient,
+    refreshRequestedAt,
+    weeklyJob?.last_success_timestamp,
+    weeklyStatus,
+  ]);
 
   const setView = (view: ReleasesView) => {
     setSearchParams({ view });
   };
 
+  const handleWeeklyRefresh = async () => {
+    const requestStartedAt = Date.now() / 1_000;
+    try {
+      const result = await weeklyRefresh.mutateAsync();
+      if (result.state === "paused" || (!result.accepted && result.error)) {
+        addToast({
+          type: "error",
+          message:
+            result.error || "Weekly refresh is paused. Resume it in Settings, then retry.",
+        });
+        return;
+      }
+      setRefreshRequestedAt(requestStartedAt);
+      addToast({
+        type: "info",
+        message:
+          result.message ||
+          (result.state === "running"
+            ? "Release refresh is already running."
+            : "Release refresh queued."),
+      });
+    } catch (error) {
+      addToast({
+        type: "error",
+        message: `Unable to refresh releases: ${error instanceof Error ? error.message : "Unknown error"}`,
+      });
+    }
+  };
+
   return (
     <div className="page-transition">
       {/* Header */}
-      <div className="px-5 py-3.5 border-b border-border flex items-center gap-3">
+      <div className="px-5 py-3.5 border-b border-border flex items-center justify-between gap-3">
         <div>
           <div className="text-[18px] font-semibold tracking-tight leading-none">
             Releases
@@ -123,7 +192,46 @@ export default function ReleasesPage() {
               : "this week · industry-wide"}
           </div>
         </div>
+        <button
+          type="button"
+          onClick={() => void handleWeeklyRefresh()}
+          disabled={
+            weeklyRefresh.isPending ||
+            weeklyStatus === "running" ||
+            weeklyStatus === "queued"
+          }
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[5px] border text-[12px] font-medium disabled:opacity-50"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <RefreshCw
+            className={`w-3.5 h-3.5 ${weeklyRefresh.isPending || weeklyStatus === "running" || weeklyStatus === "queued" ? "animate-spin" : ""}`}
+          />
+          {weeklyStatus === "running"
+            ? "Refreshing…"
+            : weeklyStatus === "queued"
+              ? "Queued…"
+              : "Refresh releases"}
+        </button>
       </div>
+
+      {refreshMessage && (
+        <div
+          role={weeklyStatus === "error" ? "alert" : "status"}
+          aria-live={weeklyStatus === "error" ? "assertive" : "polite"}
+          className="px-5 py-2 border-b border-border font-mono text-[11px]"
+          style={{
+            color:
+              weeklyStatus === "error"
+                ? "var(--status-error)"
+                : weeklyStatus === "running"
+                  ? "var(--status-active)"
+                  : "var(--muted-foreground)",
+          }}
+        >
+          {refreshMessage}
+          {weeklyStatus === "error" && " Retry after fixing the pull source connection."}
+        </div>
+      )}
 
       {/* Tab row */}
       <div className="px-5 pt-3 border-b border-border flex items-end gap-6">

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -107,7 +107,9 @@ export default function ReleasesPage() {
   const currentView: ReleasesView = viewParam === "all" ? "all" : "mine";
   const weeklyRefresh = useWeeklyRefresh();
   const queryClient = useQueryClient();
-  const [refreshRequestedAt, setRefreshRequestedAt] = useState<number | null>(null);
+  const [refreshRequestedAt, setRefreshRequestedAt] = useState<number | null>(
+    null,
+  );
   const refreshRequested = refreshRequestedAt !== null;
   const { data: jobs } = useScheduledJobs(refreshRequested);
   const { addToast } = useToast();
@@ -118,13 +120,14 @@ export default function ReleasesPage() {
     : weeklyStatus === "queued"
       ? "Refresh queued — it will start shortly."
       : weeklyStatus === "running"
-      ? "Refreshing releases…"
-      : weeklyStatus === "error"
-        ? weeklyJob?.last_error || "Refresh failed. Check the pull source, then retry."
-        : weeklyJob?.last_success_timestamp &&
-            weeklyJob.last_success_timestamp >= refreshRequestedAt
-          ? "Releases refreshed."
-          : "Refresh queued — it will start shortly.";
+        ? "Refreshing releases…"
+        : weeklyStatus === "error"
+          ? weeklyJob?.last_error ||
+            "Refresh failed. Check the pull source, then retry."
+          : weeklyJob?.last_success_timestamp &&
+              weeklyJob.last_success_timestamp >= refreshRequestedAt
+            ? "Releases refreshed."
+            : "Refresh queued — it will start shortly.";
 
   useEffect(() => {
     if (
@@ -157,7 +160,8 @@ export default function ReleasesPage() {
         addToast({
           type: "error",
           message:
-            result.error || "Weekly refresh is paused. Resume it in Settings, then retry.",
+            result.error ||
+            "Weekly refresh is paused. Resume it in Settings, then retry.",
         });
         return;
       }
@@ -229,7 +233,8 @@ export default function ReleasesPage() {
           }}
         >
           {refreshMessage}
-          {weeklyStatus === "error" && " Retry after fixing the pull source connection."}
+          {weeklyStatus === "error" &&
+            " Retry after fixing the pull source connection."}
         </div>
       )}
 

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Search, RefreshCw } from "lucide-react";
 import {
@@ -107,10 +107,10 @@ export default function ReleasesPage() {
   const currentView: ReleasesView = viewParam === "all" ? "all" : "mine";
   const weeklyRefresh = useWeeklyRefresh();
   const queryClient = useQueryClient();
-  const [refreshRequestedAt, setRefreshRequestedAt] = useState<number | null>(
-    null,
-  );
-  const refreshRequested = refreshRequestedAt !== null;
+  const [refreshRequested, setRefreshRequested] = useState(false);
+  const [refreshObservedActive, setRefreshObservedActive] = useState(false);
+  const refreshAccepted = useRef(false);
+  const refreshInvalidated = useRef(false);
   const { data: jobs } = useScheduledJobs(refreshRequested);
   const { addToast } = useToast();
   const weeklyJob = jobs?.jobs.find((job) => job.id === "weekly");
@@ -124,36 +124,31 @@ export default function ReleasesPage() {
         : weeklyStatus === "error"
           ? weeklyJob?.last_error ||
             "Refresh failed. Check the pull source, then retry."
-          : weeklyJob?.last_success_timestamp &&
-              weeklyJob.last_success_timestamp >= refreshRequestedAt
+          : weeklyStatus === "waiting" && refreshObservedActive
             ? "Releases refreshed."
             : "Refresh queued — it will start shortly.";
 
   useEffect(() => {
     if (
-      !refreshRequestedAt ||
+      !refreshRequested ||
+      !refreshAccepted.current ||
+      !refreshObservedActive ||
       weeklyStatus !== "waiting" ||
-      !weeklyJob?.last_success_timestamp ||
-      weeklyJob.last_success_timestamp < refreshRequestedAt
+      refreshInvalidated.current
     ) {
       return;
     }
+    refreshInvalidated.current = true;
     queryClient.invalidateQueries({ queryKey: ["weekly"] });
     queryClient.invalidateQueries({ queryKey: ["upcoming"] });
     queryClient.invalidateQueries({ queryKey: ["dashboard"] });
-  }, [
-    queryClient,
-    refreshRequestedAt,
-    weeklyJob?.last_success_timestamp,
-    weeklyStatus,
-  ]);
+  }, [queryClient, refreshObservedActive, refreshRequested, weeklyStatus]);
 
   const setView = (view: ReleasesView) => {
     setSearchParams({ view });
   };
 
   const handleWeeklyRefresh = async () => {
-    const requestStartedAt = Date.now() / 1_000;
     try {
       const result = await weeklyRefresh.mutateAsync();
       if (result.state === "paused" || (!result.accepted && result.error)) {
@@ -165,7 +160,12 @@ export default function ReleasesPage() {
         });
         return;
       }
-      setRefreshRequestedAt(requestStartedAt);
+      refreshAccepted.current = result.accepted;
+      refreshInvalidated.current = false;
+      setRefreshObservedActive(
+        result.state === "queued" || result.state === "running",
+      );
+      setRefreshRequested(true);
       addToast({
         type: "info",
         message:

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -157,6 +157,17 @@ export const handlers = [
           ComicImage: "https://example.com/spiderman.jpg",
         },
       ],
+      active_queue: [
+        {
+          ID: "queue-1",
+          series: "Spider-Man",
+          filename: "Spider-Man 001.cbz",
+          status: "Downloading",
+          updated_date: "2026-04-05T12:00:00",
+          site: "DDL(GetComics)",
+          comicid: "1",
+        },
+      ],
       upcoming_releases: [
         {
           ComicName: "Batman",
@@ -179,6 +190,31 @@ export const handlers = [
       scan_targets: { comic: true, manga: true },
     });
   }),
+
+  http.post("/api/weekly/refresh", () =>
+    HttpResponse.json({
+      accepted: true,
+      state: "queued",
+      message: "Weekly refresh queued.",
+    }),
+  ),
+
+  http.get("/api/system/jobs", () =>
+    HttpResponse.json({
+      jobs: [
+        {
+          id: "weekly",
+          name: "Weekly Pullist",
+          next_run_time: null,
+          trigger: "cron",
+          status: "Waiting",
+          last_success_timestamp: null,
+          last_failure_timestamp: null,
+          last_error: null,
+        },
+      ],
+    }),
+  ),
 
   // -------------------------------------------------------------------------
   // Series endpoints

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -205,9 +205,9 @@ export const handlers = [
         {
           id: "weekly",
           name: "Weekly Pullist",
-          next_run_time: null,
-          trigger: "cron",
-          status: "Waiting",
+          next_run_time: "2026-07-10T16:00:00Z",
+          trigger: "interval[0:04:00]",
+          status: "Queued",
           last_success_timestamp: null,
           last_failure_timestamp: null,
           last_error: null,

--- a/frontend/tests/pages/DashboardPage.test.tsx
+++ b/frontend/tests/pages/DashboardPage.test.tsx
@@ -43,19 +43,26 @@ describe("DashboardPage", () => {
     expect(screen.getByText("250")).toBeTruthy();
   });
 
-  it("renders queue & recent activity section", async () => {
+  it("renders separate active queue and recent activity previews", async () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Queue & recent activity")).toBeTruthy();
+      expect(screen.getByText("Active queue")).toBeTruthy();
+      expect(screen.getByText("Recent activity")).toBeTruthy();
     });
 
-    // Activity row title is "<ComicName> #<Issue_Number>" inside a Link.
     await waitFor(() => {
+      expect(screen.getByText("Downloading")).toBeTruthy();
+      expect(screen.getByText("Spider-Man 001.cbz")).toBeTruthy();
       expect(screen.getByText("Spider-Man #1")).toBeTruthy();
     });
-    expect(screen.getByText(/ago$/)).toBeTruthy();
-    expect(screen.getByRole("link", { name: "view all →" })).toBeTruthy();
+    expect(screen.getAllByText(/ago$/).length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("link", { name: "open queue →" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "open history →" }),
+    ).toBeTruthy();
   });
 
   it("starts scans for each configured library from the dashboard", async () => {
@@ -153,6 +160,7 @@ describe("DashboardPage", () => {
       http.get("/api/dashboard", () => {
         return HttpResponse.json({
           recently_downloaded: [],
+          active_queue: [],
           upcoming_releases: [],
           stats: {
             total_series: 0,
@@ -169,7 +177,8 @@ describe("DashboardPage", () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("no recent activity")).toBeTruthy();
+      expect(screen.getByText("queue is clear")).toBeTruthy();
+      expect(screen.getByText(/no activity in the last 30 days/)).toBeTruthy();
       expect(screen.getByText("nothing upcoming this week")).toBeTruthy();
     });
     expect(
@@ -177,6 +186,34 @@ describe("DashboardPage", () => {
         .getByRole("button", { name: "Scan libraries" })
         .hasAttribute("disabled"),
     ).toBe(true);
+  });
+
+  it("links the recent empty state to the full history", async () => {
+    server.use(
+      http.get("/api/dashboard", () =>
+        HttpResponse.json({
+          recently_downloaded: [],
+          active_queue: [],
+          upcoming_releases: [],
+          stats: {
+            total_series: 1,
+            total_issues: 1,
+            total_expected: 1,
+            completion_pct: 100,
+            queue_count: 0,
+          },
+          ai_activity: [],
+          ai_configured: false,
+          scan_targets: { comic: false, manga: false },
+        }),
+      ),
+    );
+
+    render(<DashboardPage />);
+
+    expect(
+      await screen.findByRole("link", { name: "open full history" }),
+    ).toBeTruthy();
   });
 
   it("renders command hint card", async () => {

--- a/frontend/tests/pages/ReleasesPage.test.tsx
+++ b/frontend/tests/pages/ReleasesPage.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/server";
+import { render, screen } from "../test-utils";
+import ReleasesPage from "@/pages/ReleasesPage";
+
+describe("ReleasesPage", () => {
+  it("queues a weekly refresh and reports its accepted state", async () => {
+    const user = userEvent.setup();
+    render(<ReleasesPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Refresh releases" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Refresh queued — it will start shortly."),
+      ).toBeTruthy();
+    });
+  });
+
+  it("explains when the scheduler is paused instead of claiming a queued refresh", async () => {
+    server.use(
+      http.post("/api/weekly/refresh", () =>
+        HttpResponse.json({
+          accepted: false,
+          state: "paused",
+          error: "Weekly refresh is paused",
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    render(<ReleasesPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Refresh releases" }),
+    );
+
+    expect(await screen.findByText("Weekly refresh is paused")).toBeTruthy();
+    expect(screen.queryByText("Refresh queued — it will start shortly.")).toBeNull();
+  });
+
+  it("reports a refresh that finishes before the accepted response is rendered", async () => {
+    server.use(
+      http.get("/api/system/jobs", () =>
+        HttpResponse.json({
+          jobs: [
+            {
+              id: "weekly",
+              name: "Weekly Pullist",
+              next_run_time: "2026-07-12T00:00:00Z",
+              trigger: "interval",
+              status: "Waiting",
+              last_success_timestamp: Date.now() / 1_000,
+              last_failure_timestamp: null,
+              last_error: null,
+            },
+          ],
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    render(<ReleasesPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Refresh releases" }),
+    );
+
+    expect(await screen.findByText("Releases refreshed.")).toBeTruthy();
+  });
+});

--- a/tests/unit/test_dashboard_service.py
+++ b/tests/unit/test_dashboard_service.py
@@ -9,7 +9,7 @@
 
 """Tests for comicarr.app.dashboard.service."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,6 +19,7 @@ import pytest
 def _default_queue_count(monkeypatch):
     monkeypatch.setattr("comicarr.app.dashboard.service.dl_queries.count_active_ddl_items", lambda: 0)
     monkeypatch.setattr("comicarr.app.dashboard.service.dl_queries.get_active_ddl_preview", lambda limit: [])
+    monkeypatch.setattr("comicarr.app.dashboard.service.storyarcs_service.get_upcoming", lambda include_downloaded: [])
 
 
 class _FakeDBConnection:
@@ -53,7 +54,7 @@ class TestGetDashboardData:
             {
                 "ComicName": "Spider-Man",
                 "Issue_Number": "1",
-                "DateAdded": "2026-04-01",
+                "DateAdded": (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S"),
                 "Status": "Snatched",
                 "Provider": "nzb",
                 "ComicID": "100",

--- a/tests/unit/test_dashboard_service.py
+++ b/tests/unit/test_dashboard_service.py
@@ -9,6 +9,7 @@
 
 """Tests for comicarr.app.dashboard.service."""
 
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,6 +18,7 @@ import pytest
 @pytest.fixture(autouse=True)
 def _default_queue_count(monkeypatch):
     monkeypatch.setattr("comicarr.app.dashboard.service.dl_queries.count_active_ddl_items", lambda: 0)
+    monkeypatch.setattr("comicarr.app.dashboard.service.dl_queries.get_active_ddl_preview", lambda limit: [])
 
 
 class _FakeDBConnection:
@@ -59,7 +61,7 @@ class TestGetDashboardData:
                 "ComicImage": "http://img/1.jpg",
             },
         ]
-        fake_db = _FakeDBConnection(select_results={"snatched": recent, "futureupcoming": []})
+        fake_db = _FakeDBConnection(select_results={"snatched": recent})
         mock_db.DBConnection.return_value = fake_db
 
         from comicarr.app.dashboard.service import get_dashboard_data
@@ -71,27 +73,67 @@ class TestGetDashboardData:
 
     @patch("comicarr.app.dashboard.service.db")
     @patch("comicarr.app.dashboard.service.comicarr")
-    def test_returns_upcoming_releases(self, mock_comicarr, mock_db):
+    def test_recent_activity_uses_an_inclusive_30_day_cutoff(self, mock_comicarr, mock_db, monkeypatch):
+        mock_comicarr.AI_CLIENT = None
+        cutoff = datetime(2026, 6, 10, 12, 0, 0)
+        monkeypatch.setattr("comicarr.app.dashboard.service.recent_activity_cutoff", lambda: cutoff)
+        fake_db = _FakeDBConnection(select_results={"snatched": []})
+        mock_db.DBConnection.return_value = fake_db
+
+        from comicarr.app.dashboard.service import get_dashboard_data
+
+        get_dashboard_data(None)
+
+        recent_query, args = next((query, args) for query, args in fake_db._select_calls if "FROM snatched" in query)
+        assert "WHERE s.DateAdded >= ?" in recent_query
+        assert args == ["2026-06-10 12:00:00"]
+
+    @patch("comicarr.app.dashboard.service.db")
+    @patch("comicarr.app.dashboard.service.comicarr")
+    def test_returns_current_week_library_releases(self, mock_comicarr, mock_db, monkeypatch):
         mock_comicarr.AI_CLIENT = None
         upcoming = [
             {
                 "ComicName": "Batman",
                 "IssueNumber": "5",
                 "IssueDate": "2026-04-06",
-                "Publisher": "DC Comics",
                 "ComicID": "300",
                 "Status": "Wanted",
             },
         ]
-        fake_db = _FakeDBConnection(select_results={"futureupcoming": upcoming, "snatched": []})
+        fake_db = _FakeDBConnection(select_results={"snatched": []})
+        mock_db.DBConnection.return_value = fake_db
+        get_upcoming = MagicMock(return_value=upcoming)
+        monkeypatch.setattr("comicarr.app.dashboard.service.storyarcs_service.get_upcoming", get_upcoming)
+
+        from comicarr.app.dashboard.service import get_dashboard_data
+
+        result = get_dashboard_data(None)
+
+        get_upcoming.assert_called_once_with(include_downloaded=True)
+        assert len(result["upcoming_releases"]) == 1
+        assert result["upcoming_releases"][0]["ComicName"] == "Batman"
+        assert all("futureupcoming" not in query for query, _args in fake_db._select_calls)
+
+    @patch("comicarr.app.dashboard.service.db")
+    @patch("comicarr.app.dashboard.service.comicarr")
+    def test_returns_active_queue_preview_with_shared_queue_query(self, mock_comicarr, mock_db, monkeypatch):
+        mock_comicarr.AI_CLIENT = None
+        queue_items = [{"ID": "queued-1", "series": "Batman", "status": "Queued"}]
+        get_active_preview = MagicMock(return_value=queue_items)
+        monkeypatch.setattr("comicarr.app.dashboard.service.dl_queries.get_active_ddl_preview", get_active_preview)
+        fake_db = _FakeDBConnection(
+            select_results={"snatched": []},
+            selectone_result={"total_series": 1, "total_issues": 1, "total_expected": 1},
+        )
         mock_db.DBConnection.return_value = fake_db
 
         from comicarr.app.dashboard.service import get_dashboard_data
 
         result = get_dashboard_data(None)
 
-        assert len(result["upcoming_releases"]) == 1
-        assert result["upcoming_releases"][0]["ComicName"] == "Batman"
+        get_active_preview.assert_called_once_with(limit=5)
+        assert result["active_queue"] == queue_items
 
     @patch("comicarr.app.dashboard.service.db")
     @patch("comicarr.app.dashboard.service.comicarr")
@@ -99,7 +141,7 @@ class TestGetDashboardData:
         mock_comicarr.AI_CLIENT = None
         stats_row = {"total_series": 10, "total_issues": 250, "total_expected": 500}
         fake_db = _FakeDBConnection(
-            select_results={"snatched": [], "futureupcoming": []},
+            select_results={"snatched": []},
             selectone_result=stats_row,
         )
         mock_db.DBConnection.return_value = fake_db
@@ -124,7 +166,7 @@ class TestGetDashboardData:
             lambda: 3,
         )
         fake_db = _FakeDBConnection(
-            select_results={"snatched": [], "futureupcoming": []},
+            select_results={"snatched": []},
             selectone_result={"total_series": 1, "total_issues": 1, "total_expected": 1},
         )
         mock_db.DBConnection.return_value = fake_db
@@ -145,7 +187,7 @@ class TestGetDashboardData:
             MagicMock(side_effect=RuntimeError("count failed")),
         )
         fake_db = _FakeDBConnection(
-            select_results={"snatched": [], "futureupcoming": []},
+            select_results={"snatched": []},
             selectone_result={"total_series": 1, "total_issues": 1, "total_expected": 1},
         )
         mock_db.DBConnection.return_value = fake_db
@@ -173,7 +215,7 @@ class TestGetDashboardData:
             },
         ]
         fake_db = _FakeDBConnection(
-            select_results={"snatched": [], "futureupcoming": [], "ai_activity_log": activity},
+            select_results={"snatched": [], "ai_activity_log": activity},
         )
         mock_db.DBConnection.return_value = fake_db
 
@@ -190,7 +232,7 @@ class TestGetDashboardData:
     def test_ai_not_configured(self, mock_comicarr, mock_db):
         mock_comicarr.AI_CLIENT = None
         mock_comicarr.CONFIG.AI_BASE_URL = None
-        fake_db = _FakeDBConnection(select_results={"snatched": [], "futureupcoming": []})
+        fake_db = _FakeDBConnection(select_results={"snatched": []})
         mock_db.DBConnection.return_value = fake_db
 
         from comicarr.app.dashboard.service import get_dashboard_data
@@ -206,7 +248,7 @@ class TestGetDashboardData:
         mock_comicarr.AI_CLIENT = None
         mock_comicarr.CONFIG.AI_BASE_URL = None
         fake_db = _FakeDBConnection(
-            select_results={"snatched": [], "futureupcoming": []},
+            select_results={"snatched": []},
             selectone_result=[],
         )
         mock_db.DBConnection.return_value = fake_db
@@ -234,7 +276,7 @@ class TestGetDashboardData:
         # Should return empty defaults, not raise
         assert result["recently_downloaded"] == []
         assert result["upcoming_releases"] == []
-        assert result["stats"] == {}
+        assert result["stats"] == {"queue_count": 0}
 
     @patch("comicarr.app.dashboard.service.db")
     @patch("comicarr.app.dashboard.service.comicarr")
@@ -242,7 +284,7 @@ class TestGetDashboardData:
         mock_comicarr.AI_CLIENT = None
         stats_row = {"total_series": 0, "total_issues": 0, "total_expected": 0}
         fake_db = _FakeDBConnection(
-            select_results={"snatched": [], "futureupcoming": []},
+            select_results={"snatched": []},
             selectone_result=stats_row,
         )
         mock_db.DBConnection.return_value = fake_db

--- a/tests/unit/test_download_activity_queries.py
+++ b/tests/unit/test_download_activity_queries.py
@@ -94,6 +94,9 @@ def test_queue_excludes_completed_rows_and_supports_search_sort_pagination(activ
     assert queued_only["total"] == 1
     assert queued_only["results"][0]["ID"] == "queued-old"
 
+    preview = queries.get_active_ddl_preview()
+    assert [row["ID"] for row in preview] == ["unknown", "queued-new", "failed", "queued-old"]
+
 
 def test_history_supports_filtering_and_oldest_first_sort(activity_db):
     with activity_db.begin() as conn:

--- a/tests/unit/test_series_scan_start.py
+++ b/tests/unit/test_series_scan_start.py
@@ -7,6 +7,7 @@
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -34,3 +35,44 @@ def test_library_scan_rejects_missing_mount(monkeypatch, scan, config_key, path,
     assert result["success"] is False
     assert error in result["error"]
     thread.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("scan", "scanner", "config_key", "path", "status_attr", "lock_attr"),
+    [
+        (
+            service.comic_library_scan,
+            "comicsync",
+            "COMIC_DIR",
+            "/library/comics",
+            "COMIC_SCAN_STATUS",
+            "_SCAN_LOCK",
+        ),
+        (
+            service.manga_library_scan,
+            "mangasync",
+            "MANGA_DIR",
+            "/library/manga",
+            "MANGA_SCAN_STATUS",
+            "_SCAN_LOCK",
+        ),
+    ],
+)
+def test_library_scan_rejects_duplicate_request_before_starting_another_worker(
+    monkeypatch, scan, scanner, config_key, path, status_attr, lock_attr
+):
+    scanner_module = getattr(__import__("comicarr", fromlist=[scanner]), scanner)
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(**{config_key: path}))
+    monkeypatch.setattr(service.os.path, "isdir", MagicMock(return_value=True))
+    monkeypatch.setattr(scanner_module, status_attr, None)
+    monkeypatch.setattr(scanner_module, lock_attr, threading.Lock())
+    thread = MagicMock()
+    monkeypatch.setattr(service.threading, "Thread", thread)
+
+    first = scan(None)
+    duplicate = scan(None)
+
+    assert first["success"] is True
+    assert duplicate == {"success": False, "error": "A library scan is already in progress"}
+    assert thread.call_count == 1
+    thread.return_value.start.assert_called_once()

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -5,6 +5,7 @@ Covers: auth login/logout, SSE streaming, config endpoints, JWT cookies.
 """
 
 import configparser
+import datetime
 import json
 import os
 import stat
@@ -176,9 +177,7 @@ class TestVerifyLogin:
         assert result["success"] is True
         assert result["username"] == "admin"
         assert ctx.config.HTTP_PASSWORD == "legacy-password"
-        ctx.config.apply_transaction.assert_called_once_with(
-            {"http_password": "$2b$12$migrated"}, configure=False
-        )
+        ctx.config.apply_transaction.assert_called_once_with({"http_password": "$2b$12$migrated"}, configure=False)
 
 
 # =============================================================================
@@ -666,6 +665,158 @@ class TestConfigService:
         result = system_service.get_job_info(ctx)
         assert len(result["jobs"]) == 1
         assert result["jobs"][0]["id"] == "search_job"
+
+    def test_get_job_info_includes_durable_weekly_outcomes(self):
+        """The weekly scheduler reports its durable outcome fields for refresh polling."""
+        ctx = _make_test_ctx()
+        mock_job = MagicMock()
+        mock_job.id = "weekly"
+        mock_job.name = "Weekly Pullist"
+        mock_job.next_run_time = "2026-07-12T00:00:00Z"
+        mock_job.trigger = "interval"
+        ctx.scheduler.get_jobs.return_value = [mock_job]
+
+        with patch.object(
+            system_service,
+            "_get_weekly_job_history",
+            return_value={
+                "status": "Error",
+                "last_success_timestamp": 100.0,
+                "last_failure_timestamp": 200.0,
+                "last_error": "upstream unavailable",
+            },
+        ):
+            result = system_service.get_job_info(ctx)
+
+        weekly = result["jobs"][0]
+        assert weekly["state"] == "error"
+        assert weekly["last_success_timestamp"] == 100.0
+        assert weekly["last_failure_timestamp"] == 200.0
+        assert weekly["last_error"] == "upstream unavailable"
+
+    def test_weekly_refresh_queues_the_existing_scheduler_job(self, monkeypatch):
+        """Manual refresh modifies the existing weekly job instead of creating work."""
+        ctx = _make_test_ctx()
+        job = MagicMock()
+        job.next_run_time = datetime.datetime(2026, 7, 12, 0, 0, 0)
+        ctx.scheduler.get_job.return_value = job
+        monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Waiting")
+        monkeypatch.setattr(comicarr, "WEEKLY_MANUAL_NEXT_RUN", None)
+
+        with patch.object(system_service.db, "upsert") as upsert:
+            result = system_service.request_weekly_refresh(ctx)
+
+        assert result["accepted"] is True
+        assert result["state"] == "queued"
+        job.modify.assert_called_once()
+        upsert.assert_called_once_with("jobhistory", {"status": "Queued"}, {"JobName": "Weekly Pullist"})
+        assert comicarr.WEEKLY_MANUAL_NEXT_RUN == job.next_run_time
+
+    def test_weekly_refresh_coalesces_an_already_queued_request(self, monkeypatch):
+        """Repeated clicks leave one scheduled run in place."""
+        ctx = _make_test_ctx()
+        job = MagicMock()
+        job.next_run_time = "2026-07-12T00:00:00Z"
+        ctx.scheduler.get_job.return_value = job
+        monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Queued")
+
+        result = system_service.request_weekly_refresh(ctx)
+
+        assert result == {
+            "accepted": False,
+            "state": "queued",
+            "next_run_time": "2026-07-12T00:00:00Z",
+        }
+        job.modify.assert_not_called()
+
+    def test_weekly_refresh_rejects_while_the_job_is_running(self, monkeypatch):
+        """A running weekly pull cannot be scheduled a second time."""
+        ctx = _make_test_ctx()
+        job = MagicMock()
+        job.next_run_time = "2026-07-12T00:00:00Z"
+        ctx.scheduler.get_job.return_value = job
+        monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Running")
+
+        result = system_service.request_weekly_refresh(ctx)
+
+        assert result["accepted"] is False
+        assert result["state"] == "running"
+        job.modify.assert_not_called()
+
+    def test_weekly_completion_preserves_the_scheduler_next_run(self, monkeypatch):
+        """A manual pull does not replace APScheduler's interval cadence."""
+        next_run = datetime.datetime(2026, 7, 10, 16, 0, 0)
+
+        class WeeklyJob:
+            next_run_time = next_run
+
+            def __init__(self):
+                self.modify_calls = 0
+
+            def __str__(self):
+                return "Weekly Pullist (trigger: interval], next run at: 2026-07-10 16:00:00 UTC)"
+
+            def modify(self, **_kwargs):
+                self.modify_calls += 1
+
+        job = WeeklyJob()
+        scheduler = MagicMock()
+        scheduler.get_jobs.return_value = [job]
+        monkeypatch.setattr(comicarr, "SCHED", scheduler)
+        monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Waiting")
+        monkeypatch.setattr(comicarr, "SCHED_WEEKLY_LAST", None)
+        monkeypatch.setattr(comicarr, "FORCE_STATUS", {})
+
+        with patch.object(system_service.db, "upsert") as upsert:
+            system_service.job_management(
+                write=True,
+                job="Weekly Pullist",
+                last_run_completed=1_783_692_000.0,
+                status="Waiting",
+            )
+
+        assert job.modify_calls == 0
+        values = upsert.call_args.args[1]
+        assert values["next_run_datetime"] == next_run
+        assert values["next_run_timestamp"] == next_run.timestamp()
+
+    def test_startup_recovers_an_interrupted_weekly_refresh(self, monkeypatch):
+        """A persisted Running state becomes safe-to-schedule after a restart."""
+        monkeypatch.setattr(comicarr, "SCHED_WEEKLY_LAST", None)
+        monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Waiting")
+        monkeypatch.setattr(
+            system_service.db,
+            "select_all",
+            lambda statement: [
+                {
+                    "JobName": "Weekly Pullist",
+                    "status": "Running",
+                    "prev_run_timestamp": 200.0,
+                    "last_success_timestamp": 100.0,
+                }
+            ],
+        )
+
+        with patch.object(system_service.db, "upsert") as upsert:
+            result = system_service.job_management(startup=True)
+
+        assert result["weekly"] == {"last": 100.0, "status": "Waiting"}
+        upsert.assert_called_once_with(
+            "jobhistory",
+            {
+                "status": "Waiting",
+                "last_failure_timestamp": 200.0,
+                "last_error": "Previous weekly refresh was interrupted by restart.",
+            },
+            {"JobName": "Weekly Pullist"},
+        )
+
+    def test_sanitize_job_error_redacts_credentials(self):
+        message = system_service.sanitize_job_error("token=secret https://user:pass@example.test failed")
+
+        assert "secret" not in message
+        assert "user:pass" not in message
+        assert "[redacted]" in message
 
     def test_get_version_info(self):
         """get_version_info returns version data from context."""

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -811,6 +811,29 @@ class TestConfigService:
             {"JobName": "Weekly Pullist"},
         )
 
+    def test_startup_normalizes_queued_weekly_refresh(self, monkeypatch):
+        """A queued weekly state becomes waiting after a restart."""
+        monkeypatch.setattr(comicarr, "SCHED_WEEKLY_LAST", None)
+        monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Waiting")
+        monkeypatch.setattr(
+            system_service.db,
+            "select_all",
+            lambda statement: [
+                {
+                    "JobName": "Weekly Pullist",
+                    "status": "Queued",
+                    "prev_run_timestamp": 200.0,
+                    "last_success_timestamp": 100.0,
+                }
+            ],
+        )
+
+        with patch.object(system_service.db, "upsert") as upsert:
+            result = system_service.job_management(startup=True)
+
+        assert result["weekly"] == {"last": 100.0, "status": "Waiting"}
+        upsert.assert_called_once_with("jobhistory", {"status": "Waiting"}, {"JobName": "Weekly Pullist"})
+
     def test_sanitize_job_error_redacts_credentials(self):
         message = system_service.sanitize_job_error("token=secret https://user:pass@example.test failed")
 

--- a/tests/unit/test_weekly_router.py
+++ b/tests/unit/test_weekly_router.py
@@ -1,0 +1,102 @@
+#  Copyright (C) 2025-2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Tests for the current-week industry releases endpoint."""
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import insert
+
+import comicarr
+from comicarr import db
+from comicarr.app.storyarcs import service as storyarcs_service
+from comicarr.app.weekly import router
+from comicarr.tables import metadata, weekly
+
+
+@pytest.fixture
+def weekly_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+def test_current_week_uses_the_sunday_based_year_at_new_year_boundary():
+    """Week zero resolves to the previous Sunday, as My Releases already does."""
+    week, year = storyarcs_service.get_current_week(today=__import__("datetime").date(2021, 1, 1))
+
+    assert (week, year) == ("52", "2020")
+
+
+def test_weekly_endpoint_filters_retained_rows_to_current_week(monkeypatch, weekly_db):
+    with weekly_db.begin() as conn:
+        conn.execute(
+            insert(weekly),
+            [
+                {
+                    "COMIC": "Current title",
+                    "ISSUE": "1",
+                    "ComicID": "current",
+                    "IssueID": "current-1",
+                    "weeknumber": "27",
+                    "year": "2026",
+                },
+                {
+                    "COMIC": "Retained old title",
+                    "ISSUE": "1",
+                    "ComicID": "old",
+                    "IssueID": "old-1",
+                    "weeknumber": "26",
+                    "year": "2026",
+                },
+            ],
+        )
+
+    monkeypatch.setattr(router.storyarcs_service, "get_current_week", lambda: ("27", "2026"))
+
+    result = router.get_weekly(ctx=None)
+
+    assert [row["COMIC"] for row in result] == ["Current title"]
+
+
+def test_weekly_endpoint_matches_unpadded_early_year_week_rows(monkeypatch, weekly_db):
+    with weekly_db.begin() as conn:
+        conn.execute(
+            insert(weekly),
+            [
+                {
+                    "COMIC": "Week one title",
+                    "ISSUE": "1",
+                    "ComicID": "week-one",
+                    "IssueID": "week-one-1",
+                    "weeknumber": "1",
+                    "year": "2026",
+                },
+                {
+                    "COMIC": "Week two title",
+                    "ISSUE": "1",
+                    "ComicID": "week-two",
+                    "IssueID": "week-two-1",
+                    "weeknumber": "2",
+                    "year": "2026",
+                },
+            ],
+        )
+
+    monkeypatch.setattr(router.storyarcs_service, "get_current_week", lambda: ("01", "2026"))
+
+    result = router.get_weekly(ctx=None)
+
+    assert [row["COMIC"] for row in result] == ["Week one title"]

--- a/tests/unit/test_weekly_scheduler.py
+++ b/tests/unit/test_weekly_scheduler.py
@@ -1,0 +1,103 @@
+"""Weekly scheduler lifecycle regression tests."""
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+import comicarr
+from comicarr import weeklypullit
+from comicarr.app.system import service as system_service
+
+
+def test_weekly_run_records_success_and_returns_to_waiting(monkeypatch):
+    job_management = MagicMock()
+    monkeypatch.setattr(weeklypullit.helpers, "job_management", job_management)
+    monkeypatch.setattr(weeklypullit.helpers, "utctimestamp", lambda: 123.0)
+    monkeypatch.setattr(weeklypullit.weeklypull, "pullit", MagicMock())
+    monkeypatch.setattr(weeklypullit.weeklypull, "future_check", MagicMock())
+    monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Queued")
+
+    weeklypullit.Weekly().run()
+
+    assert comicarr.WEEKLY_STATUS == "Waiting"
+    assert job_management.call_args_list[-1].kwargs == {
+        "write": True,
+        "job": "Weekly Pullist",
+        "last_run_completed": 123.0,
+        "status": "Waiting",
+    }
+
+
+def test_weekly_run_records_failure_and_recovers_status(monkeypatch):
+    job_management = MagicMock()
+    monkeypatch.setattr(weeklypullit.helpers, "job_management", job_management)
+    monkeypatch.setattr(weeklypullit.helpers, "utctimestamp", lambda: 456.0)
+    monkeypatch.setattr(weeklypullit.weeklypull, "pullit", MagicMock(side_effect=RuntimeError("upstream down")))
+    monkeypatch.setattr(weeklypullit.weeklypull, "future_check", MagicMock())
+    monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Queued")
+
+    weeklypullit.Weekly().run()
+
+    assert comicarr.WEEKLY_STATUS == "Error"
+    failure_call = job_management.call_args_list[-1].kwargs
+    assert failure_call["write"] is True
+    assert failure_call["job"] == "Weekly Pullist"
+    assert failure_call["last_run_completed"] == 456.0
+    assert failure_call["status"] == "Error"
+    assert failure_call["failure"] is True
+    assert str(failure_call["failure_message"]) == "upstream down"
+
+
+def test_weekly_run_records_returned_pull_failure(monkeypatch):
+    job_management = MagicMock()
+    monkeypatch.setattr(weeklypullit.helpers, "job_management", job_management)
+    monkeypatch.setattr(weeklypullit.helpers, "utctimestamp", lambda: 456.0)
+    monkeypatch.setattr(weeklypullit.weeklypull, "pullit", MagicMock(return_value={"status": "failure"}))
+    future_check = MagicMock()
+    monkeypatch.setattr(weeklypullit.weeklypull, "future_check", future_check)
+
+    weeklypullit.Weekly().run()
+
+    future_check.assert_not_called()
+    assert job_management.call_args_list[-1].kwargs["status"] == "Error"
+    assert job_management.call_args_list[-1].kwargs["failure"] is True
+
+
+def test_manual_run_restores_the_original_future_schedule(monkeypatch):
+    scheduled_run = datetime.datetime.utcnow() + datetime.timedelta(hours=4)
+    job = MagicMock()
+    scheduler = MagicMock()
+    scheduler.get_job.return_value = job
+    monkeypatch.setattr(comicarr, "SCHED", scheduler)
+    monkeypatch.setattr(comicarr, "WEEKLY_MANUAL_NEXT_RUN", scheduled_run)
+
+    weeklypullit._restore_manual_next_run()
+
+    job.modify.assert_called_once_with(next_run_time=scheduled_run)
+    assert comicarr.WEEKLY_MANUAL_NEXT_RUN is None
+
+
+def test_manual_refresh_restores_a_real_interval_trigger_schedule(monkeypatch):
+    timezone = datetime.timezone.utc
+    original_next_run = datetime.datetime.now(timezone) + datetime.timedelta(hours=4)
+    scheduler = BackgroundScheduler(timezone=timezone)
+    scheduler.add_job(
+        lambda: None,
+        trigger=IntervalTrigger(hours=4, timezone=timezone),
+        id="weekly",
+        next_run_time=original_next_run,
+    )
+    ctx = SimpleNamespace(scheduler=scheduler, weekly_status="Waiting")
+    monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Waiting")
+    monkeypatch.setattr(comicarr, "WEEKLY_MANUAL_NEXT_RUN", None)
+    monkeypatch.setattr(system_service.db, "upsert", MagicMock())
+    monkeypatch.setattr(comicarr, "SCHED", scheduler)
+
+    result = system_service.request_weekly_refresh(ctx)
+    weeklypullit._restore_manual_next_run()
+
+    assert result["accepted"] is True
+    assert scheduler.get_job("weekly").next_run_time == original_next_run


### PR DESCRIPTION
## Summary

The dashboard now distinguishes work that needs attention from historical context: it shows the active DDL queue and only the last 30 days of activity, while keeping the full Activity history untouched. Current-week releases now come from the retained weekly pull data using the same Sunday-based convention as My Releases, so old pull-list rows cannot masquerade as current releases.

Manual release refreshes reuse the existing scheduler job, report queued/running/success/failure state, retain the normal next run, and persist sanitized outcome details across restarts. Repeated library-scan requests are also rejected server-side before a second worker can start.

## Validation

- `uv run pytest tests/unit -q` — 1,078 passed.
- `cd frontend && npm run test:run` — 84 passed.
- `npm run typecheck`, `npm run lint`, `npm run build`, Ruff check/format, and `git diff --check` passed.
- Added regressions for stale weekly rows, week-01 filtering, scheduler coalescing/failure/recovery/cadence restoration, active queue preview, the 30-day activity boundary, scan concurrency, and refresh UI states.

## Post-Deploy Monitoring & Validation

1. Take and retain a pre-deploy database backup; do not clean up queue/history records automatically.
2. From Releases, select **Refresh releases** once. Confirm the control progresses through queued/running to success (or shows a sanitized error with retry guidance).
3. In container logs, search for `[WEEKLY]`; expect a complete lifecycle with no uncaught traceback. If the refresh fails, verify the stored error is sanitized, correct the pull-source configuration, and retry.
4. Verify Dashboard shows the same active queue count and preview predicate, only recent activity (30 days), and current-week library releases. Smoke-test Releases Mine/Industry, Activity Queue/History, and one scan initiation.
5. Roll back to the retained database backup and prior container image if the weekly refresh corrupts current data or produces repeated scheduler failures. Owner: deployment operator; validate immediately after deploy and again after the next scheduled run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Refresh releases” action with queued, running, completed, paused, and error status feedback.
  * Dashboard now shows an active queue preview with status indicators and links to detailed activity.
  * Recent activity is limited to the past 30 days.
* **Bug Fixes**
  * Weekly releases now display only items from the current week.
  * Improved weekly refresh recovery and error reporting.
  * Prevented duplicate comic or manga library scans from starting simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->