### PR TITLE
fix(search): prioritize recoverable search dispatch

### DIFF
--- a/.changeset/reliable-search-dispatch.md
+++ b/.changeset/reliable-search-dispatch.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Prioritize operator-requested searches over restart recovery, ensure configured Torznab providers are searched, and expose safe provider-attempt diagnostics.

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -60,6 +60,7 @@ from comicarr import (
     versioncheckit,
     weeklypullit,
 )
+from comicarr.app.search.queue import FairSearchQueue
 
 
 class ThreadSafeLock:
@@ -245,7 +246,7 @@ DDLPOOL = None
 SNATCHED_QUEUE = queue.Queue()
 NZB_QUEUE = queue.Queue()
 PP_QUEUE = queue.Queue()
-SEARCH_QUEUE = queue.Queue()
+SEARCH_QUEUE = FairSearchQueue()
 DDL_QUEUE = queue.Queue()
 RETURN_THE_NZBQUEUE = queue.Queue()
 MASS_ADD = None

--- a/comicarr/app/acquisition/maintenance.py
+++ b/comicarr/app/acquisition/maintenance.py
@@ -41,7 +41,7 @@ from comicarr.tables import (
 )
 
 SCHEMA_COMPONENT = "acquisition"
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 CONTROL_ID = "acquisition"
 RECONCILIATION_CONTROL_ID = "migration-reconciliation"
 
@@ -230,6 +230,19 @@ def _add_item_dispatch_state_column(engine):
         )
 
 
+def _add_item_queue_priority_column(engine):
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("acquisition_run_items")}
+    if "queue_priority" in columns:
+        return
+    quoted_table = engine.dialect.identifier_preparer.quote("acquisition_run_items")
+    quoted_column = engine.dialect.identifier_preparer.quote("queue_priority")
+    with engine.begin() as conn:
+        conn.execute(
+            text("ALTER TABLE %s ADD COLUMN %s VARCHAR(16) NOT NULL DEFAULT 'routine'" % (quoted_table, quoted_column))
+        )
+
+
 def _ensure_control_row(engine):
     with engine.begin() as conn:
         existing = conn.execute(
@@ -366,6 +379,10 @@ def _apply_schema_v5(engine):
     _add_item_dispatch_state_column(engine)
 
 
+def _apply_schema_v6(engine):
+    _add_item_queue_priority_column(engine)
+
+
 def _version_tables(target_version):
     tables = list(_BASE_SCHEMA_TABLES)
     if target_version >= 2:
@@ -404,6 +421,8 @@ def _verify_schema(engine, target_version=SCHEMA_VERSION):
     }
     if target_version < 5:
         required_columns["acquisition_run_items"].discard("dispatch_state")
+    if target_version < 6:
+        required_columns["acquisition_run_items"].discard("queue_priority")
     missing_columns = []
     for table_name, expected in required_columns.items():
         actual = {column["name"] for column in inspector.get_columns(table_name)}
@@ -512,6 +531,16 @@ def ensure_acquisition_schema(engine=None):
                     )
                 )
             version = 5
+        if version < 6:
+            _apply_schema_v6(engine)
+            _verify_schema(engine, target_version=6)
+            with engine.begin() as conn:
+                conn.execute(
+                    insert(acquisition_schema_versions).values(
+                        component=SCHEMA_COMPONENT, version=6, applied_at=_utcnow()
+                    )
+                )
+            version = 6
         _verify_schema(engine, target_version=SCHEMA_VERSION)
         status = SchemaStatus(True, version, None)
     except Exception as e:

--- a/comicarr/app/acquisition/runs.py
+++ b/comicarr/app/acquisition/runs.py
@@ -135,7 +135,7 @@ class RunLedger:
             raise KeyError("unknown acquisition run %s" % run_id)
         return run
 
-    def accept_item(self, run_id, entity_type, entity_id, payload=None, command_kind=None):
+    def accept_item(self, run_id, entity_type, entity_id, payload=None, command_kind=None, queue_priority="routine"):
         run = self._require_run(run_id)
         if run["completion_state"] not in {RunState.PENDING.value, RunState.RUNNING.value}:
             raise ValueError("terminal acquisition runs cannot accept new items")
@@ -151,6 +151,7 @@ class RunLedger:
             "entity_id": str(entity_id),
             "state": ItemOutcome.ACCEPTED.value,
             "dispatch_state": DispatchState.PENDING.value,
+            "queue_priority": str(queue_priority),
             "payload_json": encoded,
             "attempt_count": 0,
             "next_attempt_at": None,
@@ -179,6 +180,19 @@ class RunLedger:
                         .values(payload_json=encoded, updated_at=now)
                     )
         self.reconcile(run_id)
+        return self.get_item(run_id, entity_type, entity_id)
+
+    def set_item_queue_priority(self, run_id, entity_type, entity_id, queue_priority):
+        item = self.get_item(run_id, entity_type, entity_id)
+        if item is None:
+            raise KeyError("unknown acquisition item")
+        with self.engine.begin() as conn:
+            conn.execute(
+                update(acquisition_run_items)
+                .where(acquisition_run_items.c.item_id == item["item_id"])
+                .where(acquisition_run_items.c.state.in_([ItemOutcome.ACCEPTED.value, ItemOutcome.RUNNING.value]))
+                .values(queue_priority=str(queue_priority), updated_at=_utcnow())
+            )
         return self.get_item(run_id, entity_type, entity_id)
 
     def get_item(self, run_id, entity_type, entity_id):

--- a/comicarr/app/search/commands.py
+++ b/comicarr/app/search/commands.py
@@ -16,6 +16,7 @@ from typing import Any, Mapping
 import comicarr
 from comicarr.app.acquisition.models import DispatchState, ItemOutcome
 from comicarr.app.acquisition.policy import EligibilityInput, evaluate_eligibility, project_legacy_state
