### PR TITLE
refactor: remove orphaned WebInterface runtime paths

### DIFF
--- a/Comicarr.py
+++ b/Comicarr.py
@@ -239,6 +239,7 @@ from comicarr import (  # noqa: E402
     maintenance,
     versioncheck,
 )
+from comicarr.app.core.pidfile import check_stale_pidfile  # noqa: E402
 
 if sys.platform == "win32" and sys.executable.split("\\")[-1] == "pythonw.exe":
     sys.stdout = open(os.devnull, "w")
@@ -252,41 +253,6 @@ def handler_sigterm(signum, frame):
     # 'maintenance' intent, degrading a restart to a plain stop.
     if not comicarr.SIGNAL:
         comicarr.SIGNAL = "shutdown"
-
-
-def check_stale_pidfile(pidfile):
-    """Return True if pidfile doesn't hold a numeric value, or it
-    does, but it doesn't correspond with a valid currently used PID.
-    Only supports linux /proc fs way of getting cmdlinee by PID.
-    Returns:  Unsupported, assume it's not stale (False)
-              pidfile contents aren't numeric, return True
-              On linux, if the /proc/{pid}/cmdline file doesn't
-              exist: True (this is definitive)
-              Otherwise return True if python isn't in the cmdline
-    """
-
-    if sys.platform != "linux" or not os.path.exists("/proc"):
-        return False
-
-    with open(pidfile, "rt", encoding="utf-8") as fd:
-        sval = fd.read()
-
-    if not sval.isdigit():
-        return True
-
-    checkpid = int(sval, 10)
-    cmdlinepath = f"/proc/{checkpid}/cmdline"
-    if not os.path.exists(cmdlinepath):
-        return True
-
-    # We'll simplify the check here and only verify that the word python is part
-    # of the commandline
-
-    with open(cmdlinepath, "rt", encoding="utf-8") as fd:
-        cmdline = fd.read().replace("\0")
-
-    # If pytohn is in the cmdline, then we assume it's not stale.
-    return "python" not in cmdline
 
 
 def main():

--- a/comicarr/app/core/middleware.py
+++ b/comicarr/app/core/middleware.py
@@ -10,9 +10,8 @@
 """
 FastAPI middleware — CSRF protection, security headers, setup gate.
 
-CSRF is a global middleware (not per-route) so it's impossible to forget
-when adding new routes. During transition, CherryPy's tools.csrf is
-disabled under the WSGI bridge to avoid double-checking.
+CSRF is global middleware (not per-route), so it is impossible to forget
+when adding new routes.
 """
 
 from starlette.middleware.base import BaseHTTPMiddleware

--- a/comicarr/app/core/pidfile.py
+++ b/comicarr/app/core/pidfile.py
@@ -1,0 +1,50 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Small, import-safe helpers for Comicarr's PID-file lifecycle."""
+
+import sys
+from pathlib import Path
+
+
+def check_stale_pidfile(pidfile, *, platform_name=None, proc_root="/proc"):
+    """Return whether a Linux PID file is stale without starting Comicarr.
+
+    Unsupported platforms deliberately return ``False`` because there is no
+    portable process-command-line check with the same certainty as Linux
+    ``/proc``. A numeric PID whose command line does not mention Python is
+    treated as stale so a non-Comicarr process cannot hold the PID file.
+    """
+    platform_name = platform_name or sys.platform
+    proc_root = Path(proc_root)
+    if platform_name != "linux" or not proc_root.exists():
+        return False
+
+    try:
+        value = Path(pidfile).read_text(encoding="utf-8").strip()
+    except OSError:
+        # An unreadable file may belong to a live instance started by another
+        # user. Failing closed avoids deleting its PID-file lock.
+        return False
+
+    if not value.isdigit():
+        return True
+
+    cmdline_path = proc_root / value / "cmdline"
+    if not cmdline_path.exists():
+        return True
+
+    try:
+        cmdline = cmdline_path.read_text(encoding="utf-8", errors="replace").replace("\0", " ")
+    except OSError:
+        # A live process can transiently deny or fail the inspection.  Only a
+        # missing cmdline path is proof that this PID is no longer valid.
+        return False
+
+    return "python" not in cmdline.lower()

