### PR TITLE
fix(scan): reconcile issue files and sort matches

### DIFF
--- a/.changeset/quiet-hounds-greet.md
+++ b/.changeset/quiet-hounds-greet.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix library scan reconciliation so detected files are recorded on their issues, and sort matched scan results before unmatched folders.

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -1642,7 +1642,7 @@ def _bulk_update_issue_rows(table, rows, fields):
 
     params = [
         {
-            **{key: value for key, value in row.items() if key != "IssueID"},
+            **{f"_value_{field}": row[field] for field in fields},
             "_issue_id": row["IssueID"],
         }
         for row in rows
@@ -1650,7 +1650,7 @@ def _bulk_update_issue_rows(table, rows, fields):
     stmt = (
         update(table)
         .where(table.c.IssueID == bindparam("_issue_id"))
-        .values(**{field: bindparam(field) for field in fields})
+        .values(**{field: bindparam(f"_value_{field}") for field in fields})
     )
     with db.get_engine().begin() as conn:
         conn.execute(stmt, params)

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -1635,6 +1635,27 @@ def foundsearch(
     return
 
 
+def _bulk_update_issue_rows(table, rows, fields):
+    """Persist issue updates without colliding with SQLAlchemy's SET bind names."""
+    if not rows:
+        return
+
+    params = [
+        {
+            **{key: value for key, value in row.items() if key != "IssueID"},
+            "_issue_id": row["IssueID"],
+        }
+        for row in rows
+    ]
+    stmt = (
+        update(table)
+        .where(table.c.IssueID == bindparam("_issue_id"))
+        .values(**{field: bindparam(field) for field in fields})
+    )
+    with db.get_engine().begin() as conn:
+        conn.execute(stmt, params)
+
+
 def forceRescan(ComicID, archive=None, module=None, recheck=False):
     if module is None:
         module = ""
@@ -2498,34 +2519,8 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
     logger.fdebug("[haves] issue_status_generation took %s" % (datetime.datetime.now() - a_start))
 
     b_start = datetime.datetime.now()
-    try:
-        # Batch update issues using SQLAlchemy Core conn.execute(stmt, list_of_dicts)
-        if d_issues:
-            stmt = (
-                update(issues)
-                .where(issues.c.IssueID == bindparam("IssueID"))
-                .values(
-                    Status=bindparam("Status"),
-                    ComicSize=bindparam("ComicSize"),
-                    Location=bindparam("Location"),
-                )
-            )
-            with db.get_engine().begin() as conn:
-                conn.execute(stmt, d_issues)
-        if d_annuals:
-            stmt = (
-                update(annuals)
-                .where(annuals.c.IssueID == bindparam("IssueID"))
-                .values(
-                    Status=bindparam("Status"),
-                    ComicSize=bindparam("ComicSize"),
-                    Location=bindparam("Location"),
-                )
-            )
-            with db.get_engine().begin() as conn:
-                conn.execute(stmt, d_annuals)
-    except Exception as e:
-        logger.warn("Error updating: %s" % e)
+    _bulk_update_issue_rows(issues, d_issues, ("Status", "ComicSize", "Location"))
+    _bulk_update_issue_rows(annuals, d_annuals, ("Status", "ComicSize", "Location"))
     logger.fdebug("[haves] issue_status_writing took %s" % (datetime.datetime.now() - b_start))
 
     # if this far, forced_file is true and the file didn't parse properly due to w/e reason, we need to force the filename to link to the given issueid.
@@ -2636,19 +2631,8 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
 
     if any([len(update_iss) > 0, len(update_ann) > 0]):
         r_start = datetime.datetime.now()
-        try:
-            if len(update_iss) > 0:
-                stmt = update(issues).where(issues.c.IssueID == bindparam("IssueID")).values(Status=bindparam("Status"))
-                with db.get_engine().begin() as conn:
-                    conn.execute(stmt, update_iss)
-            if len(update_ann) > 0:
-                stmt = (
-                    update(annuals).where(annuals.c.IssueID == bindparam("IssueID")).values(Status=bindparam("Status"))
-                )
-                with db.get_engine().begin() as conn:
-                    conn.execute(stmt, update_ann)
-        except Exception as e:
-            logger.warn("Error updating: %s" % e)
+        _bulk_update_issue_rows(issues, update_iss, ("Status",))
+        _bulk_update_issue_rows(annuals, update_ann, ("Status",))
         logger.fdebug("[nothaves] issue_status_writing took %s" % (datetime.datetime.now() - r_start))
         logger.info(
             "%s Updated the status of %s issues for %s (%s) that were not found."

--- a/frontend/src/components/import/LibraryScanResults.tsx
+++ b/frontend/src/components/import/LibraryScanResults.tsx
@@ -51,7 +51,21 @@ export default function LibraryScanResults({
     setSelectedIds([]);
   };
 
-  const importableResults = results.filter((r) => !r.already_in_library);
+  const importableResults = results
+    .filter((r) => !r.already_in_library)
+    .sort((left, right) => {
+      const leftIsMatched = Boolean(left.matched && left.match?.comicid);
+      const rightIsMatched = Boolean(right.matched && right.match?.comicid);
+
+      if (leftIsMatched !== rightIsMatched) {
+        return leftIsMatched ? -1 : 1;
+      }
+
+      return left.series_name.localeCompare(right.series_name, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      });
+    });
 
   if (importableResults.length === 0) {
     return (

--- a/frontend/tests/pages/ImportPage.test.tsx
+++ b/frontend/tests/pages/ImportPage.test.tsx
@@ -134,6 +134,69 @@ describe("ImportPage", () => {
     ).toBeTruthy();
   });
 
+  it("puts matched scan candidates first and sorts each group alphabetically", async () => {
+    server.use(
+      http.get("/api/import", () =>
+        HttpResponse.json({
+          imports: [],
+          pagination: { page: 1, per_page: 100, total: 0, pages: 0 },
+          summary: { groups: 0, files: 0 },
+        }),
+      ),
+      http.get("/api/import/comic/progress", () =>
+        HttpResponse.json({
+          status: "completed",
+          progress: {},
+          scan_id: "scan-1",
+          results: [
+            { series_name: "Zeta Unmatched", file_count: 1, matched: false },
+            {
+              series_name: "Zeta Matched",
+              file_count: 1,
+              matched: true,
+              match: {
+                comicid: "2",
+                name: "Zeta Match Metadata",
+                confidence: 100,
+              },
+            },
+            { series_name: "Alpha Unmatched", file_count: 1, matched: false },
+            {
+              series_name: "Alpha Matched",
+              file_count: 1,
+              matched: true,
+              match: {
+                comicid: "1",
+                name: "Alpha Match Metadata",
+                confidence: 100,
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    render(<ImportPage />);
+
+    const alphaMatched = await screen.findByText("Alpha Matched");
+    const zetaMatched = screen.getByText("Zeta Matched");
+    const alphaUnmatched = screen.getByText("Alpha Unmatched");
+    const zetaUnmatched = screen.getByText("Zeta Unmatched");
+
+    expect(
+      alphaMatched.compareDocumentPosition(zetaMatched) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      zetaMatched.compareDocumentPosition(alphaUnmatched) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      alphaUnmatched.compareDocumentPosition(zetaUnmatched) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("clears imported manga results and keeps a durable success summary", async () => {
     let scanStarted = false;
     let confirmed = false;

--- a/frontend/tests/pages/ImportPage.test.tsx
+++ b/frontend/tests/pages/ImportPage.test.tsx
@@ -139,8 +139,13 @@ describe("ImportPage", () => {
       http.get("/api/import", () =>
         HttpResponse.json({
           imports: [],
-          pagination: { page: 1, per_page: 100, total: 0, pages: 0 },
-          summary: { groups: 0, files: 0 },
+          pagination: {
+            total: 0,
+            limit: 50,
+            offset: 0,
+            has_more: false,
+          },
+          summary: { group_count: 0, file_count: 0 },
         }),
       ),
       http.get("/api/import/comic/progress", () =>

--- a/tests/unit/test_updater_watchlist.py
+++ b/tests/unit/test_updater_watchlist.py
@@ -13,13 +13,14 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, call
 
 import pytest
+from sqlalchemy import create_engine, select
 
 import comicarr
 from comicarr import importer, updater
 from comicarr.app.acquisition.maintenance import MaintenanceBlocked, MaintenanceController, ensure_acquisition_schema
 from comicarr.app.acquisition.runs import RunLedger
 from comicarr.db import get_engine, shutdown_engine
-from comicarr.tables import metadata
+from comicarr.tables import issues, metadata
 
 
 class _LeaseContext:
@@ -36,6 +37,34 @@ class _OpenMaintenance:
 
     def assert_lease_current(self, _lease):
         return True
+
+
+def test_bulk_issue_update_persists_issue_location(monkeypatch):
+    engine = create_engine("sqlite://")
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(issues.insert(), {"IssueID": "issue-1", "Status": "Wanted"})
+
+    monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+
+    updater._bulk_update_issue_rows(
+        issues,
+        [
+            {
+                "IssueID": "issue-1",
+                "Status": "Downloaded",
+                "ComicSize": "123",
+                "Location": "Absolute Batman 001.cbz",
+            }
+        ],
+        ("Status", "ComicSize", "Location"),
+    )
+
+    with engine.connect() as conn:
+        row = conn.execute(select(issues).where(issues.c.IssueID == "issue-1")).mappings().one()
+
+    assert row["Status"] == "Downloaded"
+    assert row["Location"] == "Absolute Batman 001.cbz"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

A repeat scan can now repair the state where a series says 22/22 in the library list but 0/22 on its detail page: discovered files are persisted on their issue rows so strict ownership verification can recognize them. Reconciliation failures now surface instead of silently leaving misleading totals. Scan candidates are also ordered for actionability, with selectable matches first and alphabetical order within each group.

## Validation

- `uv run pytest tests/unit -v` (1,287 passed)
- `cd frontend && npm run test:run -- --run tests/pages/ImportPage.test.tsx` (9 passed)
- `cd frontend && npm run typecheck && npm run lint && npm run format:check && npm run build`
- `uv run ruff check comicarr/updater.py tests/unit/test_updater_watchlist.py`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Library scans now correctly associate detected files with their issues.
  * Scan results display matched items before unmatched folders.
  * Results are sorted naturally by series name within each group.
  * Bulk issue updates now reliably save status, size, and location changes.

* **Tests**
  * Added coverage for scan result ordering and issue update persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->