+from comicarr.app.search.queue import INTERACTIVE, RECOVERY, ROUTINE
 
 
 class SearchCommandError(ValueError):
@@ -76,6 +77,25 @@ def _entity_type(value: Any) -> str:
     return normalized
 
 
+def _queue_priority(value: Any) -> str:
+    priority = str(value or ROUTINE).strip().lower()
+    if priority not in {INTERACTIVE, ROUTINE, RECOVERY}:
+        raise SearchCommandError("Invalid search queue priority")
+    return priority
+
+
+def queue_priority_for_trigger(trigger: str, *, manual: bool = False) -> str:
+    """Map durable intent to the in-memory fairness class."""
+    if manual or str(trigger).strip().lower() in {
+        "manual_wanted_scan",
+        "search_all_missing",
+        "issue_wanted",
+        "storyarc_wanted",
+    }:
+        return INTERACTIVE
+    return ROUTINE
+
+
 @dataclass(frozen=True)
 class SearchCommand:
     """The stable identity and display context for one issue search."""
@@ -89,6 +109,7 @@ class SearchCommand:
     issuenumber: str | None = None
     booktype: str | None = None
     entity_type: str = "issue"
+    queue_priority: str = ROUTINE
 
     @classmethod
     def from_mapping(cls, raw_values: Mapping[str, Any]) -> "SearchCommand":
@@ -109,6 +130,7 @@ class SearchCommand:
                 values.get("entity_type")
                 or ("annual" if _bool_value(values.get("annual", False), "annual") else "issue")
             ),
+            queue_priority=_queue_priority(values.get("queue_priority")),
         )
 
     def to_mapping(self) -> dict[str, Any]:
@@ -123,6 +145,7 @@ class SearchCommand:
             "issuenumber": self.issuenumber,
             "booktype": self.booktype,
             "entity_type": self.entity_type,
+            "queue_priority": self.queue_priority,
         }
 
     def persisted_payload(self) -> dict[str, Any]:
@@ -153,6 +176,7 @@ def enqueue_search_command(
     from comicarr.app.acquisition.runs import RunLedger
 
     command = SearchCommand.from_mapping(raw_values)
+    command = replace(command, queue_priority=queue_priority_for_trigger(trigger, manual=command.manual))
     effective_run_id = _optional_text(run_id) or command.run_id or str(uuid.uuid4())
     command = replace(command, run_id=effective_run_id)
     ledger = ledger or RunLedger()
@@ -170,6 +194,7 @@ def enqueue_search_command(
         entity_type=command.entity_type,
         entity_id=command.issueid,
         payload=command.persisted_payload(),
+        queue_priority=command.queue_priority,
     )
     try:
         dispatch_persisted_search_command(command, work_queue=work_queue, maintenance=maintenance)
@@ -233,6 +258,9 @@ def dispatch_pending_search_commands(run_id, *, work_queue=None, ledger=None, ma
     from comicarr.app.acquisition.runs import RunLedger
 
     ledger = ledger or RunLedger()
+    run = ledger.get_run(run_id)
+    if run is None:
+        raise KeyError("unknown acquisition run %s" % run_id)
     work_queue = work_queue or comicarr.SEARCH_QUEUE
     dispatched = 0
     errors = []
@@ -245,6 +273,8 @@ def dispatch_pending_search_commands(run_id, *, work_queue=None, ledger=None, ma
             command = SearchCommand.from_mapping(
                 {**(item["payload"] or {}), "run_id": run_id, "entity_type": entity_type}
             )
+            command = replace(command, queue_priority=queue_priority_for_trigger(run["trigger"], manual=command.manual))
+            ledger.set_item_queue_priority(run_id, entity_type, entity_id, command.queue_priority)
         except SearchCommandError as e:
             ledger.record_outcome(run_id, entity_type, entity_id, ItemOutcome.QUARANTINED, reason=str(e))
             errors.append(type(e).__name__)
@@ -282,6 +312,8 @@ def replay_search_obligations(*, work_queue=None, ledger=None, maintenance=None)
             command = SearchCommand.from_mapping(
                 {**(item["payload"] or {}), "run_id": run_id, "entity_type": item["entity_type"]}
             )
+            command = replace(command, queue_priority=RECOVERY)
+            ledger.set_item_queue_priority(run_id, item["entity_type"], entity_id, command.queue_priority)
         except SearchCommandError as e:
             ledger.record_outcome(run_id, item["entity_type"], entity_id, ItemOutcome.QUARANTINED, reason=str(e))
             continue

--- a/comicarr/app/search/health.py
+++ b/comicarr/app/search/health.py
@@ -17,6 +17,7 @@ import time
 import comicarr
 from comicarr import db
 from comicarr.app.search import queries
+from comicarr.app.search.providers import effective_provider_plan, enabled_provider_entries, ordered_provider_names
 from comicarr.db import get_engine
 
 WORKER_PREFIX = "Worker: "
@@ -41,22 +42,11 @@ def _sanitize(value, fallback=None):
 
 
 def _provider_names(config):
-    order = getattr(config, "PROVIDER_ORDER", None) or {}
-    if isinstance(order, dict):
-        return [str(value) for _, value in sorted(order.items(), key=lambda item: str(item[0]))]
-    if isinstance(order, (list, tuple)):
-        return [str(value) for value in order]
-    return []
+    return ordered_provider_names(config)
 
 
 def _enabled_extra(entries):
-    for entry in entries or []:
-        try:
-            if str(entry[5]) == "1":
-                return True
-        except (IndexError, TypeError):
-            continue
-    return False
+    return any(enabled_provider_entries(entries))
 
 
 def _route_for_provider(row):
@@ -212,31 +202,66 @@ def build_route_readiness(
     maintenance = maintenance or {}
     now = float(now if now is not None else time.time())
     names = _route_provider_names(config, provider_stats)
+    active_blocks = {}
+    for entry in provider_blocklist:
+        try:
+            active = float(entry.get("resume") or 0) > now
+        except (TypeError, ValueError):
+            active = False
+        site = str(entry.get("site") or "").strip()
+        if active and site:
+            active_blocks[site.casefold()] = site
+
+    def is_active_blocked(name):
+        return str(name).casefold() in active_blocks
+
+    provider_plan = effective_provider_plan(
+        config,
+        is_blocked=is_active_blocked,
+    )
+    planned_by_route = {
+        route: [candidate for candidate in provider_plan if candidate.route == route] for route in _ROUTES
+    }
+    stats_by_route = {route: [row for row in provider_stats if _route_for_provider(row) == route] for route in _ROUTES}
     routes = {}
 
     for route in _ROUTES:
-        route_stats = [row for row in provider_stats if _route_for_provider(row) == route]
+        route_stats = stats_by_route[route]
+        stats_by_name = {str(row.get("provider") or "").casefold(): row for row in route_stats}
+        diagnostics = []
+        for candidate in planned_by_route[route]:
+            stat = stats_by_name.get(candidate.name.casefold()) or {}
+            try:
+                last_attempt = float(stat.get("lastrun") or 0) or None
+            except (TypeError, ValueError):
+                last_attempt = None
+            diagnostics.append(
+                {
+                    "name": candidate.name,
+                    "kind": candidate.kind,
+                    "blocked": candidate.blocked,
+                    "attempted": last_attempt is not None,
+                    "last_attempt": last_attempt,
+                }
+            )
+        if diagnostics:
+            names[route] = list(dict.fromkeys(names[route] + [item["name"] for item in diagnostics]))
         enabled = _route_enabled(config, route)
         client, client_ready, path_ready, restart_safe = _downstream_readiness(config, route)
         downstream_ready = client_ready and path_ready
-        active_blocks = []
+        route_blocks = []
         route_names = {name.lower() for name in names[route]}
-        for entry in provider_blocklist:
-            site = str(entry.get("site") or "")
-            try:
-                active = float(entry.get("resume") or 0) > now
-            except (TypeError, ValueError):
-                active = False
-            if active and site.lower() in route_names:
-                active_blocks.append(site)
-        all_blocked = bool(route_names) and len({name.lower() for name in active_blocks}) >= len(route_names)
+        for site_key, site in active_blocks.items():
+            if site_key in route_names:
+                route_blocks.append(site)
+        all_blocked = bool(route_names) and len({name.lower() for name in route_blocks}) >= len(route_names)
         maintenance_reason = maintenance.get("reason") if maintenance.get("blocked") else None
         history = route_history.get(route, {})
         try:
             blocked_until = float(history.get("next_run_timestamp") or 0)
         except (TypeError, ValueError):
             blocked_until = 0
-        history_blocked = blocked_until > now and not active_blocks
+        history_blocked = blocked_until > now and not route_blocks
         all_blocked = all_blocked or history_blocked
         ready = bool(enabled and downstream_ready and restart_safe and not all_blocked and not maintenance_reason)
         if not enabled:
@@ -268,9 +293,9 @@ def build_route_readiness(
             "enabled": enabled,
             "active": running,
             "running": running,
-            "blocked": bool(active_blocks) or history_blocked or bool(maintenance_reason),
+            "blocked": bool(route_blocks) or history_blocked or bool(maintenance_reason),
             "blocked_until": blocked_until or None,
-            "blocked_provider_count": len(active_blocks),
+            "blocked_provider_count": len(route_blocks),
             "downstream": client,
             "client_ready": client_ready,
             "path_ready": path_ready,
@@ -282,6 +307,10 @@ def build_route_readiness(
             "last_success": last_success,
             "last_failure": last_failure,
             "last_error": _sanitize(history.get("last_error")),
+            "configured_provider_count": len(diagnostics),
+            "executable_provider_count": sum(1 for item in diagnostics if enabled and not item["blocked"]),
+            "attempted_provider_count": sum(1 for item in diagnostics if item["attempted"]),
+            "providers": diagnostics,
         }
     return routes
 

--- a/comicarr/app/search/providers.py
+++ b/comicarr/app/search/providers.py
@@ -1,0 +1,110 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""One sanitized source of truth for configured search-provider candidates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable
+
+
+@dataclass(frozen=True)
+class ProviderCandidate:
+    name: str
+    kind: str
+    execution_name: str
+    entry: tuple | None = field(default=None, repr=False)
+    blocked: bool = False
+
+    @property
+    def route(self) -> str:
+        if self.kind in {"torznab", "torrent"}:
+            return "torrent"
+        if self.kind in {"newznab", "experimental"}:
+            return "nzb"
+        return "ddl"
+
+
+def enabled_provider_entries(entries: Iterable[object]):
+    for entry in entries or []:
+        try:
+            if str(entry[5]) == "1":
+                yield tuple(entry)
+        except (IndexError, TypeError):
+            continue
+
+
+def ordered_provider_names(config) -> list[str]:
+    configured = getattr(config, "PROVIDER_ORDER", None) or {}
+    if isinstance(configured, dict):
+        return [str(value) for _, value in sorted(configured.items(), key=lambda item: str(item[0]))]
+    return [str(value) for value in configured]
+
+
+def _ordered(config, candidates):
+    preferred = [name.casefold() for name in ordered_provider_names(config)]
+
+    def position(candidate):
+        names = {candidate.name.casefold(), candidate.execution_name.casefold()}
+        for index, value in enumerate(preferred):
+            if any(value == name or value in name for name in names):
+                return index
+        return len(preferred)
+
+    return sorted(candidates, key=lambda candidate: (position(candidate), candidate.name.casefold()))
+
+
+def effective_provider_plan(config, *, is_blocked: Callable[[str], bool] | None = None):
+    """Return enabled providers in effective order without exposing secrets."""
+    is_blocked = is_blocked or (lambda _name: False)
+    candidates = []
+
+    def add(name, kind, execution_name=None, entry=None):
+        candidates.append(
+            ProviderCandidate(
+                name=name,
+                kind=kind,
+                execution_name=execution_name or name,
+                entry=entry,
+                blocked=bool(is_blocked(name)),
+            )
+        )
+
+    if getattr(config, "ENABLE_DDL", False):
+        if getattr(config, "ENABLE_GETCOMICS", False):
+            add("DDL(GetComics)", "ddl")
+        if getattr(config, "ENABLE_EXTERNAL_SERVER", False):
+            add("DDL(External)", "ddl")
+    if getattr(config, "EXPERIMENTAL", False):
+        add("experimental", "experimental")
+    if getattr(config, "NEWZNAB", False):
+        for index, entry in enumerate(enabled_provider_entries(getattr(config, "EXTRA_NEWZNABS", None)), start=1):
+            name = str(entry[0]).strip() or "Newznab %s" % index
+            add(name, "newznab", "newznab: %s" % name, entry)
+    if getattr(config, "ENABLE_TORRENT_SEARCH", False):
+        if getattr(config, "ENABLE_32P", False):
+            add("32p", "torrent")
+        if getattr(config, "ENABLE_PUBLIC", False):
+            add("public torrents", "torrent")
+        if getattr(config, "ENABLE_TORZNAB", False):
+            for index, entry in enumerate(enabled_provider_entries(getattr(config, "EXTRA_TORZNABS", None)), start=1):
+                name = str(entry[0]).strip() or "Torznab %s" % index
+                add(name, "torznab", "torznab: %s" % name, entry)
+    return _ordered(config, candidates)
+
+
+def runtime_provider_entry(candidate: ProviderCandidate) -> tuple | None:
+    """Return a legacy provider tuple with a safe identity for unnamed entries."""
+    if candidate.entry is None:
+        return None
+    entry = list(candidate.entry)
+    if not str(entry[0]).strip():
+        entry[0] = candidate.name
+    return tuple(entry)

--- a/comicarr/app/search/queue.py
+++ b/comicarr/app/search/queue.py
@@ -1,0 +1,73 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Fair in-memory scheduling for durable search commands."""
+
+from __future__ import annotations
+
+import queue
+from collections import deque
+from typing import Any
+
+INTERACTIVE = "interactive"
+ROUTINE = "routine"
+RECOVERY = "recovery"
+CONTROL = "control"
+_PRIORITIES = (INTERACTIVE, ROUTINE, RECOVERY, CONTROL)
+
+
+class FairSearchQueue(queue.Queue):
+    """Favor operator work without indefinitely starving durable recovery."""
+
+    def __init__(self, maxsize: int = 0, *, interactive_burst: int = 3):
+        self.interactive_burst = max(1, int(interactive_burst))
+        super().__init__(maxsize=maxsize)
+
+    def _init(self, _maxsize: int) -> None:
+        self.queue = {priority: deque() for priority in _PRIORITIES}
+        self._interactive_streak = 0
+        self._non_recovery_streak = 0
+
+    def _priority(self, item: Any) -> str:
+        if item == "exit":
+            return CONTROL
+        if isinstance(item, dict):
+            value = str(item.get("queue_priority") or ROUTINE).strip().lower()
+            if value in {INTERACTIVE, ROUTINE, RECOVERY}:
+                return value
+        return ROUTINE
+
+    def _qsize(self) -> int:
+        return sum(len(items) for items in self.queue.values())
+
+    def _put(self, item: Any) -> None:
+        self.queue[self._priority(item)].append(item)
+
+    def _get(self) -> Any:
+        if self.queue[CONTROL]:
+            return self.queue[CONTROL].popleft()
+
+        has_background = bool(self.queue[ROUTINE] or self.queue[RECOVERY])
+        if self.queue[RECOVERY] and self._non_recovery_streak >= self.interactive_burst:
+            self._interactive_streak = 0
+            self._non_recovery_streak = 0
+            return self.queue[RECOVERY].popleft()
+        if self.queue[INTERACTIVE] and (self._interactive_streak < self.interactive_burst or not has_background):
+            self._interactive_streak += 1
+            self._non_recovery_streak += 1
+            return self.queue[INTERACTIVE].popleft()
+        for priority in (ROUTINE, RECOVERY, INTERACTIVE):
+            if self.queue[priority]:
+                self._interactive_streak = 0
+                if priority == RECOVERY:
+                    self._non_recovery_streak = 0
+                else:
+                    self._non_recovery_streak += 1
+                return self.queue[priority].popleft()
+        raise queue.Empty

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -334,14 +334,30 @@ def get_health(ctx):
     )
 
 
+def _attempt_status(state):
+    if state == ItemOutcome.ACCEPTED.value:
+        return "queued"
+    if state == ItemOutcome.RUNNING.value:
+        return "searching"
+    return state
+
+
 def get_run(ctx, run_id, include_items=True):
     """Return a durable search run without exposing provider request data."""
     from comicarr.app.acquisition.runs import RunLedger
+    from comicarr.app.search.commands import queue_priority_for_trigger
 
     ledger = RunLedger()
     run = ledger.get_run(run_id)
     if run is None or run["command_kind"] != "search":
         return {"success": False, "error": "search run not found", "status_code": 404}
+    items = ledger.list_items(run_id) if include_items else []
+    active_priorities = {
+        item.get("queue_priority", queue_priority_for_trigger(run["trigger"]))
+        for item in items
+        if item["state"] in {"accepted", "running"}
+    }
+    queue_priority = "recovery" if "recovery" in active_priorities else queue_priority_for_trigger(run["trigger"])
     return {
         "success": True,
         "run": {
@@ -364,7 +380,8 @@ def get_run(ctx, run_id, include_items=True):
                 "updated_at",
                 "completed_at",
             )
-        },
+        }
+        | {"queue_priority": queue_priority},
         "items": (
             [
                 {
@@ -375,8 +392,10 @@ def get_run(ctx, run_id, include_items=True):
                     "reason": item["reason"],
                     "updated_at": item["updated_at"],
                     "completed_at": item["completed_at"],
+                    "queue_priority": item.get("queue_priority", queue_priority),
+                    "attempt_status": _attempt_status(item["state"]),
                 }
-                for item in ledger.list_items(run_id)
+                for item in items
             ]
             if include_items
             else []

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -804,80 +804,28 @@ def search_init(
 
 
 def provider_order(initial_run=False):
-    torprovider = []
-    torp = 0
-    torznabs = 0
-    torznab_hosts = []
+    from comicarr.app.search.providers import effective_provider_plan, runtime_provider_entry
+
+    plan = effective_provider_plan(comicarr.CONFIG, is_blocked=helpers.block_provider_check)
+    tor_candidates = [
+        candidate for candidate in plan if candidate.kind in {"torznab", "torrent"} and not candidate.blocked
+    ]
+    nzb_candidates = [
+        candidate for candidate in plan if candidate.kind in {"newznab", "experimental"} and not candidate.blocked
+    ]
+    ddl_candidates = [candidate for candidate in plan if candidate.kind == "ddl" and not candidate.blocked]
+
+    torp = sum(1 for candidate in tor_candidates if candidate.kind == "torrent")
+    torznabs = sum(1 for candidate in tor_candidates if candidate.kind == "torznab")
+    nzbp = sum(1 for candidate in nzb_candidates if candidate.kind == "experimental")
+    newznabs = sum(1 for candidate in nzb_candidates if candidate.kind == "newznab")
+    ddls = len(ddl_candidates)
 
     if initial_run:
-        logger.fdebug("Checking for torrent enabled.")
-    if comicarr.CONFIG.ENABLE_TORRENT_SEARCH:
-        if comicarr.CONFIG.ENABLE_32P and not helpers.block_provider_check("32P"):
-            torprovider.append("32p")
-            torp += 1
-        if comicarr.CONFIG.ENABLE_PUBLIC and not helpers.block_provider_check("public torrents"):
-            torprovider.append("public torrents")
-            torp += 1
-        if comicarr.CONFIG.ENABLE_TORZNAB is True:
-            for torznab_host in comicarr.CONFIG.EXTRA_TORZNABS:
-                if any([torznab_host[5] == "1", torznab_host[5] == 1]):
-                    if not helpers.block_provider_check(torznab_host[0]):
-                        torznab_hosts.append(torznab_host)
-                        torprovider.append("torznab: %s" % torznab_host[0])
-                        torznabs += 1
-
-    # nzb provider selection##
-    nzbprovider = []
-    nzbp = 0
-    # --------
-    #  Xperimental
-    if comicarr.CONFIG.EXPERIMENTAL is True and not helpers.block_provider_check("experimental"):
-        nzbprovider.append("experimental")
-        nzbp += 1
-
-    newznabs = 0
-
-    newznab_hosts = []
-
-    if comicarr.CONFIG.NEWZNAB is True:
-        for newznab_host in comicarr.CONFIG.EXTRA_NEWZNABS:
-            if any([newznab_host[5] == "1", newznab_host[5] == 1]):
-                if not helpers.block_provider_check(newznab_host[0]):
-                    newznab_hosts.append(newznab_host)
-                    nzbprovider.append("newznab: %s" % newznab_host[0])
-                    newznabs += 1
-
-    ddls = 0
-    ddlprovider = []
-
-    if comicarr.CONFIG.ENABLE_DDL is True:
-        if all(
-            [
-                comicarr.CONFIG.ENABLE_GETCOMICS is True,
-                not helpers.block_provider_check("DDL(GetComics)"),
-            ]
-        ):
-            ddlprovider.append("DDL(GetComics)")
-            ddls += 1
-
-        if all(
-            [
-                comicarr.CONFIG.ENABLE_EXTERNAL_SERVER is True,
-                not helpers.block_provider_check("DDL(External)"),
-            ]
-        ):
-            ddlprovider.append("DDL(External)")
-            ddls += 1
-
-    if initial_run:
-        logger.fdebug("nzbprovider(s): %s" % nzbprovider)
-    # --------
+        logger.fdebug("nzbprovider(s): %s" % [candidate.execution_name for candidate in nzb_candidates])
     torproviders = torp + torznabs
     if initial_run:
         logger.fdebug("There are %s torrent providers you have selected." % torproviders)
-    torpr = torproviders - 1
-    if torpr < 0:
-        torpr = -1
     providercount = int(nzbp + newznabs)
     if initial_run:
         logger.fdebug("There are : %s nzb providers you have selected" % providercount)
@@ -889,9 +837,18 @@ def provider_order(initial_run=False):
 
     totalproviders = providercount + torproviders + ddls
 
-    prov_order, torznab_info, newznab_info = provider_sequence(
-        nzbprovider, torprovider, newznab_hosts, torznab_hosts, ddlprovider
-    )
+    active_plan = [candidate for candidate in plan if not candidate.blocked]
+    prov_order = [candidate.execution_name for candidate in active_plan]
+    torznab_info = [
+        {"provider": candidate.execution_name, "info": runtime_provider_entry(candidate)}
+        for candidate in active_plan
+        if candidate.kind == "torznab"
+    ]
+    newznab_info = [
+        {"provider": candidate.execution_name, "info": runtime_provider_entry(candidate)}
+        for candidate in active_plan
+        if candidate.kind == "newznab"
+    ]
     # if initial_run:
     #    logger.fdebug('search provider order is %s' % prov_order)
 
@@ -2913,67 +2870,6 @@ def searchIssueIDList(issuelist):
         logger.warn(
             "There are no search providers enabled atm - not performing the requested search for obvious reasons"
         )
-
-
-def provider_sequence(nzbprovider, torprovider, newznab_hosts, torznab_hosts, ddlprovider):
-    # provider order sequencing here.
-    newznab_info = []
-    torznab_info = []
-    prov_order = []
-
-    nzbproviders_lower = [x.lower() for x in nzbprovider]
-    torproviders_lower = [y.lower() for y in torprovider]
-    ddlproviders_lower = [z.lower() for z in ddlprovider]
-
-    if len(comicarr.CONFIG.PROVIDER_ORDER) > 0:
-        for pr_order in sorted(comicarr.CONFIG.PROVIDER_ORDER.items(), key=itemgetter(0), reverse=False):
-            if (
-                any(pr_order[1].lower() in y for y in torproviders_lower)
-                or any(pr_order[1].lower() in x for x in nzbproviders_lower)
-                or any(pr_order[1].lower() == z for z in ddlproviders_lower)
-            ):
-                if any(pr_order[1].lower() in x for x in nzbproviders_lower):
-                    # this is for nzb providers
-                    for np in nzbprovider:
-                        if all(["newznab" in np, pr_order[1].lower() in np.lower()]):
-                            for newznab_host in newznab_hosts:
-                                if newznab_host[0].lower() == pr_order[1].lower():
-                                    prov_order.append(np)
-                                    newznab_info.append({"provider": np, "info": newznab_host})
-                                    break
-                                else:
-                                    if newznab_host[0] == "":
-                                        if newznab_host[1].lower() == pr_order[1].lower():
-                                            prov_order.append(np)
-                                            newznab_info.append({"provider": np, "info": newznab_host})
-                                            break
-                        elif pr_order[1].lower() in np.lower():
-                            prov_order.append(pr_order[1])
-                            break
-                elif any(pr_order[1].lower() in y for y in torproviders_lower):
-                    for tp in torprovider:
-                        if all(["torznab" in tp, pr_order[1].lower() in tp.lower()]):
-                            for torznab_host in torznab_hosts:
-                                if torznab_host[0].lower() == pr_order[1].lower():
-                                    prov_order.append(tp)
-                                    torznab_info.append({"provider": tp, "info": torznab_host})
-                                    break
-                                else:
-                                    if torznab_host[0] == "":
-                                        if torznab_host[1].lower() == pr_order[1].lower():
-                                            prov_order.append(tp)
-                                            torznab_info.append({"provider": tp, "info": torznab_host})
-                                            break
-                        elif pr_order[1].lower() in tp.lower():
-                            prov_order.append(pr_order[1])
-                            break
-                elif any(pr_order[1].lower() == z for z in ddlproviders_lower):
-                    for dd in ddlprovider:
-                        if dd.lower() == pr_order[1].lower():
-                            prov_order.append(pr_order[1])
-                            break
-
-    return prov_order, torznab_info, newznab_info
 
 
 def nzbname_create(provider, title=None, info=None):

--- a/comicarr/tables.py
+++ b/comicarr/tables.py
@@ -739,6 +739,7 @@ acquisition_run_items = Table(
     # Queue handoff state is independent of the worker lifecycle. A durable
     # item can be accepted but not yet handed to the in-memory worker queue.
     Column("dispatch_state", String(32), nullable=False, server_default="pending"),
+    Column("queue_priority", String(16), nullable=False, server_default="routine"),
     # Validated, bounded JSON containing only the command-kind allowlist. It
     # must never contain provider credentials or downloader secrets.
     Column("payload_json", Text),

--- a/frontend/src/hooks/useAcquisitionHealth.ts
+++ b/frontend/src/hooks/useAcquisitionHealth.ts
@@ -50,6 +50,16 @@ export interface AcquisitionRouteHealth {
   last_success?: number | string | null;
   last_failure?: number | string | null;
   last_error?: string | null;
+  configured_provider_count?: number;
+  executable_provider_count?: number;
+  attempted_provider_count?: number;
+  providers?: Array<{
+    name: string;
+    kind: string;
+    blocked: boolean;
+    attempted: boolean;
+    last_attempt: number | string | null;
+  }>;
 }
 
 export interface AcquisitionWorkerHealth {

--- a/frontend/src/hooks/useSeries.ts
+++ b/frontend/src/hooks/useSeries.ts
@@ -110,10 +110,7 @@ export function useSearchRun(
   return useQuery({
     queryKey: ["search-run", runId],
     queryFn: () =>
-      apiRequest<SearchRunResult>(
-        "GET",
-        `/api/search/runs/${runId}?include_items=false`,
-      ),
+      apiRequest<SearchRunResult>("GET", `/api/search/runs/${runId}`),
     enabled: Boolean(runId),
     refetchInterval: (query) => {
       const completionState = query.state.data?.run.completion_state;

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -258,6 +258,7 @@ export interface SearchRun {
   created_at: string;
   updated_at: string;
   completed_at: string | null;
+  queue_priority: "interactive" | "routine" | "recovery";
 }
 
 export interface SearchRunItem {
@@ -268,6 +269,8 @@ export interface SearchRunItem {
   reason: string | null;
   updated_at: string;
   completed_at: string | null;
+  queue_priority: "interactive" | "routine" | "recovery";
+  attempt_status: "queued" | "searching" | SearchRunItemState;
 }
 
 export interface SearchRunResult {

--- a/tests/integration/test_acquisition_pipeline.py
+++ b/tests/integration/test_acquisition_pipeline.py
@@ -146,6 +146,7 @@ def test_bulk_wanted_run_handoff_restart_and_owned_projection(monkeypatch, tmp_p
         "issuenumber": None,
         "booktype": None,
         "entity_type": "issue",
+        "queue_priority": "interactive",
     }
     ledger = RunLedger()
     assert ledger.claim_item(run_id, "issue", "issue-1") is True

--- a/tests/unit/test_search_domain.py
+++ b/tests/unit/test_search_domain.py
@@ -199,5 +199,58 @@ def test_get_run_status_only_skips_item_deserialization(monkeypatch):
     result = search_service.get_run(_ctx(), "search-run", include_items=False)
 
     assert result["success"] is True
+    assert result["run"]["queue_priority"] == "routine"
     assert result["items"] == []
     ledger.list_items.assert_not_called()
+
+
+def test_get_run_exposes_sanitized_item_attempt_status(monkeypatch):
+    ledger = MagicMock()
+    ledger.get_run.return_value = {
+        "run_id": "search-run",
+        "command_kind": "search",
+        "trigger": "search_all_missing",
+        "scope_type": "series",
+        "scope_id": "160294",
+        "dispatch_state": "accepted",
+        "completion_state": "running",
+        "accepted_count": 1,
+        "terminal_count": 0,
+        "succeeded_count": 0,
+        "no_match_count": 0,
+        "blocked_count": 0,
+        "failed_count": 0,
+        "created_at": "t0",
+        "updated_at": "t1",
+        "completed_at": None,
+    }
+    ledger.list_items.return_value = [
+        {
+            "entity_type": "issue",
+            "entity_id": "issue-1",
+            "state": "accepted",
+            "attempt_count": 0,
+            "reason": None,
+            "updated_at": "t1",
+            "completed_at": None,
+            "queue_priority": "recovery",
+        }
+    ]
+    monkeypatch.setattr("comicarr.app.acquisition.runs.RunLedger", lambda: ledger)
+
+    result = search_service.get_run(_ctx(), "search-run")
+
+    assert result["run"]["queue_priority"] == "recovery"
+    assert result["items"] == [
+        {
+            "entity_type": "issue",
+            "entity_id": "issue-1",
+            "state": "accepted",
+            "attempt_count": 0,
+            "reason": None,
+            "updated_at": "t1",
+            "completed_at": None,
+            "queue_priority": "recovery",
+            "attempt_status": "queued",
+        }
+    ]

--- a/tests/unit/test_search_health.py
+++ b/tests/unit/test_search_health.py
@@ -97,6 +97,32 @@ def test_route_readiness_is_independent_and_never_exposes_credentials(tmp_path):
     assert "token=secret" not in serialized
 
 
+def test_health_explains_configured_but_unattempted_torznab_without_secrets(tmp_path):
+    routes = health.build_route_readiness(
+        _config(tmp_path),
+        provider_stats=[{"provider": "Torrent", "type": "torznab", "active": False, "lastrun": 0, "hits": 0}],
+    )
+
+    torrent = routes["torrent"]
+    assert torrent["configured_provider_count"] == 1
+    assert torrent["executable_provider_count"] == 1
+    assert torrent["attempted_provider_count"] == 0
+    assert torrent["providers"] == [
+        {"name": "Torrent", "kind": "torznab", "blocked": False, "attempted": False, "last_attempt": None}
+    ]
+    assert "top-secret-key" not in str(torrent)
+
+
+def test_disabled_torrent_handoff_is_not_reported_as_executable(tmp_path):
+    routes = health.build_route_readiness(
+        _config(tmp_path, ENABLE_TORRENTS=False),
+        provider_stats=[{"provider": "Torrent", "type": "torznab", "active": False, "lastrun": 0, "hits": 0}],
+    )
+
+    assert routes["torrent"]["configured_provider_count"] == 1
+    assert routes["torrent"]["executable_provider_count"] == 0
+
+
 @pytest.mark.parametrize(
     ("downloader", "config_key"),
     [(0, "LOCAL_WATCHDIR"), (1, "UTORRENT_HOST"), (3, "TRANSMISSION_HOST"), (5, "QBITTORRENT_HOST")],

--- a/tests/unit/test_search_providers.py
+++ b/tests/unit/test_search_providers.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import comicarr
+from comicarr import search
+from comicarr.app.search.providers import effective_provider_plan
+
+
+def _config(**overrides):
+    values = {
+        "ENABLE_DDL": True,
+        "ENABLE_GETCOMICS": True,
+        "ENABLE_EXTERNAL_SERVER": False,
+        "EXPERIMENTAL": False,
+        "NEWZNAB": False,
+        "EXTRA_NEWZNABS": [],
+        "ENABLE_TORRENT_SEARCH": True,
+        "ENABLE_32P": False,
+        "ENABLE_PUBLIC": False,
+        "ENABLE_TORZNAB": True,
+        "EXTRA_TORZNABS": [["Nyaa.si", "https://indexer.test/api", "1", "secret", "5070", "1", 1]],
+        "PROVIDER_ORDER": {"0": "DDL(GetComics)"},
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_effective_provider_plan_includes_enabled_torznab_missing_from_saved_order():
+    plan = effective_provider_plan(_config())
+
+    assert [(candidate.name, candidate.kind, candidate.execution_name) for candidate in plan] == [
+        ("DDL(GetComics)", "ddl", "DDL(GetComics)"),
+        ("Nyaa.si", "torznab", "torznab: Nyaa.si"),
+    ]
+    assert all("secret" not in str(candidate) for candidate in plan)
+
+
+def test_provider_order_routes_enabled_torznab_even_when_provider_order_is_stale(monkeypatch):
+    config = _config()
+    monkeypatch.setattr(comicarr, "CONFIG", config)
+    monkeypatch.setattr(search.helpers, "block_provider_check", lambda _site: False)
+
+    result = search.provider_order(initial_run=True)
+
+    assert result["prov_order"] == ["DDL(GetComics)", "torznab: Nyaa.si"]
+    assert result["torznab_info"] == [{"provider": "torznab: Nyaa.si", "info": tuple(config.EXTRA_TORZNABS[0])}]
+
+
+def test_unnamed_provider_uses_safe_display_identity_without_exposing_its_endpoint():
+    config = _config(
+        EXTRA_TORZNABS=[["", "https://user:secret@indexer.test/api?apikey=token", "1", "secret", "5070", "1", 1]]
+    )
+
+    plan = effective_provider_plan(config)
+
+    torznab = next(candidate for candidate in plan if candidate.kind == "torznab")
+    assert torznab.name == "Torznab 1"
+    assert "secret" not in repr(torznab)
+    assert "indexer.test" not in repr(torznab)
+
+
+def test_unnamed_provider_uses_safe_identity_during_legacy_execution(monkeypatch):
+    config = _config(
+        EXTRA_TORZNABS=[["", "https://user:secret@indexer.test/api?apikey=token", "1", "secret", "5070", "1", 1]]
+    )
+    monkeypatch.setattr(comicarr, "CONFIG", config)
+    monkeypatch.setattr(search.helpers, "block_provider_check", lambda _site: False)
+
+    result = search.provider_order()
+
+    assert result["torznab_info"][0]["info"][0] == "Torznab 1"
+    assert result["torznab_info"][0]["info"][1] == config.EXTRA_TORZNABS[0][1]

--- a/tests/unit/test_search_queue.py
+++ b/tests/unit/test_search_queue.py
@@ -27,6 +27,7 @@ from comicarr.app.search.commands import (
     evaluate_search_candidate,
     replay_search_obligations,
 )
+from comicarr.app.search.queue import FairSearchQueue
 from comicarr.app.series import queries as series_queries
 from comicarr.db import get_engine, shutdown_engine
 from comicarr.tables import annuals, comics, issues, metadata
@@ -80,6 +81,58 @@ def _configure_worker(monkeypatch):
 
 def _command(issue_id="issue-1"):
     return {"comicid": "comic-1", "issueid": issue_id, "manual": False}
+
+
+def test_fair_search_queue_prioritizes_operator_work_without_starving_recovery():
+    work = FairSearchQueue(interactive_burst=3)
+    work.put({**_command("recovered"), "queue_priority": "recovery"})
+    for issue_id in ("interactive-1", "interactive-2", "interactive-3", "interactive-4"):
+        work.put({**_command(issue_id), "queue_priority": "interactive"})
+
+    assert [work.get_nowait()["issueid"] for _ in range(5)] == [
+        "interactive-1",
+        "interactive-2",
+        "interactive-3",
+        "recovered",
+        "interactive-4",
+    ]
+
+
+def test_fair_search_queue_services_recovery_during_a_routine_backlog():
+    work = FairSearchQueue(interactive_burst=3)
+    work.put({**_command("recovered"), "queue_priority": "recovery"})
+    for issue_id in ("routine-1", "routine-2", "routine-3", "routine-4"):
+        work.put({**_command(issue_id), "queue_priority": "routine"})
+
+    assert [work.get_nowait()["issueid"] for _ in range(4)] == [
+        "routine-1",
+        "routine-2",
+        "routine-3",
+        "recovered",
+    ]
+
+
+def test_fair_search_queue_prioritizes_shutdown_after_current_command():
+    work = FairSearchQueue()
+    work.put({**_command("requeued"), "queue_priority": "interactive"})
+    work.put("exit")
+
+    assert work.get_nowait() == "exit"
+
+
+def test_replayed_search_commands_are_marked_lower_priority(acquisition_ledger):
+    acquisition_ledger.create_run("replay-priority", "search", "wanted_scan")
+    acquisition_ledger.accept_item(
+        "replay-priority",
+        "issue",
+        "issue-1",
+        payload={"comicid": "comic-1", "issueid": "issue-1", "manual": False},
+    )
+    work = FairSearchQueue()
+
+    assert replay_search_obligations(work_queue=work, ledger=acquisition_ledger) == 1
+    assert work.get_nowait()["queue_priority"] == "recovery"
+    assert acquisition_ledger.get_item("replay-priority", "issue", "issue-1")["queue_priority"] == "recovery"
 
 
 def test_unlocked_command_reaches_provider_search_once(monkeypatch):


### PR DESCRIPTION
## Summary

Operator-requested Wanted searches now advance ahead of restart-replayed backlog without leaving durable recovery obligations behind indefinitely.

Configured Torznab/Prowlarr candidates now flow through one ordered execution and health plan, so a preceding no-match or provider failure does not silently omit a later configured route. Search-run and route health now expose safe queue priority, attempt, and handoff state while preserving credential redaction.

## Validation

- `uv run npm run lint`
- `uv run python -m pytest tests/unit/test_acquisition_runs.py tests/unit/test_search_queue.py tests/unit/test_search_health.py tests/unit/test_search_domain.py tests/unit/test_recovery_replay.py -q` (91 passed)
- `uv run python -m pytest tests/unit/test_search_queue.py tests/unit/test_search_providers.py tests/unit/test_search_health.py tests/unit/test_search_domain.py tests/unit/test_search_missing_bulk.py tests/unit/test_manga_search.py -q` (82 passed)
- `cd frontend && npm run typecheck && npm run test:run && npm run build` (99 tests passed; the existing test environment logs localhost:3000 connection warnings but exits successfully)

The Synology container has not been changed or used to resubmit the 47-item backlog. The release image still needs to be built and deployed before the controlled, operator-selected Wanted-item check.

## New concepts

**Bounded fair scheduling** gives interactive work preference without turning recovery into permanent starvation. Strict FIFO made a newly requested search wait behind old replayed work; strict priority would make replayed work wait forever under steady operator activity.

This queue serves up to three interactive or routine commands, then dispatches one waiting recovery command. That keeps the durable restart obligation visible and progressing while retaining the fast path an operator expects.

Use this pattern for independent, idempotent background work with distinct urgency classes. Do not use it where job ordering itself is part of the correctness contract or work cannot be safely interleaved.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search jobs are now prioritized to handle manual requests promptly while fairly processing routine and recovery work.
  * Search status now shows queue priority and whether each provider attempt is queued or searching.
  * Search health reports configured, available, blocked, and previously attempted providers without exposing sensitive details.
  * Enabled search providers are consistently included and ordered according to configuration.

* **Bug Fixes**
  * Improved search recovery after restarts and ensured provider availability is accurately reflected in route readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->