### PR TITLE
fix: reconcile existing comic library scans

### DIFF
--- a/.changeset/reconcile-existing-library-series.md
+++ b/.changeset/reconcile-existing-library-series.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Reconcile scanned comic folders with existing series and show the outcome in Import.

--- a/comicarr/comicsync.py
+++ b/comicarr/comicsync.py
@@ -32,7 +32,7 @@ import time
 from sqlalchemy import select
 
 import comicarr
-from comicarr import db, logger
+from comicarr import db, logger, updater
 from comicarr.scanutil import COMIC_EXTENSIONS, find_best_match, normalize_title
 from comicarr.tables import comics
 
@@ -43,6 +43,7 @@ COMIC_SCAN_PROGRESS = {
     "processed_files": 0,
     "series_found": 0,
     "series_matched": 0,
+    "series_reconciled": 0,
     "current_series": None,
     "errors": [],
 }
@@ -86,6 +87,7 @@ def comicScan(scan_dir=None):
         "processed_files": 0,
         "series_found": 0,
         "series_matched": 0,
+        "series_reconciled": 0,
         "current_series": None,
         "errors": [],
     }
@@ -98,6 +100,7 @@ def comicScan(scan_dir=None):
         "status": "completed",
         "series_found": 0,
         "series_matched": 0,
+        "series_reconciled": 0,
         "scan_results": [],
         "errors": [],
     }
@@ -123,6 +126,9 @@ def comicScan(scan_dir=None):
                 if match_result.get("matched"):
                     results["series_matched"] += 1
                     COMIC_SCAN_PROGRESS["series_matched"] += 1
+                if match_result.get("reconciled"):
+                    results["series_reconciled"] += 1
+                    COMIC_SCAN_PROGRESS["series_reconciled"] += 1
             except Exception as e:
                 logger.error("[COMIC-SCAN] Error processing series '%s': %s" % (series_name, e))
                 error_entry = {
@@ -142,7 +148,8 @@ def comicScan(scan_dir=None):
         COMIC_SCAN_RESULTS = results["scan_results"]
 
         logger.info(
-            "[COMIC-SCAN] Scan complete. Matched: %d/%d series" % (results["series_matched"], results["series_found"])
+            "[COMIC-SCAN] Scan complete. Reconciled: %d, matched: %d/%d series"
+            % (results["series_reconciled"], results["series_matched"], results["series_found"])
         )
     except Exception as e:
         logger.error("[COMIC-SCAN] Fatal error during scan: %s" % e)
@@ -207,7 +214,7 @@ def _guess_series_from_filename(filename):
 
 
 def _load_existing_series():
-    """Load existing comic series from the library for de-duplication."""
+    """Index existing comic series by normalized display names."""
     existing = {}
     try:
         with db.get_engine().connect() as conn:
@@ -216,21 +223,69 @@ def _load_existing_series():
                 comics.c.ComicName,
                 comics.c.ComicSortName,
                 comics.c.DynamicName,
+                comics.c.ComicYear,
+                comics.c.ComicLocation,
             ).where(comics.c.ContentType != "manga")
             for row in conn.execute(stmt):
                 row_dict = dict(row._mapping)
-                name = row_dict.get("ComicName", "")
-                if name:
-                    existing[normalize_title(name)] = row_dict["ComicID"]
-                sort_name = row_dict.get("ComicSortName", "")
-                if sort_name:
-                    existing[normalize_title(sort_name)] = row_dict["ComicID"]
-                dynamic_name = row_dict.get("DynamicName", "")
-                if dynamic_name:
-                    existing[normalize_title(dynamic_name)] = row_dict["ComicID"]
+                for name in (
+                    row_dict.get("ComicName", ""),
+                    row_dict.get("ComicSortName", ""),
+                    row_dict.get("DynamicName", ""),
+                ):
+                    normalized_name = normalize_title(name) if name else ""
+                    if not normalized_name:
+                        continue
+                    candidates = existing.setdefault(normalized_name, [])
+                    if not any(candidate["ComicID"] == row_dict["ComicID"] for candidate in candidates):
+                        candidates.append(row_dict)
     except Exception as e:
         logger.error("[COMIC-SCAN] Error loading existing series: %s" % e)
     return existing
