### PR TITLE
fix: index existing comics during library scans

### DIFF
--- a/.changeset/friendly-comics-reconcile.md
+++ b/.changeset/friendly-comics-reconcile.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix library scans so existing comic series are reconciled instead of reported as unmatched.

--- a/comicarr/comicsync.py
+++ b/comicarr/comicsync.py
@@ -29,7 +29,7 @@ import re
 import threading
 import time
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 import comicarr
 from comicarr import db, logger, updater
@@ -222,16 +222,16 @@ def _load_existing_series():
                 comics.c.ComicID,
                 comics.c.ComicName,
                 comics.c.ComicSortName,
-                comics.c.DynamicName,
+                comics.c.DynamicComicName,
                 comics.c.ComicYear,
                 comics.c.ComicLocation,
-            ).where(comics.c.ContentType != "manga")
+            ).where(or_(comics.c.ContentType.is_(None), comics.c.ContentType != "manga"))
             for row in conn.execute(stmt):
                 row_dict = dict(row._mapping)
                 for name in (
                     row_dict.get("ComicName", ""),
                     row_dict.get("ComicSortName", ""),
-                    row_dict.get("DynamicName", ""),
+                    row_dict.get("DynamicComicName", ""),
                 ):
                     normalized_name = normalize_title(name) if name else ""
                     if not normalized_name:

--- a/tests/unit/test_comicsync.py
+++ b/tests/unit/test_comicsync.py
@@ -8,6 +8,7 @@ scan-then-select flow, and concurrent scan prevention.
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy import create_engine
 
 
 @pytest.fixture(autouse=True)
@@ -155,6 +156,26 @@ class TestNameSimilarity:
 
 class TestComicScan:
     """Tests for the main comicScan function."""
+
+    def test_load_existing_series_indexes_legacy_comic_dynamic_name(self, comicsync, _mock_globals):
+        engine = create_engine("sqlite://")
+        comicsync.comics.create(engine)
+        row = {
+            "ComicID": "45678",
+            "ComicName": "Absolute Batman",
+            "ComicSortName": "Absolute Batman",
+            "DynamicComicName": "absolutebatman",
+            "ComicYear": "2024",
+            "ComicLocation": "/comics/Absolute Batman (2024)",
+            "ContentType": None,
+        }
+        with engine.begin() as conn:
+            conn.execute(comicsync.comics.insert(), row)
+        _mock_globals["db"].get_engine.return_value = engine
+
+        result = comicsync._load_existing_series()
+
+        assert result["absolute batman"][0]["ComicID"] == row["ComicID"]
 
     def test_reconciles_existing_series_matched_by_folder_year(self, comicsync):
         existing_series = {

--- a/tests/unit/test_comicsync.py
+++ b/tests/unit/test_comicsync.py
@@ -162,8 +162,8 @@ class TestComicScan:
         comicsync.comics.create(engine)
         row = {
             "ComicID": "45678",
-            "ComicName": "Absolute Batman",
-            "ComicSortName": "Absolute Batman",
+            "ComicName": "Different Series",
+            "ComicSortName": "Different Series",
             "DynamicComicName": "absolutebatman",
             "ComicYear": "2024",
             "ComicLocation": "/comics/Absolute Batman (2024)",
@@ -175,7 +175,8 @@ class TestComicScan:
 
         result = comicsync._load_existing_series()
 
-        assert result["absolute batman"][0]["ComicID"] == row["ComicID"]
+        assert result["different series"][0]["ComicID"] == row["ComicID"]
+        assert result["absolutebatman"][0]["ComicID"] == row["ComicID"]
 
     def test_reconciles_existing_series_matched_by_folder_year(self, comicsync):
         existing_series = {


### PR DESCRIPTION
## Summary

Existing comic folders no longer remain "No match" merely because their stored series uses the normal `DynamicComicName` column or a legacy `NULL` content type. A library scan can now find that existing record and run reconciliation instead of prompting for a duplicate import.

## Validation

- `uv run pytest tests/unit -q` (1,286 passed)
- `PATH="$PWD/.venv/bin:$PATH" npm run lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comic series matching when dynamic comic names are available.
  * Corrected loading of legacy comic records, including entries with unspecified content types.
* **Tests**
  * Added coverage to verify dynamic comic names are correctly recognized during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->