### PR TITLE
fix: make library scan progress visible

### DIFF
--- a/.changeset/clear-library-scan-feedback.md
+++ b/.changeset/clear-library-scan-feedback.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Make library scan progress and import confirmation visible across the Dashboard and Import pages.

--- a/frontend/src/components/import/LibraryScanSection.tsx
+++ b/frontend/src/components/import/LibraryScanSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   RefreshCw,
   Library,
@@ -25,46 +25,22 @@ export default function LibraryScanSection() {
   const mangaDir = appConfig?.manga_dir as string | undefined;
   const { addToast } = useToast();
 
-  // Comic scan state
   const comicScanMutation = useComicScan();
-  const [comicScanning, setComicScanning] = useState(false);
-  const { data: comicProgress } = useComicScanProgress(comicScanning);
+  const { data: comicProgress } = useComicScanProgress();
   const comicConfirmMutation = useComicScanConfirm();
+  const [comicImported, setComicImported] = useState<number | null>(null);
 
-  // Manga scan state
   const mangaScanMutation = useMangaScan();
-  const [mangaScanning, setMangaScanning] = useState(false);
-  const { data: mangaProgress } = useMangaScanProgress(mangaScanning);
+  const { data: mangaProgress } = useMangaScanProgress();
   const mangaConfirmMutation = useMangaScanConfirm();
-
-  const comicStatus = comicProgress?.status;
-  const comicTerminal =
-    comicScanning && (comicStatus === "completed" || comicStatus === "error");
-  useEffect(() => {
-    if (!comicTerminal) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- Sync polling state with server-driven terminal status
-    setComicScanning(false);
-    if (comicStatus === "error") {
-      addToast({ type: "error", message: "Comic scan failed" });
-    }
-  }, [comicTerminal, comicStatus, addToast]);
-
-  const mangaStatus = mangaProgress?.status;
-  const mangaTerminal =
-    mangaScanning && (mangaStatus === "completed" || mangaStatus === "error");
-  useEffect(() => {
-    if (!mangaTerminal) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- Sync polling state with server-driven terminal status
-    setMangaScanning(false);
-    if (mangaStatus === "error") {
-      addToast({ type: "error", message: "Manga scan failed" });
-    }
-  }, [mangaTerminal, mangaStatus, addToast]);
+  const [mangaImported, setMangaImported] = useState<number | null>(null);
+  const comicScanning = comicProgress?.status === "scanning";
+  const mangaScanning = mangaProgress?.status === "scanning";
 
   const handleComicScan = async () => {
     try {
       await comicScanMutation.mutateAsync();
-      setComicScanning(true);
+      setComicImported(null);
       addToast({ type: "info", message: "Comic library scan started." });
     } catch (err) {
       addToast({
@@ -77,7 +53,7 @@ export default function LibraryScanSection() {
   const handleMangaScan = async () => {
     try {
       await mangaScanMutation.mutateAsync();
-      setMangaScanning(true);
+      setMangaImported(null);
       addToast({ type: "info", message: "Manga library scan started." });
     } catch (err) {
       addToast({
@@ -93,6 +69,7 @@ export default function LibraryScanSection() {
         scanId,
         selectedIds,
       });
+      setComicImported(result.imported);
       addToast({
         type: "success",
         message: `Imported ${result.imported} comic series`,
@@ -111,6 +88,7 @@ export default function LibraryScanSection() {
         scanId,
         selectedIds,
       });
+      setMangaImported(result.imported);
       addToast({
         type: "success",
         message: `Imported ${result.imported} manga series`,
@@ -167,25 +145,79 @@ export default function LibraryScanSection() {
         />
       </div>
 
-      {comicResults && comicResults.length > 0 && comicScanId && (
-        <LibraryScanResults
-          results={comicResults}
-          scanId={comicScanId}
-          onConfirm={handleComicConfirm}
-          isConfirming={comicConfirmMutation.isPending}
-          type="comic"
-        />
-      )}
+      <ScanFailure type="comic" progress={comicProgress} />
+      <ScanFailure type="manga" progress={mangaProgress} />
+      <ImportSummary type="comic" imported={comicImported} />
+      <ImportSummary type="manga" imported={mangaImported} />
 
-      {mangaResults && mangaResults.length > 0 && mangaScanId && (
-        <LibraryScanResults
-          results={mangaResults}
-          scanId={mangaScanId}
-          onConfirm={handleMangaConfirm}
-          isConfirming={mangaConfirmMutation.isPending}
-          type="manga"
-        />
-      )}
+      {comicImported === null &&
+        comicResults &&
+        comicResults.length > 0 &&
+        comicScanId && (
+          <LibraryScanResults
+            results={comicResults}
+            scanId={comicScanId}
+            onConfirm={handleComicConfirm}
+            isConfirming={comicConfirmMutation.isPending}
+            type="comic"
+          />
+        )}
+
+      {mangaImported === null &&
+        mangaResults &&
+        mangaResults.length > 0 &&
+        mangaScanId && (
+          <LibraryScanResults
+            results={mangaResults}
+            scanId={mangaScanId}
+            onConfirm={handleMangaConfirm}
+            isConfirming={mangaConfirmMutation.isPending}
+            type="manga"
+          />
+        )}
+    </div>
+  );
+}
+
+function ScanFailure({
+  type,
+  progress,
+}: {
+  type: "comic" | "manga";
+  progress?: {
+    status: string | null;
+    progress: { errors: string[] };
+  };
+}) {
+  if (progress?.status !== "error") return null;
+
+  const detail = progress.progress.errors[0];
+  return (
+    <div
+      className="rounded-[6px] border border-destructive/40 bg-destructive/10 px-3.5 py-3 text-[12px] text-foreground"
+      role="alert"
+    >
+      {type === "comic" ? "Comic" : "Manga"} library scan failed
+      {detail ? `: ${detail}` : "."}
+    </div>
+  );
+}
+
+function ImportSummary({
+  type,
+  imported,
+}: {
+  type: "comic" | "manga";
+  imported: number | null;
+}) {
+  if (imported === null) return null;
+
+  return (
+    <div
+      className="rounded-[6px] border border-[var(--status-success)]/40 bg-[var(--status-success)]/10 px-3.5 py-3 text-[12px] text-foreground"
+      role="status"
+    >
+      Imported {imported} {type} series. The library has been refreshed.
     </div>
   );
 }

--- a/frontend/src/hooks/useImport.ts
+++ b/frontend/src/hooks/useImport.ts
@@ -1,4 +1,5 @@
 import {
+  type QueryClient,
   useQuery,
   useMutation,
   useQueryClient,
@@ -181,23 +182,34 @@ export function useMangaScan(): UseMutationResult<
     mutationFn: () =>
       apiRequest<MangaScanResponse>("POST", "/api/import/manga/scan"),
     onSuccess: () => {
-      setTimeout(() => {
-        queryClient.invalidateQueries({ queryKey: ["mangaScanProgress"] });
-        queryClient.invalidateQueries({ queryKey: ["series"] });
-      }, 2000);
+      queryClient.invalidateQueries({ queryKey: ["mangaScanProgress"] });
     },
   });
 }
 
-export function useMangaScanProgress(
-  enabled = false,
-): UseQueryResult<MangaScanProgress> {
+function refetchWhileScanning(query: {
+  state: { data?: { status?: string | null } };
+}) {
+  return query.state.data?.status === "scanning" ? 2000 : false;
+}
+
+function clearImportedScanResults(
+  queryClient: QueryClient,
+  queryKey: readonly ["comicScanProgress" | "mangaScanProgress"],
+) {
+  queryClient.setQueryData<ScanProgress>(queryKey, (current) =>
+    current ? { ...current, results: null, scan_id: null } : current,
+  );
+  queryClient.invalidateQueries({ queryKey });
+  queryClient.invalidateQueries({ queryKey: ["series"] });
+}
+
+export function useMangaScanProgress(): UseQueryResult<MangaScanProgress> {
   return useQuery({
     queryKey: ["mangaScanProgress"],
     queryFn: () =>
       apiRequest<MangaScanProgress>("GET", "/api/import/manga/progress"),
-    enabled,
-    refetchInterval: enabled ? 2000 : false,
+    refetchInterval: refetchWhileScanning,
   });
 }
 
@@ -221,8 +233,7 @@ export function useMangaScanConfirm(): UseMutationResult<
         selected_ids: selectedIds,
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["mangaScanProgress"] });
-      queryClient.invalidateQueries({ queryKey: ["series"] });
+      clearImportedScanResults(queryClient, ["mangaScanProgress"]);
     },
   });
 }
@@ -247,23 +258,17 @@ export function useComicScan(): UseMutationResult<
     mutationFn: () =>
       apiRequest<ComicScanResponse>("POST", "/api/import/comic/scan"),
     onSuccess: () => {
-      setTimeout(() => {
-        queryClient.invalidateQueries({ queryKey: ["comicScanProgress"] });
-        queryClient.invalidateQueries({ queryKey: ["series"] });
-      }, 2000);
+      queryClient.invalidateQueries({ queryKey: ["comicScanProgress"] });
     },
   });
 }
 
-export function useComicScanProgress(
-  enabled = false,
-): UseQueryResult<ScanProgress> {
+export function useComicScanProgress(): UseQueryResult<ScanProgress> {
   return useQuery({
     queryKey: ["comicScanProgress"],
     queryFn: () =>
       apiRequest<ScanProgress>("GET", "/api/import/comic/progress"),
-    enabled,
-    refetchInterval: enabled ? 2000 : false,
+    refetchInterval: refetchWhileScanning,
   });
 }
 
@@ -280,8 +285,7 @@ export function useComicScanConfirm(): UseMutationResult<
         selected_ids: selectedIds,
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["comicScanProgress"] });
-      queryClient.invalidateQueries({ queryKey: ["series"] });
+      clearImportedScanResults(queryClient, ["comicScanProgress"]);
     },
   });
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { RefreshCw } from "lucide-react";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 import RelativeTime from "@/components/ui/RelativeTime";
@@ -50,61 +49,12 @@ function QueueStatus({ status }: { status: DashboardQueueItem["status"] }) {
 
 export default function DashboardPage() {
   const { data, isLoading, error } = useDashboard();
+  const navigate = useNavigate();
   const comicScan = useComicScan();
   const mangaScan = useMangaScan();
-  const [comicScanning, setComicScanning] = useState(false);
-  const [mangaScanning, setMangaScanning] = useState(false);
-  const { data: comicScanProgress, error: comicProgressError } =
-    useComicScanProgress(comicScanning);
-  const { data: mangaScanProgress, error: mangaProgressError } =
-    useMangaScanProgress(mangaScanning);
+  const { data: comicScanProgress } = useComicScanProgress();
+  const { data: mangaScanProgress } = useMangaScanProgress();
   const { addToast } = useToast();
-
-  useEffect(() => {
-    if (
-      !comicScanning ||
-      !["completed", "error"].includes(comicScanProgress?.status || "")
-    )
-      return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- Sync the dashboard action with server scan state
-    setComicScanning(false);
-    if (comicScanProgress?.status === "error") {
-      addToast({ type: "error", message: "Comic library scan failed." });
-    }
-  }, [comicScanning, comicScanProgress?.status, addToast]);
-
-  useEffect(() => {
-    if (
-      !mangaScanning ||
-      !["completed", "error"].includes(mangaScanProgress?.status || "")
-    )
-      return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- Sync the dashboard action with server scan state
-    setMangaScanning(false);
-    if (mangaScanProgress?.status === "error") {
-      addToast({ type: "error", message: "Manga library scan failed." });
-    }
-  }, [mangaScanning, mangaScanProgress?.status, addToast]);
-
-  useEffect(() => {
-    if (!comicScanning || !comicProgressError) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- Release a dashboard action whose progress request failed
-    setComicScanning(false);
-    addToast({
-      type: "error",
-      message: "Unable to monitor comic library scan.",
-    });
-  }, [comicScanning, comicProgressError, addToast]);
-
-  useEffect(() => {
-    if (!mangaScanning || !mangaProgressError) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- Release a dashboard action whose progress request failed
-    setMangaScanning(false);
-    addToast({
-      type: "error",
-      message: "Unable to monitor manga library scan.",
-    });
-  }, [mangaScanning, mangaProgressError, addToast]);
 
   if (error) {
     return (
@@ -127,6 +77,8 @@ export default function DashboardPage() {
   const totalIssues = stats?.total_issues ?? 0;
   const completion = stats?.completion_pct ?? 0;
   const queueCount = stats?.queue_count ?? 0;
+  const comicScanning = comicScanProgress?.status === "scanning";
+  const mangaScanning = mangaScanProgress?.status === "scanning";
   const scanPending =
     comicScan.isPending ||
     mangaScan.isPending ||
@@ -137,15 +89,15 @@ export default function DashboardPage() {
   );
 
   const handleLibraryScan = async () => {
-    const scans: { type: "comic" | "manga"; request: Promise<unknown> }[] = [];
+    const scanRequests: Promise<unknown>[] = [];
     if (data?.scan_targets?.comic) {
-      scans.push({ type: "comic", request: comicScan.mutateAsync() });
+      scanRequests.push(comicScan.mutateAsync());
     }
     if (data?.scan_targets?.manga) {
-      scans.push({ type: "manga", request: mangaScan.mutateAsync() });
+      scanRequests.push(mangaScan.mutateAsync());
     }
 
-    if (scans.length === 0) {
+    if (scanRequests.length === 0) {
       addToast({
         type: "error",
         message:
@@ -154,16 +106,11 @@ export default function DashboardPage() {
       return;
     }
 
-    const results = await Promise.allSettled(scans.map((scan) => scan.request));
-    results.forEach((result, index) => {
-      if (result.status !== "fulfilled") return;
-      if (scans[index].type === "comic") setComicScanning(true);
-      else setMangaScanning(true);
-    });
+    const results = await Promise.allSettled(scanRequests);
     const started = results.filter(
       (result) => result.status === "fulfilled",
     ).length;
-    if (started === scans.length) {
+    if (started === scanRequests.length) {
       addToast({
         type: "success",
         message: `${started === 2 ? "Comic and manga library scans" : "Library scan"} started.`,
@@ -175,7 +122,10 @@ export default function DashboardPage() {
       });
     } else {
       addToast({ type: "error", message: "Failed to start library scans." });
+      return;
     }
+
+    navigate("/import");
   };
 
   return (

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -331,9 +331,18 @@ export const handlers = [
       http_host: "0.0.0.0",
       http_port: 8090,
       comic_dir: "/comics",
+      manga_dir: "/manga",
       api_enabled: true,
     });
   }),
+
+  http.get("/api/import/comic/progress", () =>
+    HttpResponse.json({ status: null, progress: {}, scan_id: null, results: null }),
+  ),
+
+  http.get("/api/import/manga/progress", () =>
+    HttpResponse.json({ status: null, progress: {}, scan_id: null, results: null }),
+  ),
 
   http.put("/api/config", () => {
     return HttpResponse.json({

--- a/frontend/tests/pages/DashboardPage.test.tsx
+++ b/frontend/tests/pages/DashboardPage.test.tsx
@@ -8,10 +8,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useLocation } from "react-router-dom";
 import { server } from "../mocks/server";
 import { http, HttpResponse } from "msw";
 import { createTestQueryClient, render, screen } from "../test-utils";
 import DashboardPage from "@/pages/DashboardPage";
+
+function LocationProbe() {
+  return <div data-testid="location">{useLocation().pathname}</div>;
+}
 
 describe("DashboardPage", () => {
   beforeEach(() => {
@@ -95,7 +100,13 @@ describe("DashboardPage", () => {
     );
 
     const user = userEvent.setup();
-    render(<DashboardPage />, { queryClient });
+    render(
+      <>
+        <DashboardPage />
+        <LocationProbe />
+      </>,
+      { queryClient, route: "/", useMemoryRouter: true },
+    );
     const scanButton = await screen.findByRole("button", {
       name: "Scan libraries",
     });
@@ -113,6 +124,7 @@ describe("DashboardPage", () => {
         .getByRole("button", { name: "Scanning…" })
         .hasAttribute("disabled"),
     ).toBe(true);
+    expect(screen.getByTestId("location").textContent).toBe("/import");
   });
 
   it("reports a partial library scan startup failure", async () => {

--- a/frontend/tests/pages/ImportPage.test.tsx
+++ b/frontend/tests/pages/ImportPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../mocks/server";
 import { render, screen } from "../test-utils";
@@ -55,6 +56,149 @@ function makeGroup(overrides: Partial<ImportGroup> = {}): ImportGroup {
 }
 
 describe("ImportPage", () => {
+  it("hydrates and displays a comic scan started from another page", async () => {
+    server.use(
+      http.get("/api/import/comic/progress", () =>
+        HttpResponse.json({
+          status: "scanning",
+          progress: {
+            series_found: 12,
+            series_matched: 8,
+            current_series: "Absolute Batman",
+          },
+          scan_id: null,
+          results: null,
+        }),
+      ),
+    );
+
+    render(<ImportPage />);
+
+    expect(await screen.findByText("Absolute Batman")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "scanning" })).toBeTruthy();
+  });
+
+  it("keeps a background comic scan failure visible", async () => {
+    server.use(
+      http.get("/api/import/comic/progress", () =>
+        HttpResponse.json({
+          status: "error",
+          progress: { errors: ["ComicVine is unavailable"] },
+          scan_id: null,
+          results: null,
+        }),
+      ),
+    );
+
+    render(<ImportPage />);
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Comic library scan failed: ComicVine is unavailable",
+    );
+  });
+
+  it("clears imported manga results and keeps a durable success summary", async () => {
+    let scanStarted = false;
+    let confirmed = false;
+    server.use(
+      http.get("/api/import/manga/progress", () =>
+        HttpResponse.json({
+          status: scanStarted ? "completed" : null,
+          progress: {},
+          scan_id: scanStarted && !confirmed ? "scan-1" : null,
+          results:
+            scanStarted && !confirmed
+              ? [
+                  {
+                    series_name: "Berserk",
+                    file_count: 42,
+                    matched: true,
+                    match: {
+                      comicid: "mal-33",
+                      name: "Berserk",
+                      year: "1989",
+                      confidence: 100,
+                      source: "mal",
+                    },
+                  },
+                ]
+              : null,
+        }),
+      ),
+      http.post("/api/import/manga/scan", () => {
+        scanStarted = true;
+        return HttpResponse.json({ success: true, message: "started" });
+      }),
+      http.post("/api/import/manga/confirm", () => {
+        confirmed = true;
+        return HttpResponse.json({ success: true, imported: 1, errors: [] });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<ImportPage />);
+
+    const scanButtons = await screen.findAllByRole("button", { name: "scan" });
+    await user.click(scanButtons[1]);
+    await user.click(
+      await screen.findByRole("button", { name: "Import Selected (1)" }),
+    );
+
+    expect((await screen.findByRole("status")).textContent).toContain(
+      "Imported 1 manga series",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Import Selected (1)" }),
+    ).toBeNull();
+  });
+
+  it("clears imported comic results with the comic progress key", async () => {
+    let confirmed = false;
+    server.use(
+      http.get("/api/import/comic/progress", () =>
+        HttpResponse.json({
+          status: "completed",
+          progress: {},
+          scan_id: confirmed ? null : "scan-1",
+          results: confirmed
+            ? null
+            : [
+                {
+                  series_name: "Absolute Batman",
+                  file_count: 22,
+                  matched: true,
+                  match: {
+                    comicid: "160294",
+                    name: "Absolute Batman",
+                    year: "2024",
+                    publisher: "DC Comics",
+                    confidence: 100,
+                  },
+                },
+              ],
+        }),
+      ),
+      http.post("/api/import/comic/confirm", () => {
+        confirmed = true;
+        return HttpResponse.json({ success: true, imported: 1, errors: [] });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<ImportPage />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Import Selected (1)" }),
+    );
+
+    expect((await screen.findByRole("status")).textContent).toContain(
+      "Imported 1 comic series",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Import Selected (1)" }),
+    ).toBeNull();
+  });
+
   it("puts pending review before sources and scans when imports exist", async () => {
     server.use(
       http.get("/api/import", () =>


### PR DESCRIPTION
## Summary

The Dashboard scan action now opens Imports, where scan status is read from the server rather than page-local state. A scan started elsewhere can no longer appear idle; completed imports clear their candidate list while retaining a durable confirmation, and terminal failures remain visible.

## Validation

- `npm run test:run -- tests/pages/ImportPage.test.tsx tests/pages/DashboardPage.test.tsx` (16 passed; the test harness emitted existing localhost connection warnings)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