+
+
+def _split_trailing_year(series_name):
+    """Return a folder's display title and optional trailing series year."""
+    match = re.match(r"^(?P<title>.+?)\s*\((?P<year>\d{4})\)\s*$", series_name)
+    if not match:
+        return series_name, None
+    return match.group("title").strip(), match.group("year")
+
+
+def _find_existing_series(series_name, existing_series):
+    """Return one unambiguous existing series for a scanned folder name."""
+    title, folder_year = _split_trailing_year(series_name)
+    candidates = existing_series.get(normalize_title(title), [])
+    if folder_year:
+        candidates = [candidate for candidate in candidates if str(candidate.get("ComicYear") or "") == folder_year]
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _series_directory(files):
+    """Return the scanned series directory shared by a group of files."""
+    if len(files) == 1:
+        return os.path.dirname(files[0])
+    return os.path.commonpath(files)
+
+
+def _reconcile_existing_series(existing_series, files):
+    """Point an existing series at scanned files, then reuse the issue rescan."""
+    comic_id = existing_series["ComicID"]
+    scanned_location = _series_directory(files)
+    previous_location = existing_series.get("ComicLocation")
+    changed_location = os.path.normcase(os.path.normpath(str(previous_location or ""))) != os.path.normcase(
+        os.path.normpath(scanned_location)
+    )
+
+    if changed_location:
+        db.upsert("comics", {"ComicLocation": scanned_location}, {"ComicID": comic_id})
+
+    try:
+        updater.forceRescan(comic_id)
+    except Exception:
+        if changed_location:
+            db.upsert("comics", {"ComicLocation": previous_location}, {"ComicID": comic_id})
+        raise
 
 
 def _match_series(series_name, files, existing_series):
@@ -249,11 +304,13 @@ def _match_series(series_name, files, existing_series):
     }
 
     # Check if series already exists in library
-    normalized = normalize_title(series_name)
-    if normalized in existing_series:
+    existing = _find_existing_series(series_name, existing_series)
+    if existing:
+        _reconcile_existing_series(existing, files)
         result["already_in_library"] = True
-        result["existing_comic_id"] = existing_series[normalized]
-        logger.info("[COMIC-SCAN] Series '%s' already in library" % series_name)
+        result["existing_comic_id"] = existing["ComicID"]
+        result["reconciled"] = True
+        logger.info("[COMIC-SCAN] Reconciled existing series '%s'" % series_name)
         return result
 
     # Search ComicVine

