### PR TITLE
fix(search): recover visible Wanted search flow

### DIFF
--- a/.changeset/live-search-ui-recovery.md
+++ b/.changeset/live-search-ui-recovery.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Keep search route loading visible, harden health diagnostics, and allow a single Wanted issue to be searched without forcing the backlog.

--- a/comicarr/app/search/bulk.py
+++ b/comicarr/app/search/bulk.py
@@ -233,13 +233,13 @@ def _source_update_statement(item):
     return statement.values(AcquisitionIntent="wanted", Status="Wanted")
 
 
-def _create_run_values(run_id, series_id, now):
+def _create_run_values(run_id, series_id, now, *, trigger="search_all_missing", scope_type="series", scope_id=None):
     return {
         "run_id": run_id,
         "command_kind": "search",
-        "trigger": "search_all_missing",
-        "scope_type": "series",
-        "scope_id": str(series_id),
+        "trigger": trigger,
+        "scope_type": scope_type,
+        "scope_id": str(scope_id if scope_id is not None else series_id),
         "dispatch_state": DispatchState.PENDING.value,
         "completion_state": RunState.PENDING.value,
         "accepted_count": 0,
@@ -284,6 +284,9 @@ def confirm_preview(
     work_queue=None,
     maintenance=None,
     now=None,
+    trigger="search_all_missing",
+    scope_type="series",
+    scope_id=None,
 ):
     """Atomically create one source-intent + durable-run transaction.
 
@@ -359,7 +362,18 @@ def confirm_preview(
             else:
                 raise SearchMissingConfirmationError("bulk search preview was consumed concurrently")
         else:
-            conn.execute(insert(acquisition_runs).values(**_create_run_values(run_id, series_id, when)))
+            conn.execute(
+                insert(acquisition_runs).values(
+                    **_create_run_values(
+                        run_id,
+                        series_id,
+                        when,
+                        trigger=trigger,
+                        scope_type=scope_type,
+                        scope_id=scope_id,
+                    )
+                )
+            )
             for item, command in zip(selection, commands, strict=True):
                 if conn.execute(_source_update_statement(item)).rowcount != 1:
                     raise SearchMissingStalePreview("series acquisition state changed during confirmation")

--- a/comicarr/app/search/health.py
+++ b/comicarr/app/search/health.py
@@ -10,6 +10,7 @@
 """Sanitized, restart-durable acquisition health projections."""
 
 import datetime
+import math
 import os
 import re
 import time
@@ -27,6 +28,15 @@ _ROUTES = ("ddl", "nzb", "torrent")
 
 def _truthy(value):
     return str(value or "").strip().lower() in {"1", "true", "yes", "on", "running"}
+
+
+def _timestamp(value):
+    """Return a finite timestamp or ``None`` for legacy/malformed values."""
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError):
+        return None
+    return timestamp if math.isfinite(timestamp) and timestamp > 0 else None
 
 
 def _sanitize(value, fallback=None):
@@ -231,10 +241,7 @@ def build_route_readiness(
         diagnostics = []
         for candidate in planned_by_route[route]:
             stat = stats_by_name.get(candidate.name.casefold()) or {}
-            try:
-                last_attempt = float(stat.get("lastrun") or 0) or None
-            except (TypeError, ValueError):
-                last_attempt = None
+            last_attempt = _timestamp(stat.get("lastrun"))
             diagnostics.append(
                 {
                     "name": candidate.name,
@@ -257,11 +264,8 @@ def build_route_readiness(
         all_blocked = bool(route_names) and len({name.lower() for name in route_blocks}) >= len(route_names)
         maintenance_reason = maintenance.get("reason") if maintenance.get("blocked") else None
         history = route_history.get(route, {})
-        try:
-            blocked_until = float(history.get("next_run_timestamp") or 0)
-        except (TypeError, ValueError):
-            blocked_until = 0
-        history_blocked = blocked_until > now and not route_blocks
+        blocked_until = _timestamp(history.get("next_run_timestamp"))
+        history_blocked = bool(blocked_until and blocked_until > now and not route_blocks)
         all_blocked = all_blocked or history_blocked
         ready = bool(enabled and downstream_ready and restart_safe and not all_blocked and not maintenance_reason)
         if not enabled:
@@ -278,14 +282,14 @@ def build_route_readiness(
             reason = "providers_temporarily_blocked"
         else:
             reason = "ready"
-        attempts = [float(row["lastrun"]) for row in route_stats if row.get("lastrun") is not None]
+        attempts = [timestamp for row in route_stats if (timestamp := _timestamp(row.get("lastrun"))) is not None]
         # A completed provider attempt is an operational route success even
         # when it returns zero matches. Acquisition matching is reported
         # separately by the run ledger's no_match/succeeded counters.
         latest_attempt = max(attempts) if attempts else None
-        last_failure = history.get("last_failure_timestamp")
-        last_success = history.get("last_success_timestamp")
-        if latest_attempt is not None and (last_failure is None or latest_attempt >= float(last_failure)):
+        last_failure = _timestamp(history.get("last_failure_timestamp"))
+        last_success = _timestamp(history.get("last_success_timestamp"))
+        if latest_attempt is not None and (last_failure is None or latest_attempt >= last_failure):
             last_success = latest_attempt
         running = any(_truthy(row.get("active")) for row in route_stats)
         routes[route] = {
@@ -294,7 +298,7 @@ def build_route_readiness(
             "active": running,
             "running": running,
             "blocked": bool(route_blocks) or history_blocked or bool(maintenance_reason),
-            "blocked_until": blocked_until or None,
+            "blocked_until": blocked_until,
             "blocked_provider_count": len(route_blocks),
             "downstream": client,
             "client_ready": client_ready,
@@ -303,7 +307,9 @@ def build_route_readiness(
             "restart_safe": restart_safe,
             "ready": ready,
             "reason": _sanitize(reason),
-            "last_attempt": latest_attempt if latest_attempt is not None else history.get("prev_run_timestamp"),
+            "last_attempt": latest_attempt
+            if latest_attempt is not None
+            else _timestamp(history.get("prev_run_timestamp")),
             "last_success": last_success,
             "last_failure": last_failure,
             "last_error": _sanitize(history.get("last_error")),

--- a/comicarr/app/series/router.py
+++ b/comicarr/app/series/router.py
@@ -256,6 +256,44 @@ def unqueue_issue(
     return series_service.unqueue_issue(ctx, issue_id, audit_identity=username)
 
 
+@router.get("/series/issues/{issue_id}/search-preview", dependencies=[Depends(require_session)])
+def preview_wanted_issue_search(
+    issue_id: str,
+    request: Request,
+    username: str = Depends(require_session),
+):
+    result = series_service.preview_wanted_issue(
+        issue_id,
+        actor=username,
+        session_id=_session_identity(request, username),
+    )
+    if result.get("success") is False:
+        return JSONResponse(status_code=int(result.get("status_code") or 400), content=result)
+    return result
+
+
+@router.post("/series/issues/{issue_id}/search", dependencies=[Depends(require_session)])
+async def search_one_wanted_issue(
+    issue_id: str,
+    request: Request,
+    username: str = Depends(require_session),
+):
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    result = series_service.search_wanted_issue(
+        issue_id,
+        username,
+        preview_token=(body or {}).get("preview_token"),
+        fingerprint=(body or {}).get("fingerprint"),
+        session_id=_session_identity(request, username),
+    )
+    if result.get("success") is False:
+        return JSONResponse(status_code=int(result.get("status_code") or 400), content=result)
+    return result
+
+
 @router.get("/wanted", dependencies=[Depends(require_session)])
 def get_wanted(
     limit: int = Query(None),

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -502,6 +502,83 @@ def unqueue_issue(ctx, issue_id, audit_identity):
     return {"success": True}
 
 
+def _wanted_issue_selection(issue_id):
+    row = db.select_one(sqlalchemy.select(issues).where(issues.c.IssueID == issue_id))
+    if row is None or row.get("Status") != "Wanted":
+        return None, {"success": False, "error": "Wanted issue not found", "status_code": 404}
+    return [
+        {
+            "entity_type": "issue",
+            "entity_id": str(row["IssueID"]),
+            "issue_number": row.get("Issue_Number"),
+            "source": {
+                "status": row.get("Status"),
+                "intent": row.get("AcquisitionIntent"),
+                "location": row.get("Location"),
+                "release_date": row.get("ReleaseDate"),
+                "digital_date": row.get("DigitalDate"),
+                "issue_date": row.get("IssueDate"),
+            },
+        }
+    ], {"success": True, "comicId": str(row["ComicID"]), "issueId": str(row["IssueID"])}
+
+
+def preview_wanted_issue(issue_id, *, actor, session_id):
+    """Mint a session-bound, one-item preview for an already Wanted issue."""
+    selection, result = _wanted_issue_selection(issue_id)
+    if not result["success"]:
+        return result
+    from comicarr.app.search.bulk import create_preview
+
+    result.update(
+        create_preview(
+            db.get_engine(),
+            series_id=result["comicId"],
+            actor=actor,
+            session_id=session_id,
+            selection=selection,
+        )
+    )
+    return result
+
+
+def search_wanted_issue(issue_id, audit_identity, *, preview_token, fingerprint, session_id):
+    """Confirm exactly one Wanted item through the durable search ledger."""
+    if not preview_token or not fingerprint or not session_id:
+        return {"success": False, "error": "a current Wanted issue preview is required", "status_code": 400}
+
+    from comicarr.app.search.bulk import SearchMissingConfirmationError, SearchMissingStalePreview, confirm_preview
+
+    selection, preview = _wanted_issue_selection(issue_id)
+    if not preview["success"]:
+        return preview
+    try:
+        result = confirm_preview(
+            db.get_engine(),
+            series_id=preview["comicId"],
+            actor=audit_identity,
+            session_id=session_id,
+            preview_token=preview_token,
+            supplied_fingerprint=fingerprint,
+            current_selection=selection,
+            trigger="issue_wanted",
+            scope_type="issue",
+            scope_id=issue_id,
+        )
+    except SearchMissingStalePreview as e:
+        return {"success": False, "status": "stale_preview", "error": str(e), "status_code": 409}
+    except SearchMissingConfirmationError as e:
+        return {"success": False, "status": "invalid_preview", "error": str(e), "status_code": 409}
+    return {
+        "success": True,
+        "status": "accepted" if not result["dispatch_error"] else "pending_dispatch",
+        "accepted": result["accepted"],
+        "run_id": result["run_id"],
+        "idempotent": result["idempotent"],
+        "message": "Queued one Wanted issue for search",
+    }
+
+
 def _search_missing_preview_state(ctx, comic_id):
     """Build the current public preview and private CAS selection once."""
     detail = get_comic_detail(ctx, comic_id)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,3 @@
-import { lazy, Suspense } from "react";
 import {
   BrowserRouter,
   Routes,
@@ -15,21 +14,46 @@ import ProtectedRoute from "@/components/ProtectedRoute";
 import Layout from "@/components/layout/Layout";
 import { ToastProvider } from "@/components/ui/toast";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import { RouteLoader } from "@/components/RouteLoader";
 import { useServerEvents } from "@/hooks/useServerEvents";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 
-const LoginPage = lazy(() => import("@/pages/LoginPage"));
-const DashboardPage = lazy(() => import("@/pages/DashboardPage"));
-const SeriesListPage = lazy(() => import("@/pages/SeriesListPage"));
-const SeriesDetailPage = lazy(() => import("@/pages/SeriesDetailPage"));
-const SearchPage = lazy(() => import("@/pages/SearchPage"));
-const ReleasesPage = lazy(() => import("@/pages/ReleasesPage"));
-const WantedPage = lazy(() => import("@/pages/WantedPage"));
-const SettingsPage = lazy(() => import("@/pages/SettingsPage"));
-const StoryArcsPage = lazy(() => import("@/pages/StoryArcsPage"));
-const StoryArcDetailPage = lazy(() => import("@/pages/StoryArcDetailPage"));
-const ImportPage = lazy(() => import("@/pages/ImportPage"));
-const ActivityPage = lazy(() => import("@/pages/ActivityPage"));
+const LoginPage = () => (
+  <RouteLoader load={() => import("@/pages/LoginPage")} />
+);
+const DashboardPage = () => (
+  <RouteLoader load={() => import("@/pages/DashboardPage")} />
+);
+const SeriesListPage = () => (
+  <RouteLoader load={() => import("@/pages/SeriesListPage")} />
+);
+const SeriesDetailPage = () => (
+  <RouteLoader load={() => import("@/pages/SeriesDetailPage")} />
+);
+const SearchPage = () => (
+  <RouteLoader load={() => import("@/pages/SearchPage")} />
+);
+const ReleasesPage = () => (
+  <RouteLoader load={() => import("@/pages/ReleasesPage")} />
+);
+const WantedPage = () => (
+  <RouteLoader load={() => import("@/pages/WantedPage")} />
+);
+const SettingsPage = () => (
+  <RouteLoader load={() => import("@/pages/SettingsPage")} />
+);
+const StoryArcsPage = () => (
+  <RouteLoader load={() => import("@/pages/StoryArcsPage")} />
+);
+const StoryArcDetailPage = () => (
+  <RouteLoader load={() => import("@/pages/StoryArcDetailPage")} />
+);
+const ImportPage = () => (
+  <RouteLoader load={() => import("@/pages/ImportPage")} />
+);
+const ActivityPage = () => (
+  <RouteLoader load={() => import("@/pages/ActivityPage")} />
+);
 
 // Create a client
 const queryClient = new QueryClient({
@@ -89,60 +113,51 @@ function AppContent() {
   return (
     <BrowserRouter>
       <NuqsAdapter>
-        <Suspense fallback={null}>
-          <Routes>
-            <Route path="/login" element={<LoginPage />} />
-            <Route
-              path="/*"
-              element={
-                <ProtectedRoute>
-                  <Layout>
-                    <Suspense fallback={null}>
-                      <Routes>
-                        <Route path="/" element={<DashboardPage />} />
-                        <Route path="/library" element={<SeriesListPage />} />
-                        <Route
-                          path="/library/:comicId"
-                          element={<SeriesDetailPage />}
-                        />
-                        <Route
-                          path="/series/:comicId"
-                          element={<SeriesRedirect />}
-                        />
-                        <Route
-                          path="/series"
-                          element={<SeriesListRedirect />}
-                        />
-                        <Route path="/search" element={<SearchPage />} />
-                        <Route path="/releases" element={<ReleasesPage />} />
-                        <Route
-                          path="/upcoming"
-                          element={
-                            <Navigate to="/releases?view=mine" replace />
-                          }
-                        />
-                        <Route
-                          path="/weekly"
-                          element={<Navigate to="/releases?view=all" replace />}
-                        />
-                        <Route path="/wanted" element={<WantedPage />} />
-                        <Route path="/story-arcs" element={<StoryArcsPage />} />
-                        <Route
-                          path="/story-arcs/:storyArcId"
-                          element={<StoryArcDetailPage />}
-                        />
-                        <Route path="/activity" element={<ActivityPage />} />
-                        <Route path="/import" element={<ImportPage />} />
-                        <Route path="/settings" element={<SettingsPage />} />
-                        <Route path="*" element={<Navigate to="/" replace />} />
-                      </Routes>
-                    </Suspense>
-                  </Layout>
-                </ProtectedRoute>
-              }
-            />
-          </Routes>
-        </Suspense>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route
+            path="/*"
+            element={
+              <ProtectedRoute>
+                <Layout>
+                  <Routes>
+                    <Route path="/" element={<DashboardPage />} />
+                    <Route path="/library" element={<SeriesListPage />} />
+                    <Route
+                      path="/library/:comicId"
+                      element={<SeriesDetailPage />}
+                    />
+                    <Route
+                      path="/series/:comicId"
+                      element={<SeriesRedirect />}
+                    />
+                    <Route path="/series" element={<SeriesListRedirect />} />
+                    <Route path="/search" element={<SearchPage />} />
+                    <Route path="/releases" element={<ReleasesPage />} />
+                    <Route
+                      path="/upcoming"
+                      element={<Navigate to="/releases?view=mine" replace />}
+                    />
+                    <Route
+                      path="/weekly"
+                      element={<Navigate to="/releases?view=all" replace />}
+                    />
+                    <Route path="/wanted" element={<WantedPage />} />
+                    <Route path="/story-arcs" element={<StoryArcsPage />} />
+                    <Route
+                      path="/story-arcs/:storyArcId"
+                      element={<StoryArcDetailPage />}
+                    />
+                    <Route path="/activity" element={<ActivityPage />} />
+                    <Route path="/import" element={<ImportPage />} />
+                    <Route path="/settings" element={<SettingsPage />} />
+                    <Route path="*" element={<Navigate to="/" replace />} />
+                  </Routes>
+                </Layout>
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
       </NuqsAdapter>
     </BrowserRouter>
   );

--- a/frontend/src/components/RouteLoader.tsx
+++ b/frontend/src/components/RouteLoader.tsx
@@ -1,0 +1,175 @@
+import {
+  Component,
+  useEffect,
+  useState,
+  type ComponentType,
+  type ReactNode,
+} from "react";
+import { Button } from "@/components/ui/button";
+
+type RouteModule = { default: ComponentType };
+
+interface RouteLoaderProps {
+  load: () => Promise<RouteModule>;
+}
+
+interface RouteErrorBoundaryProps {
+  children: ReactNode;
+  onRetry: () => void;
+  retryKey: number;
+}
+
+interface RouteErrorBoundaryState {
+  error: Error | null;
+}
+
+class RouteErrorBoundary extends Component<
+  RouteErrorBoundaryProps,
+  RouteErrorBoundaryState
+> {
+  state: RouteErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): RouteErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidUpdate(previousProps: RouteErrorBoundaryProps) {
+    if (this.state.error && previousProps.retryKey !== this.props.retryKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <section
+          className="flex min-h-[12rem] items-center justify-center p-6"
+          role="alert"
+        >
+          <div
+            className="max-w-md rounded-[6px] border p-5 text-center"
+            style={{
+              borderColor:
+                "color-mix(in oklab, var(--status-error) 35%, transparent)",
+              background: "var(--status-error-bg)",
+            }}
+          >
+            <h1 className="text-base font-semibold">
+              Unable to load this page
+            </h1>
+            <p className="mt-2 text-[12px] text-muted-foreground">
+              The page code did not load. Try again or choose another section.
+            </p>
+            <Button className="mt-4" onClick={this.props.onRetry} type="button">
+              Try again
+            </Button>
+          </div>
+        </section>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+function RouteLoading() {
+  return (
+    <div
+      className="flex min-h-[12rem] items-center justify-center p-6 font-mono text-[11px] text-muted-foreground"
+      role="status"
+      aria-live="polite"
+    >
+      Loading page…
+    </div>
+  );
+}
+
+/**
+ * Loads a route module with a visible fallback and starts a fresh import on
+ * retry. Keeping the module promise in an effect avoids React's cached lazy
+ * rejection while preserving application navigation.
+ */
+export function RouteLoader({ load }: RouteLoaderProps) {
+  const [attempt, setAttempt] = useState(0);
+  const [loaded, setLoaded] = useState<{
+    attempt: number;
+    component: ComponentType;
+  } | null>(null);
+  const [loadError, setLoadError] = useState<{
+    attempt: number;
+    error: Error;
+  } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    load()
+      .then((module) => {
+        if (!cancelled) setLoaded({ attempt, component: module.default });
+      })
+      .catch((loadError: unknown) => {
+        if (!cancelled) {
+          setLoadError({
+            attempt,
+            error:
+              loadError instanceof Error
+                ? loadError
+                : new Error("Route module failed to load"),
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [attempt, load]);
+
+  const retry = () => setAttempt((current) => current + 1);
+  const LoadedRoute = loaded?.attempt === attempt ? loaded.component : null;
+  const error = loadError?.attempt === attempt ? loadError.error : null;
+
+  return (
+    <RouteErrorBoundary onRetry={retry} retryKey={attempt}>
+      {error ? (
+        <RouteLoadError error={error} onRetry={retry} />
+      ) : LoadedRoute ? (
+        <LoadedRoute />
+      ) : (
+        <RouteLoading />
+      )}
+    </RouteErrorBoundary>
+  );
+}
+
+function RouteLoadError({
+  error,
+  onRetry,
+}: {
+  error: Error;
+  onRetry: () => void;
+}) {
+  return (
+    <section
+      className="flex min-h-[12rem] items-center justify-center p-6"
+      role="alert"
+    >
+      <div
+        className="max-w-md rounded-[6px] border p-5 text-center"
+        style={{
+          borderColor:
+            "color-mix(in oklab, var(--status-error) 35%, transparent)",
+          background: "var(--status-error-bg)",
+        }}
+      >
+        <h1 className="text-base font-semibold">Unable to load this page</h1>
+        <p className="mt-2 text-[12px] text-muted-foreground">
+          {error.message ||
+            "The page code did not load. Try again or choose another section."}
+        </p>
+        <Button className="mt-4" onClick={onRetry} type="button">
+          Try again
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/RouteLoader.tsx
+++ b/frontend/src/components/RouteLoader.tsx
@@ -1,6 +1,7 @@
 import {
   Component,
   useEffect,
+  useRef,
   useState,
   type ComponentType,
   type ReactNode,
@@ -91,6 +92,7 @@ function RouteLoading() {
  */
 export function RouteLoader({ load }: RouteLoaderProps) {
   const [attempt, setAttempt] = useState(0);
+  const loadRef = useRef(load);
   const [loaded, setLoaded] = useState<{
     attempt: number;
     component: ComponentType;
@@ -101,14 +103,23 @@ export function RouteLoader({ load }: RouteLoaderProps) {
   } | null>(null);
 
   useEffect(() => {
+    loadRef.current = load;
+  }, [load]);
+
+  useEffect(() => {
     let cancelled = false;
 
-    load()
+    loadRef
+      .current()
       .then((module) => {
-        if (!cancelled) setLoaded({ attempt, component: module.default });
+        if (!cancelled) {
+          setLoadError(null);
+          setLoaded({ attempt, component: module.default });
+        }
       })
       .catch((loadError: unknown) => {
         if (!cancelled) {
+          setLoaded(null);
           setLoadError({
             attempt,
             error:
@@ -122,7 +133,7 @@ export function RouteLoader({ load }: RouteLoaderProps) {
     return () => {
       cancelled = true;
     };
-  }, [attempt, load]);
+  }, [attempt]);
 
   const retry = () => setAttempt((current) => current + 1);
   const LoadedRoute = loaded?.attempt === attempt ? loaded.component : null;

--- a/frontend/src/components/queue/BulkActionBar.tsx
+++ b/frontend/src/components/queue/BulkActionBar.tsx
@@ -1,9 +1,10 @@
-import { Download, X } from "lucide-react";
+import { Download, Search, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface BulkActionBarProps {
   selectedCount: number;
   onMarkWanted?: () => void;
+  onSearch?: () => void;
   onSkip: () => void;
   onClear: () => void;
   isLoading?: boolean;
@@ -12,6 +13,7 @@ interface BulkActionBarProps {
 export default function BulkActionBar({
   selectedCount,
   onMarkWanted,
+  onSearch,
   onSkip,
   onClear,
   isLoading,
@@ -34,6 +36,17 @@ export default function BulkActionBar({
             >
               <Download className="w-4 h-4 mr-2" />
               Mark Wanted
+            </Button>
+          )}
+          {onSearch && selectedCount === 1 && (
+            <Button
+              variant="ghost"
+              onClick={onSearch}
+              disabled={isLoading}
+              className="text-white hover:bg-white/20"
+            >
+              <Search className="w-4 h-4 mr-2" />
+              Search selected
             </Button>
           )}
           <Button

--- a/frontend/src/hooks/useQueue.ts
+++ b/frontend/src/hooks/useQueue.ts
@@ -11,11 +11,17 @@ import type {
   WantedIssue,
   UpcomingIssue,
   PaginationMeta,
+  SearchMissingResult,
 } from "@/types";
 
 interface WantedResponse {
   issues: WantedIssue[];
   pagination: PaginationMeta;
+}
+
+interface WantedSearchPreview {
+  preview_token: string;
+  fingerprint: string;
 }
 
 // Query Hooks
@@ -58,6 +64,34 @@ export function useForceSearch(): UseMutationResult<
   return useMutation({
     mutationFn: () =>
       apiRequest<ForceSearchResult>("POST", "/api/search/force"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["wanted"] });
+      queryClient.invalidateQueries({ queryKey: ["upcoming"] });
+    },
+  });
+}
+
+export function useSearchWantedIssue(): UseMutationResult<
+  SearchMissingResult,
+  Error,
+  string
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (issueId) => {
+      const preview = await apiRequest<WantedSearchPreview>(
+        "GET",
+        `/api/series/issues/${issueId}/search-preview`,
+      );
+      return apiRequest<SearchMissingResult>(
+        "POST",
+        `/api/series/issues/${issueId}/search`,
+        {
+          preview_token: preview.preview_token,
+          fingerprint: preview.fingerprint,
+        },
+      );
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["wanted"] });
       queryClient.invalidateQueries({ queryKey: ["upcoming"] });

--- a/frontend/src/pages/WantedPage.tsx
+++ b/frontend/src/pages/WantedPage.tsx
@@ -4,6 +4,7 @@ import {
   useWanted,
   useForceSearch,
   useBulkUnqueueIssues,
+  useSearchWantedIssue,
 } from "@/hooks/useQueue";
 import { useToast } from "@/components/ui/toast";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -25,6 +26,7 @@ export default function WantedPage() {
   const pagination = data?.pagination;
 
   const forceSearch = useForceSearch();
+  const searchWantedIssue = useSearchWantedIssue();
   const bulkUnqueue = useBulkUnqueueIssues();
   const { addToast } = useToast();
 
@@ -116,6 +118,27 @@ export default function WantedPage() {
           message: `Failed to start search: ${err instanceof Error ? err.message : "Unknown error"}`,
         });
       }
+    }
+  };
+
+  const handleSearchSelected = async () => {
+    const issueId = selectedIds[0];
+    if (!issueId || !window.confirm("Search this one Wanted issue?")) return;
+    try {
+      const result = await searchWantedIssue.mutateAsync(issueId);
+      addToast({
+        type: result.success ? "info" : "error",
+        title: result.success ? "Search accepted" : "Search failed",
+        message:
+          result.message || result.error || "Unable to start this search.",
+      });
+      if (result.success) setSelectedIds([]);
+    } catch (err) {
+      addToast({
+        type: "error",
+        message:
+          err instanceof Error ? err.message : "Unable to start this search.",
+      });
     }
   };
 
@@ -217,7 +240,8 @@ export default function WantedPage() {
         selectedCount={selectedIds.length}
         onSkip={handleBulkUnqueue}
         onClear={() => setSelectedIds([])}
-        isLoading={bulkUnqueue.isPending}
+        onSearch={() => void handleSearchSelected()}
+        isLoading={bulkUnqueue.isPending || searchWantedIssue.isPending}
       />
     </div>
   );

--- a/frontend/tests/components/RouteLoader.test.tsx
+++ b/frontend/tests/components/RouteLoader.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderMinimal } from "../test-utils";
+import { RouteLoader } from "@/components/RouteLoader";
+
+describe("RouteLoader", () => {
+  it("shows a visible loading state until a route module resolves", async () => {
+    let resolveModule:
+      ((module: { default: React.ComponentType }) => void) | undefined;
+    const load = vi.fn(
+      () =>
+        new Promise<{ default: React.ComponentType }>((resolve) => {
+          resolveModule = resolve;
+        }),
+    );
+
+    renderMinimal(<RouteLoader load={load} />);
+
+    expect(screen.getByRole("status").textContent).toContain("Loading page");
+
+    resolveModule?.({ default: () => <h1>Wanted</h1> });
+
+    expect(await screen.findByRole("heading", { name: "Wanted" })).toBeTruthy();
+  });
+
+  it("retries a rejected route import without requiring a full reload", async () => {
+    const load = vi
+      .fn<() => Promise<{ default: React.ComponentType }>>()
+      .mockRejectedValueOnce(new Error("missing chunk"))
+      .mockResolvedValueOnce({ default: () => <h1>Wanted</h1> });
+    const user = userEvent.setup();
+
+    renderMinimal(<RouteLoader load={load} />);
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Unable to load this page",
+    );
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByRole("heading", { name: "Wanted" })).toBeTruthy();
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/tests/e2e/navigation.smoke.spec.ts
+++ b/frontend/tests/e2e/navigation.smoke.spec.ts
@@ -6,6 +6,7 @@ const destinations = [
   { path: "/", label: "Dashboard" },
   { path: "/library", label: "Library" },
   { path: "/search", label: "Search" },
+  { path: "/wanted", label: "Wanted" },
   { path: "/activity", label: "Activity" },
   { path: "/settings", label: "Settings" },
 ];
@@ -27,8 +28,10 @@ test("protected core navigation renders without API regressions", async ({
 });
 
 test("SPA fallback serves authenticated deep links", async ({ page }) => {
-  await page.goto("/settings");
+  await page.goto("/wanted");
 
-  await expect(page).toHaveURL(/\/settings$/);
-  await expect(page.getByText("Settings").first()).toBeVisible();
+  await expect(page).toHaveURL(/\/wanted$/);
+  await expect(page.getByText("Wanted").first()).toBeVisible();
+  await page.reload();
+  await expect(page.getByText("Wanted").first()).toBeVisible();
 });

--- a/tests/unit/test_search_health.py
+++ b/tests/unit/test_search_health.py
@@ -113,6 +113,34 @@ def test_health_explains_configured_but_unattempted_torznab_without_secrets(tmp_
     assert "top-secret-key" not in str(torrent)
 
 
+def test_health_tolerates_malformed_provider_and_history_timestamps(tmp_path):
+    routes = health.build_route_readiness(
+        _config(tmp_path),
+        provider_stats=[
+            {
+                "provider": "DDL(GetComics)",
+                "type": "ddl",
+                "active": False,
+                "lastrun": "not-a-timestamp",
+                "hits": 0,
+            }
+        ],
+        route_history={
+            "ddl": {
+                "prev_run_timestamp": "also-not-a-timestamp",
+                "last_failure_timestamp": "invalid-failure-time",
+                "last_error": "token=secret provider error",
+            }
+        },
+    )
+
+    ddl = routes["ddl"]
+    assert ddl["last_attempt"] is None
+    assert ddl["last_success"] is None
+    assert ddl["last_failure"] is None
+    assert "secret" not in str(ddl)
+
+
 def test_disabled_torrent_handoff_is_not_reported_as_executable(tmp_path):
     routes = health.build_route_readiness(
         _config(tmp_path, ENABLE_TORRENTS=False),


### PR DESCRIPTION
## Summary
- show recoverable route loading instead of blank content
- harden search health timestamp parsing
- add a confirmed one-item Wanted search action

## Verification
- uv run pytest tests/unit/test_search_health.py tests/unit/test_search_domain.py tests/unit/test_search_queue.py -q
- npm run test:run
- npm run typecheck
- npm run lint
- npm run build
- COMICARR_E2E_PYTHON=../.venv/bin/python npm run test:e2e:smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Search selected” to bulk actions to search a single Wanted issue with preview, confirmation, and status feedback.
  - Introduced resilient route loading with visible loading states, load-failure messaging, and “Try again” retry.

- **Bug Fixes**
  - Search/page loading indicators now remain visible until routes fully load.
  - Health diagnostics now tolerate malformed timestamps and avoid leaking sensitive details.
  - Searching one Wanted issue no longer automatically triggers the full backlog behavior.

- **Navigation**
  - Improved deep-link and reload behavior for the Wanted page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->