--- a/comicarr/app/core/security.py
+++ b/comicarr/app/core/security.py
@@ -102,7 +102,7 @@ def create_session_token(username, secret_key, generation, login_timeout=43800):
 
 
 def validate_jwt_token(token, secret_key, current_generation):
-    """Single validation function shared by FastAPI AND CherryPy shim.
+    """Validate a JWT session token for the FastAPI application.
 
     Returns the username on success, None on failure.
     """

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -115,7 +115,7 @@ def force_process(
     """Queue a download for post-processing.
 
     For standard API calls, queues to PP_QUEUE for background processing.
-    For ComicRN/APC compatibility, calls WebInterface.post_process directly.
+    ComicRN/APC compatibility runs the post-processor directly.
     """
     if apc_version is not None:
         # ComicRN/APC compatibility mode — direct processing

--- a/comicarr/app/search/commands.py
+++ b/comicarr/app/search/commands.py
@@ -218,6 +218,39 @@ def enqueue_search_command(
     return command
 
 
+def enqueue_failed_download_retry(
+    failure,
+    *,
+    work_queue=None,
+    ledger=None,
+    run_id=None,
+    maintenance=None,
+):
+    """Persist and dispatch a manual retry from legacy failed-download data."""
+    if not isinstance(failure, Mapping):
+        raise SearchCommandError("Failed-download retry must be an object")
+
+    values = {str(key).lower(): value for key, value in failure.items()}
+    entity_type = "annual" if str(values.get("annchk", "no")).strip().lower() != "no" else "issue"
+    return enqueue_search_command(
+        {
+            "issueid": values.get("issueid"),
+            "comicid": values.get("comicid"),
+            "comicname": values.get("comicname"),
+            "issuenumber": values.get("issuenumber"),
+            "manual": True,
+            "entity_type": entity_type,
+        },
+        trigger="failed_download_retry",
+        work_queue=work_queue,
+        ledger=ledger,
+        run_id=run_id,
+        maintenance=maintenance,
+        scope_type=entity_type,
+        scope_id=values.get("issueid"),
+    )
+
+
 def _put_with_maintenance_lease(command, work_queue, maintenance=None):
     from comicarr.app.acquisition.maintenance import MaintenanceController
 

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -44,7 +44,7 @@ from comicarr.app.common.dates import normalize_utc_datetime
 from comicarr.app.core.security import LoginRateLimiter
 from comicarr.tables import comics, jobhistory, storyarcs
 
-# Shared rate limiter instance (same object used by CherryPy and FastAPI)
+# Shared rate limiter instance for authentication endpoints.
 _rate_limiter = LoginRateLimiter()
 _fallback_weekly_refresh_lock = threading.Lock()
 

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -162,7 +162,6 @@ _CONFIG_DEFINITIONS = OrderedDict(
         "AUTHENTICATION": (int, "Interface", 2),
         "LOGIN_TIMEOUT": (int, "Interface", 43800),
         "ALPHAINDEX": (bool, "Interface", True),
-        "CHERRYPY_LOGGING": (bool, "Interface", False),
         "API_ENABLED": (bool, "API", False),
         "API_KEY": (str, "API", None),
         "CALENDAR_DEFAULT_DAYS": (int, "API", 90),

--- a/comicarr/logger.py
+++ b/comicarr/logger.py
@@ -236,8 +236,6 @@ else:
         logging.getLogger("apscheduler.threadpool").setLevel(logging.WARN)
         logging.getLogger("apscheduler.scheduler").propagate = False
         logging.getLogger("apscheduler.threadpool").propagate = False
-        logging.getLogger("cherrypy").propagate = False
-
         # Close and remove old handlers. This is required to reinit the loggers
         # at runtime
         for handler in logger.handlers[:]:
@@ -357,3 +355,26 @@ else:
     message = logger.info
     exception = logger.exception
     fdebug = logger.debug
+
+
+def configure_log_level(level):
+    """Reconfigure application logging without depending on a web controller."""
+    if level is None:
+        level = 1
+    comicarr.LOG_LEVEL = level
+    if LOG_LANG.startswith("en"):
+        initLogger(
+            console=comicarr.QUIET if level == 0 else not comicarr.QUIET,
+            log_dir=comicarr.CONFIG.LOG_DIR,
+            max_logsize=comicarr.CONFIG.MAX_LOGSIZE,
+            max_logfiles=comicarr.CONFIG.MAX_LOGFILES,
+            loglevel=level,
+        )
+    else:
+        comicarr_log.stopLogger()
+        comicarr_log.initLogger(
+            loglevel=level,
+            log_dir=comicarr.CONFIG.LOG_DIR,
+            max_logsize=comicarr.CONFIG.MAX_LOGSIZE,
+            max_logfiles=comicarr.CONFIG.MAX_LOGFILES,
+        )

--- a/comicarr/maintenance.py
+++ b/comicarr/maintenance.py
@@ -506,9 +506,8 @@ class Maintenance(object):
             self.sql_close_db()
 
     def toggle_logging(self, level):
-        # force set logging to warning level only so the progress indicator can be displayed in console
-        wc = comicarr.webserve.WebInterface()
-        wc.toggleVerbose(level=level)
+        """Temporarily reconfigure logging for maintenance progress output."""
+        logger.configure_log_level(level)
 
     def backup_files(self, cfg=False, dbs=False, backupinfo=None):
         cfgloop = []

--- a/comicarr/process.py
+++ b/comicarr/process.py
@@ -85,10 +85,6 @@ class Process(object):
                 while True:
                     if chk[0]["mode"] == "fail":
                         logger.info("Initiating Failed Download handling")
-                        if chk[0]["annchk"] == "no":
-                            mode = "want"
-                        else:
-                            mode = "want_ann"
                         self.failed = True
                         break
                     elif chk[0]["mode"] == "stop":
@@ -113,19 +109,9 @@ class Process(object):
                 failchk = ppqueue.get()
                 if failchk[0]["mode"] == "retry":
                     logger.info("Attempting to return to search module with " + str(failchk[0]["issueid"]))
-                    if failchk[0]["annchk"] == "no":
-                        mode = "want"
-                    else:
-                        mode = "want_ann"
-                    qq = comicarr.webserve.WebInterface()
-                    qq.queueit(
-                        mode=mode,
-                        ComicName=failchk[0]["comicname"],
-                        ComicIssue=failchk[0]["issuenumber"],
-                        ComicID=failchk[0]["comicid"],
-                        IssueID=failchk[0]["issueid"],
-                        manualsearch=True,
-                    )
+                    from comicarr.app.search.commands import enqueue_failed_download_retry
+
+                    enqueue_failed_download_retry(failchk[0])
                 elif failchk[0]["mode"] == "stop":
                     pass
                 else:
@@ -140,10 +126,6 @@ class Process(object):
             while True:
                 if chk[0]["mode"] == "fail":
                     logger.info("Initiating Failed Download handling")
-                    if chk[0]["annchk"] == "no":
-                        mode = "want"
-                    else:
-                        mode = "want_ann"
                     self.failed = True
                     break
                 elif chk[0]["mode"] == "stop":

--- a/comicarr/sabnzbd.py
+++ b/comicarr/sabnzbd.py
@@ -419,21 +419,39 @@ class SABnzbd(object):
                     logger.warn("[Sabnzbd Completed History Removal] Unable to remove item from history..")
 
     def sab_versioncheck(self):
+        params = {"mode": "version", "output": "json", "apikey": comicarr.CONFIG.SAB_APIKEY}
         try:
-            sc = comicarr.webserve.WebInterface()
-            sab_check = sc.SABtest(
-                sabhost=comicarr.CONFIG.SAB_HOST,
-                sabusername=comicarr.CONFIG.SAB_USERNAME,
-                sabpassword=comicarr.CONFIG.SAB_PASSWORD,
-                sabapikey=comicarr.CONFIG.SAB_APIKEY,
+            response = requests.get(
+                self.sab_url,
+                params=params,
+                verify=comicarr.CONFIG.SAB_VERIFY,
+                timeout=30,
             )
         except Exception as e:
             logger.warn(
                 "[SABNZBD-VERSION-TEST] Exception encountered trying to retrieve SABnzbd version: %s. Setting history length to last 200 items."
                 % e
             )
-            sab_check = "some value"
-        else:
-            sab_check = None
+            return "some value"
 
-        return sab_check
+        if response.status_code != 200:
+            logger.warn(
+                "[SABNZBD-VERSION-TEST] SABnzbd version endpoint returned status %s. Setting history length to last 200 items."
+                % response.status_code
+            )
+            return "some value"
+
+        try:
+            payload = response.json()
+        except (TypeError, ValueError):
+            version = response.text.strip()
+        else:
+            version = payload.get("version") if isinstance(payload, dict) else response.text.strip()
+
+        if not version:
+            logger.warn("[SABNZBD-VERSION-TEST] SABnzbd returned no version. Setting history length to last 200 items.")
+            return "some value"
+
+        comicarr.CONFIG.SAB_VERSION = str(version)
+        logger.fdebug("[SABNZBD-VERSION-TEST] Detected SABnzbd version: %s" % comicarr.CONFIG.SAB_VERSION)
+        return None

--- a/tests/unit/test_orphaned_runtime_paths.py
+++ b/tests/unit/test_orphaned_runtime_paths.py
@@ -1,0 +1,187 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+import comicarr
+from comicarr import logger, maintenance, process, sabnzbd
+from comicarr.app.search import commands
+
+
+@pytest.mark.parametrize(
+    ("annchk", "entity_type"),
+    (("no", "issue"), ("yes", "annual")),
+)
+def test_failed_download_retry_uses_durable_search_command(monkeypatch, annchk, entity_type):
+    failure = {
+        "mode": "retry",
+        "annchk": annchk,
+        "issueid": "issue-1",
+        "comicid": "comic-1",
+        "comicname": "Saga",
+        "issuenumber": "1",
+    }
+    observed = []
+    legacy_queueit = MagicMock()
+
+    class FakeFailedProcessor:
+        def __init__(self, *, queue, **_kwargs):
+            self.queue = queue
+
+        def Process(self):
+            self.queue.put([failure])
+
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(FAILED_DOWNLOAD_HANDLING=True), raising=False)
+    monkeypatch.setattr(comicarr, "failed", SimpleNamespace(FailedProcessor=FakeFailedProcessor), raising=False)
+    monkeypatch.setattr(
+        comicarr,
+        "webserve",
+        SimpleNamespace(WebInterface=lambda: SimpleNamespace(queueit=legacy_queueit)),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        commands,
+        "enqueue_search_command",
+        lambda payload, **kwargs: observed.append((payload, kwargs)),
+        raising=False,
+    )
+
+    process.Process(
+        "Saga 001.cbz",
+        "/downloads/Saga",
+        failed=True,
+        download_info={"id": "nzo-1", "provider": "sabnzbd"},
+    ).post_process()
+
+    assert observed == [
+        (
+            {
+                "issueid": "issue-1",
+                "comicid": "comic-1",
+                "comicname": "Saga",
+                "issuenumber": "1",
+                "manual": True,
+                "entity_type": entity_type,
+            },
+            {
+                "trigger": "failed_download_retry",
+                "work_queue": None,
+                "ledger": None,
+                "run_id": None,
+                "maintenance": None,
+                "scope_type": entity_type,
+                "scope_id": "issue-1",
+            },
+        )
+    ]
+    legacy_queueit.assert_not_called()
+
+
+def test_sab_version_probe_sets_runtime_version_without_web_interface(monkeypatch):
+    config = SimpleNamespace(
+        SAB_HOST="https://sab.invalid",
+        SAB_APIKEY="secret",
+        SAB_VERIFY=True,
+        SAB_VERSION=None,
+        writeconfig=MagicMock(),
+    )
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"version": "4.4.1"}
+    monkeypatch.setattr(comicarr, "CONFIG", config, raising=False)
+    monkeypatch.setattr(sabnzbd.requests, "get", MagicMock(return_value=response))
+
+    result = sabnzbd.SABnzbd(params=None).sab_versioncheck()
+
+    assert result is None
+    assert config.SAB_VERSION == "4.4.1"
+    config.writeconfig.assert_not_called()
+    sabnzbd.requests.get.assert_called_once_with(
+        "https://sab.invalid/api",
+        params={"mode": "version", "output": "json", "apikey": "secret"},
+        verify=True,
+        timeout=30,
+    )
+
+
+def test_sab_version_probe_uses_plain_text_and_conservative_fallback(monkeypatch):
+    config = SimpleNamespace(
+        SAB_HOST="http://sab.invalid",
+        SAB_APIKEY="secret",
+        SAB_VERIFY=False,
+        SAB_VERSION=None,
+    )
+    text_response = MagicMock(status_code=200, text="4.3.0\n")
+    text_response.json.side_effect = ValueError("not json")
+    monkeypatch.setattr(comicarr, "CONFIG", config, raising=False)
+    monkeypatch.setattr(sabnzbd.requests, "get", MagicMock(return_value=text_response))
+
+    assert sabnzbd.SABnzbd(params=None).sab_versioncheck() is None
+    assert config.SAB_VERSION == "4.3.0"
+
+    config.SAB_VERSION = None
+    monkeypatch.setattr(sabnzbd.requests, "get", MagicMock(side_effect=requests.RequestException("offline")))
+
+    assert sabnzbd.SABnzbd(params=None).sab_versioncheck() == "some value"
+    assert config.SAB_VERSION is None
+
+    monkeypatch.setattr(sabnzbd.requests, "get", MagicMock(return_value=MagicMock(status_code=503)))
+
+    assert sabnzbd.SABnzbd(params=None).sab_versioncheck() == "some value"
+    assert config.SAB_VERSION is None
+
+    malformed_response = MagicMock(status_code=200, text="")
+    malformed_response.json.return_value = []
+    monkeypatch.setattr(sabnzbd.requests, "get", MagicMock(return_value=malformed_response))
+
+    assert sabnzbd.SABnzbd(params=None).sab_versioncheck() == "some value"
+    assert config.SAB_VERSION is None
+
+
+def test_maintenance_logging_uses_logger_boundary(monkeypatch):
+    calls = []
+    legacy_toggle = MagicMock()
+    monkeypatch.setattr(
+        comicarr,
+        "webserve",
+        SimpleNamespace(WebInterface=lambda: SimpleNamespace(toggleVerbose=legacy_toggle)),
+        raising=False,
+    )
+    monkeypatch.setattr(logger, "configure_log_level", lambda level: calls.append(level), raising=False)
+
+    instance = object.__new__(maintenance.Maintenance)
+    instance.toggle_logging(0)
+    instance.toggle_logging(2)
+
+    assert calls == [0, 2]
+    legacy_toggle.assert_not_called()
+
+
+def test_configure_log_level_preserves_quiet_console_behavior(monkeypatch):
+    calls = []
+    config = SimpleNamespace(LOG_DIR="/tmp/logs", MAX_LOGSIZE=1024, MAX_LOGFILES=3)
+    monkeypatch.setattr(comicarr, "CONFIG", config, raising=False)
+    monkeypatch.setattr(comicarr, "QUIET", False, raising=False)
+    monkeypatch.setattr(comicarr, "LOG_LEVEL", 1, raising=False)
+    monkeypatch.setattr(logger, "LOG_LANG", "en_US", raising=False)
+    monkeypatch.setattr(logger, "initLogger", lambda **kwargs: calls.append(kwargs), raising=False)
+
+    logger.configure_log_level(0)
+    logger.configure_log_level(1)
+    logger.configure_log_level(None)
+
+    assert comicarr.LOG_LEVEL == 1
+    assert calls == [
+        {"console": False, "log_dir": "/tmp/logs", "max_logsize": 1024, "max_logfiles": 3, "loglevel": 0},
+        {"console": True, "log_dir": "/tmp/logs", "max_logsize": 1024, "max_logfiles": 3, "loglevel": 1},
+        {"console": True, "log_dir": "/tmp/logs", "max_logsize": 1024, "max_logfiles": 3, "loglevel": 1},
+    ]

--- a/tests/unit/test_pidfile.py
+++ b/tests/unit/test_pidfile.py
@@ -1,0 +1,77 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+from pathlib import Path
+
+from comicarr.app.core.pidfile import check_stale_pidfile
+
+
+def test_pidfile_check_is_platform_safe_and_handles_nul_separated_cmdline(tmp_path):
+    pidfile = tmp_path / "comicarr.pid"
+    pidfile.write_text("123")
+    proc_root = tmp_path / "proc"
+    cmdline = proc_root / "123" / "cmdline"
+    cmdline.parent.mkdir(parents=True)
+    cmdline.write_bytes(b"/usr/bin/python3\x00Comicarr.py\x00")
+
+    assert check_stale_pidfile(pidfile, platform_name="darwin", proc_root=proc_root) is False
+    assert check_stale_pidfile(pidfile, platform_name="linux", proc_root=tmp_path / "missing-proc") is False
+    assert check_stale_pidfile(pidfile, platform_name="linux", proc_root=proc_root) is False
+
+
+def test_pidfile_check_detects_bad_pid_and_non_python_process(tmp_path):
+    pidfile = tmp_path / "comicarr.pid"
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+
+    pidfile.write_text("not-a-pid")
+    assert check_stale_pidfile(pidfile, platform_name="linux", proc_root=proc_root) is True
+
+    pidfile.write_text("456")
+    cmdline = proc_root / "456" / "cmdline"
+    cmdline.parent.mkdir(parents=True)
+    cmdline.write_text("/usr/bin/other\x00")
+
+    assert check_stale_pidfile(pidfile, platform_name="linux", proc_root=proc_root) is True
+
+
+def test_pidfile_check_keeps_pidfile_when_process_inspection_fails(tmp_path, monkeypatch):
+    pidfile = tmp_path / "comicarr.pid"
+    pidfile.write_text("789")
+    proc_root = tmp_path / "proc"
+    cmdline = proc_root / "789" / "cmdline"
+    cmdline.parent.mkdir(parents=True)
+    cmdline.write_text("/usr/bin/python3")
+    original_read_text = Path.read_text
+
+    def fail_only_for_cmdline(path, *args, **kwargs):
+        if path == cmdline:
+            raise PermissionError("inspection denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_only_for_cmdline)
+
+    assert check_stale_pidfile(pidfile, platform_name="linux", proc_root=proc_root) is False
+
+
+def test_pidfile_check_keeps_pidfile_when_pidfile_cannot_be_read(tmp_path, monkeypatch):
+    pidfile = tmp_path / "comicarr.pid"
+    pidfile.write_text("789")
+    proc_root = tmp_path / "proc"
+    proc_root.mkdir()
+    original_read_text = Path.read_text
+
+    def fail_only_for_pidfile(path, *args, **kwargs):
+        if path == pidfile:
+            raise PermissionError("pidfile denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_only_for_pidfile)
+
+    assert check_stale_pidfile(pidfile, platform_name="linux", proc_root=proc_root) is False

--- a/tests/unit/test_search_queue.py
+++ b/tests/unit/test_search_queue.py
@@ -23,6 +23,7 @@ from comicarr.app.acquisition.models import ItemOutcome
 from comicarr.app.acquisition.runs import RunLedger
 from comicarr.app.search import service
 from comicarr.app.search.commands import (
+    enqueue_failed_download_retry,
     enqueue_search_command,
     evaluate_search_candidate,
     replay_search_obligations,
@@ -219,6 +220,34 @@ def test_enqueue_persists_obligation_before_queue_handoff(acquisition_ledger):
 
     assert command.run_id == "search-run"
     assert acquisition_ledger.get_run("search-run")["accepted_count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("annchk", "issue_id", "entity_type"),
+    (("no", "issue-1", "issue"), ("yes", "annual-1", "annual")),
+)
+def test_failed_download_retry_persists_manual_command(acquisition_ledger, annchk, issue_id, entity_type):
+    work = queue.Queue()
+
+    command = enqueue_failed_download_retry(
+        {
+            "comicid": "comic-1",
+            "issueid": issue_id,
+            "comicname": "Saga",
+            "issuenumber": "1",
+            "annchk": annchk,
+        },
+        work_queue=work,
+        ledger=acquisition_ledger,
+        run_id="failed-download-retry",
+    )
+
+    queued = work.get_nowait()
+    assert command.entity_type == entity_type
+    assert command.manual is True
+    assert queued["entity_type"] == entity_type
+    assert queued["manual"] is True
+    assert acquisition_ledger.get_item("failed-download-retry", entity_type, issue_id)["state"] == "accepted"
 
 
 def test_fast_worker_terminal_state_does_not_fail_queue_handoff(acquisition_ledger):

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -1059,6 +1059,21 @@ def _symlink_or_skip(link_path, target_path):
 
 
 class TestConfigTransactions:
+    def test_legacy_cherrypy_logging_setting_is_ignored_but_preserved(self, tmp_path, monkeypatch):
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        if not config_module.config.has_section("Interface"):
+            config_module.config.add_section("Interface")
+        config_module.config.set("Interface", "cherrypy_logging", "True")
+
+        cfg.config_vals()
+
+        assert not hasattr(cfg, "CHERRYPY_LOGGING")
+        assert cfg.writeconfig() is True
+
+        persisted = configparser.ConfigParser()
+        persisted.read(config_path)
+        assert persisted.getboolean("Interface", "cherrypy_logging") is True
+
     def test_locked_value_write_processes_before_provider_sequence(self, tmp_path, monkeypatch):
         """Provider payloads are applied before sequencing without releasing the write lock."""
         cfg, _config_path, _config_module = _make_real_config(tmp_path, monkeypatch)


### PR DESCRIPTION
## Summary

Removes the remaining runtime dependencies on the retired CherryPy/WebInterface stack, so failed-download retries, SAB version checks, maintenance logging, and PID-file handling now use supported local boundaries.

The retry path now persists its search command before dispatch, while SAB failures retain the conservative history fallback. PID-file checks fail closed when process state cannot be verified, preventing an active instance's lock from being removed.

## Validation

- `pytest tests/unit -q` (1,298 passed)
- `npm run lint`
- `uv lock --check`
- `python Comicarr.py --help`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000?logoColor=white)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Failed download retries now create durable search commands with the correct scope and manual status.
  * Maintenance logging can be reconfigured directly, including console output and log levels.
  * SABnzbd version detection now supports both JSON and plain-text responses.

* **Bug Fixes**
  * Improved protection against removing active PID files when process checks fail.
  * SABnzbd version information is no longer updated after unsuccessful or invalid responses.
  * Legacy CherryP configuration settings are ignored at runtime while remaining preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->