--- a/frontend/src/components/import/LibraryScanResults.tsx
+++ b/frontend/src/components/import/LibraryScanResults.tsx
@@ -24,6 +24,7 @@ export default function LibraryScanResults({
   const matchedResults = results.filter(
     (r) => r.matched && r.match?.comicid && !r.already_in_library,
   );
+  const reconciledResults = results.filter((r) => r.reconciled);
   const [selectedIds, setSelectedIds] = useState<string[]>(
     matchedResults.map((r) => r.match!.comicid),
   );
@@ -57,6 +58,11 @@ export default function LibraryScanResults({
       <div className="rounded-lg border border-border bg-muted/50 p-6 text-center text-muted-foreground">
         No new series found in directory. All series are already in your
         library.
+        {reconciledResults.length > 0 && (
+          <span className="block mt-1 text-foreground">
+            Reconciled {reconciledResults.length} existing {type} series.
+          </span>
+        )}
       </div>
     );
   }
@@ -67,6 +73,11 @@ export default function LibraryScanResults({
         <div className="text-sm text-muted-foreground">
           {matchedResults.length} matched of {importableResults.length} series
           found
+          {reconciledResults.length > 0 && (
+            <span className="ml-2">
+              {reconciledResults.length} existing {type} series reconciled
+            </span>
+          )}
           {selectedIds.length > 0 && (
             <span className="ml-2 font-medium text-foreground">
               ({selectedIds.length} selected)

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -486,6 +486,7 @@ export interface ScanResult {
   file_count: number;
   matched: boolean;
   already_in_library?: boolean;
+  reconciled?: boolean;
   existing_comic_id?: string;
   match?: ScanResultMatch | null;
   error?: string;
@@ -498,6 +499,7 @@ export interface ScanProgress {
     processed_files: number;
     series_found: number;
     series_matched: number;
+    series_reconciled?: number;
     current_series: string | null;
     errors: string[];
   };

--- a/frontend/tests/pages/ImportPage.test.tsx
+++ b/frontend/tests/pages/ImportPage.test.tsx
@@ -97,6 +97,43 @@ describe("ImportPage", () => {
     );
   });
 
+  it("shows when an existing comic series was reconciled from disk", async () => {
+    server.use(
+      http.get("/api/import", () =>
+        HttpResponse.json({
+          imports: [],
+          pagination: { total: 0, limit: 50, offset: 0, has_more: false },
+          summary: { group_count: 0, file_count: 0 },
+        }),
+      ),
+      http.get("/api/import/comic/progress", () =>
+        HttpResponse.json({
+          status: "completed",
+          progress: { series_reconciled: 1 },
+          scan_id: "scan-1",
+          results: [
+            {
+              series_name: "Absolute Batman (2024)",
+              file_count: 22,
+              matched: false,
+              already_in_library: true,
+              reconciled: true,
+              existing_comic_id: "160294",
+              match: null,
+            },
+          ],
+        }),
+      ),
+    );
+
+    render(<ImportPage />);
+
+    expect(await screen.findByText(/No new series found in directory/)).toBeTruthy();
+    expect(
+      screen.getByText("Reconciled 1 existing comic series."),
+    ).toBeTruthy();
+  });
+
   it("clears imported manga results and keeps a durable success summary", async () => {
     let scanStarted = false;
     let confirmed = false;

--- a/tests/unit/test_comicsync.py
+++ b/tests/unit/test_comicsync.py
@@ -5,7 +5,6 @@ Tests cover directory walking, series matching against ComicVine,
 scan-then-select flow, and concurrent scan prevention.
 """
 
-import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -42,6 +41,7 @@ def comicsync():
         "processed_files": 0,
         "series_found": 0,
         "series_matched": 0,
+        "series_reconciled": 0,
         "current_series": None,
         "errors": [],
     }
@@ -156,6 +156,164 @@ class TestNameSimilarity:
 class TestComicScan:
     """Tests for the main comicScan function."""
 
+    def test_reconciles_existing_series_matched_by_folder_year(self, comicsync):
+        existing_series = {
+            "absolute batman": [
+                {
+                    "ComicID": "45678",
+                    "ComicName": "Absolute Batman",
+                    "ComicYear": "2024",
+                    "ComicLocation": "/old-library/Absolute Batman",
+                }
+            ]
+        }
+
+        with (
+            patch.object(
+                comicsync,
+                "_series_directory",
+                return_value="/comics/Absolute Batman (2024)",
+            ),
+            patch.object(comicsync.db, "upsert") as upsert,
+            patch.object(comicsync.updater, "forceRescan") as force_rescan,
+            patch("comicarr.mb.findComic") as find_comic,
+        ):
+            result = comicsync._match_series(
+                "Absolute Batman (2024)",
+                ["/comics/Absolute Batman (2024)/Absolute Batman 1.cbz"],
+                existing_series,
+            )
+
+        assert result["already_in_library"] is True
+        assert result["reconciled"] is True
+        assert result["existing_comic_id"] == "45678"
+        upsert.assert_called_once_with(
+            "comics",
+            {"ComicLocation": "/comics/Absolute Batman (2024)"},
+            {"ComicID": "45678"},
+        )
+        force_rescan.assert_called_once_with("45678")
+        find_comic.assert_not_called()
+
+    def test_scan_reports_reconciled_existing_series(self, comicsync):
+        existing_series = {
+            "absolute batman": [
+                {
+                    "ComicID": "45678",
+                    "ComicName": "Absolute Batman",
+                    "ComicYear": "2024",
+                    "ComicLocation": "/old-library/Absolute Batman",
+                }
+            ]
+        }
+
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch.object(
+                comicsync,
+                "_collect_series_files",
+                return_value={"Absolute Batman (2024)": ["/comics/Absolute Batman (2024)/Absolute Batman 1.cbz"]},
+            ),
+            patch.object(comicsync, "_load_existing_series", return_value=existing_series),
+            patch.object(
+                comicsync,
+                "_series_directory",
+                return_value="/comics/Absolute Batman (2024)",
+            ),
+            patch.object(comicsync.db, "upsert"),
+            patch.object(comicsync.updater, "forceRescan"),
+        ):
+            result = comicsync.comicScan("/comics")
+
+        assert result["series_reconciled"] == 1
+        assert comicsync.COMIC_SCAN_PROGRESS["series_reconciled"] == 1
+        assert result["scan_results"][0]["reconciled"] is True
+
+    def test_existing_reconciliation_skips_unchanged_location(self, comicsync):
+        existing_series = {
+            "absolute batman": [
+                {
+                    "ComicID": "45678",
+                    "ComicName": "Absolute Batman",
+                    "ComicYear": "2024",
+                    "ComicLocation": "/comics/Absolute Batman (2024)/",
+                }
+            ]
+        }
+
+        with (
+            patch.object(
+                comicsync,
+                "_series_directory",
+                return_value="/comics/Absolute Batman (2024)",
+            ),
+            patch.object(comicsync.db, "upsert") as upsert,
+            patch.object(comicsync.updater, "forceRescan") as force_rescan,
+        ):
+            result = comicsync._match_series(
+                "Absolute Batman (2024)",
+                ["/comics/Absolute Batman (2024)/Absolute Batman 1.cbz"],
+                existing_series,
+            )
+
+        assert result["reconciled"] is True
+        upsert.assert_not_called()
+        force_rescan.assert_called_once_with("45678")
+
+    def test_existing_reconciliation_restores_location_after_rescan_failure(self, comicsync):
+        existing = {
+            "ComicID": "45678",
+            "ComicName": "Absolute Batman",
+            "ComicYear": "2024",
+            "ComicLocation": "/old-library/Absolute Batman",
+        }
+
+        with (
+            patch.object(
+                comicsync,
+                "_series_directory",
+                return_value="/comics/Absolute Batman (2024)",
+            ),
+            patch.object(comicsync.db, "upsert") as upsert,
+            patch.object(
+                comicsync.updater,
+                "forceRescan",
+                side_effect=RuntimeError("rescan failed"),
+            ),
+            pytest.raises(RuntimeError, match="rescan failed"),
+        ):
+            comicsync._reconcile_existing_series(
+                existing,
+                ["/comics/Absolute Batman (2024)/Absolute Batman 1.cbz"],
+            )
+
+        assert upsert.call_args_list == [
+            (("comics", {"ComicLocation": "/comics/Absolute Batman (2024)"}, {"ComicID": "45678"}), {}),
+            (("comics", {"ComicLocation": "/old-library/Absolute Batman"}, {"ComicID": "45678"}), {}),
+        ]
+
+    def test_does_not_reconcile_same_title_with_different_year(self, comicsync):
+        existing_series = {
+            "absolute batman": [
+                {
+                    "ComicID": "45678",
+                    "ComicName": "Absolute Batman",
+                    "ComicYear": "2025",
+                    "ComicLocation": "/comics/Absolute Batman (2025)",
+                }
+            ]
+        }
+
+        with patch("comicarr.mb.findComic", return_value={"results": []}) as find_comic:
+            result = comicsync._match_series(
+                "Absolute Batman (2024)",
+                ["/comics/Absolute Batman (2024)/Absolute Batman 1.cbz"],
+                existing_series,
+            )
+
+        assert result["already_in_library"] is False
+        find_comic.assert_called_once()
+
     def test_happy_path_matches_series(self, comicsync, _mock_globals):
         mock_engine = MagicMock()
         mock_conn = MagicMock()
@@ -181,9 +339,13 @@ class TestComicScan:
 
         with (
             patch("os.path.isdir", return_value=True),
-            patch.object(comicsync, "_collect_series_files", return_value={
-                "Batman": ["/comics/Batman/001.cbz", "/comics/Batman/002.cbz"],
-            }),
+            patch.object(
+                comicsync,
+                "_collect_series_files",
+                return_value={
+                    "Batman": ["/comics/Batman/001.cbz", "/comics/Batman/002.cbz"],
+                },
+            ),
             patch("comicarr.mb.findComic", return_value=cv_results),
         ):
             result = comicsync.comicScan("/comics")
@@ -216,9 +378,13 @@ class TestComicScan:
 
         with (
             patch("os.path.isdir", return_value=True),
-            patch.object(comicsync, "_collect_series_files", return_value={
-                "Batman": ["/comics/Batman/001.cbz"],
-            }),
+            patch.object(
+                comicsync,
+                "_collect_series_files",
+                return_value={
+                    "Batman": ["/comics/Batman/001.cbz"],
+                },
+            ),
             patch("comicarr.mb.findComic", side_effect=Exception("API unreachable")),
         ):
             result = comicsync.comicScan("/comics")


### PR DESCRIPTION
## Summary

Library scans now repair an existing comic series instead of presenting its files as an import candidate. A folder such as `Absolute Batman (2024)` is matched to its existing title and year, its verified library path is updated, and the normal issue rescan recalculates ownership without creating a duplicate series.

The Import page now reports how many existing comic series were reconciled. Ambiguous same-title entries and year mismatches remain unmatched rather than being assigned to the wrong volume.

## Validation

- `uv run pytest tests/unit -q -o addopts=""` (1,281 passed)
- `uv run ruff check comicarr/` and `uv run ruff format --check comicarr/`
- `npm run test:run` (104 passed; test harness emitted existing localhost connection warnings)
- `npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm run build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
