### PR TITLE
refactor: migrate FastAPI queries to Core

### DIFF
--- a/Comicarr.py
+++ b/Comicarr.py
@@ -534,11 +534,18 @@ def main():
 
     RuntimeCapabilityDiagnostics().loaders()
 
+    # Configuration, schema readiness, encrypted secrets, setup token, and
+    # version metadata are now available. Create the one canonical runtime
+    # before any scheduler or worker can observe mutable queue/lock state.
+    from comicarr.app.core.runtime import create_runtime
+
+    runtime = create_runtime()
+
     if comicarr.CONFIG.LAUNCH_BROWSER and not args_nolaunch:
         comicarr.launch_browser(comicarr.CONFIG.HTTP_HOST, http_port, comicarr.CONFIG.HTTP_ROOT)
 
     # Start the background threads
-    comicarr.start()
+    comicarr.start(runtime)
 
     # Register the SIGTERM handler before startup replay: replay_pipeline()
     # below can spend real time probing downloaders and inline-redriving PP,

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -884,19 +884,13 @@ def resume_acquisition_runtime(config=None):
     ctx = get_runtime_if_initialized()
     config = config or (ctx.config if ctx is not None else CONFIG)
 
-    def schedule(queue_name):
-        if ctx is not None:
-            queue_schedule(queue_name, "start", ctx=ctx)
-        else:
-            queue_schedule(queue_name, "start")
-
     with ACQUISITION_RESUME_LOCK:
         gate = refresh_runtime_state(config)
         if gate.blocked:
             raise RuntimeError("acquisition remains blocked: %s" % (gate.reason or "unknown gate"))
 
         try:
-            replayed = replay_acquisition_obligations(ctx=ctx) if ctx is not None else replay_acquisition_obligations()
+            replayed = replay_acquisition_obligations(ctx=ctx)
         except Exception as e:
             set_runtime_acquisition_status(
                 workers_blocked=True,
@@ -905,7 +899,7 @@ def resume_acquisition_runtime(config=None):
             raise RuntimeError("durable acquisition replay failed") from e
 
         queues_started = ["search_queue"]
-        schedule("search_queue")
+        queue_schedule("search_queue", "start", ctx=ctx)
         if all(
             [
                 bool(getattr(config, "ENABLE_TORRENTS", False)),
@@ -913,7 +907,7 @@ def resume_acquisition_runtime(config=None):
                 OS_DETECT != "Windows",
             ]
         ) and getattr(config, "TORRENT_DOWNLOADER", None) in {2, 4}:
-            schedule("snatched_queue")
+            queue_schedule("snatched_queue", "start", ctx=ctx)
             queues_started.append("snatched_queue")
         if bool(getattr(config, "POST_PROCESSING", False)) and (
             (
@@ -925,13 +919,13 @@ def resume_acquisition_runtime(config=None):
                 and bool(getattr(config, "NZBGET_CLIENT_POST_PROCESSING", False))
             )
         ):
-            schedule("nzb_queue")
+            queue_schedule("nzb_queue", "start", ctx=ctx)
             queues_started.append("nzb_queue")
         if bool(getattr(config, "POST_PROCESSING", False)):
-            schedule("pp_queue")
+            queue_schedule("pp_queue", "start", ctx=ctx)
             queues_started.append("pp_queue")
         if bool(getattr(config, "ENABLE_DDL", False)):
-            schedule("ddl_queue")
+            queue_schedule("ddl_queue", "start", ctx=ctx)
             queues_started.append("ddl_queue")
 
         # The broad scheduler-status writer is still a documented legacy
@@ -1346,25 +1340,18 @@ def start(ctx):
 
 def queue_schedule(queuetype, mode, ctx=None):
     """Start/stop legacy workers while preserving canonical pool identity."""
-    from comicarr.app.core.runtime import get_runtime_if_initialized, set_runtime_field
+    from comicarr.app.core.runtime import POOL_CONTEXT_FIELDS, get_runtime_if_initialized, set_runtime_field
 
     ctx = ctx or get_runtime_if_initialized()
-    pool_fields = {
-        "SNPOOL": "sn_pool",
-        "NZBPOOL": "nzb_pool",
-        "SEARCHPOOL": "search_pool",
-        "PPPOOL": "pp_pool",
-        "DDLPOOL": "ddl_pool",
-    }
 
     def get_pool(pool_attr):
         if ctx is not None:
-            return getattr(ctx, pool_fields[pool_attr])
+            return getattr(ctx, POOL_CONTEXT_FIELDS[pool_attr])
         return getattr(comicarr, pool_attr)
 
     def set_pool(pool_attr, pool):
         if ctx is not None:
-            set_runtime_field(ctx, pool_fields[pool_attr], pool)
+            set_runtime_field(ctx, POOL_CONTEXT_FIELDS[pool_attr], pool)
         else:
             setattr(comicarr, pool_attr, pool)
 

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -884,13 +884,19 @@ def resume_acquisition_runtime(config=None):
     ctx = get_runtime_if_initialized()
     config = config or (ctx.config if ctx is not None else CONFIG)
 
+    def schedule(queue_name):
+        if ctx is not None:
+            queue_schedule(queue_name, "start", ctx=ctx)
+        else:
+            queue_schedule(queue_name, "start")
+
     with ACQUISITION_RESUME_LOCK:
         gate = refresh_runtime_state(config)
         if gate.blocked:
             raise RuntimeError("acquisition remains blocked: %s" % (gate.reason or "unknown gate"))
 
         try:
-            replayed = replay_acquisition_obligations(ctx=ctx)
+            replayed = replay_acquisition_obligations(ctx=ctx) if ctx is not None else replay_acquisition_obligations()
         except Exception as e:
             set_runtime_acquisition_status(
                 workers_blocked=True,
@@ -899,7 +905,7 @@ def resume_acquisition_runtime(config=None):
             raise RuntimeError("durable acquisition replay failed") from e
 
         queues_started = ["search_queue"]
-        queue_schedule("search_queue", "start", ctx=ctx)
+        schedule("search_queue")
         if all(
             [
                 bool(getattr(config, "ENABLE_TORRENTS", False)),
@@ -907,7 +913,7 @@ def resume_acquisition_runtime(config=None):
                 OS_DETECT != "Windows",
             ]
         ) and getattr(config, "TORRENT_DOWNLOADER", None) in {2, 4}:
-            queue_schedule("snatched_queue", "start", ctx=ctx)
+            schedule("snatched_queue")
             queues_started.append("snatched_queue")
         if bool(getattr(config, "POST_PROCESSING", False)) and (
             (
@@ -919,13 +925,13 @@ def resume_acquisition_runtime(config=None):
                 and bool(getattr(config, "NZBGET_CLIENT_POST_PROCESSING", False))
             )
         ):
-            queue_schedule("nzb_queue", "start", ctx=ctx)
+            schedule("nzb_queue")
             queues_started.append("nzb_queue")
         if bool(getattr(config, "POST_PROCESSING", False)):
-            queue_schedule("pp_queue", "start", ctx=ctx)
+            schedule("pp_queue")
             queues_started.append("pp_queue")
         if bool(getattr(config, "ENABLE_DDL", False)):
-            queue_schedule("ddl_queue", "start", ctx=ctx)
+            schedule("ddl_queue")
             queues_started.append("ddl_queue")
 
         # The broad scheduler-status writer is still a documented legacy

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -855,12 +855,13 @@ def launch_browser(host, port, root):
         logger.error("Could not launch browser: %s" % e)
 
 
-def replay_acquisition_obligations():
+def replay_acquisition_obligations(ctx=None):
     """Restore durable search and refresh commands before workers start."""
     from comicarr import importer as importer_module
     from comicarr.app.search.commands import replay_search_obligations
 
-    search_count = replay_search_obligations(work_queue=SEARCH_QUEUE)
+    search_queue = ctx.search_queue if ctx is not None else SEARCH_QUEUE
+    search_count = replay_search_obligations(work_queue=search_queue)
     refresh_count = importer_module.replay_refresh_obligations(start_worker=True)
     if search_count or refresh_count:
         logger.info("[ACQUISITION] Replayed %s search and %s refresh obligations" % (search_count, refresh_count))
@@ -878,22 +879,33 @@ def resume_acquisition_runtime(config=None):
     """
 
     from comicarr.app.acquisition.maintenance import refresh_runtime_state
+    from comicarr.app.core.runtime import get_runtime_if_initialized, set_runtime_acquisition_status
 
-    config = config or CONFIG
+    ctx = get_runtime_if_initialized()
+    config = config or (ctx.config if ctx is not None else CONFIG)
+
+    def schedule(queue_name):
+        if ctx is not None:
+            queue_schedule(queue_name, "start", ctx=ctx)
+        else:
+            queue_schedule(queue_name, "start")
+
     with ACQUISITION_RESUME_LOCK:
         gate = refresh_runtime_state(config)
         if gate.blocked:
             raise RuntimeError("acquisition remains blocked: %s" % (gate.reason or "unknown gate"))
 
         try:
-            replayed = replay_acquisition_obligations()
+            replayed = replay_acquisition_obligations(ctx=ctx) if ctx is not None else replay_acquisition_obligations()
         except Exception as e:
-            comicarr.ACQUISITION_WORKERS_BLOCKED = True
-            comicarr.ACQUISITION_BLOCK_REASON = "obligation_replay_failed"
+            set_runtime_acquisition_status(
+                workers_blocked=True,
+                block_reason="obligation_replay_failed",
+            )
             raise RuntimeError("durable acquisition replay failed") from e
 
         queues_started = ["search_queue"]
-        queue_schedule("search_queue", "start")
+        schedule("search_queue")
         if all(
             [
                 bool(getattr(config, "ENABLE_TORRENTS", False)),
@@ -901,7 +913,7 @@ def resume_acquisition_runtime(config=None):
                 OS_DETECT != "Windows",
             ]
         ) and getattr(config, "TORRENT_DOWNLOADER", None) in {2, 4}:
-            queue_schedule("snatched_queue", "start")
+            schedule("snatched_queue")
             queues_started.append("snatched_queue")
         if bool(getattr(config, "POST_PROCESSING", False)) and (
             (
@@ -913,15 +925,19 @@ def resume_acquisition_runtime(config=None):
                 and bool(getattr(config, "NZBGET_CLIENT_POST_PROCESSING", False))
             )
         ):
-            queue_schedule("nzb_queue", "start")
+            schedule("nzb_queue")
             queues_started.append("nzb_queue")
         if bool(getattr(config, "POST_PROCESSING", False)):
-            queue_schedule("pp_queue", "start")
+            schedule("pp_queue")
             queues_started.append("pp_queue")
         if bool(getattr(config, "ENABLE_DDL", False)):
-            queue_schedule("ddl_queue", "start")
+            schedule("ddl_queue")
             queues_started.append("ddl_queue")
 
+        # The broad scheduler-status writer is still a documented legacy
+        # compatibility consumer. Keep its live scalar decisions here until
+        # that coherent system-service wave migrates; queues/pools/scheduler
+        # themselves already use the shared canonical identities above.
         scheduler_statuses = {
             "dbupdater": UPDATER_STATUS,
             "search": SEARCH_STATUS,
@@ -930,11 +946,12 @@ def resume_acquisition_runtime(config=None):
             "monitor": MONITOR_STATUS,
             "importinbox": IMPORTINBOX_STATUS,
         }
+        scheduler = ctx.scheduler if ctx is not None else SCHED
         resumed_jobs = []
         for job_id, status in scheduler_statuses.items():
             if status == "Paused":
                 continue
-            job = SCHED.get_job(job_id)
+            job = scheduler.get_job(job_id)
             if job is None:
                 continue
             job.resume()
@@ -956,7 +973,27 @@ def resume_acquisition_runtime(config=None):
         }
 
 
-def start():
+def start(ctx):
+    """Start scheduler/workers against the pre-created canonical runtime.
+
+    ``Comicarr.py`` creates ``ctx`` only after configuration, schema, and
+    secrets are ready. Rejecting a missing or divergent context prevents a
+    worker from starting against a copied queue/lock/scheduler view.
+    """
+    from comicarr.app.core.runtime import RuntimeNotInitializedError, set_runtime_acquisition_status, set_runtime_field
+
+    if ctx is None or ctx.disposed:
+        raise RuntimeNotInitializedError("Workers cannot start before an active runtime context exists")
+    if (
+        ctx.scheduler is not SCHED
+        or ctx.search_queue is not SEARCH_QUEUE
+        or ctx.ddl_queue is not DDL_QUEUE
+        or ctx.ddl_lock is not DDL_LOCK
+        or ctx.ddl_queued is not DDL_QUEUED
+    ):
+        raise RuntimeNotInitializedError(
+            "Workers must start with the canonical runtime's shared scheduler, queues, locks, and DDL state"
+        )
 
     global _INITIALIZED, started
 
@@ -1043,35 +1080,39 @@ def start():
                 acquisition_gate = refresh_runtime_state(comicarr.CONFIG)
             except Exception as e:
                 acquisition_gate = None
-                comicarr.ACQUISITION_WORKERS_BLOCKED = True
-                comicarr.ACQUISITION_BLOCK_REASON = "maintenance_gate_unavailable"
+                set_runtime_acquisition_status(
+                    workers_blocked=True,
+                    block_reason="maintenance_gate_unavailable",
+                )
                 logger.error("[ACQUISITION] Refusing worker startup because gate refresh failed: %s" % e)
 
-            if comicarr.ACQUISITION_WORKERS_BLOCKED:
+            if ctx.acquisition_workers_blocked:
                 if VERSION_STATUS != "Paused":
                     VERSION_SCHEDULER.resume()
                 logger.warn(
                     "[ACQUISITION] Background acquisition is blocked (%s); diagnostics remain available"
-                    % (acquisition_gate.reason if acquisition_gate else comicarr.ACQUISITION_BLOCK_REASON)
+                    % (acquisition_gate.reason if acquisition_gate else ctx.acquisition_block_reason)
                 )
                 try:
                     SCHED.start()
                 except Exception as e:
                     logger.error("[ACQUISITION] Unable to start diagnostics scheduler: %s" % e)
-                started = True
+                set_runtime_field(ctx, "started", True)
                 return
 
             try:
-                replay_acquisition_obligations()
+                replay_acquisition_obligations(ctx=ctx)
             except Exception as e:
-                comicarr.ACQUISITION_WORKERS_BLOCKED = True
-                comicarr.ACQUISITION_BLOCK_REASON = "obligation_replay_failed"
+                set_runtime_acquisition_status(
+                    workers_blocked=True,
+                    block_reason="obligation_replay_failed",
+                )
                 logger.error("[ACQUISITION] Durable obligation replay failed; workers remain blocked: %s" % e)
                 try:
                     SCHED.start()
                 except Exception as scheduler_error:
                     logger.error("[ACQUISITION] Unable to start diagnostics scheduler: %s" % scheduler_error)
-                started = True
+                set_runtime_field(ctx, "started", True)
                 return
 
             # load up the previous runs from the job sql table so we know stuff...
@@ -1147,24 +1188,24 @@ def start():
                         SEARCH_SCHEDULER.modify(next_run_time=search_diff)
 
             # thread queue control..
-            queue_schedule("search_queue", "start")
+            queue_schedule("search_queue", "start", ctx=ctx)
 
             if all([CONFIG.ENABLE_TORRENTS, CONFIG.AUTO_SNATCH, OS_DETECT != "Windows"]) and any(
                 [CONFIG.TORRENT_DOWNLOADER == 2, CONFIG.TORRENT_DOWNLOADER == 4]
             ):
-                queue_schedule("snatched_queue", "start")
+                queue_schedule("snatched_queue", "start", ctx=ctx)
 
             if CONFIG.POST_PROCESSING is True and (
                 all([CONFIG.NZB_DOWNLOADER == 0, CONFIG.SAB_CLIENT_POST_PROCESSING is True])
                 or all([CONFIG.NZB_DOWNLOADER == 1, CONFIG.NZBGET_CLIENT_POST_PROCESSING is True])
             ):
-                queue_schedule("nzb_queue", "start")
+                queue_schedule("nzb_queue", "start", ctx=ctx)
 
             if CONFIG.POST_PROCESSING is True:
-                queue_schedule("pp_queue", "start")
+                queue_schedule("pp_queue", "start", ctx=ctx)
 
             if CONFIG.ENABLE_DDL is True:
-                queue_schedule("ddl_queue", "start")
+                queue_schedule("ddl_queue", "start", ctx=ctx)
                 if CONFIG.DDL_STUCK_NOTIFY is True:
                     _add_recurring_job(
                         func=helpers.ddl_health_check,
@@ -1300,12 +1341,35 @@ def start():
                 logger.info(e)
                 SCHED.print_jobs()
 
-        started = True
+        set_runtime_field(ctx, "started", True)
 
 
-def queue_schedule(queuetype, mode):
+def queue_schedule(queuetype, mode, ctx=None):
+    """Start/stop legacy workers while preserving canonical pool identity."""
+    from comicarr.app.core.runtime import get_runtime_if_initialized, set_runtime_field
+
+    ctx = ctx or get_runtime_if_initialized()
+    pool_fields = {
+        "SNPOOL": "sn_pool",
+        "NZBPOOL": "nzb_pool",
+        "SEARCHPOOL": "search_pool",
+        "PPPOOL": "pp_pool",
+        "DDLPOOL": "ddl_pool",
+    }
+
+    def get_pool(pool_attr):
+        if ctx is not None:
+            return getattr(ctx, pool_fields[pool_attr])
+        return getattr(comicarr, pool_attr)
+
+    def set_pool(pool_attr, pool):
+        if ctx is not None:
+            set_runtime_field(ctx, pool_fields[pool_attr], pool)
+        else:
+            setattr(comicarr, pool_attr, pool)
+
     def start(pool_attr, target, q_arg, name, before_msg, after_msg):
-        pool = getattr(comicarr, pool_attr)
+        pool = get_pool(pool_attr)
         try:
             if pool.is_alive() is True:
                 return
@@ -1314,7 +1378,7 @@ def queue_schedule(queuetype, mode):
 
         logger.info("[%s] %s" % (name, before_msg))
         thread = threading.Thread(target=target, args=(q_arg,), name=name)
-        setattr(comicarr, pool_attr, thread)
+        set_pool(pool_attr, thread)
         thread.start()
         logger.info("[%s] %s" % (name, after_msg))
 
@@ -1354,7 +1418,7 @@ def queue_schedule(queuetype, mode):
             )
         elif queuetype == "nzb_queue":
             try:
-                if comicarr.NZBPOOL.is_alive() is True:
+                if get_pool("NZBPOOL").is_alive() is True:
                     return
             except Exception:
                 pass
@@ -1367,8 +1431,9 @@ def queue_schedule(queuetype, mode):
                 logger.info(
                     "[NZBGET-MONITOR] Completed post-processing handling enabled for NZBGet. Attempting to background load...."
                 )
-            comicarr.NZBPOOL = threading.Thread(target=helpers.nzb_monitor, args=(NZB_QUEUE,), name="AUTO-COMPLETE-NZB")
-            comicarr.NZBPOOL.start()
+            pool = threading.Thread(target=helpers.nzb_monitor, args=(NZB_QUEUE,), name="AUTO-COMPLETE-NZB")
+            set_pool("NZBPOOL", pool)
+            pool.start()
             if CONFIG.NZB_DOWNLOADER == 0:
                 logger.info(
                     "[AUTO-COMPLETE-NZB] Succesfully started Completed post-processing handling for SABnzbd - will now monitor for completed nzbs within sabnzbd and post-process automatically..."
@@ -1398,7 +1463,7 @@ def queue_schedule(queuetype, mode):
             )
         elif queuetype == "ddl_queue":
             try:
-                if DDLPOOL.is_alive() is True:
+                if get_pool("DDLPOOL").is_alive() is True:
                     return
             except Exception:
                 pass
@@ -1418,7 +1483,7 @@ def queue_schedule(queuetype, mode):
                 or all([comicarr.CONFIG.NZB_DOWNLOADER == 1, comicarr.CONFIG.NZBGET_CLIENT_POST_PROCESSING is True])
             ):
                 return
-            shutdown(comicarr.NZBPOOL, comicarr.NZB_QUEUE, "NZB auto-complete queue")
+            shutdown(get_pool("NZBPOOL"), comicarr.NZB_QUEUE, "NZB auto-complete queue")
 
         if (queuetype == "snatched_queue") or mode == "shutdown":
             if all(
@@ -1430,20 +1495,20 @@ def queue_schedule(queuetype, mode):
                 ]
             ) and any([comicarr.CONFIG.TORRENT_DOWNLOADER == 2, comicarr.CONFIG.TORRENT_DOWNLOADER == 4]):
                 return
-            shutdown(comicarr.SNPOOL, comicarr.SNATCHED_QUEUE, "auto-snatch")
+            shutdown(get_pool("SNPOOL"), comicarr.SNATCHED_QUEUE, "auto-snatch")
 
         if (queuetype == "search_queue") or mode == "shutdown":
-            shutdown(comicarr.SEARCHPOOL, comicarr.SEARCH_QUEUE, "search queue")
+            shutdown(get_pool("SEARCHPOOL"), comicarr.SEARCH_QUEUE, "search queue")
 
         if (queuetype == "pp_queue") or mode == "shutdown":
             if all([comicarr.CONFIG.POST_PROCESSING is True, mode != "shutdown"]):
                 return
-            shutdown(comicarr.PPPOOL, comicarr.PP_QUEUE, "post-processing queue")
+            shutdown(get_pool("PPPOOL"), comicarr.PP_QUEUE, "post-processing queue")
 
         if (queuetype == "ddl_queue") or mode == "shutdown":
             if all([comicarr.CONFIG.ENABLE_DDL is True, mode != "shutdown"]):
                 return
-            shutdown(comicarr.DDLPOOL, comicarr.DDL_QUEUE, "DDL download queue")
+            shutdown(get_pool("DDLPOOL"), comicarr.DDL_QUEUE, "DDL download queue")
 
 
 def sql_db():

--- a/comicarr/app/acquisition/maintenance.py
+++ b/comicarr/app/acquisition/maintenance.py
@@ -184,9 +184,14 @@ class MaintenanceConflict(RuntimeError):
 
 
 def _set_schema_globals(status):
-    comicarr.ACQUISITION_SCHEMA_READY = status.ready
-    comicarr.ACQUISITION_SCHEMA_VERSION = status.version
-    comicarr.ACQUISITION_SCHEMA_ERROR = status.error
+    """Project schema readiness through the canonical runtime when available."""
+    from comicarr.app.core.runtime import set_runtime_acquisition_status
+
+    set_runtime_acquisition_status(
+        schema_ready=status.ready,
+        schema_version=status.version,
+        schema_error=status.error,
+    )
 
 
 def _current_version(engine):
@@ -1082,6 +1087,10 @@ def refresh_runtime_state(config=None, engine=None):
             heartbeat_at=fence.heartbeat_at,
             reconciliation_state=reconciliation_state,
         )
-    comicarr.ACQUISITION_WORKERS_BLOCKED = status.blocked
-    comicarr.ACQUISITION_BLOCK_REASON = status.reason
+    from comicarr.app.core.runtime import set_runtime_acquisition_status
+
+    set_runtime_acquisition_status(
+        workers_blocked=status.blocked,
+        block_reason=status.reason,
+    )
     return status

--- a/comicarr/app/ai/enrichment.py
+++ b/comicarr/app/ai/enrichment.py
@@ -22,10 +22,10 @@ import time
 import xml.etree.ElementTree as ET
 import zipfile
 
-import comicarr
 from comicarr import logger
 from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
+from comicarr.app.ai.runtime import get_ai_runtime
 from comicarr.app.ai.sanitize import sanitize_input, spotlight_wrap
 from comicarr.app.ai.schemas import MetadataEnrichment
 from comicarr.app.ai.structured import request_structured
@@ -46,11 +46,12 @@ def enrich_metadata(cbz_path, issue_id):
 
     Returns number of fields enriched, or 0 on skip/failure.
     """
-    if comicarr.AI_CLIENT is None:
+    ctx = get_ai_runtime()
+    if ctx is None or ctx.ai_client is None or ctx.config is None:
         return 0
-    if not comicarr.AI_CIRCUIT_BREAKER.allow_request():
+    if ctx.ai_circuit_breaker is None or not ctx.ai_circuit_breaker.allow_request():
         return 0
-    if not comicarr.AI_RATE_LIMITER.can_request():
+    if ctx.ai_rate_limiter is None or not ctx.ai_rate_limiter.can_request():
         return 0
 
     # Read ComicInfo.xml from CBZ
@@ -93,16 +94,16 @@ def enrich_metadata(cbz_path, issue_id):
     start_time = time.time()
     try:
         result = request_structured(
-            client=comicarr.AI_CLIENT,
-            model=comicarr.CONFIG.AI_MODEL,
+            client=ctx.ai_client,
+            model=ctx.config.AI_MODEL,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             schema_class=MetadataEnrichment,
             temperature=0.1,
-            timeout=comicarr.CONFIG.AI_TIMEOUT or 30,
+            timeout=ctx.config.AI_TIMEOUT or 30,
         )
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_success()
+        ctx.ai_circuit_breaker.record_success()
 
         # Filter: only accept values for fields that were actually blank
         enriched = {}
@@ -122,7 +123,7 @@ def enrich_metadata(cbz_path, issue_id):
         ai_service.log_activity(
             feature_type="enrichment",
             action="Enriched %d fields for issue %s" % (len(enriched), issue_id),
-            model=comicarr.CONFIG.AI_MODEL,
+            model=ctx.config.AI_MODEL,
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,
@@ -136,11 +137,11 @@ def enrich_metadata(cbz_path, issue_id):
 
     except Exception as e:
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_failure()
+        ctx.ai_circuit_breaker.record_failure()
         ai_service.log_activity(
             feature_type="enrichment",
             action="Enrichment failed for issue %s" % issue_id,
-            model=comicarr.CONFIG.AI_MODEL or "",
+            model=ctx.config.AI_MODEL or "",
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,

--- a/comicarr/app/ai/enrichment.py
+++ b/comicarr/app/ai/enrichment.py
@@ -23,7 +23,8 @@ import xml.etree.ElementTree as ET
 import zipfile
 
 import comicarr
-from comicarr import db, logger
+from comicarr import logger
+from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
 from comicarr.app.ai.sanitize import sanitize_input, spotlight_wrap
 from comicarr.app.ai.schemas import MetadataEnrichment
@@ -222,28 +223,29 @@ def _store_history(issue_id, enriched_fields):
 
     now = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
     for field_name, ai_value in enriched_fields.items():
-        db.DBConnection().action(
-            "INSERT INTO ai_metadata_history "
-            "(entity_type, entity_id, field_name, original_value, ai_value, source, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            ["issue", issue_id, field_name, None, ai_value, "enrichment", now],
+        ai_queries.insert_metadata_history(
+            {
+                "entity_type": "issue",
+                "entity_id": issue_id,
+                "field_name": field_name,
+                "original_value": None,
+                "ai_value": ai_value,
+                "source": "enrichment",
+                "created_at": now,
+            }
         )
 
 
 def revert_field(issue_id, field_name, cbz_path):
     """Revert an AI-enriched field back to blank."""
     # Validate issue exists
-    issue = db.DBConnection().select("SELECT IssueID FROM issues WHERE IssueID = ?", [issue_id])
-    if not issue:
+    if not ai_queries.issue_exists(issue_id):
         raise ValueError("Issue %s not found" % issue_id)
 
     # Remove enriched value from CBZ (set field to empty)
     _write_comicinfo(cbz_path, {field_name: ""})
 
     # Delete history entry
-    db.DBConnection().action(
-        "DELETE FROM ai_metadata_history WHERE entity_type = ? AND entity_id = ? AND field_name = ? AND source = ?",
-        ["issue", issue_id, field_name, "enrichment"],
-    )
+    ai_queries.delete_metadata_history("issue", issue_id, field_name, "enrichment")
 
     logger.fdebug("[AI-ENRICH] Reverted %s for issue %s" % (field_name, issue_id))

--- a/comicarr/app/ai/parsing.py
+++ b/comicarr/app/ai/parsing.py
@@ -14,10 +14,10 @@ for structured metadata extraction when regex-based parsing fails.
 
 import time
 
-import comicarr
 from comicarr import logger
 from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
+from comicarr.app.ai.runtime import get_ai_runtime
 from comicarr.app.ai.sanitize import sanitize_input
 from comicarr.app.ai.schemas import FilenameParse
 from comicarr.app.ai.structured import request_structured
@@ -29,12 +29,13 @@ def ai_parse_filename(filename, watchcomic=None, publisher=None):
     Returns a parseit()-compatible dict on success, or None on failure.
     """
     # Check AI is configured and available
-    if comicarr.AI_CLIENT is None:
+    ctx = get_ai_runtime()
+    if ctx is None or ctx.ai_client is None or ctx.config is None:
         return None
-    if not comicarr.AI_CIRCUIT_BREAKER.allow_request():
+    if ctx.ai_circuit_breaker is None or not ctx.ai_circuit_breaker.allow_request():
         logger.fdebug("[AI-PARSE] Circuit breaker open — skipping AI parse")
         return None
-    if not comicarr.AI_RATE_LIMITER.can_request():
+    if ctx.ai_rate_limiter is None or not ctx.ai_rate_limiter.can_request():
         logger.fdebug("[AI-PARSE] Rate limit reached — skipping AI parse")
         return None
 
@@ -56,23 +57,23 @@ def ai_parse_filename(filename, watchcomic=None, publisher=None):
     start_time = time.time()
     try:
         result = request_structured(
-            client=comicarr.AI_CLIENT,
-            model=comicarr.CONFIG.AI_MODEL,
+            client=ctx.ai_client,
+            model=ctx.config.AI_MODEL,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             schema_class=FilenameParse,
             temperature=0.1,
-            timeout=comicarr.CONFIG.AI_TIMEOUT or 30,
+            timeout=ctx.config.AI_TIMEOUT or 30,
         )
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_success()
+        ctx.ai_circuit_breaker.record_success()
 
         # Validate against monitored series
         if not _validate_against_library(result.series_name):
             ai_service.log_activity(
                 feature_type="parsing",
                 action="AI parsed '%s' but no library match for '%s'" % (filename, result.series_name),
-                model=comicarr.CONFIG.AI_MODEL,
+                model=ctx.config.AI_MODEL,
                 prompt_tokens=0,
                 completion_tokens=0,
                 latency_ms=latency_ms,
@@ -88,7 +89,7 @@ def ai_parse_filename(filename, watchcomic=None, publisher=None):
         ai_service.log_activity(
             feature_type="parsing",
             action="AI parsed '%s' → %s #%s" % (filename, result.series_name, result.issue_number),
-            model=comicarr.CONFIG.AI_MODEL,
+            model=ctx.config.AI_MODEL,
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,
@@ -102,11 +103,11 @@ def ai_parse_filename(filename, watchcomic=None, publisher=None):
 
     except Exception as e:
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_failure()
+        ctx.ai_circuit_breaker.record_failure()
         ai_service.log_activity(
             feature_type="parsing",
             action="AI parse failed for '%s'" % filename,
-            model=comicarr.CONFIG.AI_MODEL or "",
+            model=ctx.config.AI_MODEL or "",
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,

--- a/comicarr/app/ai/parsing.py
+++ b/comicarr/app/ai/parsing.py
@@ -15,7 +15,8 @@ for structured metadata extraction when regex-based parsing fails.
 import time
 
 import comicarr
-from comicarr import db, logger
+from comicarr import logger
+from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
 from comicarr.app.ai.sanitize import sanitize_input
 from comicarr.app.ai.schemas import FilenameParse
@@ -122,24 +123,18 @@ def _validate_against_library(series_name):
         return False
 
     # Exact match first
-    result = db.DBConnection().select(
-        "SELECT ComicID FROM comics WHERE ComicName = ? OR DynamicComicName = ? LIMIT 1",
-        [series_name, series_name.lower().strip()],
-    )
+    result = ai_queries.find_exact_library_match(series_name, series_name.lower().strip())
     if result:
         return True
 
     # Case-insensitive match
-    result = db.DBConnection().select(
-        "SELECT ComicID FROM comics WHERE LOWER(ComicName) = LOWER(?) LIMIT 1", [series_name]
-    )
+    result = ai_queries.find_case_insensitive_library_match(series_name)
     if result:
         return True
 
     # Check AlternateSearch field (##-delimited)
-    result = db.DBConnection().select("SELECT AlternateSearch FROM comics WHERE AlternateSearch IS NOT NULL")
     search_lower = series_name.lower()
-    for row in result or []:
+    for row in ai_queries.get_alternate_search_values():
         alternates = (row.get("AlternateSearch") or "").split("##")
         for alt in alternates:
             if alt.strip().lower() == search_lower:

--- a/comicarr/app/ai/pull_list.py
+++ b/comicarr/app/ai/pull_list.py
@@ -19,10 +19,10 @@ import json
 import time
 from datetime import datetime, timedelta
 
-import comicarr
 from comicarr import logger
 from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
+from comicarr.app.ai.runtime import get_ai_runtime
 from comicarr.app.ai.schemas import PullSuggestions
 from comicarr.app.ai.structured import request_structured
 
@@ -37,15 +37,16 @@ def generate_suggestions(weekly_data=None, collection_patterns=None):
     Returns a list of suggestion dicts, each with: comic_name, publisher, reason.
     Results are cached in ai_cache with cache_type="suggestions".
     """
-    if comicarr.AI_CLIENT is None:
+    ctx = get_ai_runtime()
+    if ctx is None or ctx.ai_client is None or ctx.config is None:
         logger.fdebug("[AI-PULLLIST] AI not configured, skipping suggestions")
         return []
 
-    if not comicarr.AI_CIRCUIT_BREAKER.allow_request():
+    if ctx.ai_circuit_breaker is None or not ctx.ai_circuit_breaker.allow_request():
         logger.fdebug("[AI-PULLLIST] Circuit breaker open, skipping suggestions")
         return []
 
-    if not comicarr.AI_RATE_LIMITER.can_request():
+    if ctx.ai_rate_limiter is None or not ctx.ai_rate_limiter.can_request():
         logger.fdebug("[AI-PULLLIST] Rate limit reached, skipping suggestions")
         return []
 
@@ -88,16 +89,16 @@ def generate_suggestions(weekly_data=None, collection_patterns=None):
     start_time = time.time()
     try:
         result = request_structured(
-            client=comicarr.AI_CLIENT,
-            model=comicarr.CONFIG.AI_MODEL,
+            client=ctx.ai_client,
+            model=ctx.config.AI_MODEL,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             schema_class=PullSuggestions,
             temperature=0.3,
-            timeout=getattr(comicarr.CONFIG, "AI_TIMEOUT", 30) or 30,
+            timeout=getattr(ctx.config, "AI_TIMEOUT", 30) or 30,
         )
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_success()
+        ctx.ai_circuit_breaker.record_success()
 
         suggestions = []
         for item in result.suggestions[:5]:
@@ -116,7 +117,7 @@ def generate_suggestions(weekly_data=None, collection_patterns=None):
         ai_service.log_activity(
             feature_type="pulllist",
             action="Generated %d pull list suggestions" % len(suggestions),
-            model=comicarr.CONFIG.AI_MODEL,
+            model=ctx.config.AI_MODEL,
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,
@@ -128,11 +129,11 @@ def generate_suggestions(weekly_data=None, collection_patterns=None):
 
     except Exception as e:
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_failure()
+        ctx.ai_circuit_breaker.record_failure()
         ai_service.log_activity(
             feature_type="pulllist",
             action="Pull list suggestion generation failed",
-            model=getattr(comicarr.CONFIG, "AI_MODEL", "") or "",
+            model=getattr(ctx.config, "AI_MODEL", "") or "",
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,

--- a/comicarr/app/ai/pull_list.py
+++ b/comicarr/app/ai/pull_list.py
@@ -20,7 +20,8 @@ import time
 from datetime import datetime, timedelta
 
 import comicarr
-from comicarr import db, logger
+from comicarr import logger
+from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
 from comicarr.app.ai.schemas import PullSuggestions
 from comicarr.app.ai.structured import request_structured
@@ -158,10 +159,7 @@ def get_collection_patterns():
 
     try:
         # Get publisher distribution
-        publisher_rows = db.DBConnection().select(
-            "SELECT ComicPublisher, COUNT(*) as count FROM comics "
-            "WHERE Status = 'Active' GROUP BY ComicPublisher ORDER BY count DESC LIMIT 10"
-        )
+        publisher_rows = ai_queries.get_active_publisher_counts()
         if publisher_rows:
             patterns["publishers"] = [
                 {"name": r["ComicPublisher"], "count": r["count"]} for r in publisher_rows if r.get("ComicPublisher")
@@ -169,24 +167,15 @@ def get_collection_patterns():
             patterns["top_publishers"] = [r["ComicPublisher"] for r in publisher_rows[:5] if r.get("ComicPublisher")]
 
         # Get series count
-        count_rows = db.DBConnection().select("SELECT COUNT(*) as count FROM comics WHERE Status = 'Active'")
-        if count_rows:
-            patterns["series_count"] = count_rows[0].get("count", 0)
+        patterns["series_count"] = ai_queries.get_active_series_count()
 
         # Get monitored series names (for context)
-        series_rows = db.DBConnection().select(
-            "SELECT ComicName FROM comics WHERE Status = 'Active' ORDER BY ComicSortName LIMIT 30"
-        )
-        if series_rows:
-            patterns["monitored_series"] = [r["ComicName"] for r in series_rows if r.get("ComicName")]
+        patterns["monitored_series"] = ai_queries.get_active_series_names()
 
         # Get average completion rate
-        completion_rows = db.DBConnection().select(
-            "SELECT AVG(CAST(Have AS FLOAT) / NULLIF(CAST(Total AS FLOAT), 0) * 100) as avg_pct "
-            "FROM comics WHERE Status = 'Active' AND Total > 0"
-        )
-        if completion_rows and completion_rows[0].get("avg_pct") is not None:
-            patterns["avg_completion"] = round(completion_rows[0]["avg_pct"], 1)
+        average_completion = ai_queries.get_active_completion_rate()
+        if average_completion is not None:
+            patterns["avg_completion"] = round(average_completion, 1)
 
     except Exception as e:
         logger.error("[AI-PULLLIST] Failed to gather collection patterns: %s" % e)
@@ -203,11 +192,7 @@ def get_cached_suggestions():
 def _get_weekly_releases():
     """Get this week's releases that are NOT currently tracked by the user."""
     try:
-        results = db.DBConnection().select(
-            "SELECT COMIC, PUBLISHER, ISSUE, STATUS FROM weekly "
-            "WHERE STATUS IS NULL OR STATUS = '' "
-            "ORDER BY PUBLISHER, COMIC LIMIT 100"
-        )
+        results = ai_queries.get_untracked_weekly_releases()
         return results if results else []
     except Exception as e:
         logger.error("[AI-PULLLIST] Failed to get weekly releases: %s" % e)
@@ -217,11 +202,9 @@ def _get_weekly_releases():
 def _get_cached_suggestions():
     """Retrieve cached suggestions if still fresh. Returns list or None."""
     try:
-        rows = db.DBConnection().select(
-            "SELECT data, expires_at FROM ai_cache WHERE cache_key = ? AND cache_type = ?", [CACHE_KEY, CACHE_TYPE]
-        )
-        if rows and rows[0].get("data"):
-            expires_at = rows[0].get("expires_at", "")
+        row = ai_queries.get_cache_entry(CACHE_KEY, CACHE_TYPE)
+        if row and row.get("data"):
+            expires_at = row.get("expires_at", "")
             if expires_at:
                 try:
                     expiry = datetime.strptime(expires_at, "%Y-%m-%d %H:%M:%S")
@@ -229,7 +212,7 @@ def _get_cached_suggestions():
                         return None
                 except (ValueError, TypeError):
                     pass
-            return json.loads(rows[0]["data"])
+            return json.loads(row["data"])
     except Exception as e:
         logger.error("[AI-PULLLIST] Cache read error: %s" % e)
     return None
@@ -240,16 +223,12 @@ def _cache_suggestions(suggestions):
     try:
         now = datetime.utcnow()
         expires = now + timedelta(hours=CACHE_TTL_HOURS)
-        db.DBConnection().action(
-            "INSERT OR REPLACE INTO ai_cache (cache_key, cache_type, data, created_at, expires_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            [
-                CACHE_KEY,
-                CACHE_TYPE,
-                json.dumps(suggestions),
-                now.strftime("%Y-%m-%d %H:%M:%S"),
-                expires.strftime("%Y-%m-%d %H:%M:%S"),
-            ],
+        ai_queries.upsert_cache_entry(
+            CACHE_KEY,
+            CACHE_TYPE,
+            json.dumps(suggestions),
+            now.strftime("%Y-%m-%d %H:%M:%S"),
+            expires.strftime("%Y-%m-%d %H:%M:%S"),
         )
     except Exception as e:
         logger.error("[AI-PULLLIST] Cache write error: %s" % e)

--- a/comicarr/app/ai/queries.py
+++ b/comicarr/app/ai/queries.py
@@ -1,0 +1,235 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""SQLAlchemy Core queries owned by the AI domain."""
+
+import time
+
+from sqlalchemy import Float, cast, delete, func, insert, or_, select, update
+from sqlalchemy.exc import OperationalError
+
+from comicarr import db, logger
+from comicarr.tables import ai_activity_log as t_ai_activity_log
+from comicarr.tables import ai_cache as t_ai_cache
+from comicarr.tables import ai_metadata_history as t_ai_metadata_history
+from comicarr.tables import comics as t_comics
+from comicarr.tables import issues as t_issues
+from comicarr.tables import storyarcs as t_storyarcs
+from comicarr.tables import weekly as t_weekly
+
+_WRITE_ATTEMPTS = 5
+
+
+def _run_write(operation):
+    """Run a Core mutation with the legacy shim's in-process lock/retry contract."""
+    # Keep ordering with remaining legacy DBConnection.action callers until the
+    # root shim itself can be retired.
+    with db._db_lock:
+        for attempt in range(_WRITE_ATTEMPTS):
+            try:
+                with db.get_engine().begin() as conn:
+                    operation(conn)
+                return
+            except OperationalError as error:
+                error_message = str(error)
+                if "locked" not in error_message and "unable to open" not in error_message:
+                    logger.error("[AI-QUERIES] Database error executing Core mutation: %s", error)
+                    raise
+                logger.warn("[AI-QUERIES] Database write retry %d: %s", attempt + 1, error)
+                time.sleep(1)
+
+
+def insert_activity(values):
+    """Insert a durable AI activity record."""
+    _run_write(lambda conn: conn.execute(insert(t_ai_activity_log).values(**values)))
+
+
+def get_activity(limit=50, offset=0):
+    """Return activity records in the legacy newest-id-first order."""
+    stmt = select(t_ai_activity_log).order_by(t_ai_activity_log.c.id.desc()).limit(int(limit)).offset(int(offset))
+    return db.select_all(stmt)
+
+
+def insert_metadata_history(values):
+    """Insert one metadata-history record in its own compatibility transaction."""
+    _run_write(lambda conn: conn.execute(insert(t_ai_metadata_history).values(**values)))
+
+
+def issue_exists(issue_id):
+    """Return whether an issue exists without leaking shim empty-list semantics."""
+    stmt = select(t_issues.c.IssueID).where(t_issues.c.IssueID == issue_id).limit(1)
+    return db.select_one(stmt) is not None
+
+
+def delete_metadata_history(entity_type, entity_id, field_name, source):
+    """Delete matching AI metadata history records."""
+    stmt = delete(t_ai_metadata_history).where(
+        t_ai_metadata_history.c.entity_type == entity_type,
+        t_ai_metadata_history.c.entity_id == entity_id,
+        t_ai_metadata_history.c.field_name == field_name,
+        t_ai_metadata_history.c.source == source,
+    )
+    _run_write(lambda conn: conn.execute(stmt))
+
+
+def find_exact_library_match(series_name, dynamic_name):
+    """Find the legacy exact-name or dynamic-name library match."""
+    stmt = (
+        select(t_comics.c.ComicID)
+        .where(or_(t_comics.c.ComicName == series_name, t_comics.c.DynamicComicName == dynamic_name))
+        .limit(1)
+    )
+    return db.select_one(stmt)
+
+
+def find_case_insensitive_library_match(series_name):
+    """Find a series name using the legacy LOWER(column) comparison."""
+    stmt = select(t_comics.c.ComicID).where(func.lower(t_comics.c.ComicName) == func.lower(series_name)).limit(1)
+    return db.select_one(stmt)
+
+
+def get_alternate_search_values():
+    """Return every non-null alternate-search value for client-side matching."""
+    return db.select_all(select(t_comics.c.AlternateSearch).where(t_comics.c.AlternateSearch.is_not(None)))
+
+
+def get_alternate_search(comic_id):
+    """Return a single series's alternate-search field, or ``None`` when absent."""
+    stmt = select(t_comics.c.AlternateSearch).where(t_comics.c.ComicID == comic_id).limit(1)
+    return db.select_one(stmt)
+
+
+def update_alternate_search(comic_id, alternate_search):
+    """Persist the legacy ##-delimited alternate-search field."""
+    stmt = update(t_comics).where(t_comics.c.ComicID == comic_id).values(AlternateSearch=alternate_search)
+    _run_write(lambda conn: conn.execute(stmt))
+
+
+def get_cache_entry(cache_key, cache_type):
+    """Return the data and expiry for a typed cache key, or ``None`` when absent."""
+    stmt = (
+        select(t_ai_cache.c.data, t_ai_cache.c.expires_at)
+        .where(t_ai_cache.c.cache_key == cache_key, t_ai_cache.c.cache_type == cache_type)
+        .limit(1)
+    )
+    return db.select_one(stmt)
+
+
+def upsert_cache_entry(cache_key, cache_type, data, created_at, expires_at):
+    """Atomically replace an AI cache entry using its declared unique key."""
+    values = {
+        "cache_type": cache_type,
+        "data": data,
+        "created_at": created_at,
+        "expires_at": expires_at,
+    }
+    _run_write(
+        lambda conn: db.upsert_conn(
+            conn,
+            "ai_cache",
+            values,
+            {"cache_key": cache_key},
+        )
+    )
+
+
+def get_active_publisher_counts():
+    """Return the ten most common active-library publishers."""
+    count = func.count().label("count")
+    stmt = (
+        select(t_comics.c.ComicPublisher, count)
+        .where(t_comics.c.Status == "Active")
+        .group_by(t_comics.c.ComicPublisher)
+        .order_by(count.desc())
+        .limit(10)
+    )
+    return db.select_all(stmt)
+
+
+def get_active_series_count():
+    """Return the active-library series count."""
+    stmt = select(func.count().label("count")).select_from(t_comics).where(t_comics.c.Status == "Active")
+    return (db.select_one(stmt) or {}).get("count", 0) or 0
+
+
+def get_active_series_names():
+    """Return active series in the established sort-name order."""
+    stmt = (
+        select(t_comics.c.ComicName).where(t_comics.c.Status == "Active").order_by(t_comics.c.ComicSortName).limit(30)
+    )
+    return [row["ComicName"] for row in db.select_all(stmt) if row.get("ComicName")]
+
+
+def get_active_completion_rate():
+    """Return the legacy average per-series completion percentage, if any."""
+    completion = cast(t_comics.c.Have, Float) / func.nullif(cast(t_comics.c.Total, Float), 0) * 100
+    stmt = select(func.avg(completion).label("avg_pct")).where(t_comics.c.Status == "Active", t_comics.c.Total > 0)
+    return (db.select_one(stmt) or {}).get("avg_pct")
+
+
+def get_untracked_weekly_releases():
+    """Return untracked weekly releases in publisher/title order."""
+    stmt = (
+        select(t_weekly.c.COMIC, t_weekly.c.PUBLISHER, t_weekly.c.ISSUE, t_weekly.c.STATUS)
+        .where(or_(t_weekly.c.STATUS.is_(None), t_weekly.c.STATUS == ""))
+        .order_by(t_weekly.c.PUBLISHER, t_weekly.c.COMIC)
+        .limit(100)
+    )
+    return db.select_all(stmt)
+
+
+def find_series_candidates(series_name):
+    """Return the first five legacy LIKE candidates for an AI story-arc issue."""
+    stmt = (
+        select(t_comics.c.ComicID, t_comics.c.ComicName)
+        .where(t_comics.c.ComicName.like("%%%s%%" % series_name))
+        .limit(5)
+    )
+    return db.select_all(stmt)
+
+
+def find_issue_by_comic_and_number(comic_id, issue_number):
+    """Return the first matching issue identifier, or ``None``."""
+    stmt = (
+        select(t_issues.c.IssueID)
+        .where(t_issues.c.ComicID == comic_id, t_issues.c.Issue_Number == issue_number)
+        .limit(1)
+    )
+    return db.select_one(stmt)
+
+
+def get_issue_status_by_id(issue_id):
+    """Return an issue status by identifier, or ``None``."""
+    return db.select_one(select(t_issues.c.Status).where(t_issues.c.IssueID == issue_id).limit(1))
+
+
+def get_issue_status_by_comic_and_number(comic_id, issue_number):
+    """Return an issue status by comic and issue number, or ``None``."""
+    stmt = (
+        select(t_issues.c.Status)
+        .where(t_issues.c.ComicID == comic_id, t_issues.c.Issue_Number == issue_number)
+        .limit(1)
+    )
+    return db.select_one(stmt)
+
+
+def replace_storyarc(values):
+    """Replace one AI story-arc row, clearing fields omitted by the save payload.
+
+    The legacy ``INSERT OR REPLACE`` behavior intentionally discarded values
+    not included in the generated-arc payload. A conventional upsert would
+    retain stale columns, so use an explicit delete/insert pair in one
+    transaction for portable equivalent semantics.
+    """
+
+    def replace(conn):
+        conn.execute(delete(t_storyarcs).where(t_storyarcs.c.IssueArcID == values["IssueArcID"]))
+        conn.execute(insert(t_storyarcs).values(**values))
+
+    _run_write(replace)

--- a/comicarr/app/ai/reconciliation.py
+++ b/comicarr/app/ai/reconciliation.py
@@ -19,7 +19,8 @@ If AI is not configured, existing behaviour (CV wins) is preserved.
 import time
 
 import comicarr
-from comicarr import db, logger
+from comicarr import logger
+from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
 from comicarr.app.ai.enrichment import _write_comicinfo
 from comicarr.app.ai.sanitize import spotlight_wrap
@@ -175,16 +176,28 @@ def _store_reconciliation_history(issue_id, conflicts, resolved):
         if ai_value is None:
             continue
         # Row for comicinfo provider value
-        db.DBConnection().action(
-            "INSERT INTO ai_metadata_history "
-            "(entity_type, entity_id, field_name, original_value, ai_value, source, provider, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            ["issue", issue_id, field, sources["comicinfo"], ai_value, "reconciliation", "comicinfo", now],
+        ai_queries.insert_metadata_history(
+            {
+                "entity_type": "issue",
+                "entity_id": issue_id,
+                "field_name": field,
+                "original_value": sources["comicinfo"],
+                "ai_value": ai_value,
+                "source": "reconciliation",
+                "provider": "comicinfo",
+                "created_at": now,
+            }
         )
         # Row for cv provider value
-        db.DBConnection().action(
-            "INSERT INTO ai_metadata_history "
-            "(entity_type, entity_id, field_name, original_value, ai_value, source, provider, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            ["issue", issue_id, field, sources["cv"], ai_value, "reconciliation", "cv", now],
+        ai_queries.insert_metadata_history(
+            {
+                "entity_type": "issue",
+                "entity_id": issue_id,
+                "field_name": field,
+                "original_value": sources["cv"],
+                "ai_value": ai_value,
+                "source": "reconciliation",
+                "provider": "cv",
+                "created_at": now,
+            }
         )

--- a/comicarr/app/ai/reconciliation.py
+++ b/comicarr/app/ai/reconciliation.py
@@ -18,11 +18,11 @@ If AI is not configured, existing behaviour (CV wins) is preserved.
 
 import time
 
-import comicarr
 from comicarr import logger
 from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
 from comicarr.app.ai.enrichment import _write_comicinfo
+from comicarr.app.ai.runtime import get_ai_runtime
 from comicarr.app.ai.sanitize import spotlight_wrap
 from comicarr.app.ai.schemas import ReconciliationChoice
 from comicarr.app.ai.structured import request_structured
@@ -71,13 +71,14 @@ def reconcile_metadata(cbz_path, issue_id, pre_cmtag_info, post_cmtag_info):
     )
 
     # Check AI availability — if not available, CV wins by default
-    if comicarr.AI_CLIENT is None:
+    ctx = get_ai_runtime()
+    if ctx is None or ctx.ai_client is None or ctx.config is None:
         logger.fdebug("[AI-RECONCILE] AI not configured — CV values win by default")
         return 0
-    if not comicarr.AI_CIRCUIT_BREAKER.allow_request():
+    if ctx.ai_circuit_breaker is None or not ctx.ai_circuit_breaker.allow_request():
         logger.fdebug("[AI-RECONCILE] Circuit breaker open — CV values win by default")
         return 0
-    if not comicarr.AI_RATE_LIMITER.can_request():
+    if ctx.ai_rate_limiter is None or not ctx.ai_rate_limiter.can_request():
         logger.fdebug("[AI-RECONCILE] Rate limiter at cap — CV values win by default")
         return 0
 
@@ -99,16 +100,16 @@ def reconcile_metadata(cbz_path, issue_id, pre_cmtag_info, post_cmtag_info):
     start_time = time.time()
     try:
         result = request_structured(
-            client=comicarr.AI_CLIENT,
-            model=comicarr.CONFIG.AI_MODEL,
+            client=ctx.ai_client,
+            model=ctx.config.AI_MODEL,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             schema_class=ReconciliationChoice,
             temperature=0.1,
-            timeout=comicarr.CONFIG.AI_TIMEOUT or 30,
+            timeout=ctx.config.AI_TIMEOUT or 30,
         )
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_success()
+        ctx.ai_circuit_breaker.record_success()
 
         # Validate: each selected value MUST match one of the input values
         resolved = {}
@@ -137,7 +138,7 @@ def reconcile_metadata(cbz_path, issue_id, pre_cmtag_info, post_cmtag_info):
         ai_service.log_activity(
             feature_type="reconciliation",
             action="Reconciled %d fields for issue %s" % (len(resolved), issue_id),
-            model=comicarr.CONFIG.AI_MODEL,
+            model=ctx.config.AI_MODEL,
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,
@@ -151,11 +152,11 @@ def reconcile_metadata(cbz_path, issue_id, pre_cmtag_info, post_cmtag_info):
 
     except Exception as e:
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_failure()
+        ctx.ai_circuit_breaker.record_failure()
         ai_service.log_activity(
             feature_type="reconciliation",
             action="Reconciliation failed for issue %s" % issue_id,
-            model=comicarr.CONFIG.AI_MODEL or "",
+            model=ctx.config.AI_MODEL or "",
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,

--- a/comicarr/app/ai/runtime.py
+++ b/comicarr/app/ai/runtime.py
@@ -1,0 +1,26 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Canonical runtime accessor for AI consumers.
+
+AI entry points can be reached by legacy background work before FastAPI is
+serving. They therefore treat an unavailable/disposed runtime as an
+unconfigured AI service, while every active consumer reads the one canonical
+``AppContext`` bundle created by the process runtime factory.
+"""
+
+from comicarr.app.core.runtime import get_runtime_if_initialized
+
+
+def get_ai_runtime():
+    """Return the active canonical runtime, or ``None`` before/after lifecycle."""
+    ctx = get_runtime_if_initialized()
+    if ctx is None or ctx.disposed:
+        return None
+    return ctx

--- a/comicarr/app/ai/search_expansion.py
+++ b/comicarr/app/ai/search_expansion.py
@@ -21,7 +21,8 @@ import time
 from datetime import datetime
 
 import comicarr
-from comicarr import db, logger
+from comicarr import logger
+from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
 from comicarr.app.ai.sanitize import sanitize_input
 from comicarr.app.ai.schemas import SearchExpansion
@@ -130,16 +131,19 @@ def persist_successful_expansion(comic_id, successful_alternate):
     current = _get_alternate_search(comic_id)
     if successful_alternate.lower() not in {a.lower() for a in current}:
         new_value = "##".join(current + [successful_alternate]) if current else successful_alternate
-        db.DBConnection().action("UPDATE comics SET AlternateSearch = ? WHERE ComicID = ?", [new_value, comic_id])
+        ai_queries.update_alternate_search(comic_id, new_value)
 
     # Track in ai_cache for counting AI expansions
     existing = _get_ai_expansions(comic_id)
     existing.append(successful_alternate)
     now = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
 
-    db.DBConnection().action(
-        "INSERT OR REPLACE INTO ai_cache (cache_key, cache_type, data, created_at, expires_at) VALUES (?, ?, ?, ?, ?)",
-        ["expansion_%s" % comic_id, "expansion", json.dumps(existing), now, "9999-12-31"],
+    ai_queries.upsert_cache_entry(
+        "expansion_%s" % comic_id,
+        "expansion",
+        json.dumps(existing),
+        now,
+        "9999-12-31",
     )
 
     logger.fdebug('[AI-SEARCH] Persisted expansion "%s" for comic %s' % (successful_alternate, comic_id))
@@ -147,20 +151,18 @@ def persist_successful_expansion(comic_id, successful_alternate):
 
 def _get_alternate_search(comic_id):
     """Get current AlternateSearch values for a comic."""
-    result = db.DBConnection().select("SELECT AlternateSearch FROM comics WHERE ComicID = ?", [comic_id])
-    if result and result[0].get("AlternateSearch"):
-        return [a.strip() for a in result[0]["AlternateSearch"].split("##") if a.strip()]
+    result = ai_queries.get_alternate_search(comic_id)
+    if result and result.get("AlternateSearch"):
+        return [a.strip() for a in result["AlternateSearch"].split("##") if a.strip()]
     return []
 
 
 def _get_ai_expansions(comic_id):
     """Get AI-generated expansions from cache."""
-    result = db.DBConnection().select(
-        "SELECT data FROM ai_cache WHERE cache_key = ? AND cache_type = ?", ["expansion_%s" % comic_id, "expansion"]
-    )
-    if result and result[0].get("data"):
+    result = ai_queries.get_cache_entry("expansion_%s" % comic_id, "expansion")
+    if result and result.get("data"):
         try:
-            return json.loads(result[0]["data"])
+            return json.loads(result["data"])
         except (json.JSONDecodeError, TypeError):
             pass
     return []

--- a/comicarr/app/ai/search_expansion.py
+++ b/comicarr/app/ai/search_expansion.py
@@ -20,10 +20,10 @@ import json
 import time
 from datetime import datetime
 
-import comicarr
 from comicarr import logger
 from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
+from comicarr.app.ai.runtime import get_ai_runtime
 from comicarr.app.ai.sanitize import sanitize_input
 from comicarr.app.ai.schemas import SearchExpansion
 from comicarr.app.ai.structured import request_structured
@@ -34,12 +34,13 @@ def expand_search_queries(comic_id, series_name, publisher=None, year=None):
 
     Returns list of alternate query strings, or empty list on failure.
     """
-    if comicarr.AI_CLIENT is None:
+    ctx = get_ai_runtime()
+    if ctx is None or ctx.ai_client is None or ctx.config is None:
         return []
-    if not comicarr.AI_CIRCUIT_BREAKER.allow_request():
+    if ctx.ai_circuit_breaker is None or not ctx.ai_circuit_breaker.allow_request():
         logger.fdebug("[AI-SEARCH] Circuit breaker open, skipping expansion for %s" % comic_id)
         return []
-    if not comicarr.AI_RATE_LIMITER.can_request():
+    if ctx.ai_rate_limiter is None or not ctx.ai_rate_limiter.can_request():
         logger.fdebug("[AI-SEARCH] Rate limit reached, skipping expansion for %s" % comic_id)
         return []
 
@@ -71,16 +72,16 @@ def expand_search_queries(comic_id, series_name, publisher=None, year=None):
     start_time = time.time()
     try:
         result = request_structured(
-            client=comicarr.AI_CLIENT,
-            model=comicarr.CONFIG.AI_MODEL,
+            client=ctx.ai_client,
+            model=ctx.config.AI_MODEL,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             schema_class=SearchExpansion,
             temperature=0.3,
-            timeout=comicarr.CONFIG.AI_TIMEOUT or 30,
+            timeout=ctx.config.AI_TIMEOUT or 30,
         )
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_success()
+        ctx.ai_circuit_breaker.record_success()
 
         # Deduplicate against existing alternates
         new_alternates = []
@@ -96,7 +97,7 @@ def expand_search_queries(comic_id, series_name, publisher=None, year=None):
         ai_service.log_activity(
             feature_type="search",
             action="Generated %d alternates for '%s'" % (len(new_alternates), series_name),
-            model=comicarr.CONFIG.AI_MODEL,
+            model=ctx.config.AI_MODEL,
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,
@@ -110,11 +111,11 @@ def expand_search_queries(comic_id, series_name, publisher=None, year=None):
 
     except Exception as e:
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_failure()
+        ctx.ai_circuit_breaker.record_failure()
         ai_service.log_activity(
             feature_type="search",
             action="Search expansion failed for '%s'" % series_name,
-            model=comicarr.CONFIG.AI_MODEL or "",
+            model=ctx.config.AI_MODEL or "",
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,

--- a/comicarr/app/ai/service.py
+++ b/comicarr/app/ai/service.py
@@ -14,9 +14,9 @@ AI service — business logic for activity logging, status, and connection testi
 import datetime
 import time
 
-import comicarr
 from comicarr import logger
 from comicarr.app.ai import queries as ai_queries
+from comicarr.app.ai.runtime import get_ai_runtime
 
 
 def log_activity(
@@ -56,10 +56,8 @@ def log_activity(
 
     # Publish SSE event for real-time frontend updates
     try:
-        event_bus = getattr(comicarr, "EVENT_BUS", None)
-        if event_bus is None:
-            # Try AppContext path (FastAPI lifespan stores it on app.state.ctx)
-            pass
+        ctx = get_ai_runtime()
+        event_bus = ctx.event_bus if ctx is not None else None
         if event_bus:
             event_bus.publish_sync(
                 "ai_activity",
@@ -86,7 +84,8 @@ def get_activity(limit=50, offset=0):
 
 def get_ai_status():
     """Return a dict describing current AI configuration and usage state."""
-    config = comicarr.CONFIG
+    ctx = get_ai_runtime()
+    config = ctx.config if ctx is not None else None
 
     configured = (
         bool(
@@ -99,13 +98,13 @@ def get_ai_status():
     )
 
     circuit_state = "closed"
-    cb = comicarr.AI_CIRCUIT_BREAKER
+    cb = ctx.ai_circuit_breaker if ctx is not None else None
     if cb:
         circuit_state = cb.state
 
     today_tokens = 0
     today_requests = 0
-    rl = comicarr.AI_RATE_LIMITER
+    rl = ctx.ai_rate_limiter if ctx is not None else None
     if rl:
         today_tokens = rl.today_tokens
         today_requests = rl.today_requests

--- a/comicarr/app/ai/service.py
+++ b/comicarr/app/ai/service.py
@@ -15,7 +15,8 @@ import datetime
 import time
 
 import comicarr
-from comicarr import db, logger
+from comicarr import logger
+from comicarr.app.ai import queries as ai_queries
 
 
 def log_activity(
@@ -35,24 +36,20 @@ def log_activity(
     success_str = "true" if success else "false"
 
     try:
-        db.DBConnection().action(
-            "INSERT INTO ai_activity_log "
-            "(timestamp, feature_type, action_description, model, prompt_tokens, "
-            "completion_tokens, latency_ms, success, error_message, entity_type, entity_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            [
-                timestamp,
-                feature_type,
-                action,
-                model,
-                prompt_tokens,
-                completion_tokens,
-                latency_ms,
-                success_str,
-                error_message,
-                entity_type,
-                entity_id,
-            ],
+        ai_queries.insert_activity(
+            {
+                "timestamp": timestamp,
+                "feature_type": feature_type,
+                "action_description": action,
+                "model": model,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "latency_ms": latency_ms,
+                "success": success_str,
+                "error_message": error_message,
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+            }
         )
     except Exception as e:
         logger.error("[AI-SERVICE] Failed to log activity: %s" % e)
@@ -80,10 +77,7 @@ def log_activity(
 def get_activity(limit=50, offset=0):
     """Read recent activity log entries."""
     try:
-        rows = db.DBConnection().select(
-            "SELECT * FROM ai_activity_log ORDER BY id DESC LIMIT ? OFFSET ?",
-            [limit, offset],
-        )
+        rows = ai_queries.get_activity(limit, offset)
         return rows if rows else []
     except Exception as e:
         logger.error("[AI-SERVICE] Failed to read activity log: %s" % e)

--- a/comicarr/app/ai/story_arcs.py
+++ b/comicarr/app/ai/story_arcs.py
@@ -18,10 +18,10 @@ and saves to the storyarcs table.
 import time
 import uuid
 
-import comicarr
 from comicarr import logger
 from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
+from comicarr.app.ai.runtime import get_ai_runtime
 from comicarr.app.ai.sanitize import sanitize_input
 from comicarr.app.ai.schemas import ReadingOrder
 from comicarr.app.ai.structured import request_structured
@@ -33,15 +33,16 @@ def generate_reading_order(arc_description):
     Each issue dict has: series_name, issue_number, title, reading_order_position.
     Returns empty list if AI is not configured or on error.
     """
-    if comicarr.AI_CLIENT is None:
+    ctx = get_ai_runtime()
+    if ctx is None or ctx.ai_client is None or ctx.config is None:
         logger.fdebug("[AI-ARC] AI not configured, cannot generate reading order")
         return {"success": False, "error": "AI is not configured", "issues": []}
 
-    if not comicarr.AI_CIRCUIT_BREAKER.allow_request():
+    if ctx.ai_circuit_breaker is None or not ctx.ai_circuit_breaker.allow_request():
         logger.fdebug("[AI-ARC] Circuit breaker open, skipping reading order generation")
         return {"success": False, "error": "AI service temporarily unavailable", "issues": []}
 
-    if not comicarr.AI_RATE_LIMITER.can_request():
+    if ctx.ai_rate_limiter is None or not ctx.ai_rate_limiter.can_request():
         logger.fdebug("[AI-ARC] Rate limit reached, skipping reading order generation")
         return {"success": False, "error": "AI rate limit reached, try again later", "issues": []}
 
@@ -63,16 +64,16 @@ def generate_reading_order(arc_description):
     start_time = time.time()
     try:
         result = request_structured(
-            client=comicarr.AI_CLIENT,
-            model=comicarr.CONFIG.AI_MODEL,
+            client=ctx.ai_client,
+            model=ctx.config.AI_MODEL,
             system_prompt=system_prompt,
             user_prompt=user_prompt,
             schema_class=ReadingOrder,
             temperature=0.2,
-            timeout=getattr(comicarr.CONFIG, "AI_TIMEOUT", 30) or 30,
+            timeout=getattr(ctx.config, "AI_TIMEOUT", 30) or 30,
         )
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_success()
+        ctx.ai_circuit_breaker.record_success()
 
         issues = []
         for item in result.issues:
@@ -92,7 +93,7 @@ def generate_reading_order(arc_description):
         ai_service.log_activity(
             feature_type="storyarc",
             action="Generated reading order for '%s' (%d issues)" % (sanitized[:50], len(issues)),
-            model=comicarr.CONFIG.AI_MODEL,
+            model=ctx.config.AI_MODEL,
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,
@@ -106,11 +107,11 @@ def generate_reading_order(arc_description):
 
     except Exception as e:
         latency_ms = int((time.time() - start_time) * 1000)
-        comicarr.AI_CIRCUIT_BREAKER.record_failure()
+        ctx.ai_circuit_breaker.record_failure()
         ai_service.log_activity(
             feature_type="storyarc",
             action="Reading order generation failed for '%s'" % sanitized[:50],
-            model=getattr(comicarr.CONFIG, "AI_MODEL", "") or "",
+            model=getattr(ctx.config, "AI_MODEL", "") or "",
             prompt_tokens=0,
             completion_tokens=0,
             latency_ms=latency_ms,

--- a/comicarr/app/ai/story_arcs.py
+++ b/comicarr/app/ai/story_arcs.py
@@ -19,7 +19,8 @@ import time
 import uuid
 
 import comicarr
-from comicarr import db, logger
+from comicarr import logger
+from comicarr.app.ai import queries as ai_queries
 from comicarr.app.ai import service as ai_service
 from comicarr.app.ai.sanitize import sanitize_input
 from comicarr.app.ai.schemas import ReadingOrder
@@ -135,9 +136,7 @@ def enrich_with_providers(issues):
 
         try:
             # Search the comics table for a matching series
-            results = db.DBConnection().select(
-                "SELECT ComicID, ComicName FROM comics WHERE ComicName LIKE ? LIMIT 5", ["%%%s%%" % series_name]
-            )
+            results = ai_queries.find_series_candidates(series_name)
 
             if results:
                 # Take the best match (first result)
@@ -147,12 +146,9 @@ def enrich_with_providers(issues):
 
                 # Try to find the specific issue
                 if comic_id and issue_number:
-                    issue_results = db.DBConnection().select(
-                        "SELECT IssueID FROM issues WHERE ComicID = ? AND Issue_Number = ? LIMIT 1",
-                        [comic_id, issue_number],
-                    )
-                    if issue_results:
-                        issue["issue_id"] = issue_results[0].get("IssueID")
+                    issue_result = ai_queries.find_issue_by_comic_and_number(comic_id, issue_number)
+                    if issue_result:
+                        issue["issue_id"] = issue_result.get("IssueID")
 
         except Exception as e:
             logger.error('[AI-ARC] Provider enrichment error for "%s #%s": %s' % (series_name, issue_number, e))
@@ -178,16 +174,14 @@ def map_to_library(issues):
         try:
             # Check the issues table for this specific issue
             if issue_id:
-                result = db.DBConnection().select("SELECT Status FROM issues WHERE IssueID = ? LIMIT 1", [issue_id])
+                result = ai_queries.get_issue_status_by_id(issue_id)
             elif issue_number:
-                result = db.DBConnection().select(
-                    "SELECT Status FROM issues WHERE ComicID = ? AND Issue_Number = ? LIMIT 1", [comic_id, issue_number]
-                )
+                result = ai_queries.get_issue_status_by_comic_and_number(comic_id, issue_number)
             else:
                 result = None
 
             if result:
-                status = result[0].get("Status", "")
+                status = result.get("Status", "")
                 if status in ("Downloaded", "Archived"):
                     issue["library_status"] = "owned"
                 elif status == "Wanted":
@@ -234,26 +228,7 @@ def save_arc(arc_name, issues):
                 "DateAdded": now,
             }
 
-            db.DBConnection().action(
-                "INSERT OR REPLACE INTO storyarcs "
-                "(StoryArcID, StoryArc, ComicName, IssueNumber, IssueName, ReadingOrder, "
-                "ComicID, IssueID, Status, IssueArcID, Manual, DateAdded) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                [
-                    values["StoryArcID"],
-                    values["StoryArc"],
-                    values["ComicName"],
-                    values["IssueNumber"],
-                    values["IssueName"],
-                    values["ReadingOrder"],
-                    values["ComicID"],
-                    values["IssueID"],
-                    values["Status"],
-                    values["IssueArcID"],
-                    values["Manual"],
-                    values["DateAdded"],
-                ],
-            )
+            ai_queries.replace_storyarc(values)
 
         logger.fdebug('[AI-ARC] Saved arc "%s" with %d issues (ID: %s)' % (arc_name, len(issues), arc_id))
         return {"success": True, "arc_id": arc_id}

--- a/comicarr/app/core/context.py
+++ b/comicarr/app/core/context.py
@@ -19,8 +19,9 @@ Ownership categories and boundaries:
 
 * immutable configuration: paths and ``config`` are fixed after factory
   creation; configuration writes use the existing Config transaction boundary.
-* long-lived services: scheduler, provider sessions, crypto, and AI clients
-  are created once and closed by the lifespan after workers drain.
+* long-lived services: scheduler, provider sessions, crypto, AI clients, and
+  the event bus are created once. Lifespan first quiesces scheduler jobs, then
+  closes the event bus before draining workers and closing other clients.
 * queues and locks: all worker/request-visible queues and locks are adopted by
   identity from the legacy runtime.  The compatibility bridge may expose the
   same object to an unmigrated caller, but it must never clone one.
@@ -32,9 +33,12 @@ Ownership categories and boundaries:
   projected into ``comicarr`` temporarily for legacy engines.  Context is the
   canonical writer for migrated code; the projection is not a second owner.
 
-Shutdown owner/order is the FastAPI lifespan: stop scheduling, signal queues,
-join workers off the event loop, close clients, dispose database resources,
-then mark the context disposed so no later request can use it.
+Shutdown owner/order is the FastAPI lifespan: quiesce scheduled jobs off the
+event loop, close the event bus, signal queues, join workers off the event
+loop, close clients, dispose database resources, then mark the context
+disposed so no later request can use it. If scheduler quiescence times out,
+lifespan leaves runtime resources intact for Comicarr.py's terminal process
+exit instead of disposing them underneath a still-running job.
 
 Type annotations are an explicit exception to the project's "no type hints"
 rule — structured shared-state objects where types genuinely pay for themselves.

--- a/comicarr/app/core/context.py
+++ b/comicarr/app/core/context.py
@@ -7,11 +7,34 @@
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 
-"""
-AppContext — typed dataclass replacing 130+ module-level globals.
+"""The process-wide runtime state contract.
 
-Created once at startup via FastAPI's lifespan, stored on app.state,
-and injected into routes via Depends(get_context).
+``AppContext`` has one owner per process lifecycle.  It is created by
+``comicarr.app.core.runtime.create_runtime`` *after* configuration, schema
+readiness, and secret setup have completed, and *before* the legacy workers
+start.  FastAPI's lifespan only attaches that instance to ``app.state``; it
+never rebuilds a snapshot.
+
+Ownership categories and boundaries:
+
+* immutable configuration: paths and ``config`` are fixed after factory
+  creation; configuration writes use the existing Config transaction boundary.
+* long-lived services: scheduler, provider sessions, crypto, and AI clients
+  are created once and closed by the lifespan after workers drain.
+* queues and locks: all worker/request-visible queues and locks are adopted by
+  identity from the legacy runtime.  The compatibility bridge may expose the
+  same object to an unmigrated caller, but it must never clone one.
+* request-visible state: statuses, progress, migration/acquisition gate, and
+  lifecycle values are updated through the runtime bridge's lock.  Durable
+  acquisition decisions remain serialized by ``MaintenanceController``'s
+  database transaction/fence before their in-memory projection is updated.
+* legacy compatibility state: worker-pool references and scalar aliases stay
+  projected into ``comicarr`` temporarily for legacy engines.  Context is the
+  canonical writer for migrated code; the projection is not a second owner.
+
+Shutdown owner/order is the FastAPI lifespan: stop scheduling, signal queues,
+join workers off the event loop, close clients, dispose database resources,
+then mark the context disposed so no later request can use it.
 
 Type annotations are an explicit exception to the project's "no type hints"
 rule — structured shared-state objects where types genuinely pay for themselves.
@@ -35,11 +58,15 @@ class AppContext:
     # Scheduler
     scheduler: object = None  # BackgroundScheduler
 
-    # Thread-safe locks
+    # Thread-safe locks. ``runtime_lock`` serializes context/legacy projection
+    # writes; the acquired queue and domain locks retain their legacy locking
+    # semantics and identities.
+    runtime_lock: object = field(default_factory=threading.RLock)
     init_lock: threading.Lock = field(default_factory=threading.Lock)
     search_lock: object = None  # ThreadSafeLock
     api_lock: object = None  # ThreadSafeLock
     ddl_lock: object = None  # ThreadSafeLock
+    acquisition_resume_lock: object = None  # threading.Lock
 
     # Work queues (inter-thread communication)
     snatched_queue: queue.Queue = field(default_factory=queue.Queue)
@@ -51,6 +78,16 @@ class AppContext:
     add_list: queue.Queue = field(default_factory=queue.Queue)
     issue_watch_list: queue.Queue = field(default_factory=queue.Queue)
     refresh_queue: queue.Queue = field(default_factory=queue.Queue)
+
+    # Worker references. These stay compatibility-projected while the legacy
+    # worker bootstrap is being strangled; the objects themselves are shared.
+    sn_pool: object = None
+    nzb_pool: object = None
+    search_pool: object = None
+    pp_pool: object = None
+    ddl_pool: object = None
+    mass_add_pool: object = None
+    mass_refresh_pool: object = None
 
     # SSE
     event_bus: object = None  # EventBus instance
@@ -86,6 +123,8 @@ class AppContext:
     version_status: str = "Waiting"
     updater_status: str = "Waiting"
     force_status: dict = field(default_factory=dict)
+    importinbox_status: str = "Waiting"
+    weekly_manual_next_run: object = None
 
     # Import progress tracking
     import_status: str = None
@@ -126,7 +165,39 @@ class AppContext:
     start_up: bool = True
     update_value: dict = field(default_factory=dict)
 
+    # Database/acquisition runtime projection. Durable maintenance state is
+    # owned by the database fence; these fields expose its latest safe view.
+    db_empty: bool = False
+    acquisition_schema_ready: bool = False
+    acquisition_schema_version: int = 0
+    acquisition_schema_error: str = None
+    acquisition_workers_blocked: bool = True
+    acquisition_block_reason: str = "schema_unavailable"
+
+    # Migration status is request-visible and projected for legacy callers.
+    migration_in_progress: bool = False
+    migration_status: str = "idle"
+    migration_current_table: str = ""
+    migration_tables_complete: int = 0
+    migration_tables_total: int = 0
+    migration_error: str = None
+    migration_reconciliation: object = None
+
+    # Lifecycle terminal state. Accessors reject a disposed context rather
+    # than allowing a request/background callback to touch closed resources.
+    disposed: bool = False
+
 
 def get_context(request: Request) -> AppContext:
     """FastAPI dependency — injects the application context."""
-    return request.app.state.ctx
+    try:
+        ctx = request.app.state.ctx
+    except AttributeError as e:
+        from comicarr.app.core.runtime import RuntimeNotInitializedError
+
+        raise RuntimeNotInitializedError("Runtime context is not initialized") from e
+    if ctx is None or getattr(ctx, "disposed", False):
+        from comicarr.app.core.runtime import RuntimeNotInitializedError
+
+        raise RuntimeNotInitializedError("Runtime context is not initialized or has been disposed")
+    return ctx

--- a/comicarr/app/core/events.py
+++ b/comicarr/app/core/events.py
@@ -40,10 +40,22 @@ class EventBus:
         self._subscribers = {}
         self._counter = 0
         self._loop = None
+        self._closing = False
 
     def set_loop(self, loop):
         """Called during lifespan startup to capture the running event loop."""
-        self._loop = loop
+        with self._lock:
+            self._loop = loop
+
+    def close(self):
+        """Reject future publishes once the runtime begins shutting down.
+
+        The close flag and publisher snapshot share one lock. A publish that
+        has already acquired the lock may still be delivered, but no caller
+        can enqueue a new event after this method returns.
+        """
+        with self._lock:
+            self._closing = True
 
     def subscribe(self):
         """Create a new subscriber queue. Returns (sub_id, queue)."""
@@ -98,18 +110,17 @@ class EventBus:
         Uses loop.call_soon_threadsafe() to ensure the event loop is
         properly woken up when events are published from worker threads.
         """
-        if self._loop is None:
-            return
-
-        event = AppEvent(event_type, payload)
         with self._lock:
-            snapshot = list(self._subscribers.values())
+            if self._closing or self._loop is None:
+                return False
 
-        for q in snapshot:
-            try:
-                self._loop.call_soon_threadsafe(self._enqueue_latest, q, event)
-            except RuntimeError:
-                pass  # Event loop closed during shutdown
+            event = AppEvent(event_type, payload)
+            for q in self._subscribers.values():
+                try:
+                    self._loop.call_soon_threadsafe(self._enqueue_latest, q, event)
+                except RuntimeError:
+                    pass  # Event loop closed during shutdown
+        return True
 
     @property
     def subscriber_count(self):

--- a/comicarr/app/core/runtime.py
+++ b/comicarr/app/core/runtime.py
@@ -1,0 +1,301 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Single-shot creation and temporary legacy projection for ``AppContext``.
+
+The factory deliberately *adopts* initialized legacy objects.  In particular,
+queues, locks, sets, dictionaries, scheduler, and client instances are passed
+to ``AppContext`` by reference.  No mutable object is copied during this
+transition: unmigrated legacy code and migrated context consumers therefore
+observe the same state until the legacy aliases can be removed.
+"""
+
+import os
+import threading
+
+from comicarr.app.core.context import AppContext
+from comicarr.app.core.events import EventBus
+from comicarr.app.core.security import generate_ephemeral_key, load_or_create_jwt_key
+
+
+class RuntimeNotInitializedError(RuntimeError):
+    """Raised when code attempts to use runtime state outside its lifecycle."""
+
+
+# The factory lock makes normal startup single-shot even if a future bootstrap
+# path races with a server/lifespan integration test. The singleton is private;
+# consumers use get_runtime(), FastAPI's get_context(), or an explicit ctx.
+_runtime_lock = threading.Lock()
+_runtime = None
+_UNSET = object()
+
+
+# ``AppContext`` fields that still need a temporary legacy projection. Mutable
+# entries in this map always point to the exact same object. Scalar projections
+# are written through set_runtime_field under ctx.runtime_lock so migrated code
+# has one writer while old engines are drained.
+_CONTEXT_TO_LEGACY = {
+    "prog_dir": "PROG_DIR",
+    "data_dir": "DATA_DIR",
+    "db_file": "DB_FILE",
+    "config": "CONFIG",
+    "scheduler": "SCHED",
+    "init_lock": "INIT_LOCK",
+    "search_lock": "SEARCHLOCK",
+    "api_lock": "APILOCK",
+    "ddl_lock": "DDL_LOCK",
+    "acquisition_resume_lock": "ACQUISITION_RESUME_LOCK",
+    "snatched_queue": "SNATCHED_QUEUE",
+    "nzb_queue": "NZB_QUEUE",
+    "pp_queue": "PP_QUEUE",
+    "search_queue": "SEARCH_QUEUE",
+    "ddl_queue": "DDL_QUEUE",
+    "return_nzb_queue": "RETURN_THE_NZBQUEUE",
+    "add_list": "ADD_LIST",
+    "issue_watch_list": "ISSUE_WATCH_LIST",
+    "refresh_queue": "REFRESH_QUEUE",
+    "sn_pool": "SNPOOL",
+    "nzb_pool": "NZBPOOL",
+    "search_pool": "SEARCHPOOL",
+    "pp_pool": "PPPOOL",
+    "ddl_pool": "DDLPOOL",
+    "mass_add_pool": "MASS_ADD",
+    "mass_refresh_pool": "MASS_REFRESH",
+    "cv_session": "CV_SESSION",
+    "cv_rate_limiter": "CV_RATE_LIMITER",
+    "cv_cache": "CV_CACHE",
+    "metron_api": "METRON_API",
+    "ai_client": "AI_CLIENT",
+    "ai_async_client": "AI_ASYNC_CLIENT",
+    "ai_circuit_breaker": "AI_CIRCUIT_BREAKER",
+    "ai_rate_limiter": "AI_RATE_LIMITER",
+    "comic_sort": "COMICSORT",
+    "publisher_imprints": "PUBLISHER_IMPRINTS",
+    "provider_blocklist": "PROVIDER_BLOCKLIST",
+    "ddl_queued": "DDL_QUEUED",
+    "ddl_stuck_notified": "DDL_STUCK_NOTIFIED",
+    "pack_issueids_dont_queue": "PACK_ISSUEIDS_DONT_QUEUE",
+    "folder_cache": "FOLDER_CACHE",
+    "check_folder_cache": "CHECK_FOLDER_CACHE",
+    "monitor_status": "MONITOR_STATUS",
+    "search_status": "SEARCH_STATUS",
+    "rss_status": "RSS_STATUS",
+    "weekly_status": "WEEKLY_STATUS",
+    "version_status": "VERSION_STATUS",
+    "updater_status": "UPDATER_STATUS",
+    "force_status": "FORCE_STATUS",
+    "importinbox_status": "IMPORTINBOX_STATUS",
+    "weekly_manual_next_run": "WEEKLY_MANUAL_NEXT_RUN",
+    "import_status": "IMPORT_STATUS",
+    "import_files": "IMPORT_FILES",
+    "import_totalfiles": "IMPORT_TOTALFILES",
+    "import_cid_count": "IMPORT_CID_COUNT",
+    "import_parsed_count": "IMPORT_PARSED_COUNT",
+    "import_failure_count": "IMPORT_FAILURE_COUNT",
+    "import_lock": "IMPORTLOCK",
+    "import_button": "IMPORTBUTTON",
+    "download_apikey": "DOWNLOAD_APIKEY",
+    "sse_key": "SSE_KEY",
+    "setup_token": "SETUP_TOKEN",
+    "backend_status_ws": "BACKENDSTATUS_WS",
+    "backend_status_cv": "BACKENDSTATUS_CV",
+    "provider_status": "PROVIDER_STATUS",
+    "current_version": "CURRENT_VERSION",
+    "current_version_name": "CURRENT_VERSION_NAME",
+    "current_release_name": "CURRENT_RELEASE_NAME",
+    "latest_version": "LATEST_VERSION",
+    "commits_behind": "COMMITS_BEHIND",
+    "install_type": "INSTALL_TYPE",
+    "current_branch": "CURRENT_BRANCH",
+    "signal": "SIGNAL",
+    "started": "started",
+    "start_up": "START_UP",
+    "update_value": "UPDATE_VALUE",
+    "db_empty": "DB_EMPTY",
+    "acquisition_schema_ready": "ACQUISITION_SCHEMA_READY",
+    "acquisition_schema_version": "ACQUISITION_SCHEMA_VERSION",
+    "acquisition_schema_error": "ACQUISITION_SCHEMA_ERROR",
+    "acquisition_workers_blocked": "ACQUISITION_WORKERS_BLOCKED",
+    "acquisition_block_reason": "ACQUISITION_BLOCK_REASON",
+    "migration_in_progress": "MIGRATION_IN_PROGRESS",
+    "migration_status": "MIGRATION_STATUS",
+    "migration_current_table": "MIGRATION_CURRENT_TABLE",
+    "migration_tables_complete": "MIGRATION_TABLES_COMPLETE",
+    "migration_tables_total": "MIGRATION_TABLES_TOTAL",
+    "migration_error": "MIGRATION_ERROR",
+    "migration_reconciliation": "MIGRATION_RECONCILIATION",
+}
+
+
+def _legacy_value(comicarr, field, default=None):
+    """Read an initialized legacy value without fabricating a mutable default."""
+    return getattr(comicarr, _CONTEXT_TO_LEGACY[field], default)
+
+
+def _adopt_legacy_runtime():
+    """Build context kwargs from existing process objects, preserving identity."""
+    import comicarr
+
+    return {
+        field: _legacy_value(comicarr, field)
+        for field in _CONTEXT_TO_LEGACY
+        if field
+        not in {
+            "sse_key",
+            "ai_client",
+            "ai_async_client",
+            "ai_circuit_breaker",
+            "ai_rate_limiter",
+        }
+    }
+
+
+def _initialize_ai_clients(ctx):
+    """Create one AI client bundle at the runtime lifecycle boundary.
+
+    AI consumers remain on their existing legacy aliases for this ownership
+    wave; the aliases receive these same instances through the bridge below.
+    """
+    ai_config = ctx.config
+    if not ai_config or not getattr(ai_config, "AI_BASE_URL", None) or not getattr(ai_config, "AI_API_KEY", None):
+        return
+
+    from comicarr import logger
+    from comicarr.app.ai.circuit_breaker import CircuitBreaker
+    from comicarr.app.ai.client import create_ai_clients
+    from comicarr.app.ai.rate_limiter import AIRateLimiter
+
+    sync_client, async_client = create_ai_clients(ai_config)
+    if not sync_client:
+        return
+
+    ctx.ai_client = sync_client
+    ctx.ai_async_client = async_client
+    ctx.ai_circuit_breaker = CircuitBreaker(
+        threshold=getattr(ai_config, "AI_CIRCUIT_THRESHOLD", 5),
+        cooldown=getattr(ai_config, "AI_CIRCUIT_COOLDOWN", 300),
+    )
+    ctx.ai_rate_limiter = AIRateLimiter(
+        rpm_limit=getattr(ai_config, "AI_RPM_LIMIT", 20),
+        daily_token_limit=getattr(ai_config, "AI_DAILY_TOKEN_LIMIT", 100000),
+    )
+    logger.info("[AI] Client initialized: %s" % getattr(ai_config, "AI_BASE_URL", ""))
+
+
+def _project_context(ctx):
+    """Expose context values to remaining legacy engines without copying them."""
+    import comicarr
+
+    for field, legacy_name in _CONTEXT_TO_LEGACY.items():
+        if field == "disposed":
+            continue
+        setattr(comicarr, legacy_name, getattr(ctx, field))
+
+
+def create_runtime():
+    """Create and return the single canonical process runtime.
+
+    Configuration must already exist. This intentionally fails closed rather
+    than constructing an incomplete context that could let workers run before
+    schema/secret setup finishes.
+    """
+    global _runtime
+
+    with _runtime_lock:
+        if _runtime is not None:
+            return _runtime
+
+        import comicarr
+
+        if getattr(comicarr, "CONFIG", None) is None:
+            raise RuntimeNotInitializedError(
+                "Runtime context cannot be created before configuration, schema, and secret initialization"
+            )
+
+        ctx = AppContext(**_adopt_legacy_runtime())
+        ctx.sse_key = getattr(comicarr, "SSE_KEY", None) or generate_ephemeral_key()
+        ctx.event_bus = EventBus()
+
+        secure_dir = getattr(ctx.config, "SECURE_DIR", None)
+        ctx.jwt_secret_key = load_or_create_jwt_key(secure_dir) if secure_dir else os.urandom(32)
+        _initialize_ai_clients(ctx)
+        _project_context(ctx)
+        _runtime = ctx
+        return ctx
+
+
+def get_runtime():
+    """Return the initialized process runtime or fail clearly before startup."""
+    if _runtime is None:
+        raise RuntimeNotInitializedError("Runtime context is not initialized")
+    if _runtime.disposed:
+        raise RuntimeNotInitializedError("Runtime context has been disposed")
+    return _runtime
+
+
+def get_runtime_if_initialized():
+    """Best-effort compatibility helper for legacy code that runs pre-factory."""
+    return _runtime
+
+
+def set_runtime_field(ctx, field, value, *, project_legacy=True):
+    """Write a canonical field and, while needed, its legacy projection.
+
+    This is intentionally the only bridge used by migrated lifecycle/system/
+    acquisition writers. Mutable values are assigned by identity; no clone or
+    value snapshot is produced.
+    """
+    if ctx is None:
+        raise RuntimeNotInitializedError("Runtime context is not initialized")
+    if ctx.disposed:
+        raise RuntimeNotInitializedError("Runtime context has been disposed")
+
+    with ctx.runtime_lock:
+        setattr(ctx, field, value)
+        if project_legacy:
+            legacy_name = _CONTEXT_TO_LEGACY.get(field)
+            if legacy_name:
+                import comicarr
+
+                setattr(comicarr, legacy_name, value)
+    return value
+
+
+def set_runtime_acquisition_status(
+    *,
+    schema_ready=_UNSET,
+    schema_version=_UNSET,
+    schema_error=_UNSET,
+    workers_blocked=_UNSET,
+    block_reason=_UNSET,
+):
+    """Project durable acquisition status into context when it already exists.
+
+    Schema setup runs before runtime creation, so pre-factory calls keep the
+    existing globals authoritative. Once the factory exists, all values are
+    updated under the runtime lock and projected to legacy callers.
+    """
+    import comicarr
+
+    ctx = get_runtime_if_initialized()
+    values = {
+        "acquisition_schema_ready": schema_ready,
+        "acquisition_schema_version": schema_version,
+        "acquisition_schema_error": schema_error,
+        "acquisition_workers_blocked": workers_blocked,
+        "acquisition_block_reason": block_reason,
+    }
+    for field, value in values.items():
+        if value is _UNSET:
+            continue
+        if ctx is None:
+            legacy_name = _CONTEXT_TO_LEGACY[field]
+            setattr(comicarr, legacy_name, value)
+        else:
+            set_runtime_field(ctx, field, value)

--- a/comicarr/app/core/runtime.py
+++ b/comicarr/app/core/runtime.py
@@ -133,6 +133,20 @@ _CONTEXT_TO_LEGACY = {
 }
 
 
+# Keep the legacy worker names and their canonical context fields in one
+# ordered mapping. Startup stores these identities here and lifespan drains
+# them in this same order.
+POOL_CONTEXT_FIELDS = {
+    "SNPOOL": "sn_pool",
+    "NZBPOOL": "nzb_pool",
+    "SEARCHPOOL": "search_pool",
+    "PPPOOL": "pp_pool",
+    "DDLPOOL": "ddl_pool",
+    "MASS_ADD": "mass_add_pool",
+    "MASS_REFRESH": "mass_refresh_pool",
+}
+
+
 def _legacy_value(comicarr, field, default=None):
     """Read an initialized legacy value without fabricating a mutable default."""
     return getattr(comicarr, _CONTEXT_TO_LEGACY[field], default)

--- a/comicarr/app/core/runtime.py
+++ b/comicarr/app/core/runtime.py
@@ -159,8 +159,8 @@ def _adopt_legacy_runtime():
 def _initialize_ai_clients(ctx):
     """Create one AI client bundle at the runtime lifecycle boundary.
 
-    AI consumers remain on their existing legacy aliases for this ownership
-    wave; the aliases receive these same instances through the bridge below.
+    Canonical consumers read this context bundle. Remaining legacy aliases
+    receive these same instances through the temporary bridge below.
     """
     ai_config = ctx.config
     if not ai_config or not getattr(ai_config, "AI_BASE_URL", None) or not getattr(ai_config, "AI_API_KEY", None):

--- a/comicarr/app/dashboard/queries.py
+++ b/comicarr/app/dashboard/queries.py
@@ -1,0 +1,85 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""SQLAlchemy Core projections owned by the dashboard domain."""
+
+from sqlalchemy import func, or_, select
+
+from comicarr import db
+from comicarr.tables import ai_activity_log as t_ai_activity_log
+from comicarr.tables import comics as t_comics
+from comicarr.tables import snatched as t_snatched
+
+
+def get_recent_activity(cutoff, limit=10):
+    """Return the bounded, newest-first snatch preview at an inclusive cutoff."""
+    stmt = (
+        select(
+            t_snatched.c.ComicName,
+            t_snatched.c.Issue_Number,
+            t_snatched.c.DateAdded,
+            t_snatched.c.Status,
+            t_snatched.c.Provider,
+            t_snatched.c.ComicID,
+            t_snatched.c.IssueID,
+            t_comics.c.ComicImage,
+        )
+        .select_from(t_snatched.outerjoin(t_comics, t_snatched.c.ComicID == t_comics.c.ComicID))
+        .where(t_snatched.c.DateAdded >= cutoff)
+        .order_by(t_snatched.c.DateAdded.desc())
+        .limit(int(limit))
+    )
+    return db.select_all(stmt)
+
+
+def get_library_stats(content_type=None):
+    """Return combined, manga-only, or comic-only library aggregates."""
+    if content_type == "manga":
+        columns = (
+            func.count().label("manga_series"),
+            func.coalesce(func.sum(t_comics.c.Have), 0).label("manga_have"),
+            func.coalesce(func.sum(t_comics.c.Total), 0).label("manga_total"),
+        )
+        conditions = (t_comics.c.Status != "Paused", t_comics.c.ContentType == "manga")
+    elif content_type == "comic":
+        columns = (
+            func.count().label("comic_series"),
+            func.coalesce(func.sum(t_comics.c.Have), 0).label("comic_have"),
+            func.coalesce(func.sum(t_comics.c.Total), 0).label("comic_total"),
+        )
+        conditions = (
+            t_comics.c.Status != "Paused",
+            or_(t_comics.c.ContentType.is_(None), t_comics.c.ContentType == "comic"),
+        )
+    else:
+        columns = (
+            func.count().label("total_series"),
+            func.coalesce(func.sum(t_comics.c.Have), 0).label("total_issues"),
+            func.coalesce(func.sum(t_comics.c.Total), 0).label("total_expected"),
+        )
+        conditions = (t_comics.c.Status != "Paused",)
+
+    return db.select_one(select(*columns).select_from(t_comics).where(*conditions))
+
+
+def get_recent_ai_activity(limit=5):
+    """Return the dashboard's compact newest-first AI activity preview."""
+    stmt = (
+        select(
+            t_ai_activity_log.c.timestamp,
+            t_ai_activity_log.c.feature_type,
+            t_ai_activity_log.c.action_description,
+            t_ai_activity_log.c.prompt_tokens,
+            t_ai_activity_log.c.completion_tokens,
+            t_ai_activity_log.c.success,
+        )
+        .order_by(t_ai_activity_log.c.timestamp.desc())
+        .limit(int(limit))
+    )
+    return db.select_all(stmt)

--- a/comicarr/app/dashboard/service.py
+++ b/comicarr/app/dashboard/service.py
@@ -15,7 +15,8 @@ the home dashboard view.
 from datetime import datetime, timedelta
 
 import comicarr
-from comicarr import db, logger
+from comicarr import logger
+from comicarr.app.dashboard import queries as dashboard_queries
 from comicarr.app.downloads import queries as dl_queries
 from comicarr.app.storyarcs import service as storyarcs_service
 
@@ -49,13 +50,7 @@ def get_dashboard_data(ctx):
     # Recent activity is a bounded preview. Full history retains all rows.
     try:
         cutoff = recent_activity_cutoff().strftime("%Y-%m-%d %H:%M:%S")
-        recent = db.DBConnection().select(
-            "SELECT s.ComicName, s.Issue_Number, s.DateAdded, s.Status, s.Provider, "
-            "s.ComicID, s.IssueID, c.ComicImage "
-            "FROM snatched s LEFT JOIN comics c ON s.ComicID = c.ComicID "
-            "WHERE s.DateAdded >= ? ORDER BY s.DateAdded DESC LIMIT 10",
-            [cutoff],
-        )
+        recent = dashboard_queries.get_recent_activity(cutoff)
         result["recently_downloaded"] = recent or []
     except Exception as e:
         logger.error("[DASHBOARD] Error fetching recent downloads: %s" % e)
@@ -68,12 +63,7 @@ def get_dashboard_data(ctx):
 
     # Stats: aggregate from comics (combined + per content type)
     try:
-        stats = db.DBConnection().selectone(
-            "SELECT COUNT(*) as total_series, "
-            "COALESCE(SUM(Have), 0) as total_issues, "
-            "COALESCE(SUM(Total), 0) as total_expected "
-            "FROM comics WHERE Status != 'Paused'"
-        )
+        stats = dashboard_queries.get_library_stats()
         if stats:
             total_expected = stats.get("total_expected", 0) or 0
             total_issues = stats.get("total_issues", 0) or 0
@@ -86,12 +76,7 @@ def get_dashboard_data(ctx):
             result["stats"].setdefault("queue_count", 0)
 
         # Manga-specific stats
-        manga_stats = db.DBConnection().selectone(
-            "SELECT COUNT(*) as manga_series, "
-            "COALESCE(SUM(Have), 0) as manga_have, "
-            "COALESCE(SUM(Total), 0) as manga_total "
-            "FROM comics WHERE Status != 'Paused' AND ContentType = 'manga'"
-        )
+        manga_stats = dashboard_queries.get_library_stats("manga")
         if manga_stats:
             manga_total = manga_stats.get("manga_total", 0) or 0
             manga_have = manga_stats.get("manga_have", 0) or 0
@@ -101,12 +86,7 @@ def get_dashboard_data(ctx):
             result["stats"]["manga_completion_pct"] = round(manga_have / manga_total * 100, 1) if manga_total > 0 else 0
 
         # Comic-specific stats (non-manga)
-        comic_stats = db.DBConnection().selectone(
-            "SELECT COUNT(*) as comic_series, "
-            "COALESCE(SUM(Have), 0) as comic_have, "
-            "COALESCE(SUM(Total), 0) as comic_total "
-            "FROM comics WHERE Status != 'Paused' AND (ContentType IS NULL OR ContentType = 'comic')"
-        )
+        comic_stats = dashboard_queries.get_library_stats("comic")
         if comic_stats:
             result["stats"]["comic_series"] = comic_stats.get("comic_series", 0)
             result["stats"]["comic_have"] = comic_stats.get("comic_have", 0) or 0
@@ -132,11 +112,7 @@ def get_dashboard_data(ctx):
     if comicarr.AI_CLIENT is not None or ai_base_url:
         result["ai_configured"] = True
         try:
-            activity = db.DBConnection().select(
-                "SELECT timestamp, feature_type, action_description, "
-                "prompt_tokens, completion_tokens, success "
-                "FROM ai_activity_log ORDER BY timestamp DESC LIMIT 5"
-            )
+            activity = dashboard_queries.get_recent_ai_activity()
             result["ai_activity"] = activity or []
         except Exception as e:
             logger.error("[DASHBOARD] Error fetching AI activity: %s" % e)

--- a/comicarr/app/main.py
+++ b/comicarr/app/main.py
@@ -29,7 +29,12 @@ from comicarr.app.core.middleware import (
     SecurityHeadersMiddleware,
     SetupGateMiddleware,
 )
-from comicarr.app.core.runtime import get_runtime, set_runtime_acquisition_status, set_runtime_field
+from comicarr.app.core.runtime import (
+    POOL_CONTEXT_FIELDS,
+    get_runtime,
+    set_runtime_acquisition_status,
+    set_runtime_field,
+)
 
 # Bounded worker-drain timeout for the authoritative lifespan shutdown drain.
 # The legacy ad-hoc value was pool.join(5) which is almost certainly too short
@@ -43,16 +48,7 @@ SHUTDOWN_DRAIN_TIMEOUT = 30.0
 # queue_schedule()'s shutdown branch so the FastAPI lifespan is the single
 # authoritative drain. MASS_ADD and MASS_REFRESH are on-demand but still own
 # database work and must not outlive engine disposal.
-_WORKER_POOLS = ("SNPOOL", "NZBPOOL", "SEARCHPOOL", "PPPOOL", "DDLPOOL", "MASS_ADD", "MASS_REFRESH")
-_CONTEXT_POOL_FIELDS = {
-    "SNPOOL": "sn_pool",
-    "NZBPOOL": "nzb_pool",
-    "SEARCHPOOL": "search_pool",
-    "PPPOOL": "pp_pool",
-    "DDLPOOL": "ddl_pool",
-    "MASS_ADD": "mass_add_pool",
-    "MASS_REFRESH": "mass_refresh_pool",
-}
+_WORKER_POOLS = tuple(POOL_CONTEXT_FIELDS)
 
 
 def _drain_worker_pools(timeout, ctx=None):
@@ -75,7 +71,7 @@ def _drain_worker_pools(timeout, ctx=None):
     deadline = time.monotonic() + timeout
 
     for pool_attr in _WORKER_POOLS:
-        pool = getattr(ctx, _CONTEXT_POOL_FIELDS[pool_attr], None) if ctx is not None else None
+        pool = getattr(ctx, POOL_CONTEXT_FIELDS[pool_attr], None) if ctx is not None else None
         if pool is None:
             # Pre-factory legacy tests and the remaining bootstrap bridge use
             # the same pool objects through these aliases.

--- a/comicarr/app/main.py
+++ b/comicarr/app/main.py
@@ -12,7 +12,6 @@ FastAPI application — lifespan, router composition, static file serving.
 """
 
 import asyncio
-import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
@@ -23,7 +22,6 @@ from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException
 from starlette.staticfiles import StaticFiles
 
-from comicarr.app.core.context import AppContext
 from comicarr.app.core.events import EventBus
 from comicarr.app.core.exceptions import register_exception_handlers
 from comicarr.app.core.middleware import (
@@ -31,7 +29,7 @@ from comicarr.app.core.middleware import (
     SecurityHeadersMiddleware,
     SetupGateMiddleware,
 )
-from comicarr.app.core.security import generate_ephemeral_key, load_or_create_jwt_key
+from comicarr.app.core.runtime import get_runtime, set_runtime_acquisition_status, set_runtime_field
 
 # Bounded worker-drain timeout for the authoritative lifespan shutdown drain.
 # The legacy ad-hoc value was pool.join(5) which is almost certainly too short
@@ -43,12 +41,21 @@ SHUTDOWN_DRAIN_TIMEOUT = 30.0
 
 # All pipeline worker pools. The bounded join below is RELOCATED here from
 # queue_schedule()'s shutdown branch so the FastAPI lifespan is the single
-# authoritative drain. MASS_REFRESH is on-demand but still owns database work
-# and must not outlive engine disposal.
-_WORKER_POOLS = ("SNPOOL", "NZBPOOL", "SEARCHPOOL", "PPPOOL", "DDLPOOL", "MASS_REFRESH")
+# authoritative drain. MASS_ADD and MASS_REFRESH are on-demand but still own
+# database work and must not outlive engine disposal.
+_WORKER_POOLS = ("SNPOOL", "NZBPOOL", "SEARCHPOOL", "PPPOOL", "DDLPOOL", "MASS_ADD", "MASS_REFRESH")
+_CONTEXT_POOL_FIELDS = {
+    "SNPOOL": "sn_pool",
+    "NZBPOOL": "nzb_pool",
+    "SEARCHPOOL": "search_pool",
+    "PPPOOL": "pp_pool",
+    "DDLPOOL": "ddl_pool",
+    "MASS_ADD": "mass_add_pool",
+    "MASS_REFRESH": "mass_refresh_pool",
+}
 
 
-def _drain_worker_pools(timeout):
+def _drain_worker_pools(timeout, ctx=None):
     """Bounded join of every live worker pool — runs OFF the event loop.
 
     Relocated from queue_schedule()'s shutdown branch. Each pool gets a
@@ -68,7 +75,11 @@ def _drain_worker_pools(timeout):
     deadline = time.monotonic() + timeout
 
     for pool_attr in _WORKER_POOLS:
-        pool = getattr(comicarr, pool_attr, None)
+        pool = getattr(ctx, _CONTEXT_POOL_FIELDS[pool_attr], None) if ctx is not None else None
+        if pool is None:
+            # Pre-factory legacy tests and the remaining bootstrap bridge use
+            # the same pool objects through these aliases.
+            pool = getattr(comicarr, pool_attr, None)
         if pool is None:
             continue
         try:
@@ -92,88 +103,6 @@ def _drain_worker_pools(timeout):
             logger.error("[SHUTDOWN] Error joining %s: %s" % (pool_attr, e))
 
 
-def _build_context_from_globals():
-    """Bridge: populate AppContext from existing comicarr.__init__ globals.
-
-    This is the transition layer. As domains migrate, they'll read from
-    AppContext instead of comicarr.VARIABLE. Eventually the globals go away.
-    """
-    import comicarr
-
-    ctx = AppContext(
-        prog_dir=comicarr.PROG_DIR or "",
-        data_dir=comicarr.DATA_DIR or "",
-        db_file=comicarr.DB_FILE or "",
-        config=comicarr.CONFIG,
-        scheduler=comicarr.SCHED,
-        init_lock=comicarr.INIT_LOCK,
-        search_lock=comicarr.SEARCHLOCK,
-        api_lock=comicarr.APILOCK,
-        ddl_lock=comicarr.DDL_LOCK,
-        snatched_queue=comicarr.SNATCHED_QUEUE,
-        nzb_queue=comicarr.NZB_QUEUE,
-        pp_queue=comicarr.PP_QUEUE,
-        search_queue=comicarr.SEARCH_QUEUE,
-        ddl_queue=comicarr.DDL_QUEUE,
-        return_nzb_queue=comicarr.RETURN_THE_NZBQUEUE,
-        add_list=comicarr.ADD_LIST,
-        issue_watch_list=comicarr.ISSUE_WATCH_LIST,
-        refresh_queue=comicarr.REFRESH_QUEUE,
-        cv_session=comicarr.CV_SESSION,
-        cv_rate_limiter=comicarr.CV_RATE_LIMITER,
-        cv_cache=comicarr.CV_CACHE,
-        metron_api=comicarr.METRON_API,
-        comic_sort=comicarr.COMICSORT,
-        publisher_imprints=comicarr.PUBLISHER_IMPRINTS or {},
-        provider_blocklist=comicarr.PROVIDER_BLOCKLIST or [],
-        ddl_queued=set(comicarr.DDL_QUEUED) if comicarr.DDL_QUEUED else set(),
-        ddl_stuck_notified=comicarr.DDL_STUCK_NOTIFIED or set(),
-        pack_issueids_dont_queue=comicarr.PACK_ISSUEIDS_DONT_QUEUE or {},
-        folder_cache=comicarr.FOLDER_CACHE,
-        check_folder_cache=comicarr.CHECK_FOLDER_CACHE,
-        monitor_status=comicarr.MONITOR_STATUS or "Waiting",
-        search_status=comicarr.SEARCH_STATUS or "Waiting",
-        rss_status=comicarr.RSS_STATUS or "Waiting",
-        weekly_status=comicarr.WEEKLY_STATUS or "Waiting",
-        version_status=comicarr.VERSION_STATUS or "Waiting",
-        updater_status=comicarr.UPDATER_STATUS or "Waiting",
-        force_status=comicarr.FORCE_STATUS or {},
-        import_status=comicarr.IMPORT_STATUS,
-        import_files=comicarr.IMPORT_FILES or 0,
-        import_totalfiles=comicarr.IMPORT_TOTALFILES or 0,
-        import_cid_count=comicarr.IMPORT_CID_COUNT or 0,
-        import_parsed_count=comicarr.IMPORT_PARSED_COUNT or 0,
-        import_failure_count=comicarr.IMPORT_FAILURE_COUNT or 0,
-        import_lock=comicarr.IMPORTLOCK or False,
-        import_button=comicarr.IMPORTBUTTON or False,
-        download_apikey=comicarr.DOWNLOAD_APIKEY,
-        sse_key=comicarr.SSE_KEY or generate_ephemeral_key(),
-        setup_token=comicarr.SETUP_TOKEN,
-        backend_status_ws=comicarr.BACKENDSTATUS_WS or "up",
-        backend_status_cv=comicarr.BACKENDSTATUS_CV or "up",
-        provider_status=comicarr.PROVIDER_STATUS or {},
-        current_version=comicarr.CURRENT_VERSION,
-        current_version_name=comicarr.CURRENT_VERSION_NAME,
-        current_release_name=comicarr.CURRENT_RELEASE_NAME,
-        latest_version=comicarr.LATEST_VERSION,
-        commits_behind=comicarr.COMMITS_BEHIND,
-        install_type=comicarr.INSTALL_TYPE,
-        current_branch=comicarr.CURRENT_BRANCH,
-        signal=comicarr.SIGNAL,
-        started=comicarr.started,
-        start_up=comicarr.START_UP,
-        update_value=comicarr.UPDATE_VALUE or {},
-    )
-
-    secure_dir = getattr(comicarr.CONFIG, "SECURE_DIR", None) if comicarr.CONFIG else None
-    if secure_dir:
-        ctx.jwt_secret_key = load_or_create_jwt_key(secure_dir)
-    else:
-        ctx.jwt_secret_key = os.urandom(32)
-
-    return ctx
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """FastAPI lifespan — startup and shutdown."""
@@ -181,9 +110,11 @@ async def lifespan(app: FastAPI):
     executor = ThreadPoolExecutor(max_workers=20)
     loop.set_default_executor(executor)
 
-    ctx = _build_context_from_globals()
+    # Worker bootstrap creates the only process runtime. Lifespan attaches it
+    # to FastAPI; rebuilding a context here would fork queue/lock/set state.
+    ctx = get_runtime()
 
-    event_bus = EventBus()
+    event_bus = ctx.event_bus or EventBus()
     event_bus.set_loop(loop)
     ctx.event_bus = event_bus
 
@@ -199,44 +130,17 @@ async def lifespan(app: FastAPI):
     except Exception:
         import comicarr
 
-        comicarr.ACQUISITION_WORKERS_BLOCKED = True
-        comicarr.ACQUISITION_BLOCK_REASON = "maintenance_gate_unavailable"
+        set_runtime_acquisition_status(
+            workers_blocked=True,
+            block_reason="maintenance_gate_unavailable",
+        )
         app.state.acquisition_maintenance = {
             "blocked": True,
             "reason": "maintenance_gate_unavailable",
             "schema_ready": bool(getattr(comicarr, "ACQUISITION_SCHEMA_READY", False)),
         }
 
-    # Initialize AI client if configured
     from comicarr import logger
-    from comicarr.app.ai.circuit_breaker import CircuitBreaker
-    from comicarr.app.ai.client import create_ai_clients
-    from comicarr.app.ai.rate_limiter import AIRateLimiter
-
-    ai_config = ctx.config
-    if ai_config and getattr(ai_config, "AI_BASE_URL", None) and getattr(ai_config, "AI_API_KEY", None):
-        sync_client, async_client = create_ai_clients(ai_config)
-        if sync_client:
-            cb = CircuitBreaker(
-                threshold=getattr(ai_config, "AI_CIRCUIT_THRESHOLD", 5),
-                cooldown=getattr(ai_config, "AI_CIRCUIT_COOLDOWN", 300),
-            )
-            rl = AIRateLimiter(
-                rpm_limit=getattr(ai_config, "AI_RPM_LIMIT", 20),
-                daily_token_limit=getattr(ai_config, "AI_DAILY_TOKEN_LIMIT", 100000),
-            )
-            ctx.ai_client = sync_client
-            ctx.ai_async_client = async_client
-            ctx.ai_circuit_breaker = cb
-            ctx.ai_rate_limiter = rl
-            # Set module-level for background pipeline access
-            import comicarr as _comicarr
-
-            _comicarr.AI_CLIENT = sync_client
-            _comicarr.AI_ASYNC_CLIENT = async_client
-            _comicarr.AI_CIRCUIT_BREAKER = cb
-            _comicarr.AI_RATE_LIMITER = rl
-            logger.info("[AI] Client initialized: %s" % getattr(ai_config, "AI_BASE_URL", ""))
 
     yield
 
@@ -276,6 +180,10 @@ async def lifespan(app: FastAPI):
         ctx.pp_queue,
         ctx.search_queue,
         ctx.ddl_queue,
+        # MASS_ADD reads ADD_LIST as its shutdown sentinel. ISSUE_WATCH_LIST
+        # carries real issue IDs, so it is drained rather than poisoned with a
+        # value that could be treated as an issue during an in-flight loop.
+        ctx.add_list,
         ctx.refresh_queue,
     ]:
         try:
@@ -292,7 +200,7 @@ async def lifespan(app: FastAPI):
     #    worker journal write never hits a disposed engine (R7/R8/AE5).
     drain_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="shutdown-drain")
     try:
-        await loop.run_in_executor(drain_executor, _drain_worker_pools, SHUTDOWN_DRAIN_TIMEOUT)
+        await loop.run_in_executor(drain_executor, _drain_worker_pools, SHUTDOWN_DRAIN_TIMEOUT, ctx)
         logger.info("[SHUTDOWN] Worker drain complete")
     except Exception as e:
         logger.error("[SHUTDOWN] Error during worker drain: %s" % e)
@@ -304,6 +212,13 @@ async def lifespan(app: FastAPI):
             logger.info("[SHUTDOWN] AI async client closed")
         except Exception as e:
             logger.error("[SHUTDOWN] Error closing AI client: %s" % e)
+
+    if ctx.ai_client:
+        try:
+            ctx.ai_client.close()
+            logger.info("[SHUTDOWN] AI sync client closed")
+        except Exception as e:
+            logger.error("[SHUTDOWN] Error closing AI sync client: %s" % e)
 
     if ctx.cv_session:
         try:
@@ -341,8 +256,9 @@ async def lifespan(app: FastAPI):
     #    `if not comicarr.SIGNAL:` preserves restart/update/maintenance
     #    intent (documented prior regression: an unconditional write here
     #    made restart indistinguishable from shutdown).
-    if not comicarr.SIGNAL:
-        comicarr.SIGNAL = "shutdown"
+    signal = comicarr.SIGNAL or ctx.signal or "shutdown"
+    set_runtime_field(ctx, "signal", signal)
+    set_runtime_field(ctx, "disposed", True, project_legacy=False)
 
     logger.info("[SHUTDOWN] FastAPI lifespan shutdown complete")
 

--- a/comicarr/app/main.py
+++ b/comicarr/app/main.py
@@ -17,6 +17,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+from apscheduler.schedulers.base import SchedulerNotRunningError
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException
@@ -43,6 +44,11 @@ from comicarr.app.core.runtime import (
 # NAS deployment. Regardless of this value, the terminal non-blocking
 # hard-kill backstop in comicarr.shutdown() guarantees the process exits.
 SHUTDOWN_DRAIN_TIMEOUT = 30.0
+
+# Scheduler jobs can own the same database and queues as workers. Give an
+# in-flight job a bounded grace period, then preserve live resources for the
+# terminal process exit rather than dispose underneath it.
+SCHEDULER_DRAIN_TIMEOUT = 30.0
 
 # All pipeline worker pools. The bounded join below is RELOCATED here from
 # queue_schedule()'s shutdown branch so the FastAPI lifespan is the single
@@ -150,8 +156,8 @@ async def lifespan(app: FastAPI):
     # happens. The legacy second path (Comicarr.py -> shutdown() -> halt() ->
     # queue_schedule drain) is reduced to signalling + the terminal branch.
     # Order is load-bearing:
-    #   1. scheduler.shutdown(wait=False)  — stop new pipeline work
-    #   2. q.put('exit') for all 5 queues  — stop intake
+    #   1. scheduler.shutdown(wait=True) OFF the loop — quiesce scheduled work
+    #   2. close EventBus, then q.put('exit') for all queues — stop intake
     #   3. bounded pool.join OFF the loop, on a DEDICATED executor
     #      (== final journal flush: workers write the journal synchronously
     #       via the façade, so "drain workers fully" IS the flush guarantee)
@@ -160,15 +166,52 @@ async def lifespan(app: FastAPI):
     #   6. executor / drain-executor shutdown — AFTER the drain
     #   7. default SIGNAL only if unset (never clobber restart/update/maint)
 
-    # 1. Stop accepting new scheduled pipeline work.
+    # The scheduler can have a running job that writes durable state or hands
+    # work to a queue. APScheduler's wait=False leaves that job running, which
+    # would let it outlive engine disposal. Reuse one dedicated executor so
+    # waiting for it never blocks the FastAPI event loop.
+    drain_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="shutdown-drain")
+
+    # 1. Stop accepting new scheduled pipeline work and wait for the work that
+    # was already running to finish before queues or resources are retired. A
+    # bounded wait preserves the terminal hard-kill liveness path for a hung
+    # third-party call; in that case resource disposal is deliberately skipped.
+    scheduler_quiesced = True
     if ctx.scheduler:
         try:
-            ctx.scheduler.shutdown(wait=False)
-            logger.info("[SHUTDOWN] APScheduler stopped")
+            scheduler_shutdown = loop.run_in_executor(drain_executor, lambda: ctx.scheduler.shutdown(wait=True))
+            await asyncio.wait_for(asyncio.shield(scheduler_shutdown), timeout=SCHEDULER_DRAIN_TIMEOUT)
+            logger.info("[SHUTDOWN] APScheduler stopped and running jobs drained")
+        except asyncio.TimeoutError:
+            scheduler_quiesced = False
+            logger.error("[SHUTDOWN] Scheduler drain timed out; preserving runtime resources for terminal process exit")
+        except SchedulerNotRunningError:
+            logger.info("[SHUTDOWN] APScheduler was already stopped")
         except Exception as e:
-            logger.error("[SHUTDOWN] Error stopping scheduler: %s" % e)
+            scheduler_quiesced = False
+            logger.error("[SHUTDOWN] Error stopping scheduler; preserving runtime resources: %s" % e)
 
-    # 2. Signal every worker queue to stop intake. Workers finish their current
+    # 2. Reject events from any worker that survives long enough to observe
+    # shutdown. The EventBus close gate is synchronized with publisher
+    # snapshots, so no event can be enqueued after this returns.
+    if ctx.event_bus:
+        try:
+            ctx.event_bus.close()
+        except Exception as e:
+            logger.error("[SHUTDOWN] Error closing event bus: %s" % e)
+
+    if not scheduler_quiesced:
+        # A job that failed to quiesce may still use the database, clients, or
+        # queues. Returning lets Comicarr.py take its terminal os._exit path;
+        # closing those resources here would recreate the shutdown race.
+        try:
+            drain_executor.shutdown(wait=False)
+            executor.shutdown(wait=False)
+        except Exception as e:
+            logger.error("[SHUTDOWN] Error releasing timeout executors: %s" % e)
+        return
+
+    # 3. Signal every worker queue to stop intake. Workers finish their current
     #    item, then exit on the sentinel.
     for q in [
         ctx.snatched_queue,
@@ -194,7 +237,6 @@ async def lifespan(app: FastAPI):
     #    down below; a dedicated executor keeps the drain independent of that
     #    teardown. This MUST complete before engine.dispose() so an in-flight
     #    worker journal write never hits a disposed engine (R7/R8/AE5).
-    drain_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="shutdown-drain")
     try:
         await loop.run_in_executor(drain_executor, _drain_worker_pools, SHUTDOWN_DRAIN_TIMEOUT, ctx)
         logger.info("[SHUTDOWN] Worker drain complete")

--- a/comicarr/app/system/router.py
+++ b/comicarr/app/system/router.py
@@ -223,10 +223,9 @@ def shutdown_system(ctx: AppContext = Depends(get_context)):
     import os
     import signal
 
-    import comicarr
+    from comicarr.app.core.runtime import set_runtime_field
 
-    ctx.signal = "shutdown"
-    comicarr.SIGNAL = "shutdown"
+    set_runtime_field(ctx, "signal", "shutdown")
     if ctx.event_bus:
         ctx.event_bus.publish_sync("shutdown", {"message": "Now shutting down system."})
     os.kill(os.getpid(), signal.SIGTERM)
@@ -239,10 +238,9 @@ def restart_system(ctx: AppContext = Depends(get_context)):
     import os
     import signal
 
-    import comicarr
+    from comicarr.app.core.runtime import set_runtime_field
 
-    ctx.signal = "restart"
-    comicarr.SIGNAL = "restart"
+    set_runtime_field(ctx, "signal", "restart")
     if ctx.event_bus:
         ctx.event_bus.publish_sync("restart", {"message": "Now restarting system."})
     os.kill(os.getpid(), signal.SIGTERM)

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -158,8 +158,8 @@ def announce_setup_token(setup_token):
 
 def initial_setup(ctx, username, password, setup_token):
     """Handle first-run credential setup."""
-    import comicarr
     from comicarr import encrypted
+    from comicarr.app.core.runtime import set_runtime_field
 
     if getattr(ctx.config, "HTTP_USERNAME", None) and getattr(ctx.config, "HTTP_PASSWORD", None):
         return {"success": False, "error": "Credentials already configured"}
@@ -192,12 +192,10 @@ def initial_setup(ctx, username, password, setup_token):
 
     logger.info("[AUTH-SETUP] Initial credentials configured for user: %s" % username)
 
-    ctx.setup_token = None
-    comicarr.SETUP_TOKEN = None
+    set_runtime_field(ctx, "setup_token", None)
 
     # Signal restart for session config to take effect
-    ctx.signal = "restart"
-    comicarr.SIGNAL = "restart"
+    set_runtime_field(ctx, "signal", "restart")
 
     return {"success": True, "username": username, "needs_restart": True}
 
@@ -749,6 +747,8 @@ def _get_job_history(job_name):
 
 def request_weekly_refresh(ctx):
     """Queue the existing weekly APScheduler job for an immediate, coalesced run."""
+    from comicarr.app.core.runtime import set_runtime_field
+
     with get_weekly_refresh_lock():
         scheduler = getattr(ctx, "scheduler", None)
         if scheduler is None:
@@ -758,7 +758,7 @@ def request_weekly_refresh(ctx):
         if job is None:
             return {"accepted": False, "state": "unavailable", "error": "Weekly scheduler job is unavailable"}
 
-        state = _weekly_state(getattr(comicarr, "WEEKLY_STATUS", "Waiting"))
+        state = _weekly_state(ctx.weekly_status)
         if state == "running":
             return {
                 "accepted": False,
@@ -775,10 +775,9 @@ def request_weekly_refresh(ctx):
             }
 
         next_run_time = datetime.datetime.utcnow()
-        comicarr.WEEKLY_MANUAL_NEXT_RUN = job.next_run_time
+        set_runtime_field(ctx, "weekly_manual_next_run", job.next_run_time)
         job.modify(next_run_time=next_run_time)
-        comicarr.WEEKLY_STATUS = "Queued"
-        ctx.weekly_status = "Queued"
+        set_runtime_field(ctx, "weekly_status", "Queued")
         try:
             db.upsert("jobhistory", {"status": "Queued"}, {"JobName": WEEKLY_JOB_NAME})
         except Exception as e:
@@ -888,7 +887,7 @@ def get_startup_diagnostics(ctx, include_acquisition=True):
             db_empty = count == 0
     except Exception as e:
         logger.warn("[DIAGNOSTICS] Live db_empty check failed, falling back to startup flag: %s" % e)
-        db_empty = comicarr.DB_EMPTY
+        db_empty = ctx.db_empty
 
     result = {
         "db_empty": db_empty,
@@ -901,7 +900,7 @@ def get_startup_diagnostics(ctx, include_acquisition=True):
 
             result["acquisition"] = get_search_health(
                 ctx.config,
-                provider_blocklist=getattr(ctx, "provider_blocklist", None) or comicarr.PROVIDER_BLOCKLIST,
+                provider_blocklist=ctx.provider_blocklist,
             )
         except Exception as e:
             result["acquisition"] = {"blocked": True, "reason": "health_unavailable", "error": sanitize_job_error(e)}

--- a/comicarr/app/weekly/queries.py
+++ b/comicarr/app/weekly/queries.py
@@ -1,0 +1,34 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""SQLAlchemy Core projections owned by the weekly domain."""
+
+from sqlalchemy import select
+
+from comicarr import db
+from comicarr.tables import weekly as t_weekly
+
+
+def get_weekly_releases(week, year):
+    """Return current-week industry releases using the legacy unpadded week key."""
+    normalized_week = str(int(week))
+    stmt = (
+        select(
+            t_weekly.c.COMIC,
+            t_weekly.c.ISSUE,
+            t_weekly.c.PUBLISHER,
+            t_weekly.c.SHIPDATE,
+            t_weekly.c.STATUS,
+            t_weekly.c.ComicID,
+            t_weekly.c.IssueID,
+        )
+        .where(t_weekly.c.weeknumber == normalized_week, t_weekly.c.year == year)
+        .order_by(t_weekly.c.COMIC.asc())
+    )
+    return db.select_all(stmt)

--- a/comicarr/app/weekly/router.py
+++ b/comicarr/app/weekly/router.py
@@ -18,6 +18,7 @@ from comicarr.app.core.context import AppContext, get_context
 from comicarr.app.core.security import require_session
 from comicarr.app.storyarcs import service as storyarcs_service
 from comicarr.app.system import service as system_service
+from comicarr.app.weekly import queries as weekly_queries
 
 router = APIRouter(prefix="/api/weekly", tags=["weekly"])
 
@@ -26,15 +27,11 @@ router = APIRouter(prefix="/api/weekly", tags=["weekly"])
 @router.get("/", dependencies=[Depends(require_session)])
 def get_weekly(ctx: AppContext = Depends(get_context)):
     """Return industry releases for the application current Sunday-based week."""
-    from comicarr import db, logger
+    from comicarr import logger
 
     try:
         week, year = storyarcs_service.get_current_week()
-        rows = db.DBConnection().select(
-            "SELECT COMIC, ISSUE, PUBLISHER, SHIPDATE, STATUS, ComicID, IssueID "
-            "FROM weekly WHERE weeknumber = ? AND year = ? ORDER BY COMIC ASC",
-            [str(int(week)), year],
-        )
+        rows = weekly_queries.get_weekly_releases(week, year)
         return rows or []
     except Exception as e:
         logger.error("[WEEKLY] Error fetching weekly data: %s" % e)

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -73,6 +73,17 @@ def _set_mass_add_pool(ctx, pool):
     set_runtime_field(ctx, "mass_add_pool", pool)
 
 
+def _set_mass_refresh_pool(ctx, pool):
+    """Publish the same MASS_REFRESH worker reference to runtime and legacy code."""
+    if ctx is None:
+        comicarr.MASS_REFRESH = pool
+        return
+
+    from comicarr.app.core.runtime import set_runtime_field
+
+    set_runtime_field(ctx, "mass_refresh_pool", pool)
+
+
 def is_exists(comicid):
 
     with db.get_engine().connect() as conn:
@@ -3024,14 +3035,15 @@ _REFRESH_WORKER_LOCK = threading.RLock()
 def _start_refresh_worker():
     """Start the on-demand worker under the same lock used for retirement."""
     with _REFRESH_WORKER_LOCK:
-        worker = getattr(comicarr, "MASS_REFRESH", None)
+        ctx = _mass_add_runtime_context()
+        worker = ctx.mass_refresh_pool if ctx is not None else getattr(comicarr, "MASS_REFRESH", None)
         if worker is not None and getattr(worker, "is_alive", lambda: False)():
             return False
         logger.info("[MASS-REFRESH] MASS_REFRESH thread not started. Started & submitting.")
-        comicarr.MASS_REFRESH = threading.Thread(
-            target=updater.addvialist, args=(comicarr.REFRESH_QUEUE,), name="mass-refresh"
-        )
-        comicarr.MASS_REFRESH.start()
+        refresh_queue = ctx.refresh_queue if ctx is not None else comicarr.REFRESH_QUEUE
+        worker = threading.Thread(target=updater.addvialist, args=(refresh_queue,), name="mass-refresh")
+        _set_mass_refresh_pool(ctx, worker)
+        worker.start()
         return True
 
 
@@ -3044,8 +3056,10 @@ def refresh_worker_should_retire(refresh_queue):
     with _REFRESH_WORKER_LOCK:
         if not refresh_queue.empty():
             return False
-        if getattr(comicarr, "MASS_REFRESH", None) is threading.current_thread():
-            comicarr.MASS_REFRESH = None
+        ctx = _mass_add_runtime_context()
+        worker = ctx.mass_refresh_pool if ctx is not None else getattr(comicarr, "MASS_REFRESH", None)
+        if worker is threading.current_thread():
+            _set_mass_refresh_pool(ctx, None)
         return True
 
 
@@ -3063,8 +3077,10 @@ def _handoff_refresh_items(queue_items, *, start_worker, maintenance=None):
     ) as lease:
         controller.assert_lease_current(lease)
         with _REFRESH_WORKER_LOCK:
+            ctx = _mass_add_runtime_context()
+            refresh_queue = ctx.refresh_queue if ctx is not None else comicarr.REFRESH_QUEUE
             for queue_item in queue_items:
-                comicarr.REFRESH_QUEUE.put(queue_item)
+                refresh_queue.put(queue_item)
             if start_worker:
                 _start_refresh_worker()
 

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -2986,7 +2986,8 @@ def importer_thread(serieslist):
     add_list = ctx.add_list if ctx is not None else comicarr.ADD_LIST
     issue_watch_list = ctx.issue_watch_list if ctx is not None else comicarr.ISSUE_WATCH_LIST
 
-    list(map(add_list.put, serieslist))
+    for series in serieslist:
+        add_list.put(series)
 
     try:
         pool = ctx.mass_add_pool if ctx is not None else comicarr.MASS_ADD
@@ -3004,8 +3005,6 @@ def importer_thread(serieslist):
         pool = threading.Thread(target=addvialist, args=(add_list, issue_watch_list), name="mass-add")
         _set_mass_add_pool(ctx, pool)
         pool.start()
-        if not pool:
-            pool.join(5)
 
 
 def issue_watcher_thread(issuelist):
@@ -3015,7 +3014,8 @@ def issue_watcher_thread(issuelist):
 
     ctx = _mass_add_runtime_context()
     issue_watch_list = ctx.issue_watch_list if ctx is not None else comicarr.ISSUE_WATCH_LIST
-    list(map(issue_watch_list.put, issuelist))
+    for issue in issuelist:
+        issue_watch_list.put(issue)
 
 
 _REFRESH_WORKER_LOCK = threading.RLock()

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -54,6 +54,25 @@ from comicarr import (
 from comicarr.tables import annuals, comics, issues
 
 
+def _mass_add_runtime_context():
+    """Return the active canonical runtime, if the process has one."""
+    from comicarr.app.core.runtime import get_runtime_if_initialized
+
+    ctx = get_runtime_if_initialized()
+    return ctx if ctx is not None and not ctx.disposed else None
+
+
+def _set_mass_add_pool(ctx, pool):
+    """Publish the same MASS_ADD worker reference to runtime and legacy code."""
+    if ctx is None:
+        comicarr.MASS_ADD = pool
+        return
+
+    from comicarr.app.core.runtime import set_runtime_field
+
+    set_runtime_field(ctx, "mass_add_pool", pool)
+
+
 def is_exists(comicid):
 
     with db.get_engine().connect() as conn:
@@ -125,7 +144,7 @@ def addvialist(seriesQueue, issueWantQueue):
             issueItem = issueWantQueue.get(True)
             markIssueWantedById(issueItem)
         else:
-            comicarr.ADD_LIST.put("exit")
+            seriesQueue.put("exit")
     return False
 
 
@@ -2963,10 +2982,15 @@ def importer_thread(serieslist):
 
     threaded_call = True
 
-    list(map(comicarr.ADD_LIST.put, serieslist))
+    ctx = _mass_add_runtime_context()
+    add_list = ctx.add_list if ctx is not None else comicarr.ADD_LIST
+    issue_watch_list = ctx.issue_watch_list if ctx is not None else comicarr.ISSUE_WATCH_LIST
+
+    list(map(add_list.put, serieslist))
 
     try:
-        if comicarr.MASS_ADD.is_alive():
+        pool = ctx.mass_add_pool if ctx is not None else comicarr.MASS_ADD
+        if pool.is_alive():
             logger.info(
                 "[MASS-ADD] MASS_ADD thread already running. Adding an additional %s items to existing queue"
                 % len(serieslist)
@@ -2977,12 +3001,11 @@ def importer_thread(serieslist):
 
     if threaded_call is True:
         logger.info("[MASS-ADD] MASS_ADD thread not started. Started & submitting.")
-        comicarr.MASS_ADD = threading.Thread(
-            target=addvialist, args=(comicarr.ADD_LIST, comicarr.ISSUE_WATCH_LIST), name="mass-add"
-        )
-        comicarr.MASS_ADD.start()
-        if not comicarr.MASS_ADD:
-            comicarr.MASS_ADD.join(5)
+        pool = threading.Thread(target=addvialist, args=(add_list, issue_watch_list), name="mass-add")
+        _set_mass_add_pool(ctx, pool)
+        pool.start()
+        if not pool:
+            pool.join(5)
 
 
 def issue_watcher_thread(issuelist):
@@ -2990,7 +3013,9 @@ def issue_watcher_thread(issuelist):
     if type(issuelist) != list:
         issuelist = [issuelist]
 
-    list(map(comicarr.ISSUE_WATCH_LIST.put, issuelist))
+    ctx = _mass_add_runtime_context()
+    issue_watch_list = ctx.issue_watch_list if ctx is not None else comicarr.ISSUE_WATCH_LIST
+    list(map(issue_watch_list.put, issuelist))
 
 
 _REFRESH_WORKER_LOCK = threading.RLock()

--- a/comicarr/weeklypullit.py
+++ b/comicarr/weeklypullit.py
@@ -24,10 +24,37 @@ import comicarr
 from comicarr import helpers, logger, weeklypull
 
 
+def _weekly_runtime_context():
+    """Return the canonical context when lifecycle startup has completed."""
+    from comicarr.app.core.runtime import get_runtime_if_initialized
+
+    ctx = get_runtime_if_initialized()
+    return ctx if ctx is not None and not ctx.disposed else None
+
+
+def _get_weekly_runtime_value(context_field, legacy_name):
+    """Read canonical weekly state, with a pre-factory legacy fallback."""
+    ctx = _weekly_runtime_context()
+    if ctx is not None:
+        return getattr(ctx, context_field)
+    return getattr(comicarr, legacy_name)
+
+
+def _set_weekly_runtime_value(context_field, legacy_name, value):
+    """Write weekly state once and project the same value to legacy callers."""
+    ctx = _weekly_runtime_context()
+    if ctx is not None:
+        from comicarr.app.core.runtime import set_runtime_field
+
+        return set_runtime_field(ctx, context_field, value)
+    setattr(comicarr, legacy_name, value)
+    return value
+
+
 def _restore_manual_next_run():
     """Restore the recurring schedule displaced by an immediate manual run."""
-    scheduled_run = getattr(comicarr, "WEEKLY_MANUAL_NEXT_RUN", None)
-    comicarr.WEEKLY_MANUAL_NEXT_RUN = None
+    scheduled_run = _get_weekly_runtime_value("weekly_manual_next_run", "WEEKLY_MANUAL_NEXT_RUN")
+    _set_weekly_runtime_value("weekly_manual_next_run", "WEEKLY_MANUAL_NEXT_RUN", None)
     if not isinstance(scheduled_run, datetime.datetime):
         return
 
@@ -36,7 +63,8 @@ def _restore_manual_next_run():
         return
 
     try:
-        job = comicarr.SCHED.get_job("weekly")
+        scheduler = _get_weekly_runtime_value("scheduler", "SCHED")
+        job = scheduler.get_job("weekly") if scheduler is not None else None
         if job is not None:
             job.modify(next_run_time=scheduled_run)
     except Exception as e:
@@ -55,7 +83,7 @@ class Weekly:
             helpers.job_management(
                 write=True, job="Weekly Pullist", current_run=helpers.utctimestamp(), status="Running"
             )
-            comicarr.WEEKLY_STATUS = "Running"
+            _set_weekly_runtime_value("weekly_status", "WEEKLY_STATUS", "Running")
             try:
                 pull_result = weeklypull.pullit()
                 if isinstance(pull_result, dict) and pull_result.get("status") == "failure":
@@ -72,11 +100,11 @@ class Weekly:
                     failure=True,
                     failure_message=e,
                 )
-                comicarr.WEEKLY_STATUS = "Error"
+                _set_weekly_runtime_value("weekly_status", "WEEKLY_STATUS", "Error")
                 raise
 
             _restore_manual_next_run()
             helpers.job_management(
                 write=True, job="Weekly Pullist", last_run_completed=helpers.utctimestamp(), status="Waiting"
             )
-            comicarr.WEEKLY_STATUS = "Waiting"
+            _set_weekly_runtime_value("weekly_status", "WEEKLY_STATUS", "Waiting")

--- a/docs/architecture/runtime-context.md
+++ b/docs/architecture/runtime-context.md
@@ -72,9 +72,10 @@ instance to `app.state.ctx`; it does not construct a second view.
 
 ## Transitional boundary
 
-The system router, acquisition maintenance gate, and `weeklypullit` state
-writer are the first migrated ownership boundary. `tests/unit/test_runtime_context.py`
-keeps an explicit allowlist for direct `comicarr.<UPPERCASE>` accesses in those
-files; it is empty. The larger `app/system/service.py` scheduler surface
-remains a documented compatibility consumer until its coherent ownership wave,
+The system router, acquisition maintenance gate, `weeklypullit` state writer,
+and the bounded AI runtime consumers are the first migrated ownership boundary.
+`tests/unit/test_runtime_context.py` keeps an explicit allowlist for direct
+`comicarr.<UPPERCASE>` accesses in those files; it is empty. The larger
+`app/system/service.py` scheduler surface and non-selected domains remain
+documented compatibility consumers until their coherent ownership waves,
 rather than being silently rewritten in this change.

--- a/docs/architecture/runtime-context.md
+++ b/docs/architecture/runtime-context.md
@@ -1,0 +1,80 @@
+# Runtime context ownership
+
+`AppContext` is the one runtime owner for a Comicarr process. It is created
+once by `comicarr.app.core.runtime.create_runtime()` after `comicarr.initialize`
+has loaded configuration, applied schema readiness checks, and decrypted or
+generated startup secrets. `Comicarr.py` creates it before `comicarr.start()`
+can start a scheduler or worker. FastAPI lifespan attaches that existing
+instance to `app.state.ctx`; it does not construct a second view.
+
+## Ownership contract
+
+| State category | Examples | Creation/writer | Reader/shutdown owner | Identity rule |
+| --- | --- | --- | --- | --- |
+| Immutable configuration | paths, `config`, build metadata | startup configuration | routes/services; no disposal | fixed after factory creation |
+| Long-lived services | scheduler, CV session/cache, Metron, AI bundle, event bus | runtime factory; event loop is attached in lifespan | workers/routes; lifespan closes clients after drain | one instance per process |
+| Queues and locks | `ddl_queued`, all work queues, search/API/DDL locks, acquisition resume lock | existing bootstrap objects adopted by factory | workers, scheduler, routes; lifespan signals queues then drains pools | must be the exact same object, never a copy |
+| Request-visible state | scheduler status, setup/JWT state, import progress, version state | migrated services write with `set_runtime_field()` | system/API readers; discarded with process | bridge serializes migrated writes with `runtime_lock` |
+| Durable-acquisition projection | schema readiness, maintenance block reason, migration reconciliation | `MaintenanceController` database transactions/fences, then runtime projection | startup diagnostics and acquisition workers | durable DB fence is authoritative; context is its live projection |
+| Legacy compatibility | module aliases and worker-pool references | `runtime.py` projection while legacy engines remain | unmigrated legacy code only | aliases share object identities; mutable data is never cloned |
+
+### Complete field classification
+
+- Immutable configuration: `prog_dir`, `data_dir`, `db_file`, `config`.
+- Long-lived services: `scheduler`, `event_bus`, `cv_session`,
+  `cv_rate_limiter`, `cv_cache`, `metron_api`, `fernet`, `ai_client`,
+  `ai_async_client`, `ai_circuit_breaker`, `ai_rate_limiter`.
+- Locks: `runtime_lock`, `init_lock`, `search_lock`, `api_lock`, `ddl_lock`,
+  `acquisition_resume_lock`.
+- Queues: `snatched_queue`, `nzb_queue`, `pp_queue`, `search_queue`,
+  `ddl_queue`, `return_nzb_queue`, `add_list`, `issue_watch_list`,
+  `refresh_queue`.
+- Compatibility worker references: `sn_pool`, `nzb_pool`, `search_pool`,
+  `pp_pool`, `ddl_pool`, `mass_add_pool`, `mass_refresh_pool`.
+- Mutable process state: `comic_sort`, `publisher_imprints`,
+  `provider_blocklist`, `ddl_queued`, `ddl_stuck_notified`,
+  `pack_issueids_dont_queue`, `folder_cache`, `check_folder_cache`,
+  `force_status`, `update_value`, `provider_status`.
+- Scheduler/request status: `monitor_status`, `search_status`, `rss_status`,
+  `weekly_status`, `version_status`, `updater_status`, `importinbox_status`,
+  `weekly_manual_next_run`, `import_status`, `import_files`,
+  `import_totalfiles`, `import_cid_count`, `import_parsed_count`,
+  `import_failure_count`, `import_lock`, `import_button`.
+- Auth/session state: `download_apikey`, `sse_key`, `setup_token`,
+  `jwt_secret_key`, `jwt_generation`.
+- Provider/version state: `backend_status_ws`, `backend_status_cv`,
+  `current_version`, `current_version_name`, `current_release_name`,
+  `latest_version`, `commits_behind`, `install_type`, `current_branch`.
+- Lifecycle state: `signal`, `started`, `start_up`, `disposed`.
+- Durable-acquisition projection: `db_empty`, `acquisition_schema_ready`,
+  `acquisition_schema_version`, `acquisition_schema_error`,
+  `acquisition_workers_blocked`, `acquisition_block_reason`,
+  `migration_in_progress`, `migration_status`, `migration_current_table`,
+  `migration_tables_complete`, `migration_tables_total`, `migration_error`,
+  `migration_reconciliation`.
+
+## Lifecycle
+
+1. `comicarr.initialize()` establishes config, schema/migration state, and
+   secrets. A schema or maintenance failure closes the acquisition gate but
+   still permits authenticated diagnostics.
+2. `create_runtime()` adopts the initialized objects exactly once and projects
+   the same identities to temporary legacy aliases. It also builds the AI
+   client bundle at this lifecycle boundary.
+3. `comicarr.start(runtime)` rejects a missing or divergent context before
+   starting scheduler/worker activity. Worker pool references are written
+   through the compatibility bridge so the shutdown owner sees the same pools.
+4. FastAPI lifespan stores that instance on `app.state.ctx`, sets the event-bus
+   loop, and re-reads the durable acquisition gate.
+5. Lifespan shutdown stops scheduling, signals queues, joins worker pools off
+   the event loop, closes external clients, disposes the database, then marks
+   the context disposed. `get_context()` fails closed after that point.
+
+## Transitional boundary
+
+The system router, acquisition maintenance gate, and `weeklypullit` state
+writer are the first migrated ownership boundary. `tests/unit/test_runtime_context.py`
+keeps an explicit allowlist for direct `comicarr.<UPPERCASE>` accesses in those
+files; it is empty. The larger `app/system/service.py` scheduler surface
+remains a documented compatibility consumer until its coherent ownership wave,
+rather than being silently rewritten in this change.

--- a/docs/architecture/runtime-context.md
+++ b/docs/architecture/runtime-context.md
@@ -12,7 +12,7 @@ instance to `app.state.ctx`; it does not construct a second view.
 | State category | Examples | Creation/writer | Reader/shutdown owner | Identity rule |
 | --- | --- | --- | --- | --- |
 | Immutable configuration | paths, `config`, build metadata | startup configuration | routes/services; no disposal | fixed after factory creation |
-| Long-lived services | scheduler, CV session/cache, Metron, AI bundle, event bus | runtime factory; event loop is attached in lifespan | workers/routes; lifespan closes clients after drain | one instance per process |
+| Long-lived services | scheduler, CV session/cache, Metron, AI bundle, event bus | runtime factory; event loop is attached in lifespan | workers/routes; lifespan quiesces jobs, closes the event bus, then closes clients after drain | one instance per process |
 | Queues and locks | `ddl_queued`, all work queues, search/API/DDL locks, acquisition resume lock | existing bootstrap objects adopted by factory | workers, scheduler, routes; lifespan signals queues then drains pools | must be the exact same object, never a copy |
 | Request-visible state | scheduler status, setup/JWT state, import progress, version state | migrated services write with `set_runtime_field()` | system/API readers; discarded with process | bridge serializes migrated writes with `runtime_lock` |
 | Durable-acquisition projection | schema readiness, maintenance block reason, migration reconciliation | `MaintenanceController` database transactions/fences, then runtime projection | startup diagnostics and acquisition workers | durable DB fence is authoritative; context is its live projection |
@@ -66,9 +66,13 @@ instance to `app.state.ctx`; it does not construct a second view.
    through the compatibility bridge so the shutdown owner sees the same pools.
 4. FastAPI lifespan stores that instance on `app.state.ctx`, sets the event-bus
    loop, and re-reads the durable acquisition gate.
-5. Lifespan shutdown stops scheduling, signals queues, joins worker pools off
-   the event loop, closes external clients, disposes the database, then marks
-   the context disposed. `get_context()` fails closed after that point.
+5. Lifespan shutdown quiesces running scheduler jobs off the event loop,
+   closes the event bus to reject late publications, signals queues, joins
+   worker pools off the event loop, closes external clients, disposes the
+   database, then marks the context disposed. If scheduler quiescence times
+   out, it leaves the resources intact for Comicarr.py's terminal exit rather
+   than dispose them underneath the live job. `get_context()` fails closed
+   after normal teardown.
 
 ## Transitional boundary
 

--- a/tests/integration/test_restart_recovery.py
+++ b/tests/integration/test_restart_recovery.py
@@ -790,7 +790,7 @@ async def test_ae5_inflight_write_completes_before_dispose_then_replay_finishes(
     cm = lifespan(app)
     pool = _SlowWorkerPool()
     with (
-        patch("comicarr.app.main._build_context_from_globals", return_value=ctx),
+        patch("comicarr.app.main.get_runtime", return_value=ctx),
         patch.object(comicarr, "SNPOOL", pool, create=True),
         patch.object(comicarr, "NZBPOOL", None, create=True),
         patch.object(comicarr, "SEARCHPOOL", None, create=True),

--- a/tests/unit/test_ai_enrichment.py
+++ b/tests/unit/test_ai_enrichment.py
@@ -11,9 +11,9 @@
 
 import os
 import zipfile
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import MagicMock, patch
 
 from comicarr.app.ai.enrichment import (
     ENRICHABLE_FIELDS,
@@ -45,16 +45,32 @@ _COMICINFO_TEMPLATE = """\
 """
 
 
-def _make_cbz(tmp_path, title="Batman #1", series="Batman", number="1",
-              publisher="DC Comics", year="2020", writer="Tom King",
-              penciller="David Finch", genre="", age_rating="",
-              filename="test.cbz", include_comicinfo=True):
+def _make_cbz(
+    tmp_path,
+    title="Batman #1",
+    series="Batman",
+    number="1",
+    publisher="DC Comics",
+    year="2020",
+    writer="Tom King",
+    penciller="David Finch",
+    genre="",
+    age_rating="",
+    filename="test.cbz",
+    include_comicinfo=True,
+):
     """Create a minimal CBZ with a ComicInfo.xml for testing."""
     cbz_path = os.path.join(str(tmp_path), filename)
     xml = _COMICINFO_TEMPLATE.format(
-        title=title, series=series, number=number, publisher=publisher,
-        year=year, writer=writer, penciller=penciller,
-        genre=genre, age_rating=age_rating,
+        title=title,
+        series=series,
+        number=number,
+        publisher=publisher,
+        year=year,
+        writer=writer,
+        penciller=penciller,
+        genre=genre,
+        age_rating=age_rating,
     )
     with zipfile.ZipFile(cbz_path, "w") as zf:
         if include_comicinfo:
@@ -86,10 +102,12 @@ def _make_mock_rate_limiter(can=True):
 # _read_comicinfo
 # ---------------------------------------------------------------------------
 
+
 class TestReadComicinfo:
     def test_reads_fields_from_cbz(self, tmp_path):
-        cbz_path = _make_cbz(tmp_path, series="Spider-Man", number="300",
-                             publisher="Marvel", genre="Superhero", age_rating="T+")
+        cbz_path = _make_cbz(
+            tmp_path, series="Spider-Man", number="300", publisher="Marvel", genre="Superhero", age_rating="T+"
+        )
         result = _read_comicinfo(cbz_path)
         assert result is not None
         assert result["Series"] == "Spider-Man"
@@ -119,6 +137,7 @@ class TestReadComicinfo:
 # _write_comicinfo
 # ---------------------------------------------------------------------------
 
+
 class TestWriteComicinfo:
     def test_writes_enriched_values(self, tmp_path):
         cbz_path = _make_cbz(tmp_path, genre="", age_rating="")
@@ -142,31 +161,27 @@ class TestWriteComicinfo:
 # _store_history
 # ---------------------------------------------------------------------------
 
+
 class TestStoreHistory:
-    @patch("comicarr.app.ai.enrichment.db")
-    def test_writes_to_ai_metadata_history(self, mock_db):
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
+    @patch("comicarr.app.ai.enrichment.ai_queries")
+    def test_writes_to_ai_metadata_history(self, mock_queries):
 
         _store_history("12345", {"Genre": "Superhero", "AgeRating": "T+"})
-        assert conn.action.call_count == 2
+        assert mock_queries.insert_metadata_history.call_count == 2
 
-        # Check first call
-        call_args = conn.action.call_args_list[0]
-        sql = call_args[0][0]
-        params = call_args[0][1]
-        assert "INSERT INTO ai_metadata_history" in sql
-        assert params[0] == "issue"
-        assert params[1] == "12345"
-        assert params[2] == "Genre"
-        assert params[3] is None  # original_value
-        assert params[4] == "Superhero"
-        assert params[5] == "enrichment"
+        inserted = mock_queries.insert_metadata_history.call_args_list[0].args[0]
+        assert inserted["entity_type"] == "issue"
+        assert inserted["entity_id"] == "12345"
+        assert inserted["field_name"] == "Genre"
+        assert inserted["original_value"] is None
+        assert inserted["ai_value"] == "Superhero"
+        assert inserted["source"] == "enrichment"
 
 
 # ---------------------------------------------------------------------------
 # enrich_metadata
 # ---------------------------------------------------------------------------
+
 
 class TestEnrichMetadata:
     @patch("comicarr.app.ai.enrichment.comicarr")
@@ -205,8 +220,16 @@ class TestEnrichMetadata:
         mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
         # Create CBZ with all context fields blank
         cbz_path = _make_cbz(
-            tmp_path, title="", series="", number="", publisher="",
-            year="", writer="", penciller="", genre="", age_rating="",
+            tmp_path,
+            title="",
+            series="",
+            number="",
+            publisher="",
+            year="",
+            writer="",
+            penciller="",
+            genre="",
+            age_rating="",
         )
         assert enrich_metadata(cbz_path, "12345") == 0
 
@@ -224,9 +247,7 @@ class TestEnrichMetadata:
         cbz_path = _make_cbz(tmp_path, genre="Superhero", age_rating="")
 
         # AI returns both Genre and AgeRating — only AgeRating should be accepted
-        mock_req.return_value = MetadataEnrichment(
-            fields={"Genre": "Action", "AgeRating": "T+"}
-        )
+        mock_req.return_value = MetadataEnrichment(fields={"Genre": "Action", "AgeRating": "T+"})
 
         result = enrich_metadata(cbz_path, "12345")
         assert result == 1
@@ -282,9 +303,7 @@ class TestEnrichMetadata:
 
         cbz_path = _make_cbz(tmp_path, genre="", age_rating="")
 
-        mock_req.return_value = MetadataEnrichment(
-            fields={"Genre": "Superhero", "AgeRating": "T+"}
-        )
+        mock_req.return_value = MetadataEnrichment(fields={"Genre": "Superhero", "AgeRating": "T+"})
 
         result = enrich_metadata(cbz_path, "12345")
         assert result == 2
@@ -338,9 +357,7 @@ class TestEnrichMetadata:
         cbz_path = _make_cbz(tmp_path, genre="", age_rating="")
 
         # AI returns empty/whitespace values
-        mock_req.return_value = MetadataEnrichment(
-            fields={"Genre": "", "AgeRating": "   "}
-        )
+        mock_req.return_value = MetadataEnrichment(fields={"Genre": "", "AgeRating": "   "})
 
         result = enrich_metadata(cbz_path, "12345")
         assert result == 0
@@ -351,47 +368,38 @@ class TestEnrichMetadata:
 # revert_field
 # ---------------------------------------------------------------------------
 
+
 class TestRevertField:
-    @patch("comicarr.app.ai.enrichment.db")
-    def test_validates_issue_exists(self, mock_db):
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
-        conn.select.return_value = []
+    @patch("comicarr.app.ai.enrichment.ai_queries")
+    def test_validates_issue_exists(self, mock_queries):
+        mock_queries.issue_exists.return_value = False
 
         with pytest.raises(ValueError, match="Issue .* not found"):
             revert_field("99999", "Genre", "/path/to/comic.cbz")
 
     @patch("comicarr.app.ai.enrichment._write_comicinfo")
-    @patch("comicarr.app.ai.enrichment.db")
-    def test_reverts_field_to_empty(self, mock_db, mock_write):
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
-        conn.select.return_value = [{"IssueID": "12345"}]
+    @patch("comicarr.app.ai.enrichment.ai_queries")
+    def test_reverts_field_to_empty(self, mock_queries, mock_write):
+        mock_queries.issue_exists.return_value = True
 
         revert_field("12345", "Genre", "/path/to/comic.cbz")
 
         mock_write.assert_called_once_with("/path/to/comic.cbz", {"Genre": ""})
 
     @patch("comicarr.app.ai.enrichment._write_comicinfo")
-    @patch("comicarr.app.ai.enrichment.db")
-    def test_deletes_history_entry(self, mock_db, mock_write):
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
-        conn.select.return_value = [{"IssueID": "12345"}]
+    @patch("comicarr.app.ai.enrichment.ai_queries")
+    def test_deletes_history_entry(self, mock_queries, mock_write):
+        mock_queries.issue_exists.return_value = True
 
         revert_field("12345", "Genre", "/path/to/comic.cbz")
 
-        # Second call should be the DELETE
-        delete_call = conn.action.call_args
-        sql = delete_call[0][0]
-        params = delete_call[0][1]
-        assert "DELETE FROM ai_metadata_history" in sql
-        assert params == ["issue", "12345", "Genre", "enrichment"]
+        mock_queries.delete_metadata_history.assert_called_once_with("issue", "12345", "Genre", "enrichment")
 
 
 # ---------------------------------------------------------------------------
 # ENRICHABLE_FIELDS constant
 # ---------------------------------------------------------------------------
+
 
 class TestEnrichableFields:
     def test_only_genre_and_age_rating(self):

--- a/tests/unit/test_ai_enrichment.py
+++ b/tests/unit/test_ai_enrichment.py
@@ -184,40 +184,45 @@ class TestStoreHistory:
 
 
 class TestEnrichMetadata:
-    @patch("comicarr.app.ai.enrichment.comicarr")
-    def test_skips_when_ai_not_configured(self, mock_cm, tmp_path):
-        mock_cm.AI_CLIENT = None
+    @patch("comicarr.app.ai.enrichment.get_ai_runtime")
+    def test_skips_when_ai_not_configured(self, mock_get_runtime, tmp_path):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = None
         cbz_path = _make_cbz(tmp_path)
         assert enrich_metadata(cbz_path, "12345") == 0
 
-    @patch("comicarr.app.ai.enrichment.comicarr")
-    def test_skips_when_circuit_breaker_open(self, mock_cm, tmp_path):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=False)
+    @patch("comicarr.app.ai.enrichment.get_ai_runtime")
+    def test_skips_when_circuit_breaker_open(self, mock_get_runtime, tmp_path):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=False)
         cbz_path = _make_cbz(tmp_path)
         assert enrich_metadata(cbz_path, "12345") == 0
 
-    @patch("comicarr.app.ai.enrichment.comicarr")
-    def test_skips_when_rate_limiter_at_cap(self, mock_cm, tmp_path):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=False)
+    @patch("comicarr.app.ai.enrichment.get_ai_runtime")
+    def test_skips_when_rate_limiter_at_cap(self, mock_get_runtime, tmp_path):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=False)
         cbz_path = _make_cbz(tmp_path)
         assert enrich_metadata(cbz_path, "12345") == 0
 
-    @patch("comicarr.app.ai.enrichment.comicarr")
-    def test_skips_when_all_fields_populated(self, mock_cm, tmp_path):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
+    @patch("comicarr.app.ai.enrichment.get_ai_runtime")
+    def test_skips_when_all_fields_populated(self, mock_get_runtime, tmp_path):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
         cbz_path = _make_cbz(tmp_path, genre="Superhero", age_rating="T+")
         assert enrich_metadata(cbz_path, "12345") == 0
 
-    @patch("comicarr.app.ai.enrichment.comicarr")
-    def test_skips_when_no_context_fields(self, mock_cm, tmp_path):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
+    @patch("comicarr.app.ai.enrichment.get_ai_runtime")
+    def test_skips_when_no_context_fields(self, mock_get_runtime, tmp_path):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
         # Create CBZ with all context fields blank
         cbz_path = _make_cbz(
             tmp_path,
@@ -236,12 +241,13 @@ class TestEnrichMetadata:
     @patch("comicarr.app.ai.enrichment._store_history")
     @patch("comicarr.app.ai.enrichment.ai_service")
     @patch("comicarr.app.ai.enrichment.request_structured")
-    @patch("comicarr.app.ai.enrichment.comicarr")
-    def test_filters_out_fields_not_in_blank_list(self, mock_cm, mock_req, mock_svc, mock_store, tmp_path):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+    @patch("comicarr.app.ai.enrichment.get_ai_runtime")
+    def test_filters_out_fields_not_in_blank_list(self, mock_get_runtime, mock_req, mock_svc, mock_store, tmp_path):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         # Genre is already populated, AgeRating is blank
         cbz_path = _make_cbz(tmp_path, genre="Superhero", age_rating="")
@@ -259,13 +265,14 @@ class TestEnrichMetadata:
     @patch("comicarr.app.ai.enrichment._store_history")
     @patch("comicarr.app.ai.enrichment.ai_service")
     @patch("comicarr.app.ai.enrichment.request_structured")
-    @patch("comicarr.app.ai.enrichment.comicarr")
-    def test_only_enriches_genre_and_age_rating(self, mock_cm, mock_req, mock_svc, mock_store, tmp_path):
+    @patch("comicarr.app.ai.enrichment.get_ai_runtime")
+    def test_only_enriches_genre_and_age_rating(self, mock_get_runtime, mock_req, mock_svc, mock_store, tmp_path):
         """AI returns Summary and Characters — they must NOT be written."""
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         cbz_path = _make_cbz(tmp_path, genre="", age_rating="")
 
@@ -294,12 +301,13 @@ class TestEnrichMetadata:
     @patch("comicarr.app.ai.enrichment._store_history")
     @patch("comicarr.app.ai.enrichment.ai_service")
     @patch("comicarr.app.ai.enrichment.request_structured")
-    @patch("comicarr.app.ai.enrichment.comicarr")
-    def test_happy_path_blank_genre_filled(self, mock_cm, mock_req, mock_svc, mock_store, tmp_path):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+    @patch("comicarr.app.ai.enrichment.get_ai_runtime")
+    def test_happy_path_blank_genre_filled(self, mock_get_runtime, mock_req, mock_svc, mock_store, tmp_path):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         cbz_path = _make_cbz(tmp_path, genre="", age_rating="")
 
@@ -317,7 +325,7 @@ class TestEnrichMetadata:
         mock_store.assert_called_once_with("12345", {"Genre": "Superhero", "AgeRating": "T+"})
 
         # Verify circuit breaker success recorded
-        mock_cm.AI_CIRCUIT_BREAKER.record_success.assert_called_once()
+        mock_ctx.ai_circuit_breaker.record_success.assert_called_once()
 
         # Verify activity logged
         mock_svc.log_activity.assert_called_once()
@@ -326,12 +334,13 @@ class TestEnrichMetadata:
 
     @patch("comicarr.app.ai.enrichment.ai_service")
     @patch("comicarr.app.ai.enrichment.request_structured")
-    @patch("comicarr.app.ai.enrichment.comicarr")
-    def test_ai_error_records_failure(self, mock_cm, mock_req, mock_svc, tmp_path):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+    @patch("comicarr.app.ai.enrichment.get_ai_runtime")
+    def test_ai_error_records_failure(self, mock_get_runtime, mock_req, mock_svc, tmp_path):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         cbz_path = _make_cbz(tmp_path, genre="", age_rating="")
 
@@ -340,19 +349,20 @@ class TestEnrichMetadata:
         result = enrich_metadata(cbz_path, "12345")
         assert result == 0
 
-        mock_cm.AI_CIRCUIT_BREAKER.record_failure.assert_called_once()
+        mock_ctx.ai_circuit_breaker.record_failure.assert_called_once()
         mock_svc.log_activity.assert_called_once()
         assert mock_svc.log_activity.call_args[1]["success"] is False
 
     @patch("comicarr.app.ai.enrichment._store_history")
     @patch("comicarr.app.ai.enrichment.ai_service")
     @patch("comicarr.app.ai.enrichment.request_structured")
-    @patch("comicarr.app.ai.enrichment.comicarr")
-    def test_skips_when_ai_returns_empty_values(self, mock_cm, mock_req, mock_svc, mock_store, tmp_path):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+    @patch("comicarr.app.ai.enrichment.get_ai_runtime")
+    def test_skips_when_ai_returns_empty_values(self, mock_get_runtime, mock_req, mock_svc, mock_store, tmp_path):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         cbz_path = _make_cbz(tmp_path, genre="", age_rating="")
 

--- a/tests/unit/test_ai_parsing.py
+++ b/tests/unit/test_ai_parsing.py
@@ -144,12 +144,13 @@ class TestAiParseFilename:
     @patch("comicarr.app.ai.parsing.ai_service")
     @patch("comicarr.app.ai.parsing.request_structured")
     @patch("comicarr.app.ai.parsing._validate_against_library")
-    @patch("comicarr.app.ai.parsing.comicarr")
-    def test_happy_path(self, mock_cm, mock_validate, mock_req, mock_svc):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+    @patch("comicarr.app.ai.parsing.get_ai_runtime")
+    def test_happy_path(self, mock_get_runtime, mock_validate, mock_req, mock_svc):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         ai_result = _make_ai_result(series="Spider-Man", issue="300", year="1988")
         mock_req.return_value = ai_result
@@ -164,30 +165,33 @@ class TestAiParseFilename:
         assert result["issue_year"] == "1988"
         assert result["ai_parsed"] is True
 
-        mock_cm.AI_CIRCUIT_BREAKER.record_success.assert_called_once()
+        mock_ctx.ai_circuit_breaker.record_success.assert_called_once()
         mock_svc.log_activity.assert_called_once()
         assert mock_svc.log_activity.call_args[1]["success"] is True
 
-    @patch("comicarr.app.ai.parsing.comicarr")
-    def test_ai_not_configured(self, mock_cm):
-        mock_cm.AI_CLIENT = None
+    @patch("comicarr.app.ai.parsing.get_ai_runtime")
+    def test_ai_not_configured(self, mock_get_runtime):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = None
 
         result = ai_parse_filename("anything.cbz")
         assert result is None
 
-    @patch("comicarr.app.ai.parsing.comicarr")
-    def test_circuit_breaker_open(self, mock_cm):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=False)
+    @patch("comicarr.app.ai.parsing.get_ai_runtime")
+    def test_circuit_breaker_open(self, mock_get_runtime):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=False)
 
         result = ai_parse_filename("anything.cbz")
         assert result is None
 
-    @patch("comicarr.app.ai.parsing.comicarr")
-    def test_rate_limiter_at_cap(self, mock_cm):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=False)
+    @patch("comicarr.app.ai.parsing.get_ai_runtime")
+    def test_rate_limiter_at_cap(self, mock_get_runtime):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=False)
 
         result = ai_parse_filename("anything.cbz")
         assert result is None
@@ -195,12 +199,13 @@ class TestAiParseFilename:
     @patch("comicarr.app.ai.parsing.ai_service")
     @patch("comicarr.app.ai.parsing.request_structured")
     @patch("comicarr.app.ai.parsing._validate_against_library")
-    @patch("comicarr.app.ai.parsing.comicarr")
-    def test_no_library_match(self, mock_cm, mock_validate, mock_req, mock_svc):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+    @patch("comicarr.app.ai.parsing.get_ai_runtime")
+    def test_no_library_match(self, mock_get_runtime, mock_validate, mock_req, mock_svc):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         mock_req.return_value = _make_ai_result(series="UnknownComic", issue="1")
         mock_validate.return_value = False
@@ -214,37 +219,39 @@ class TestAiParseFilename:
 
     @patch("comicarr.app.ai.parsing.ai_service")
     @patch("comicarr.app.ai.parsing.request_structured")
-    @patch("comicarr.app.ai.parsing.comicarr")
-    def test_llm_timeout(self, mock_cm, mock_req, mock_svc):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+    @patch("comicarr.app.ai.parsing.get_ai_runtime")
+    def test_llm_timeout(self, mock_get_runtime, mock_req, mock_svc):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         mock_req.side_effect = TimeoutError("Request timed out")
 
         result = ai_parse_filename("timeout-file.cbz")
         assert result is None
 
-        mock_cm.AI_CIRCUIT_BREAKER.record_failure.assert_called_once()
+        mock_ctx.ai_circuit_breaker.record_failure.assert_called_once()
         mock_svc.log_activity.assert_called_once()
         assert mock_svc.log_activity.call_args[1]["success"] is False
 
     @patch("comicarr.app.ai.parsing.ai_service")
     @patch("comicarr.app.ai.parsing.request_structured")
-    @patch("comicarr.app.ai.parsing.comicarr")
-    def test_llm_invalid_json(self, mock_cm, mock_req, mock_svc):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+    @patch("comicarr.app.ai.parsing.get_ai_runtime")
+    def test_llm_invalid_json(self, mock_get_runtime, mock_req, mock_svc):
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         mock_req.side_effect = ValueError("Failed to parse structured response from LLM")
 
         result = ai_parse_filename("bad-response.cbz")
         assert result is None
 
-        mock_cm.AI_CIRCUIT_BREAKER.record_failure.assert_called_once()
+        mock_ctx.ai_circuit_breaker.record_failure.assert_called_once()
         mock_svc.log_activity.assert_called_once()
         assert mock_svc.log_activity.call_args[1]["success"] is False
         assert "Failed to parse" in (mock_svc.log_activity.call_args[1]["error_message"] or "")
@@ -252,13 +259,14 @@ class TestAiParseFilename:
     @patch("comicarr.app.ai.parsing.ai_service")
     @patch("comicarr.app.ai.parsing.request_structured")
     @patch("comicarr.app.ai.parsing._validate_against_library")
-    @patch("comicarr.app.ai.parsing.comicarr")
-    def test_watchcomic_and_publisher_passed(self, mock_cm, mock_validate, mock_req, mock_svc):
+    @patch("comicarr.app.ai.parsing.get_ai_runtime")
+    def test_watchcomic_and_publisher_passed(self, mock_get_runtime, mock_validate, mock_req, mock_svc):
         """Verify that watchcomic and publisher context is forwarded to the LLM."""
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         mock_req.return_value = _make_ai_result()
         mock_validate.return_value = True
@@ -273,13 +281,14 @@ class TestAiParseFilename:
     @patch("comicarr.app.ai.parsing.ai_service")
     @patch("comicarr.app.ai.parsing.request_structured")
     @patch("comicarr.app.ai.parsing._validate_against_library")
-    @patch("comicarr.app.ai.parsing.comicarr")
-    def test_result_has_all_parseit_keys(self, mock_cm, mock_validate, mock_req, mock_svc):
+    @patch("comicarr.app.ai.parsing.get_ai_runtime")
+    def test_result_has_all_parseit_keys(self, mock_get_runtime, mock_validate, mock_req, mock_svc):
         """The returned dict must include every key listFiles() accesses."""
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+        mock_ctx = mock_get_runtime.return_value
+        mock_ctx.ai_client = MagicMock()
+        mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=True)
+        mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=True)
+        mock_ctx.config = _make_mock_config()
 
         mock_req.return_value = _make_ai_result()
         mock_validate.return_value = True

--- a/tests/unit/test_ai_parsing.py
+++ b/tests/unit/test_ai_parsing.py
@@ -18,6 +18,7 @@ from comicarr.app.ai.schemas import FilenameParse
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_mock_config():
     cfg = MagicMock()
     cfg.AI_MODEL = "gpt-4o-mini"
@@ -49,6 +50,7 @@ def _make_ai_result(series="Batman", issue="42", year="2024", volume=None):
 # ---------------------------------------------------------------------------
 # _build_parse_dict
 # ---------------------------------------------------------------------------
+
 
 class TestBuildParseDict:
     def test_correct_keys_and_status(self):
@@ -93,44 +95,36 @@ class TestBuildParseDict:
 # _validate_against_library
 # ---------------------------------------------------------------------------
 
+
 class TestValidateAgainstLibrary:
-    @patch("comicarr.app.ai.parsing.db")
-    def test_exact_match(self, mock_db):
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
-        conn.select.return_value = [{"ComicID": "123"}]
+    @patch("comicarr.app.ai.parsing.ai_queries")
+    def test_exact_match(self, mock_queries):
+        mock_queries.find_exact_library_match.return_value = {"ComicID": "123"}
 
         assert _validate_against_library("Batman") is True
-        conn.select.assert_called_once()
+        mock_queries.find_exact_library_match.assert_called_once_with("Batman", "batman")
 
-    @patch("comicarr.app.ai.parsing.db")
-    def test_case_insensitive_match(self, mock_db):
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
-        # First call (exact) returns nothing, second (case insensitive) returns match
-        conn.select.side_effect = [[], [{"ComicID": "456"}]]
+    @patch("comicarr.app.ai.parsing.ai_queries")
+    def test_case_insensitive_match(self, mock_queries):
+        mock_queries.find_exact_library_match.return_value = None
+        mock_queries.find_case_insensitive_library_match.return_value = {"ComicID": "456"}
 
         assert _validate_against_library("batman") is True
-        assert conn.select.call_count == 2
+        mock_queries.find_case_insensitive_library_match.assert_called_once_with("batman")
 
-    @patch("comicarr.app.ai.parsing.db")
-    def test_alternate_search_match(self, mock_db):
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
-        # Exact: no match, case-insensitive: no match, alternate search: has data
-        conn.select.side_effect = [
-            [],
-            [],
-            [{"AlternateSearch": "Dark Knight##The Batman##TDK"}],
-        ]
+    @patch("comicarr.app.ai.parsing.ai_queries")
+    def test_alternate_search_match(self, mock_queries):
+        mock_queries.find_exact_library_match.return_value = None
+        mock_queries.find_case_insensitive_library_match.return_value = None
+        mock_queries.get_alternate_search_values.return_value = [{"AlternateSearch": "Dark Knight##The Batman##TDK"}]
 
         assert _validate_against_library("The Batman") is True
 
-    @patch("comicarr.app.ai.parsing.db")
-    def test_no_match(self, mock_db):
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
-        conn.select.side_effect = [[], [], []]
+    @patch("comicarr.app.ai.parsing.ai_queries")
+    def test_no_match(self, mock_queries):
+        mock_queries.find_exact_library_match.return_value = None
+        mock_queries.find_case_insensitive_library_match.return_value = None
+        mock_queries.get_alternate_search_values.return_value = []
 
         assert _validate_against_library("NonexistentComic") is False
 
@@ -142,6 +136,7 @@ class TestValidateAgainstLibrary:
 # ---------------------------------------------------------------------------
 # ai_parse_filename
 # ---------------------------------------------------------------------------
+
 
 class TestAiParseFilename:
     """Tests for the main ai_parse_filename entry point."""
@@ -294,12 +289,24 @@ class TestAiParseFilename:
 
         # Keys required by listFiles() justparse path
         required_keys = [
-            "parse_status", "sub", "comicfilename", "comiclocation",
-            "series_name", "series_name_decoded", "issueid",
-            "alt_series", "alt_issue", "dynamic_name",
-            "series_volume", "issue_year", "issue_number",
-            "scangroup", "reading_order", "booktype",
-            "justthedigits", "annual_comicid",
+            "parse_status",
+            "sub",
+            "comicfilename",
+            "comiclocation",
+            "series_name",
+            "series_name_decoded",
+            "issueid",
+            "alt_series",
+            "alt_issue",
+            "dynamic_name",
+            "series_volume",
+            "issue_year",
+            "issue_number",
+            "scangroup",
+            "reading_order",
+            "booktype",
+            "justthedigits",
+            "annual_comicid",
         ]
         for key in required_keys:
             assert key in result, "Missing key: %s" % key

--- a/tests/unit/test_ai_reconciliation.py
+++ b/tests/unit/test_ai_reconciliation.py
@@ -11,9 +11,7 @@
 
 import os
 import zipfile
-
-import pytest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from comicarr.app.ai.enrichment import _read_comicinfo
 from comicarr.app.ai.reconciliation import (
@@ -44,16 +42,33 @@ _COMICINFO_TEMPLATE = """\
 """
 
 
-def _make_cbz(tmp_path, title="Batman #1", series="Batman", number="1",
-              publisher="DC Comics", year="2020", writer="Tom King",
-              penciller="David Finch", genre="Superhero", age_rating="T+",
-              summary="The Dark Knight.", filename="test.cbz"):
+def _make_cbz(
+    tmp_path,
+    title="Batman #1",
+    series="Batman",
+    number="1",
+    publisher="DC Comics",
+    year="2020",
+    writer="Tom King",
+    penciller="David Finch",
+    genre="Superhero",
+    age_rating="T+",
+    summary="The Dark Knight.",
+    filename="test.cbz",
+):
     """Create a minimal CBZ with a ComicInfo.xml for testing."""
     cbz_path = os.path.join(str(tmp_path), filename)
     xml = _COMICINFO_TEMPLATE.format(
-        title=title, series=series, number=number, publisher=publisher,
-        year=year, writer=writer, penciller=penciller,
-        genre=genre, age_rating=age_rating, summary=summary,
+        title=title,
+        series=series,
+        number=number,
+        publisher=publisher,
+        year=year,
+        writer=writer,
+        penciller=penciller,
+        genre=genre,
+        age_rating=age_rating,
+        summary=summary,
     )
     with zipfile.ZipFile(cbz_path, "w") as zf:
         zf.writestr("ComicInfo.xml", xml.encode("utf-8"))
@@ -83,6 +98,7 @@ def _make_mock_rate_limiter(can=True):
 # ---------------------------------------------------------------------------
 # No conflicts
 # ---------------------------------------------------------------------------
+
 
 class TestNoConflicts:
     def test_returns_zero_when_no_conflicts(self, tmp_path):
@@ -123,6 +139,7 @@ class TestNoConflicts:
 # AI not configured
 # ---------------------------------------------------------------------------
 
+
 class TestAINotConfigured:
     @patch("comicarr.app.ai.reconciliation.comicarr")
     def test_returns_zero_when_ai_client_none(self, mock_cm, tmp_path):
@@ -156,6 +173,7 @@ class TestAINotConfigured:
 # ---------------------------------------------------------------------------
 # Conflicts detected and resolved
 # ---------------------------------------------------------------------------
+
 
 class TestConflictsResolved:
     @patch("comicarr.app.ai.reconciliation._store_reconciliation_history")
@@ -210,11 +228,13 @@ class TestConflictsResolved:
         post = {"Publisher": "DC Comics", "Writer": "Scott Snyder", "Genre": "Superhero"}
 
         # AI picks: CV publisher, pre writer, CV genre
-        mock_req.return_value = ReconciliationChoice(choices={
-            "Publisher": "DC Comics",
-            "Writer": "Tom King",
-            "Genre": "Superhero",
-        })
+        mock_req.return_value = ReconciliationChoice(
+            choices={
+                "Publisher": "DC Comics",
+                "Writer": "Tom King",
+                "Genre": "Superhero",
+            }
+        )
 
         result = reconcile_metadata(cbz_path, "12345", pre, post)
         assert result == 3
@@ -253,6 +273,7 @@ class TestConflictsResolved:
 # AI selects value not matching input — falls back to CV
 # ---------------------------------------------------------------------------
 
+
 class TestSynthesisRejection:
     @patch("comicarr.app.ai.reconciliation._store_reconciliation_history")
     @patch("comicarr.app.ai.reconciliation.ai_service")
@@ -270,9 +291,7 @@ class TestSynthesisRejection:
         post = {"Publisher": "DC Comics"}
 
         # AI synthesises a new value
-        mock_req.return_value = ReconciliationChoice(
-            choices={"Publisher": "DC Comics Inc."}
-        )
+        mock_req.return_value = ReconciliationChoice(choices={"Publisher": "DC Comics Inc."})
 
         result = reconcile_metadata(cbz_path, "12345", pre, post)
         assert result == 1
@@ -285,6 +304,7 @@ class TestSynthesisRejection:
 # ---------------------------------------------------------------------------
 # LLM timeout
 # ---------------------------------------------------------------------------
+
 
 class TestLLMTimeout:
     @patch("comicarr.app.ai.reconciliation.ai_service")
@@ -318,6 +338,7 @@ class TestLLMTimeout:
 # Single-field conflict still triggers reconciliation
 # ---------------------------------------------------------------------------
 
+
 class TestSingleFieldConflict:
     @patch("comicarr.app.ai.reconciliation._store_reconciliation_history")
     @patch("comicarr.app.ai.reconciliation.ai_service")
@@ -345,12 +366,11 @@ class TestSingleFieldConflict:
 # History entries
 # ---------------------------------------------------------------------------
 
+
 class TestHistoryEntries:
-    @patch("comicarr.app.ai.reconciliation.db")
-    def test_stores_both_provider_rows(self, mock_db):
+    @patch("comicarr.app.ai.reconciliation.ai_queries")
+    def test_stores_both_provider_rows(self, mock_queries):
         """Each conflict should produce two history rows: comicinfo and cv."""
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
 
         conflicts = {
             "Publisher": {"comicinfo": "DC", "cv": "DC Comics"},
@@ -359,34 +379,28 @@ class TestHistoryEntries:
 
         _store_reconciliation_history("12345", conflicts, resolved)
 
-        assert conn.action.call_count == 2
+        assert mock_queries.insert_metadata_history.call_count == 2
 
         # First call: comicinfo provider
-        first_call = conn.action.call_args_list[0]
-        sql = first_call[0][0]
-        params = first_call[0][1]
-        assert "INSERT INTO ai_metadata_history" in sql
-        assert params[0] == "issue"
-        assert params[1] == "12345"
-        assert params[2] == "Publisher"
-        assert params[3] == "DC"  # original_value = comicinfo value
-        assert params[4] == "DC Comics"  # ai_value = resolved value
-        assert params[5] == "reconciliation"
-        assert params[6] == "comicinfo"
+        first_call = mock_queries.insert_metadata_history.call_args_list[0].args[0]
+        assert first_call["entity_type"] == "issue"
+        assert first_call["entity_id"] == "12345"
+        assert first_call["field_name"] == "Publisher"
+        assert first_call["original_value"] == "DC"
+        assert first_call["ai_value"] == "DC Comics"
+        assert first_call["source"] == "reconciliation"
+        assert first_call["provider"] == "comicinfo"
 
         # Second call: cv provider
-        second_call = conn.action.call_args_list[1]
-        params = second_call[0][1]
-        assert params[3] == "DC Comics"  # original_value = cv value
-        assert params[4] == "DC Comics"  # ai_value = resolved value
-        assert params[5] == "reconciliation"
-        assert params[6] == "cv"
+        second_call = mock_queries.insert_metadata_history.call_args_list[1].args[0]
+        assert second_call["original_value"] == "DC Comics"
+        assert second_call["ai_value"] == "DC Comics"
+        assert second_call["source"] == "reconciliation"
+        assert second_call["provider"] == "cv"
 
-    @patch("comicarr.app.ai.reconciliation.db")
-    def test_multiple_conflicts_multiple_history_rows(self, mock_db):
+    @patch("comicarr.app.ai.reconciliation.ai_queries")
+    def test_multiple_conflicts_multiple_history_rows(self, mock_queries):
         """Two conflicts should produce four history rows."""
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
 
         conflicts = {
             "Publisher": {"comicinfo": "DC", "cv": "DC Comics"},
@@ -395,13 +409,11 @@ class TestHistoryEntries:
         resolved = {"Publisher": "DC Comics", "Writer": "Tom King"}
 
         _store_reconciliation_history("12345", conflicts, resolved)
-        assert conn.action.call_count == 4
+        assert mock_queries.insert_metadata_history.call_count == 4
 
-    @patch("comicarr.app.ai.reconciliation.db")
-    def test_skips_unresolved_fields(self, mock_db):
+    @patch("comicarr.app.ai.reconciliation.ai_queries")
+    def test_skips_unresolved_fields(self, mock_queries):
         """Fields not in resolved dict should not produce history rows."""
-        conn = MagicMock()
-        mock_db.DBConnection.return_value = conn
 
         conflicts = {
             "Publisher": {"comicinfo": "DC", "cv": "DC Comics"},
@@ -410,18 +422,27 @@ class TestHistoryEntries:
         resolved = {"Publisher": "DC Comics"}  # Writer not resolved
 
         _store_reconciliation_history("12345", conflicts, resolved)
-        assert conn.action.call_count == 2  # Only Publisher rows
+        assert mock_queries.insert_metadata_history.call_count == 2  # Only Publisher rows
 
 
 # ---------------------------------------------------------------------------
 # RECONCILABLE_FIELDS constant
 # ---------------------------------------------------------------------------
 
+
 class TestReconcilableFields:
     def test_expected_fields_present(self):
         expected = {
-            "Title", "Summary", "Publisher", "Genre", "AgeRating",
-            "Writer", "Penciller", "Inker", "Colorist", "Letterer",
+            "Title",
+            "Summary",
+            "Publisher",
+            "Genre",
+            "AgeRating",
+            "Writer",
+            "Penciller",
+            "Inker",
+            "Colorist",
+            "Letterer",
         }
         assert set(RECONCILABLE_FIELDS) == expected
 

--- a/tests/unit/test_ai_reconciliation.py
+++ b/tests/unit/test_ai_reconciliation.py
@@ -95,6 +95,15 @@ def _make_mock_rate_limiter(can=True):
     return rl
 
 
+def _configure_available_ai(mock_get_ai_runtime, *, allow=True, can=True):
+    mock_ctx = mock_get_ai_runtime.return_value
+    mock_ctx.ai_client = MagicMock()
+    mock_ctx.ai_circuit_breaker = _make_mock_circuit_breaker(allow=allow)
+    mock_ctx.ai_rate_limiter = _make_mock_rate_limiter(can=can)
+    mock_ctx.config = _make_mock_config()
+    return mock_ctx
+
+
 # ---------------------------------------------------------------------------
 # No conflicts
 # ---------------------------------------------------------------------------
@@ -141,29 +150,27 @@ class TestNoConflicts:
 
 
 class TestAINotConfigured:
-    @patch("comicarr.app.ai.reconciliation.comicarr")
-    def test_returns_zero_when_ai_client_none(self, mock_cm, tmp_path):
+    @patch("comicarr.app.ai.reconciliation.get_ai_runtime")
+    def test_returns_zero_when_ai_client_none(self, mock_get_ai_runtime, tmp_path):
         """CV wins by default when AI is not configured."""
-        mock_cm.AI_CLIENT = None
+        mock_ctx = mock_get_ai_runtime.return_value
+        mock_ctx.ai_client = None
         pre = {"Title": "Dark Knight", "Publisher": "DC"}
         post = {"Title": "Batman #1", "Publisher": "DC Comics"}
         cbz_path = _make_cbz(tmp_path)
         assert reconcile_metadata(cbz_path, "12345", pre, post) == 0
 
-    @patch("comicarr.app.ai.reconciliation.comicarr")
-    def test_returns_zero_when_circuit_breaker_open(self, mock_cm, tmp_path):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=False)
+    @patch("comicarr.app.ai.reconciliation.get_ai_runtime")
+    def test_returns_zero_when_circuit_breaker_open(self, mock_get_ai_runtime, tmp_path):
+        _configure_available_ai(mock_get_ai_runtime, allow=False)
         pre = {"Title": "Dark Knight", "Publisher": "DC"}
         post = {"Title": "Batman #1", "Publisher": "DC Comics"}
         cbz_path = _make_cbz(tmp_path)
         assert reconcile_metadata(cbz_path, "12345", pre, post) == 0
 
-    @patch("comicarr.app.ai.reconciliation.comicarr")
-    def test_returns_zero_when_rate_limiter_at_cap(self, mock_cm, tmp_path):
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=False)
+    @patch("comicarr.app.ai.reconciliation.get_ai_runtime")
+    def test_returns_zero_when_rate_limiter_at_cap(self, mock_get_ai_runtime, tmp_path):
+        _configure_available_ai(mock_get_ai_runtime, can=False)
         pre = {"Title": "Dark Knight", "Publisher": "DC"}
         post = {"Title": "Batman #1", "Publisher": "DC Comics"}
         cbz_path = _make_cbz(tmp_path)
@@ -179,13 +186,10 @@ class TestConflictsResolved:
     @patch("comicarr.app.ai.reconciliation._store_reconciliation_history")
     @patch("comicarr.app.ai.reconciliation.ai_service")
     @patch("comicarr.app.ai.reconciliation.request_structured")
-    @patch("comicarr.app.ai.reconciliation.comicarr")
-    def test_happy_path_single_conflict(self, mock_cm, mock_req, mock_svc, mock_store, tmp_path):
+    @patch("comicarr.app.ai.reconciliation.get_ai_runtime")
+    def test_happy_path_single_conflict(self, mock_get_ai_runtime, mock_req, mock_svc, mock_store, tmp_path):
         """One conflicting field is resolved and written back."""
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+        mock_ctx = _configure_available_ai(mock_get_ai_runtime)
 
         cbz_path = _make_cbz(tmp_path, publisher="DC Comics")
         pre = {"Publisher": "DC"}
@@ -205,7 +209,7 @@ class TestConflictsResolved:
         mock_store.assert_called_once()
 
         # Verify circuit breaker success recorded
-        mock_cm.AI_CIRCUIT_BREAKER.record_success.assert_called_once()
+        mock_ctx.ai_circuit_breaker.record_success.assert_called_once()
 
         # Verify activity logged
         mock_svc.log_activity.assert_called_once()
@@ -215,13 +219,10 @@ class TestConflictsResolved:
     @patch("comicarr.app.ai.reconciliation._store_reconciliation_history")
     @patch("comicarr.app.ai.reconciliation.ai_service")
     @patch("comicarr.app.ai.reconciliation.request_structured")
-    @patch("comicarr.app.ai.reconciliation.comicarr")
-    def test_happy_path_multiple_conflicts(self, mock_cm, mock_req, mock_svc, mock_store, tmp_path):
+    @patch("comicarr.app.ai.reconciliation.get_ai_runtime")
+    def test_happy_path_multiple_conflicts(self, mock_get_ai_runtime, mock_req, mock_svc, mock_store, tmp_path):
         """Multiple conflicting fields are resolved."""
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+        _configure_available_ai(mock_get_ai_runtime)
 
         cbz_path = _make_cbz(tmp_path, publisher="DC Comics", writer="Tom King")
         pre = {"Publisher": "DC", "Writer": "Tom King", "Genre": "Action"}
@@ -248,13 +249,10 @@ class TestConflictsResolved:
     @patch("comicarr.app.ai.reconciliation._store_reconciliation_history")
     @patch("comicarr.app.ai.reconciliation.ai_service")
     @patch("comicarr.app.ai.reconciliation.request_structured")
-    @patch("comicarr.app.ai.reconciliation.comicarr")
-    def test_ai_picks_comicinfo_value(self, mock_cm, mock_req, mock_svc, mock_store, tmp_path):
+    @patch("comicarr.app.ai.reconciliation.get_ai_runtime")
+    def test_ai_picks_comicinfo_value(self, mock_get_ai_runtime, mock_req, mock_svc, mock_store, tmp_path):
         """AI selects the ComicInfo.xml value over CV."""
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+        _configure_available_ai(mock_get_ai_runtime)
 
         cbz_path = _make_cbz(tmp_path, writer="Scott Snyder")
         pre = {"Writer": "Scott Snyder"}
@@ -278,13 +276,10 @@ class TestSynthesisRejection:
     @patch("comicarr.app.ai.reconciliation._store_reconciliation_history")
     @patch("comicarr.app.ai.reconciliation.ai_service")
     @patch("comicarr.app.ai.reconciliation.request_structured")
-    @patch("comicarr.app.ai.reconciliation.comicarr")
-    def test_synthesised_value_falls_back_to_cv(self, mock_cm, mock_req, mock_svc, mock_store, tmp_path):
+    @patch("comicarr.app.ai.reconciliation.get_ai_runtime")
+    def test_synthesised_value_falls_back_to_cv(self, mock_get_ai_runtime, mock_req, mock_svc, mock_store, tmp_path):
         """When AI returns a value not matching either source, CV wins."""
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+        _configure_available_ai(mock_get_ai_runtime)
 
         cbz_path = _make_cbz(tmp_path, publisher="DC Comics")
         pre = {"Publisher": "DC"}
@@ -309,13 +304,10 @@ class TestSynthesisRejection:
 class TestLLMTimeout:
     @patch("comicarr.app.ai.reconciliation.ai_service")
     @patch("comicarr.app.ai.reconciliation.request_structured")
-    @patch("comicarr.app.ai.reconciliation.comicarr")
-    def test_timeout_returns_zero(self, mock_cm, mock_req, mock_svc, tmp_path):
+    @patch("comicarr.app.ai.reconciliation.get_ai_runtime")
+    def test_timeout_returns_zero(self, mock_get_ai_runtime, mock_req, mock_svc, tmp_path):
         """LLM timeout means CV wins — returns 0."""
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+        mock_ctx = _configure_available_ai(mock_get_ai_runtime)
 
         cbz_path = _make_cbz(tmp_path)
         pre = {"Publisher": "DC"}
@@ -327,7 +319,7 @@ class TestLLMTimeout:
         assert result == 0
 
         # Circuit breaker failure recorded
-        mock_cm.AI_CIRCUIT_BREAKER.record_failure.assert_called_once()
+        mock_ctx.ai_circuit_breaker.record_failure.assert_called_once()
 
         # Activity logged as failure
         mock_svc.log_activity.assert_called_once()
@@ -343,13 +335,12 @@ class TestSingleFieldConflict:
     @patch("comicarr.app.ai.reconciliation._store_reconciliation_history")
     @patch("comicarr.app.ai.reconciliation.ai_service")
     @patch("comicarr.app.ai.reconciliation.request_structured")
-    @patch("comicarr.app.ai.reconciliation.comicarr")
-    def test_one_field_conflict_triggers_reconciliation(self, mock_cm, mock_req, mock_svc, mock_store, tmp_path):
+    @patch("comicarr.app.ai.reconciliation.get_ai_runtime")
+    def test_one_field_conflict_triggers_reconciliation(
+        self, mock_get_ai_runtime, mock_req, mock_svc, mock_store, tmp_path
+    ):
         """Even a single conflicting field should trigger AI reconciliation."""
-        mock_cm.AI_CLIENT = MagicMock()
-        mock_cm.AI_CIRCUIT_BREAKER = _make_mock_circuit_breaker(allow=True)
-        mock_cm.AI_RATE_LIMITER = _make_mock_rate_limiter(can=True)
-        mock_cm.CONFIG = _make_mock_config()
+        _configure_available_ai(mock_get_ai_runtime)
 
         cbz_path = _make_cbz(tmp_path, genre="Superhero")
         pre = {"Genre": "Action"}

--- a/tests/unit/test_ai_runtime_context.py
+++ b/tests/unit/test_ai_runtime_context.py
@@ -1,0 +1,223 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Canonical runtime ownership tests for the bounded AI consumer wave."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from comicarr.app.ai import service as ai_service
+from comicarr.app.ai.parsing import ai_parse_filename
+from comicarr.app.ai.pull_list import generate_suggestions
+from comicarr.app.ai.runtime import get_ai_runtime
+from comicarr.app.ai.schemas import PullSuggestions, ReadingOrder
+from comicarr.app.ai.story_arcs import generate_reading_order
+from comicarr.app.core import runtime as core_runtime
+from comicarr.app.core.context import AppContext
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime(monkeypatch):
+    monkeypatch.setattr(core_runtime, "_runtime", None)
+    yield
+    monkeypatch.setattr(core_runtime, "_runtime", None)
+
+
+def _make_context():
+    config = SimpleNamespace(
+        AI_BASE_URL="https://ai.example.test/v1",
+        AI_API_KEY="test-key",
+        AI_MODEL="test-model",
+        AI_TIMEOUT=30,
+        AI_DAILY_TOKEN_LIMIT=1000,
+        AI_RPM_LIMIT=12,
+    )
+    circuit_breaker = MagicMock()
+    circuit_breaker.allow_request.return_value = True
+    circuit_breaker.state = "closed"
+    rate_limiter = MagicMock()
+    rate_limiter.can_request.return_value = True
+    rate_limiter.today_tokens = 24
+    rate_limiter.today_requests = 3
+    return AppContext(
+        config=config,
+        ai_client=MagicMock(name="ai_client"),
+        ai_circuit_breaker=circuit_breaker,
+        ai_rate_limiter=rate_limiter,
+        event_bus=MagicMock(name="event_bus"),
+    )
+
+
+def test_ai_runtime_is_unavailable_before_context_initialization():
+    assert get_ai_runtime() is None
+    assert ai_parse_filename("uninitialized.cbz") is None
+    assert generate_suggestions(weekly_data=[{"COMIC": "Batman", "ISSUE": "1"}]) == []
+    assert generate_reading_order("Knightfall") == {
+        "success": False,
+        "error": "AI is not configured",
+        "issues": [],
+    }
+
+
+def test_ai_status_and_activity_use_the_canonical_runtime_bundle(monkeypatch):
+    ctx = _make_context()
+    monkeypatch.setattr(core_runtime, "_runtime", ctx)
+
+    with patch.object(ai_service.ai_queries, "insert_activity") as insert_activity:
+        ai_service.log_activity("parsing", "Parsed issue", "test-model", 5, 2, 10, True)
+
+    insert_activity.assert_called_once()
+    ctx.event_bus.publish_sync.assert_called_once_with(
+        "ai_activity",
+        {
+            "feature_type": "parsing",
+            "action": "Parsed issue",
+            "success": True,
+            "latency_ms": 10,
+        },
+    )
+    assert ai_service.get_ai_status() == {
+        "configured": True,
+        "circuit_state": "closed",
+        "today_tokens": 24,
+        "today_requests": 3,
+        "daily_limit": 1000,
+        "rpm_limit": 12,
+    }
+
+
+def test_activity_remains_durable_when_the_runtime_is_unavailable():
+    with patch.object(ai_service.ai_queries, "insert_activity") as insert_activity:
+        ai_service.log_activity("parsing", "Parsed issue", "test-model", 5, 2, 10, True)
+
+    insert_activity.assert_called_once()
+
+
+def test_activity_remains_durable_when_event_bus_publish_fails(monkeypatch):
+    ctx = _make_context()
+    ctx.event_bus.publish_sync.side_effect = RuntimeError("event bus unavailable")
+    monkeypatch.setattr(core_runtime, "_runtime", ctx)
+
+    with patch.object(ai_service.ai_queries, "insert_activity") as insert_activity:
+        assert ai_service.log_activity("parsing", "Parsed issue", "test-model", 5, 2, 10, True) is None
+
+    insert_activity.assert_called_once()
+    ctx.event_bus.publish_sync.assert_called_once()
+
+
+def test_ai_parse_uses_context_client_and_records_context_breaker_failure(monkeypatch):
+    ctx = _make_context()
+    monkeypatch.setattr(core_runtime, "_runtime", ctx)
+
+    with (
+        patch("comicarr.app.ai.parsing.request_structured", side_effect=TimeoutError("upstream timeout")) as request,
+        patch("comicarr.app.ai.parsing.ai_service.log_activity") as log_activity,
+    ):
+        assert ai_parse_filename("Batman 001.cbz") is None
+
+    assert request.call_args.kwargs["client"] is ctx.ai_client
+    assert request.call_args.kwargs["model"] == "test-model"
+    ctx.ai_circuit_breaker.record_failure.assert_called_once()
+    log_activity.assert_called_once()
+
+
+def test_pull_list_uses_the_context_owned_client_and_limits(monkeypatch):
+    ctx = _make_context()
+    monkeypatch.setattr(core_runtime, "_runtime", ctx)
+    result = PullSuggestions(
+        suggestions=[
+            {
+                "comic_name": "Detective Comics",
+                "publisher": "DC",
+                "reason": "Matches your Batman collection",
+                "resolved_comic_id": "123",
+            }
+        ]
+    )
+
+    with (
+        patch("comicarr.app.ai.pull_list._get_cached_suggestions", return_value=None),
+        patch("comicarr.app.ai.pull_list._cache_suggestions") as cache_suggestions,
+        patch("comicarr.app.ai.pull_list.request_structured", return_value=result) as request,
+        patch("comicarr.app.ai.pull_list.ai_service.log_activity") as log_activity,
+    ):
+        suggestions = generate_suggestions(
+            weekly_data=[{"COMIC": "Detective Comics", "ISSUE": "1090", "PUBLISHER": "DC"}],
+            collection_patterns={"series_count": 1},
+        )
+
+    assert suggestions == [
+        {
+            "comic_name": "Detective Comics",
+            "publisher": "DC",
+            "reason": "Matches your Batman collection",
+            "resolved_comic_id": "123",
+        }
+    ]
+    assert request.call_args.kwargs["client"] is ctx.ai_client
+    assert request.call_args.kwargs["model"] == "test-model"
+    ctx.ai_circuit_breaker.record_success.assert_called_once()
+    cache_suggestions.assert_called_once_with(suggestions)
+    log_activity.assert_called_once()
+
+
+def test_story_arc_uses_the_context_owned_client_and_records_failures(monkeypatch):
+    ctx = _make_context()
+    monkeypatch.setattr(core_runtime, "_runtime", ctx)
+    result = ReadingOrder(
+        issues=[
+            {
+                "series_name": "Batman",
+                "issue_number": "497",
+                "title": "The Broken Bat",
+                "reading_order_position": 1,
+            }
+        ]
+    )
+
+    with (
+        patch("comicarr.app.ai.story_arcs.request_structured", return_value=result) as request,
+        patch("comicarr.app.ai.story_arcs.ai_service.log_activity") as log_activity,
+    ):
+        response = generate_reading_order("Knightfall")
+
+    assert response == {
+        "success": True,
+        "issues": [
+            {
+                "series_name": "Batman",
+                "issue_number": "497",
+                "title": "The Broken Bat",
+                "reading_order": 1,
+                "comic_id": None,
+                "issue_id": None,
+                "verified": False,
+                "library_status": "not_tracked",
+            }
+        ],
+    }
+    assert request.call_args.kwargs["client"] is ctx.ai_client
+    assert request.call_args.kwargs["model"] == "test-model"
+    ctx.ai_circuit_breaker.record_success.assert_called_once()
+    log_activity.assert_called_once()
+
+    with (
+        patch("comicarr.app.ai.story_arcs.request_structured", side_effect=TimeoutError("upstream timeout")),
+        patch("comicarr.app.ai.story_arcs.ai_service.log_activity") as failed_log_activity,
+    ):
+        assert generate_reading_order("Knightfall") == {
+            "success": False,
+            "error": "upstream timeout",
+            "issues": [],
+        }
+
+    ctx.ai_circuit_breaker.record_failure.assert_called_once()
+    failed_log_activity.assert_called_once()

--- a/tests/unit/test_ai_search_expansion.py
+++ b/tests/unit/test_ai_search_expansion.py
@@ -15,15 +15,17 @@ from unittest.mock import MagicMock, patch
 from comicarr.app.ai.schemas import SearchExpansion
 
 
-def _configure_available_ai(mock_comicarr):
-    mock_comicarr.AI_CLIENT = MagicMock()
-    mock_comicarr.AI_CIRCUIT_BREAKER = MagicMock()
-    mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = True
-    mock_comicarr.AI_RATE_LIMITER = MagicMock()
-    mock_comicarr.AI_RATE_LIMITER.can_request.return_value = True
-    mock_comicarr.CONFIG = MagicMock()
-    mock_comicarr.CONFIG.AI_MODEL = "gpt-4"
-    mock_comicarr.CONFIG.AI_TIMEOUT = 30
+def _configure_available_ai(mock_get_ai_runtime):
+    mock_ctx = mock_get_ai_runtime.return_value
+    mock_ctx.ai_client = MagicMock()
+    mock_ctx.ai_circuit_breaker = MagicMock()
+    mock_ctx.ai_circuit_breaker.allow_request.return_value = True
+    mock_ctx.ai_rate_limiter = MagicMock()
+    mock_ctx.ai_rate_limiter.can_request.return_value = True
+    mock_ctx.config = MagicMock()
+    mock_ctx.config.AI_MODEL = "gpt-4"
+    mock_ctx.config.AI_TIMEOUT = 30
+    return mock_ctx
 
 
 class TestExpandSearchQueries:
@@ -32,9 +34,9 @@ class TestExpandSearchQueries:
     @patch("comicarr.app.ai.search_expansion.ai_service")
     @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.request_structured")
-    @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_returns_alternates_on_success(self, mock_comicarr, mock_structured, mock_queries, mock_ai_service):
-        _configure_available_ai(mock_comicarr)
+    @patch("comicarr.app.ai.search_expansion.get_ai_runtime")
+    def test_returns_alternates_on_success(self, mock_get_ai_runtime, mock_structured, mock_queries, mock_ai_service):
+        mock_ctx = _configure_available_ai(mock_get_ai_runtime)
         mock_queries.get_cache_entry.return_value = None
         mock_queries.get_alternate_search.return_value = None
         mock_structured.return_value = SearchExpansion(queries=["The Amazing Spider-Man", "ASM", "Spider-Man Marvel"])
@@ -44,30 +46,31 @@ class TestExpandSearchQueries:
         result = expand_search_queries("12345", "Spider-Man", publisher="Marvel", year="2020")
 
         assert result == ["The Amazing Spider-Man", "ASM", "Spider-Man Marvel"]
-        mock_comicarr.AI_CIRCUIT_BREAKER.record_success.assert_called_once()
+        mock_ctx.ai_circuit_breaker.record_success.assert_called_once()
         mock_ai_service.log_activity.assert_called_once()
 
-    @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_ai_not_configured_returns_empty(self, mock_comicarr):
-        mock_comicarr.AI_CLIENT = None
+    @patch("comicarr.app.ai.search_expansion.get_ai_runtime")
+    def test_ai_not_configured_returns_empty(self, mock_get_ai_runtime):
+        mock_ctx = mock_get_ai_runtime.return_value
+        mock_ctx.ai_client = None
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
         assert expand_search_queries("12345", "Spider-Man") == []
 
-    @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_circuit_breaker_open_returns_empty(self, mock_comicarr):
-        _configure_available_ai(mock_comicarr)
-        mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = False
+    @patch("comicarr.app.ai.search_expansion.get_ai_runtime")
+    def test_circuit_breaker_open_returns_empty(self, mock_get_ai_runtime):
+        mock_ctx = _configure_available_ai(mock_get_ai_runtime)
+        mock_ctx.ai_circuit_breaker.allow_request.return_value = False
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
         assert expand_search_queries("12345", "Spider-Man") == []
 
     @patch("comicarr.app.ai.search_expansion.ai_queries")
-    @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_already_has_five_expansions_returns_empty(self, mock_comicarr, mock_queries):
-        _configure_available_ai(mock_comicarr)
+    @patch("comicarr.app.ai.search_expansion.get_ai_runtime")
+    def test_already_has_five_expansions_returns_empty(self, mock_get_ai_runtime, mock_queries):
+        _configure_available_ai(mock_get_ai_runtime)
         mock_queries.get_cache_entry.return_value = {"data": json.dumps(["alt1", "alt2", "alt3", "alt4", "alt5"])}
 
         from comicarr.app.ai.search_expansion import expand_search_queries
@@ -77,11 +80,11 @@ class TestExpandSearchQueries:
     @patch("comicarr.app.ai.search_expansion.ai_service")
     @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.request_structured")
-    @patch("comicarr.app.ai.search_expansion.comicarr")
+    @patch("comicarr.app.ai.search_expansion.get_ai_runtime")
     def test_deduplicates_against_existing_alternates(
-        self, mock_comicarr, mock_structured, mock_queries, mock_ai_service
+        self, mock_get_ai_runtime, mock_structured, mock_queries, mock_ai_service
     ):
-        _configure_available_ai(mock_comicarr)
+        _configure_available_ai(mock_get_ai_runtime)
         mock_queries.get_cache_entry.return_value = None
         mock_queries.get_alternate_search.return_value = {"AlternateSearch": "The Dark Knight"}
         mock_structured.return_value = SearchExpansion(queries=["The Dark Knight", "TDK", "Batman Dark Knight"])
@@ -93,9 +96,11 @@ class TestExpandSearchQueries:
     @patch("comicarr.app.ai.search_expansion.ai_service")
     @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.request_structured")
-    @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_deduplicates_against_series_name(self, mock_comicarr, mock_structured, mock_queries, mock_ai_service):
-        _configure_available_ai(mock_comicarr)
+    @patch("comicarr.app.ai.search_expansion.get_ai_runtime")
+    def test_deduplicates_against_series_name(
+        self, mock_get_ai_runtime, mock_structured, mock_queries, mock_ai_service
+    ):
+        _configure_available_ai(mock_get_ai_runtime)
         mock_queries.get_cache_entry.return_value = None
         mock_queries.get_alternate_search.return_value = None
         mock_structured.return_value = SearchExpansion(queries=["batman", "The Dark Knight"])
@@ -107,9 +112,9 @@ class TestExpandSearchQueries:
     @patch("comicarr.app.ai.search_expansion.ai_service")
     @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.request_structured")
-    @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_llm_timeout_returns_empty(self, mock_comicarr, mock_structured, mock_queries, mock_ai_service):
-        _configure_available_ai(mock_comicarr)
+    @patch("comicarr.app.ai.search_expansion.get_ai_runtime")
+    def test_llm_timeout_returns_empty(self, mock_get_ai_runtime, mock_structured, mock_queries, mock_ai_service):
+        mock_ctx = _configure_available_ai(mock_get_ai_runtime)
         mock_queries.get_cache_entry.return_value = None
         mock_queries.get_alternate_search.return_value = None
         mock_structured.side_effect = TimeoutError("Request timed out")
@@ -117,14 +122,14 @@ class TestExpandSearchQueries:
         from comicarr.app.ai.search_expansion import expand_search_queries
 
         assert expand_search_queries("12345", "Spider-Man") == []
-        mock_comicarr.AI_CIRCUIT_BREAKER.record_failure.assert_called_once()
+        mock_ctx.ai_circuit_breaker.record_failure.assert_called_once()
 
     @patch("comicarr.app.ai.search_expansion.ai_service")
     @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.request_structured")
-    @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_llm_returns_empty_array(self, mock_comicarr, mock_structured, mock_queries, mock_ai_service):
-        _configure_available_ai(mock_comicarr)
+    @patch("comicarr.app.ai.search_expansion.get_ai_runtime")
+    def test_llm_returns_empty_array(self, mock_get_ai_runtime, mock_structured, mock_queries, mock_ai_service):
+        mock_ctx = _configure_available_ai(mock_get_ai_runtime)
         mock_queries.get_cache_entry.return_value = None
         mock_queries.get_alternate_search.return_value = None
         mock_structured.return_value = SearchExpansion(queries=[])
@@ -132,12 +137,12 @@ class TestExpandSearchQueries:
         from comicarr.app.ai.search_expansion import expand_search_queries
 
         assert expand_search_queries("12345", "Spider-Man") == []
-        mock_comicarr.AI_CIRCUIT_BREAKER.record_success.assert_called_once()
+        mock_ctx.ai_circuit_breaker.record_success.assert_called_once()
 
-    @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_rate_limit_reached_returns_empty(self, mock_comicarr):
-        _configure_available_ai(mock_comicarr)
-        mock_comicarr.AI_RATE_LIMITER.can_request.return_value = False
+    @patch("comicarr.app.ai.search_expansion.get_ai_runtime")
+    def test_rate_limit_reached_returns_empty(self, mock_get_ai_runtime):
+        mock_ctx = _configure_available_ai(mock_get_ai_runtime)
+        mock_ctx.ai_rate_limiter.can_request.return_value = False
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 

--- a/tests/unit/test_ai_search_expansion.py
+++ b/tests/unit/test_ai_search_expansion.py
@@ -7,68 +7,43 @@
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 
-"""Tests for comicarr.app.ai.search_expansion."""
+"""Tests for ``comicarr.app.ai.search_expansion``."""
 
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from comicarr.app.ai.schemas import SearchExpansion
 
 
-class _FakeDBConnection:
-    """Minimal DB stub for search expansion tests."""
-
-    def __init__(self, select_results=None):
-        self._select_results = select_results or {}
-        self._action_calls = []
-
-    def select(self, query, args=None):
-        for key, val in self._select_results.items():
-            if key in query:
-                return val
-        return []
-
-    def action(self, query, args=None):
-        self._action_calls.append((query, args))
+def _configure_available_ai(mock_comicarr):
+    mock_comicarr.AI_CLIENT = MagicMock()
+    mock_comicarr.AI_CIRCUIT_BREAKER = MagicMock()
+    mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = True
+    mock_comicarr.AI_RATE_LIMITER = MagicMock()
+    mock_comicarr.AI_RATE_LIMITER.can_request.return_value = True
+    mock_comicarr.CONFIG = MagicMock()
+    mock_comicarr.CONFIG.AI_MODEL = "gpt-4"
+    mock_comicarr.CONFIG.AI_TIMEOUT = 30
 
 
 class TestExpandSearchQueries:
-    """Test expand_search_queries function."""
+    """Test AI expansion behavior independently from the Core query layer."""
 
     @patch("comicarr.app.ai.search_expansion.ai_service")
-    @patch("comicarr.app.ai.search_expansion.db")
+    @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.request_structured")
     @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_returns_alternates_on_success(self, mock_comicarr, mock_structured, mock_db, mock_ai_service):
-        mock_comicarr.AI_CLIENT = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = True
-        mock_comicarr.AI_RATE_LIMITER = MagicMock()
-        mock_comicarr.AI_RATE_LIMITER.can_request.return_value = True
-        mock_comicarr.CONFIG = MagicMock()
-        mock_comicarr.CONFIG.AI_MODEL = "gpt-4"
-        mock_comicarr.CONFIG.AI_TIMEOUT = 30
-
-        fake_db = _FakeDBConnection(select_results={
-            "AlternateSearch": [],
-            "ai_cache": [],
-        })
-        mock_db.DBConnection.return_value = fake_db
-
-        mock_structured.return_value = SearchExpansion(
-            queries=["The Amazing Spider-Man", "ASM", "Spider-Man Marvel"]
-        )
+    def test_returns_alternates_on_success(self, mock_comicarr, mock_structured, mock_queries, mock_ai_service):
+        _configure_available_ai(mock_comicarr)
+        mock_queries.get_cache_entry.return_value = None
+        mock_queries.get_alternate_search.return_value = None
+        mock_structured.return_value = SearchExpansion(queries=["The Amazing Spider-Man", "ASM", "Spider-Man Marvel"])
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
         result = expand_search_queries("12345", "Spider-Man", publisher="Marvel", year="2020")
 
-        assert len(result) == 3
-        assert "The Amazing Spider-Man" in result
-        assert "ASM" in result
-        assert "Spider-Man Marvel" in result
+        assert result == ["The Amazing Spider-Man", "ASM", "Spider-Man Marvel"]
         mock_comicarr.AI_CIRCUIT_BREAKER.record_success.assert_called_once()
         mock_ai_service.log_activity.assert_called_once()
 
@@ -78,259 +53,145 @@ class TestExpandSearchQueries:
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
-        result = expand_search_queries("12345", "Spider-Man")
-
-        assert result == []
+        assert expand_search_queries("12345", "Spider-Man") == []
 
     @patch("comicarr.app.ai.search_expansion.comicarr")
     def test_circuit_breaker_open_returns_empty(self, mock_comicarr):
-        mock_comicarr.AI_CLIENT = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER = MagicMock()
+        _configure_available_ai(mock_comicarr)
         mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = False
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
-        result = expand_search_queries("12345", "Spider-Man")
+        assert expand_search_queries("12345", "Spider-Man") == []
 
-        assert result == []
-
-    @patch("comicarr.app.ai.search_expansion.db")
+    @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_already_has_5_expansions_returns_empty(self, mock_comicarr, mock_db):
-        mock_comicarr.AI_CLIENT = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = True
-        mock_comicarr.AI_RATE_LIMITER = MagicMock()
-        mock_comicarr.AI_RATE_LIMITER.can_request.return_value = True
-
-        five_expansions = json.dumps(["alt1", "alt2", "alt3", "alt4", "alt5"])
-        fake_db = _FakeDBConnection(select_results={
-            "ai_cache": [{"data": five_expansions}],
-        })
-        mock_db.DBConnection.return_value = fake_db
+    def test_already_has_five_expansions_returns_empty(self, mock_comicarr, mock_queries):
+        _configure_available_ai(mock_comicarr)
+        mock_queries.get_cache_entry.return_value = {"data": json.dumps(["alt1", "alt2", "alt3", "alt4", "alt5"])}
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
-        result = expand_search_queries("12345", "Spider-Man")
-
-        assert result == []
+        assert expand_search_queries("12345", "Spider-Man") == []
 
     @patch("comicarr.app.ai.search_expansion.ai_service")
-    @patch("comicarr.app.ai.search_expansion.db")
+    @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.request_structured")
     @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_deduplicates_against_existing_alternates(self, mock_comicarr, mock_structured, mock_db, mock_ai_service):
-        mock_comicarr.AI_CLIENT = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = True
-        mock_comicarr.AI_RATE_LIMITER = MagicMock()
-        mock_comicarr.AI_RATE_LIMITER.can_request.return_value = True
-        mock_comicarr.CONFIG = MagicMock()
-        mock_comicarr.CONFIG.AI_MODEL = "gpt-4"
-        mock_comicarr.CONFIG.AI_TIMEOUT = 30
-
-        fake_db = _FakeDBConnection(select_results={
-            "AlternateSearch": [{"AlternateSearch": "The Dark Knight"}],
-            "ai_cache": [],
-        })
-        mock_db.DBConnection.return_value = fake_db
-
-        # LLM returns one that matches existing and two new ones
-        mock_structured.return_value = SearchExpansion(
-            queries=["The Dark Knight", "TDK", "Batman Dark Knight"]
-        )
+    def test_deduplicates_against_existing_alternates(
+        self, mock_comicarr, mock_structured, mock_queries, mock_ai_service
+    ):
+        _configure_available_ai(mock_comicarr)
+        mock_queries.get_cache_entry.return_value = None
+        mock_queries.get_alternate_search.return_value = {"AlternateSearch": "The Dark Knight"}
+        mock_structured.return_value = SearchExpansion(queries=["The Dark Knight", "TDK", "Batman Dark Knight"])
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
-        result = expand_search_queries("12345", "Batman")
-
-        # "The Dark Knight" should be filtered out as it already exists
-        assert "The Dark Knight" not in result
-        assert "TDK" in result
-        assert "Batman Dark Knight" in result
-        assert len(result) == 2
+        assert expand_search_queries("12345", "Batman") == ["TDK", "Batman Dark Knight"]
 
     @patch("comicarr.app.ai.search_expansion.ai_service")
-    @patch("comicarr.app.ai.search_expansion.db")
+    @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.request_structured")
     @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_deduplicates_against_series_name(self, mock_comicarr, mock_structured, mock_db, mock_ai_service):
-        mock_comicarr.AI_CLIENT = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = True
-        mock_comicarr.AI_RATE_LIMITER = MagicMock()
-        mock_comicarr.AI_RATE_LIMITER.can_request.return_value = True
-        mock_comicarr.CONFIG = MagicMock()
-        mock_comicarr.CONFIG.AI_MODEL = "gpt-4"
-        mock_comicarr.CONFIG.AI_TIMEOUT = 30
-
-        fake_db = _FakeDBConnection(select_results={
-            "AlternateSearch": [],
-            "ai_cache": [],
-        })
-        mock_db.DBConnection.return_value = fake_db
-
-        # LLM returns the series name itself as one of the alternates
-        mock_structured.return_value = SearchExpansion(
-            queries=["batman", "The Dark Knight"]
-        )
+    def test_deduplicates_against_series_name(self, mock_comicarr, mock_structured, mock_queries, mock_ai_service):
+        _configure_available_ai(mock_comicarr)
+        mock_queries.get_cache_entry.return_value = None
+        mock_queries.get_alternate_search.return_value = None
+        mock_structured.return_value = SearchExpansion(queries=["batman", "The Dark Knight"])
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
-        result = expand_search_queries("12345", "Batman")
-
-        # "batman" should be filtered out as it matches series name (case-insensitive)
-        assert len(result) == 1
-        assert "The Dark Knight" in result
+        assert expand_search_queries("12345", "Batman") == ["The Dark Knight"]
 
     @patch("comicarr.app.ai.search_expansion.ai_service")
-    @patch("comicarr.app.ai.search_expansion.db")
+    @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.request_structured")
     @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_llm_timeout_returns_empty(self, mock_comicarr, mock_structured, mock_db, mock_ai_service):
-        mock_comicarr.AI_CLIENT = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = True
-        mock_comicarr.AI_RATE_LIMITER = MagicMock()
-        mock_comicarr.AI_RATE_LIMITER.can_request.return_value = True
-        mock_comicarr.CONFIG = MagicMock()
-        mock_comicarr.CONFIG.AI_MODEL = "gpt-4"
-        mock_comicarr.CONFIG.AI_TIMEOUT = 30
-
-        fake_db = _FakeDBConnection(select_results={
-            "AlternateSearch": [],
-            "ai_cache": [],
-        })
-        mock_db.DBConnection.return_value = fake_db
-
+    def test_llm_timeout_returns_empty(self, mock_comicarr, mock_structured, mock_queries, mock_ai_service):
+        _configure_available_ai(mock_comicarr)
+        mock_queries.get_cache_entry.return_value = None
+        mock_queries.get_alternate_search.return_value = None
         mock_structured.side_effect = TimeoutError("Request timed out")
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
-        result = expand_search_queries("12345", "Spider-Man")
-
-        assert result == []
+        assert expand_search_queries("12345", "Spider-Man") == []
         mock_comicarr.AI_CIRCUIT_BREAKER.record_failure.assert_called_once()
 
     @patch("comicarr.app.ai.search_expansion.ai_service")
-    @patch("comicarr.app.ai.search_expansion.db")
+    @patch("comicarr.app.ai.search_expansion.ai_queries")
     @patch("comicarr.app.ai.search_expansion.request_structured")
     @patch("comicarr.app.ai.search_expansion.comicarr")
-    def test_llm_returns_empty_array(self, mock_comicarr, mock_structured, mock_db, mock_ai_service):
-        mock_comicarr.AI_CLIENT = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = True
-        mock_comicarr.AI_RATE_LIMITER = MagicMock()
-        mock_comicarr.AI_RATE_LIMITER.can_request.return_value = True
-        mock_comicarr.CONFIG = MagicMock()
-        mock_comicarr.CONFIG.AI_MODEL = "gpt-4"
-        mock_comicarr.CONFIG.AI_TIMEOUT = 30
-
-        fake_db = _FakeDBConnection(select_results={
-            "AlternateSearch": [],
-            "ai_cache": [],
-        })
-        mock_db.DBConnection.return_value = fake_db
-
+    def test_llm_returns_empty_array(self, mock_comicarr, mock_structured, mock_queries, mock_ai_service):
+        _configure_available_ai(mock_comicarr)
+        mock_queries.get_cache_entry.return_value = None
+        mock_queries.get_alternate_search.return_value = None
         mock_structured.return_value = SearchExpansion(queries=[])
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
-        result = expand_search_queries("12345", "Spider-Man")
-
-        assert result == []
+        assert expand_search_queries("12345", "Spider-Man") == []
         mock_comicarr.AI_CIRCUIT_BREAKER.record_success.assert_called_once()
 
     @patch("comicarr.app.ai.search_expansion.comicarr")
     def test_rate_limit_reached_returns_empty(self, mock_comicarr):
-        mock_comicarr.AI_CLIENT = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER = MagicMock()
-        mock_comicarr.AI_CIRCUIT_BREAKER.allow_request.return_value = True
-        mock_comicarr.AI_RATE_LIMITER = MagicMock()
+        _configure_available_ai(mock_comicarr)
         mock_comicarr.AI_RATE_LIMITER.can_request.return_value = False
 
         from comicarr.app.ai.search_expansion import expand_search_queries
 
-        result = expand_search_queries("12345", "Spider-Man")
-
-        assert result == []
+        assert expand_search_queries("12345", "Spider-Man") == []
 
 
 class TestPersistSuccessfulExpansion:
-    """Test persist_successful_expansion function."""
+    """Test the query-helper calls that persist successful expansions."""
 
-    @patch("comicarr.app.ai.search_expansion.db")
-    def test_updates_alternate_search_and_cache(self, mock_db):
-        fake_db = _FakeDBConnection(select_results={
-            "AlternateSearch": [{"AlternateSearch": "Existing Alt"}],
-            "ai_cache": [],
-        })
-        mock_db.DBConnection.return_value = fake_db
+    @patch("comicarr.app.ai.search_expansion.ai_queries")
+    def test_updates_alternate_search_and_cache(self, mock_queries):
+        mock_queries.get_alternate_search.return_value = {"AlternateSearch": "Existing Alt"}
+        mock_queries.get_cache_entry.return_value = None
 
         from comicarr.app.ai.search_expansion import persist_successful_expansion
 
         persist_successful_expansion("12345", "New Alt")
 
-        # Should have 2 action calls: UPDATE comics + INSERT ai_cache
-        assert len(fake_db._action_calls) == 2
+        mock_queries.update_alternate_search.assert_called_once_with("12345", "Existing Alt##New Alt")
+        cache_call = mock_queries.upsert_cache_entry.call_args.args
+        assert cache_call[:2] == ("expansion_12345", "expansion")
+        assert json.loads(cache_call[2]) == ["New Alt"]
+        assert cache_call[4] == "9999-12-31"
 
-        update_query, update_args = fake_db._action_calls[0]
-        assert "UPDATE comics SET AlternateSearch" in update_query
-        assert update_args[0] == "Existing Alt##New Alt"
-        assert update_args[1] == "12345"
-
-        cache_query, cache_args = fake_db._action_calls[1]
-        assert "INSERT OR REPLACE INTO ai_cache" in cache_query
-        assert cache_args[0] == "expansion_12345"
-        assert cache_args[1] == "expansion"
-        assert json.loads(cache_args[2]) == ["New Alt"]
-
-    @patch("comicarr.app.ai.search_expansion.db")
-    def test_does_not_duplicate_existing_alternate(self, mock_db):
-        fake_db = _FakeDBConnection(select_results={
-            "AlternateSearch": [{"AlternateSearch": "Existing Alt"}],
-            "ai_cache": [],
-        })
-        mock_db.DBConnection.return_value = fake_db
+    @patch("comicarr.app.ai.search_expansion.ai_queries")
+    def test_does_not_duplicate_existing_alternate(self, mock_queries):
+        mock_queries.get_alternate_search.return_value = {"AlternateSearch": "Existing Alt"}
+        mock_queries.get_cache_entry.return_value = None
 
         from comicarr.app.ai.search_expansion import persist_successful_expansion
 
         persist_successful_expansion("12345", "existing alt")
 
-        # Should only have the ai_cache insert, no UPDATE since it already exists (case-insensitive)
-        assert len(fake_db._action_calls) == 1
-        cache_query, _ = fake_db._action_calls[0]
-        assert "ai_cache" in cache_query
+        mock_queries.update_alternate_search.assert_not_called()
+        assert json.loads(mock_queries.upsert_cache_entry.call_args.args[2]) == ["existing alt"]
 
-    @patch("comicarr.app.ai.search_expansion.db")
-    def test_first_alternate_no_existing(self, mock_db):
-        fake_db = _FakeDBConnection(select_results={
-            "AlternateSearch": [],
-            "ai_cache": [],
-        })
-        mock_db.DBConnection.return_value = fake_db
+    @patch("comicarr.app.ai.search_expansion.ai_queries")
+    def test_first_alternate_has_no_existing_value(self, mock_queries):
+        mock_queries.get_alternate_search.return_value = None
+        mock_queries.get_cache_entry.return_value = None
 
         from comicarr.app.ai.search_expansion import persist_successful_expansion
 
         persist_successful_expansion("12345", "New Alt")
 
-        update_query, update_args = fake_db._action_calls[0]
-        assert "UPDATE comics SET AlternateSearch" in update_query
-        assert update_args[0] == "New Alt"
+        mock_queries.update_alternate_search.assert_called_once_with("12345", "New Alt")
 
-    @patch("comicarr.app.ai.search_expansion.db")
-    def test_appends_to_ai_cache(self, mock_db):
-        existing_cache = json.dumps(["prev alt 1", "prev alt 2"])
-        fake_db = _FakeDBConnection(select_results={
-            "AlternateSearch": [{"AlternateSearch": "prev alt 1##prev alt 2"}],
-            "ai_cache": [{"data": existing_cache}],
-        })
-        mock_db.DBConnection.return_value = fake_db
+    @patch("comicarr.app.ai.search_expansion.ai_queries")
+    def test_appends_to_ai_cache(self, mock_queries):
+        mock_queries.get_alternate_search.return_value = {"AlternateSearch": "prev alt 1##prev alt 2"}
+        mock_queries.get_cache_entry.return_value = {"data": json.dumps(["prev alt 1", "prev alt 2"])}
 
         from comicarr.app.ai.search_expansion import persist_successful_expansion
 
         persist_successful_expansion("12345", "New Alt")
 
-        cache_query, cache_args = fake_db._action_calls[1]
-        cached_list = json.loads(cache_args[2])
-        assert cached_list == ["prev alt 1", "prev alt 2", "New Alt"]
+        assert json.loads(mock_queries.upsert_cache_entry.call_args.args[2]) == ["prev alt 1", "prev alt 2", "New Alt"]

--- a/tests/unit/test_app_query_migrations.py
+++ b/tests/unit/test_app_query_migrations.py
@@ -1,0 +1,481 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Seeded-database contracts for FastAPI domain Core query helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import insert, select
+from sqlalchemy.exc import OperationalError
+
+import comicarr
+from comicarr import db
+from comicarr.app.ai import pull_list
+from comicarr.app.ai import queries as ai_queries
+from comicarr.app.ai import story_arcs as ai_story_arcs
+from comicarr.app.dashboard import queries as dashboard_queries
+from comicarr.app.weekly import queries as weekly_queries
+from comicarr.tables import (
+    ai_activity_log,
+    ai_cache,
+    ai_metadata_history,
+    comics,
+    issues,
+    metadata,
+    snatched,
+    storyarcs,
+    weekly,
+)
+
+
+@pytest.fixture
+def query_db(tmp_path, monkeypatch):
+    """Use a file-backed SQLite engine so domain helpers exercise the real chain."""
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+def _seed_library(engine):
+    with engine.begin() as conn:
+        conn.execute(
+            insert(comics),
+            [
+                {
+                    "ComicID": "comic-alpha",
+                    "ComicName": "Alpha",
+                    "ComicSortName": "Alpha",
+                    "ComicPublisher": "Marvel",
+                    "DynamicComicName": "alpha",
+                    "AlternateSearch": "The Alpha##A-Force",
+                    "ComicImage": "alpha.jpg",
+                    "Status": "Active",
+                    "Have": 5,
+                    "Total": 10,
+                    "ContentType": "comic",
+                },
+                {
+                    "ComicID": "comic-beta",
+                    "ComicName": "Beta",
+                    "ComicSortName": "Beta",
+                    "ComicPublisher": "Marvel",
+                    "DynamicComicName": None,
+                    "AlternateSearch": None,
+                    "ComicImage": None,
+                    "Status": "Active",
+                    "Have": 2,
+                    "Total": 4,
+                    "ContentType": "manga",
+                },
+                {
+                    "ComicID": "comic-gamma",
+                    "ComicName": "Gamma",
+                    "ComicSortName": "Gamma",
+                    "ComicPublisher": "DC",
+                    "DynamicComicName": None,
+                    "AlternateSearch": None,
+                    "ComicImage": None,
+                    "Status": "Active",
+                    "Have": 0,
+                    "Total": 0,
+                    "ContentType": "comic",
+                },
+                {
+                    "ComicID": "comic-paused",
+                    "ComicName": "Paused",
+                    "ComicSortName": "Paused",
+                    "ComicPublisher": "DC",
+                    "DynamicComicName": None,
+                    "AlternateSearch": None,
+                    "ComicImage": None,
+                    "Status": "Paused",
+                    "Have": 99,
+                    "Total": 99,
+                    "ContentType": "comic",
+                },
+            ],
+        )
+        conn.execute(
+            insert(issues),
+            [
+                {
+                    "IssueID": "issue-alpha-1",
+                    "ComicID": "comic-alpha",
+                    "Issue_Number": "1",
+                    "Status": "Downloaded",
+                },
+            ],
+        )
+
+
+def test_ai_cache_helpers_preserve_json_expiry_upsert_and_no_row_semantics(query_db):
+    assert ai_queries.get_cache_entry("missing", "suggestions") is None
+
+    ai_queries.upsert_cache_entry(
+        "suggestions",
+        "suggestions",
+        '["first"]',
+        "2026-06-10 12:00:00",
+        "2026-06-10 18:00:00",
+    )
+    ai_queries.upsert_cache_entry(
+        "suggestions",
+        "suggestions",
+        '["updated", "value"]',
+        "2026-06-10 13:00:00",
+        "2026-06-11 13:00:00",
+    )
+
+    cached = ai_queries.get_cache_entry("suggestions", "suggestions")
+    assert cached == {
+        "data": '["updated", "value"]',
+        "expires_at": "2026-06-11 13:00:00",
+    }
+    with query_db.connect() as conn:
+        rows = conn.execute(select(ai_cache).where(ai_cache.c.cache_key == "suggestions")).all()
+    assert len(rows) == 1
+
+
+def test_suggestion_cache_decodes_fresh_json_and_rejects_expired_entries(query_db):
+    ai_queries.upsert_cache_entry(
+        pull_list.CACHE_KEY,
+        pull_list.CACHE_TYPE,
+        '[{"title": "Fresh"}]',
+        "2026-06-10 12:00:00",
+        "9999-12-31 23:59:59",
+    )
+    assert pull_list._get_cached_suggestions() == [{"title": "Fresh"}]
+
+    ai_queries.upsert_cache_entry(
+        pull_list.CACHE_KEY,
+        pull_list.CACHE_TYPE,
+        '[{"title": "Expired"}]',
+        "2026-06-10 12:00:00",
+        "2000-01-01 00:00:00",
+    )
+    assert pull_list._get_cached_suggestions() is None
+
+
+def test_ai_activity_and_history_helpers_mutate_seeded_database(query_db):
+    ai_queries.insert_activity(
+        {
+            "timestamp": "2026-06-10T12:00:00",
+            "feature_type": "older",
+            "action_description": "older activity",
+            "model": "test",
+            "prompt_tokens": 1,
+            "completion_tokens": 2,
+            "latency_ms": 3,
+            "success": "true",
+            "error_message": None,
+            "entity_type": "issue",
+            "entity_id": "issue-1",
+        }
+    )
+    ai_queries.insert_activity(
+        {
+            "timestamp": "2026-06-10T12:00:01",
+            "feature_type": "newer",
+            "action_description": "newer activity",
+            "model": "test",
+            "prompt_tokens": 4,
+            "completion_tokens": 5,
+            "latency_ms": 6,
+            "success": "false",
+            "error_message": "failed",
+            "entity_type": "issue",
+            "entity_id": "issue-2",
+        }
+    )
+    assert [row["feature_type"] for row in ai_queries.get_activity(limit=1)] == ["newer"]
+    assert [row["feature_type"] for row in ai_queries.get_activity(limit=1, offset=1)] == ["older"]
+
+    ai_queries.insert_metadata_history(
+        {
+            "entity_type": "issue",
+            "entity_id": "issue-1",
+            "field_name": "Genre",
+            "original_value": "Old",
+            "ai_value": "New",
+            "source": "enrichment",
+            "created_at": "2026-06-10 12:00:00",
+        }
+    )
+    ai_queries.insert_metadata_history(
+        {
+            "entity_type": "issue",
+            "entity_id": "issue-1",
+            "field_name": "Genre",
+            "original_value": "Old",
+            "ai_value": "New",
+            "source": "reconciliation",
+            "provider": "comicinfo",
+            "created_at": "2026-06-10 12:00:01",
+        }
+    )
+    ai_queries.delete_metadata_history("issue", "issue-1", "Genre", "enrichment")
+    with query_db.connect() as conn:
+        rows = conn.execute(select(ai_metadata_history.c.source, ai_metadata_history.c.provider)).mappings().all()
+    assert [dict(row) for row in rows] == [{"source": "reconciliation", "provider": "comicinfo"}]
+
+
+def test_ai_lookup_and_untracked_weekly_helpers_use_seeded_rows(query_db):
+    _seed_library(query_db)
+
+    assert ai_queries.issue_exists("issue-alpha-1") is True
+    assert ai_queries.issue_exists("missing") is False
+    assert ai_queries.get_alternate_search("comic-alpha") == {"AlternateSearch": "The Alpha##A-Force"}
+    assert ai_queries.get_alternate_search("missing") is None
+    ai_queries.update_alternate_search("comic-alpha", "Updated")
+    assert ai_queries.get_alternate_search("comic-alpha") == {"AlternateSearch": "Updated"}
+    assert ai_queries.find_series_candidates("lph") == [{"ComicID": "comic-alpha", "ComicName": "Alpha"}]
+    assert ai_queries.find_issue_by_comic_and_number("comic-alpha", "1") == {"IssueID": "issue-alpha-1"}
+    assert ai_queries.find_issue_by_comic_and_number("comic-alpha", "2") is None
+    assert ai_queries.get_issue_status_by_comic_and_number("comic-alpha", "1") == {"Status": "Downloaded"}
+    assert ai_queries.get_issue_status_by_comic_and_number("comic-alpha", "2") is None
+
+    with query_db.begin() as conn:
+        conn.execute(
+            insert(weekly),
+            [
+                {
+                    "COMIC": "Zulu",
+                    "PUBLISHER": "Marvel",
+                    "ISSUE": "1",
+                    "STATUS": "",
+                    "ComicID": "zulu",
+                    "IssueID": "zulu-1",
+                },
+                {
+                    "COMIC": "Alpha",
+                    "PUBLISHER": "Marvel",
+                    "ISSUE": "1",
+                    "STATUS": None,
+                    "ComicID": "weekly-alpha",
+                    "IssueID": "weekly-alpha-1",
+                },
+                {
+                    "COMIC": "Tracked",
+                    "PUBLISHER": "Marvel",
+                    "ISSUE": "1",
+                    "STATUS": "Wanted",
+                    "ComicID": "tracked",
+                    "IssueID": "tracked-1",
+                },
+            ],
+        )
+    assert [row["COMIC"] for row in ai_queries.get_untracked_weekly_releases()] == ["Alpha", "Zulu"]
+
+
+class _RetryingWriteEngine:
+    def __init__(self, locked_attempts):
+        self.locked_attempts = locked_attempts
+        self.execute_calls = 0
+
+    def begin(self):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def execute(self, _statement):
+        self.execute_calls += 1
+        if self.execute_calls <= self.locked_attempts:
+            raise OperationalError("database is locked", None, RuntimeError("database is locked"))
+
+
+def test_ai_writes_keep_legacy_lock_retry_and_exhaustion_contract(monkeypatch):
+    retries = []
+    retrying_engine = _RetryingWriteEngine(locked_attempts=1)
+    monkeypatch.setattr(ai_queries.db, "get_engine", lambda: retrying_engine)
+    monkeypatch.setattr(ai_queries.time, "sleep", retries.append)
+
+    ai_queries.insert_activity({"timestamp": "2026-06-10T12:00:00"})
+
+    assert retrying_engine.execute_calls == 2
+    assert retries == [1]
+
+    exhausted_engine = _RetryingWriteEngine(locked_attempts=ai_queries._WRITE_ATTEMPTS)
+    monkeypatch.setattr(ai_queries.db, "get_engine", lambda: exhausted_engine)
+    ai_queries.insert_metadata_history({"entity_type": "issue", "entity_id": "issue-1"})
+
+    assert exhausted_engine.execute_calls == ai_queries._WRITE_ATTEMPTS
+    assert retries == [1] * (ai_queries._WRITE_ATTEMPTS + 1)
+
+
+def test_ai_library_and_story_arc_helpers_preserve_order_and_safe_no_rows(query_db):
+    _seed_library(query_db)
+
+    assert [row["ComicPublisher"] for row in ai_queries.get_active_publisher_counts()] == ["Marvel", "DC"]
+    assert ai_queries.get_active_series_count() == 3
+    assert ai_queries.get_active_series_names() == ["Alpha", "Beta", "Gamma"]
+    assert ai_queries.get_active_completion_rate() == 50.0
+    assert ai_queries.find_exact_library_match("Alpha", "alpha") == {"ComicID": "comic-alpha"}
+    assert ai_queries.find_case_insensitive_library_match("ALPHA") == {"ComicID": "comic-alpha"}
+    assert ai_queries.get_alternate_search_values() == [{"AlternateSearch": "The Alpha##A-Force"}]
+    assert ai_queries.get_issue_status_by_id("missing") is None
+    assert ai_queries.get_issue_status_by_id("issue-alpha-1") == {"Status": "Downloaded"}
+
+    values = {
+        "StoryArcID": "AI_TEST",
+        "StoryArc": "Test arc",
+        "ComicName": "Alpha",
+        "IssueNumber": "1",
+        "IssueName": "First",
+        "ReadingOrder": 1,
+        "ComicID": "comic-alpha",
+        "IssueID": "issue-alpha-1",
+        "Status": "Added",
+        "IssueArcID": "AI_TEST_1",
+        "Manual": "ai",
+        "DateAdded": "2026-06-10 12:00:00",
+    }
+    ai_queries.replace_storyarc(values)
+    ai_queries.replace_storyarc({**values, "Status": "Wanted"})
+    with query_db.connect() as conn:
+        rows = conn.execute(select(storyarcs).where(storyarcs.c.IssueArcID == "AI_TEST_1")).mappings().all()
+    assert len(rows) == 1
+    assert {name: rows[0][name] for name in values} == {**values, "Status": "Wanted"}
+
+
+def test_save_arc_replaces_legacy_row_and_clears_omitted_columns(query_db):
+    issue_arc_id = "AI_REPLACE0_1"
+    with query_db.begin() as conn:
+        conn.execute(
+            insert(storyarcs),
+            {
+                "StoryArcID": "AI_REPLACE0",
+                "StoryArc": "Old arc",
+                "ComicName": "Legacy title",
+                "IssueNumber": "0",
+                "IssueArcID": issue_arc_id,
+                "Publisher": "Legacy publisher",
+                "ArcImage": "legacy.jpg",
+                "Manual": "legacy",
+            },
+        )
+
+    with patch("comicarr.app.ai.story_arcs.uuid.uuid4", return_value=SimpleNamespace(hex="replace00rest")):
+        result = ai_story_arcs.save_arc(
+            "New arc",
+            [
+                {
+                    "series_name": "Alpha",
+                    "issue_number": "1",
+                    "title": "First",
+                    "reading_order": 1,
+                    "comic_id": "comic-alpha",
+                    "issue_id": "issue-alpha-1",
+                    "library_status": "wanted",
+                }
+            ],
+        )
+
+    assert result == {"success": True, "arc_id": "AI_REPLACE0"}
+    with query_db.connect() as conn:
+        row = conn.execute(select(storyarcs).where(storyarcs.c.IssueArcID == issue_arc_id)).mappings().one()
+    assert row["StoryArc"] == "New arc"
+    assert row["Status"] == "Wanted"
+    assert row["Publisher"] is None
+    assert row["ArcImage"] is None
+
+
+def test_dashboard_helpers_keep_inclusive_cutoff_order_and_content_type_totals(query_db):
+    _seed_library(query_db)
+    with query_db.begin() as conn:
+        conn.execute(
+            insert(snatched),
+            [
+                {
+                    "IssueID": "boundary",
+                    "ComicID": "comic-alpha",
+                    "ComicName": "Alpha",
+                    "Issue_Number": "1",
+                    "Status": "Snatched",
+                    "Provider": "one",
+                    "DateAdded": "2026-06-10 12:00:00",
+                },
+                {
+                    "IssueID": "newest",
+                    "ComicID": "comic-alpha",
+                    "ComicName": "Alpha",
+                    "Issue_Number": "2",
+                    "Status": "Snatched",
+                    "Provider": "two",
+                    "DateAdded": "2026-06-10 12:00:01",
+                },
+                {
+                    "IssueID": "old",
+                    "ComicID": "comic-alpha",
+                    "ComicName": "Alpha",
+                    "Issue_Number": "0",
+                    "Status": "Snatched",
+                    "Provider": "three",
+                    "DateAdded": "2026-06-10 11:59:59",
+                },
+            ],
+        )
+        conn.execute(
+            insert(ai_activity_log),
+            [
+                {"timestamp": "2026-06-10T12:00:00", "feature_type": "older", "success": "true"},
+                {"timestamp": "2026-06-10T12:00:01", "feature_type": "newer", "success": "true"},
+            ],
+        )
+
+    recent = dashboard_queries.get_recent_activity("2026-06-10 12:00:00")
+    assert [row["IssueID"] for row in recent] == ["newest", "boundary"]
+    assert dashboard_queries.get_library_stats() == {
+        "total_series": 3,
+        "total_issues": 7,
+        "total_expected": 14,
+    }
+    assert dashboard_queries.get_library_stats("manga") == {
+        "manga_series": 1,
+        "manga_have": 2,
+        "manga_total": 4,
+    }
+    assert dashboard_queries.get_library_stats("comic") == {
+        "comic_series": 2,
+        "comic_have": 5,
+        "comic_total": 10,
+    }
+    assert [row["feature_type"] for row in dashboard_queries.get_recent_ai_activity()] == ["newer", "older"]
+
+
+def test_weekly_helper_matches_unpadded_week_and_orders_by_title(query_db):
+    with query_db.begin() as conn:
+        conn.execute(
+            insert(weekly),
+            [
+                {"COMIC": "Zulu", "ISSUE": "1", "ComicID": "z", "IssueID": "z-1", "weeknumber": "1", "year": "2026"},
+                {"COMIC": "Alpha", "ISSUE": "1", "ComicID": "a", "IssueID": "a-1", "weeknumber": "1", "year": "2026"},
+                {
+                    "COMIC": "Other week",
+                    "ISSUE": "1",
+                    "ComicID": "other",
+                    "IssueID": "other-1",
+                    "weeknumber": "2",
+                    "year": "2026",
+                },
+            ],
+        )
+
+    assert [row["COMIC"] for row in weekly_queries.get_weekly_releases("01", "2026")] == ["Alpha", "Zulu"]
+    assert weekly_queries.get_weekly_releases("03", "2026") == []

--- a/tests/unit/test_dashboard_service.py
+++ b/tests/unit/test_dashboard_service.py
@@ -7,291 +7,171 @@
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 
-"""Tests for comicarr.app.dashboard.service."""
+"""Tests for dashboard orchestration around Core query helpers."""
 
-from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
+from comicarr.app.dashboard import service
+
 
 @pytest.fixture(autouse=True)
-def _default_queue_count(monkeypatch):
-    monkeypatch.setattr("comicarr.app.dashboard.service.dl_queries.count_active_ddl_items", lambda: 0)
-    monkeypatch.setattr("comicarr.app.dashboard.service.dl_queries.get_active_ddl_preview", lambda limit: [])
-    monkeypatch.setattr("comicarr.app.dashboard.service.storyarcs_service.get_upcoming", lambda include_downloaded: [])
-
-
-class _FakeDBConnection:
-    """Minimal DB stub for testing dashboard queries."""
-
-    def __init__(self, select_results=None, selectone_result=None):
-        self._select_results = select_results or {}
-        self._selectone_result = selectone_result
-        self._select_calls = []
-        self._selectone_calls = []
-
-    def select(self, query, args=None):
-        self._select_calls.append((query, args))
-        for key, val in self._select_results.items():
-            if key in query:
-                return val
-        return []
-
-    def selectone(self, query, args=None):
-        self._selectone_calls.append((query, args))
-        return self._selectone_result or []
+def _dashboard_dependencies(monkeypatch):
+    """Keep service tests focused on payload/default behavior, not database transport."""
+    runtime = SimpleNamespace(
+        AI_CLIENT=None,
+        CONFIG=SimpleNamespace(AI_BASE_URL=None, COMIC_DIR=None, MANGA_DIR=None),
+    )
+    monkeypatch.setattr(service, "comicarr", runtime)
+    monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", lambda cutoff: [])
+    monkeypatch.setattr(service.dashboard_queries, "get_library_stats", lambda content_type=None: None)
+    monkeypatch.setattr(service.dashboard_queries, "get_recent_ai_activity", lambda: [])
+    monkeypatch.setattr(service.dl_queries, "count_active_ddl_items", lambda: 0)
+    monkeypatch.setattr(service.dl_queries, "get_active_ddl_preview", lambda limit: [])
+    monkeypatch.setattr(service.storyarcs_service, "get_upcoming", lambda include_downloaded: [])
 
 
 class TestGetDashboardData:
-    """Test dashboard data aggregation."""
+    """Test dashboard aggregation and error defaults."""
 
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_returns_recently_downloaded(self, mock_comicarr, mock_db):
-        mock_comicarr.AI_CLIENT = None
-        recent = [
-            {
-                "ComicName": "Spider-Man",
-                "Issue_Number": "1",
-                "DateAdded": (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S"),
-                "Status": "Snatched",
-                "Provider": "nzb",
-                "ComicID": "100",
-                "IssueID": "200",
-                "ComicImage": "http://img/1.jpg",
-            },
-        ]
-        fake_db = _FakeDBConnection(select_results={"snatched": recent})
-        mock_db.DBConnection.return_value = fake_db
+    def test_returns_recently_downloaded(self, monkeypatch):
+        recent = [{"ComicName": "Spider-Man", "Issue_Number": "1", "IssueID": "200"}]
+        monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", lambda cutoff: recent)
 
-        from comicarr.app.dashboard.service import get_dashboard_data
+        result = service.get_dashboard_data(None)
 
-        result = get_dashboard_data(None)
+        assert result["recently_downloaded"] == recent
 
-        assert len(result["recently_downloaded"]) == 1
-        assert result["recently_downloaded"][0]["ComicName"] == "Spider-Man"
-
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_recent_activity_uses_an_inclusive_30_day_cutoff(self, mock_comicarr, mock_db, monkeypatch):
-        mock_comicarr.AI_CLIENT = None
+    def test_recent_activity_uses_an_inclusive_30_day_cutoff(self, monkeypatch):
         cutoff = datetime(2026, 6, 10, 12, 0, 0)
-        monkeypatch.setattr("comicarr.app.dashboard.service.recent_activity_cutoff", lambda: cutoff)
-        fake_db = _FakeDBConnection(select_results={"snatched": []})
-        mock_db.DBConnection.return_value = fake_db
+        seen = []
+        monkeypatch.setattr(service, "recent_activity_cutoff", lambda: cutoff)
+        monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", seen.append)
 
-        from comicarr.app.dashboard.service import get_dashboard_data
+        service.get_dashboard_data(None)
 
-        get_dashboard_data(None)
+        assert seen == ["2026-06-10 12:00:00"]
 
-        recent_query, args = next((query, args) for query, args in fake_db._select_calls if "FROM snatched" in query)
-        assert "WHERE s.DateAdded >= ?" in recent_query
-        assert args == ["2026-06-10 12:00:00"]
-
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_returns_current_week_library_releases(self, mock_comicarr, mock_db, monkeypatch):
-        mock_comicarr.AI_CLIENT = None
-        upcoming = [
-            {
-                "ComicName": "Batman",
-                "IssueNumber": "5",
-                "IssueDate": "2026-04-06",
-                "ComicID": "300",
-                "Status": "Wanted",
-            },
-        ]
-        fake_db = _FakeDBConnection(select_results={"snatched": []})
-        mock_db.DBConnection.return_value = fake_db
+    def test_returns_current_week_library_releases(self, monkeypatch):
+        upcoming = [{"ComicName": "Batman", "IssueNumber": "5", "Status": "Wanted"}]
         get_upcoming = MagicMock(return_value=upcoming)
-        monkeypatch.setattr("comicarr.app.dashboard.service.storyarcs_service.get_upcoming", get_upcoming)
+        monkeypatch.setattr(service.storyarcs_service, "get_upcoming", get_upcoming)
 
-        from comicarr.app.dashboard.service import get_dashboard_data
-
-        result = get_dashboard_data(None)
+        result = service.get_dashboard_data(None)
 
         get_upcoming.assert_called_once_with(include_downloaded=True)
-        assert len(result["upcoming_releases"]) == 1
-        assert result["upcoming_releases"][0]["ComicName"] == "Batman"
-        assert all("futureupcoming" not in query for query, _args in fake_db._select_calls)
+        assert result["upcoming_releases"] == upcoming
 
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_returns_active_queue_preview_with_shared_queue_query(self, mock_comicarr, mock_db, monkeypatch):
-        mock_comicarr.AI_CLIENT = None
+    def test_returns_active_queue_projection(self, monkeypatch):
         queue_items = [{"ID": "queued-1", "series": "Batman", "status": "Queued"}]
         get_active_preview = MagicMock(return_value=queue_items)
-        monkeypatch.setattr("comicarr.app.dashboard.service.dl_queries.get_active_ddl_preview", get_active_preview)
-        fake_db = _FakeDBConnection(
-            select_results={"snatched": []},
-            selectone_result={"total_series": 1, "total_issues": 1, "total_expected": 1},
-        )
-        mock_db.DBConnection.return_value = fake_db
+        monkeypatch.setattr(service.dl_queries, "get_active_ddl_preview", get_active_preview)
 
-        from comicarr.app.dashboard.service import get_dashboard_data
-
-        result = get_dashboard_data(None)
+        result = service.get_dashboard_data(None)
 
         get_active_preview.assert_called_once_with(limit=5)
         assert result["active_queue"] == queue_items
 
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_returns_stats(self, mock_comicarr, mock_db):
-        mock_comicarr.AI_CLIENT = None
-        stats_row = {"total_series": 10, "total_issues": 250, "total_expected": 500}
-        fake_db = _FakeDBConnection(
-            select_results={"snatched": []},
-            selectone_result=stats_row,
-        )
-        mock_db.DBConnection.return_value = fake_db
-
-        from comicarr.app.dashboard.service import get_dashboard_data
-
-        result = get_dashboard_data(None)
-
-        assert result["stats"]["total_series"] == 10
-        assert result["stats"]["total_issues"] == 250
-        assert result["stats"]["total_expected"] == 500
-        assert result["stats"]["completion_pct"] == 50.0
-
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_returns_active_queue_count(self, mock_comicarr, mock_db, monkeypatch):
-        mock_comicarr.AI_CLIENT = None
-        mock_comicarr.CONFIG.COMIC_DIR = "/comics"
-        mock_comicarr.CONFIG.MANGA_DIR = "/manga"
+    def test_returns_combined_and_content_type_stats(self, monkeypatch):
+        stats = {
+            None: {"total_series": 10, "total_issues": 250, "total_expected": 500},
+            "manga": {"manga_series": 2, "manga_have": 10, "manga_total": 20},
+            "comic": {"comic_series": 8, "comic_have": 240, "comic_total": 480},
+        }
         monkeypatch.setattr(
-            "comicarr.app.dashboard.service.dl_queries.count_active_ddl_items",
-            lambda: 3,
+            service.dashboard_queries, "get_library_stats", lambda content_type=None: stats[content_type]
         )
-        fake_db = _FakeDBConnection(
-            select_results={"snatched": []},
-            selectone_result={"total_series": 1, "total_issues": 1, "total_expected": 1},
-        )
-        mock_db.DBConnection.return_value = fake_db
 
-        from comicarr.app.dashboard.service import get_dashboard_data
+        result = service.get_dashboard_data(None)
 
-        result = get_dashboard_data(None)
+        assert result["stats"] == {
+            "total_series": 10,
+            "total_issues": 250,
+            "total_expected": 500,
+            "completion_pct": 50.0,
+            "queue_count": 0,
+            "manga_series": 2,
+            "manga_have": 10,
+            "manga_total": 20,
+            "manga_completion_pct": 50.0,
+            "comic_series": 8,
+            "comic_have": 240,
+            "comic_total": 480,
+        }
+
+    def test_returns_active_queue_count_and_scan_targets(self, monkeypatch):
+        service.comicarr.CONFIG.COMIC_DIR = "/comics"
+        service.comicarr.CONFIG.MANGA_DIR = "/manga"
+        monkeypatch.setattr(service.dl_queries, "count_active_ddl_items", lambda: 3)
+
+        result = service.get_dashboard_data(None)
 
         assert result["stats"]["queue_count"] == 3
         assert result["scan_targets"] == {"comic": True, "manga": True}
 
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_queue_count_failure_preserves_other_stats(self, mock_comicarr, mock_db, monkeypatch):
-        mock_comicarr.AI_CLIENT = None
+    def test_queue_count_failure_preserves_other_stats(self, monkeypatch):
         monkeypatch.setattr(
-            "comicarr.app.dashboard.service.dl_queries.count_active_ddl_items",
-            MagicMock(side_effect=RuntimeError("count failed")),
+            service.dashboard_queries,
+            "get_library_stats",
+            lambda content_type=None: (
+                {"total_series": 1, "total_issues": 1, "total_expected": 1} if content_type is None else None
+            ),
         )
-        fake_db = _FakeDBConnection(
-            select_results={"snatched": []},
-            selectone_result={"total_series": 1, "total_issues": 1, "total_expected": 1},
+        monkeypatch.setattr(
+            service.dl_queries, "count_active_ddl_items", MagicMock(side_effect=RuntimeError("count failed"))
         )
-        mock_db.DBConnection.return_value = fake_db
 
-        from comicarr.app.dashboard.service import get_dashboard_data
-
-        result = get_dashboard_data(None)
+        result = service.get_dashboard_data(None)
 
         assert result["stats"]["queue_count"] == 0
         assert result["stats"]["total_series"] == 1
-        assert result["stats"]["total_issues"] == 1
 
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_returns_ai_activity_when_configured(self, mock_comicarr, mock_db):
-        mock_comicarr.AI_CLIENT = MagicMock()
-        activity = [
-            {
-                "timestamp": "2026-04-05T12:00:00",
-                "feature_type": "search",
-                "action_description": "Expanded search query",
-                "prompt_tokens": 100,
-                "completion_tokens": 50,
-                "success": True,
-            },
-        ]
-        fake_db = _FakeDBConnection(
-            select_results={"snatched": [], "ai_activity_log": activity},
-        )
-        mock_db.DBConnection.return_value = fake_db
+    def test_returns_ai_activity_when_configured(self, monkeypatch):
+        service.comicarr.AI_CLIENT = MagicMock()
+        activity = [{"feature_type": "search", "success": True}]
+        monkeypatch.setattr(service.dashboard_queries, "get_recent_ai_activity", lambda: activity)
 
-        from comicarr.app.dashboard.service import get_dashboard_data
-
-        result = get_dashboard_data(None)
+        result = service.get_dashboard_data(None)
 
         assert result["ai_configured"] is True
-        assert len(result["ai_activity"]) == 1
-        assert result["ai_activity"][0]["feature_type"] == "search"
+        assert result["ai_activity"] == activity
 
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_ai_not_configured(self, mock_comicarr, mock_db):
-        mock_comicarr.AI_CLIENT = None
-        mock_comicarr.CONFIG.AI_BASE_URL = None
-        fake_db = _FakeDBConnection(select_results={"snatched": []})
-        mock_db.DBConnection.return_value = fake_db
-
-        from comicarr.app.dashboard.service import get_dashboard_data
-
-        result = get_dashboard_data(None)
+    def test_ai_not_configured_keeps_empty_activity(self):
+        result = service.get_dashboard_data(None)
 
         assert result["ai_configured"] is False
         assert result["ai_activity"] == []
 
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_handles_empty_tables(self, mock_comicarr, mock_db):
-        mock_comicarr.AI_CLIENT = None
-        mock_comicarr.CONFIG.AI_BASE_URL = None
-        fake_db = _FakeDBConnection(
-            select_results={"snatched": []},
-            selectone_result=[],
+    def test_handles_query_errors_gracefully(self, monkeypatch):
+        monkeypatch.setattr(
+            service.dashboard_queries,
+            "get_recent_activity",
+            MagicMock(side_effect=RuntimeError("connection failed")),
         )
-        mock_db.DBConnection.return_value = fake_db
+        monkeypatch.setattr(
+            service.dashboard_queries,
+            "get_library_stats",
+            MagicMock(side_effect=RuntimeError("connection failed")),
+        )
 
-        from comicarr.app.dashboard.service import get_dashboard_data
-
-        result = get_dashboard_data(None)
+        result = service.get_dashboard_data(None)
 
         assert result["recently_downloaded"] == []
         assert result["upcoming_releases"] == []
         assert result["stats"] == {"queue_count": 0}
-        assert result["ai_activity"] == []
-        assert result["ai_configured"] is False
 
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_handles_db_errors_gracefully(self, mock_comicarr, mock_db):
-        mock_comicarr.AI_CLIENT = None
-        mock_db.DBConnection.side_effect = Exception("DB connection failed")
-
-        from comicarr.app.dashboard.service import get_dashboard_data
-
-        result = get_dashboard_data(None)
-
-        # Should return empty defaults, not raise
-        assert result["recently_downloaded"] == []
-        assert result["upcoming_releases"] == []
-        assert result["stats"] == {"queue_count": 0}
-
-    @patch("comicarr.app.dashboard.service.db")
-    @patch("comicarr.app.dashboard.service.comicarr")
-    def test_completion_pct_zero_when_no_expected(self, mock_comicarr, mock_db):
-        mock_comicarr.AI_CLIENT = None
-        stats_row = {"total_series": 0, "total_issues": 0, "total_expected": 0}
-        fake_db = _FakeDBConnection(
-            select_results={"snatched": []},
-            selectone_result=stats_row,
+    def test_completion_percentage_is_zero_when_no_expected_issues(self, monkeypatch):
+        monkeypatch.setattr(
+            service.dashboard_queries,
+            "get_library_stats",
+            lambda content_type=None: (
+                {"total_series": 0, "total_issues": 0, "total_expected": 0} if content_type is None else None
+            ),
         )
-        mock_db.DBConnection.return_value = fake_db
 
-        from comicarr.app.dashboard.service import get_dashboard_data
-
-        result = get_dashboard_data(None)
+        result = service.get_dashboard_data(None)
 
         assert result["stats"]["completion_pct"] == 0

--- a/tests/unit/test_fastapi_db_boundary.py
+++ b/tests/unit/test_fastapi_db_boundary.py
@@ -1,0 +1,19 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Architecture boundary tests for FastAPI-domain database access."""
+
+from pathlib import Path
+
+
+def test_fastapi_domains_do_not_use_the_legacy_db_connection_shim():
+    app_root = Path(__file__).parents[2] / "comicarr" / "app"
+    offenders = [path for path in app_root.rglob("*.py") if "DBConnection(" in path.read_text()]
+
+    assert offenders == []

--- a/tests/unit/test_importer_addvialist.py
+++ b/tests/unit/test_importer_addvialist.py
@@ -106,3 +106,25 @@ def test_importer_thread_projects_mass_add_pool_to_canonical_runtime(monkeypatch
     assert comicarr.MASS_ADD is pool
     assert ctx.add_list.get_nowait() == {"comicid": "12345", "comicname": None}
     pool.start.assert_called_once()
+
+
+def test_refresh_worker_projects_pool_to_canonical_runtime(monkeypatch):
+    """The on-demand refresh worker must share the lifecycle-owned pool and queue."""
+    ctx = AppContext()
+    pool = MagicMock(name="mass_refresh_pool")
+    thread = MagicMock(return_value=pool)
+    monkeypatch.setattr(runtime, "_runtime", ctx)
+    monkeypatch.setattr(comicarr, "MASS_REFRESH", None)
+    monkeypatch.setattr(importer.threading, "Thread", thread)
+
+    assert importer._start_refresh_worker() is True
+
+    assert ctx.mass_refresh_pool is pool
+    assert comicarr.MASS_REFRESH is pool
+    thread.assert_called_once_with(target=importer.updater.addvialist, args=(ctx.refresh_queue,), name="mass-refresh")
+    pool.start.assert_called_once()
+
+    monkeypatch.setattr(importer.threading, "current_thread", lambda: pool)
+    assert importer.refresh_worker_should_retire(ctx.refresh_queue) is True
+    assert ctx.mass_refresh_pool is None
+    assert comicarr.MASS_REFRESH is None

--- a/tests/unit/test_importer_addvialist.py
+++ b/tests/unit/test_importer_addvialist.py
@@ -12,9 +12,12 @@ Tests for comicarr.importer.addvialist — mass-add queue handling.
 """
 
 import queue
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import comicarr
+from comicarr import importer
+from comicarr.app.core import runtime
+from comicarr.app.core.context import AppContext
 from comicarr.importer import addvialist
 
 
@@ -87,3 +90,19 @@ class TestAddComicPayloads:
 
         assert result["success"] is True
         mock_thread.assert_called_once_with([{"comicid": "12345", "comicname": None, "seriesyear": None}])
+
+
+def test_importer_thread_projects_mass_add_pool_to_canonical_runtime(monkeypatch):
+    """The DB-writing MASS_ADD thread must share the lifecycle-owned pool reference."""
+    ctx = AppContext()
+    pool = MagicMock(name="mass_add_pool")
+    monkeypatch.setattr(runtime, "_runtime", ctx)
+    monkeypatch.setattr(comicarr, "MASS_ADD", None)
+    monkeypatch.setattr(importer.threading, "Thread", MagicMock(return_value=pool))
+
+    importer.importer_thread([{"comicid": "12345", "comicname": None}])
+
+    assert ctx.mass_add_pool is pool
+    assert comicarr.MASS_ADD is pool
+    assert ctx.add_list.get_nowait() == {"comicid": "12345", "comicname": None}
+    pool.start.assert_called_once()

--- a/tests/unit/test_runtime_context.py
+++ b/tests/unit/test_runtime_context.py
@@ -33,6 +33,13 @@ RUNTIME_GLOBAL_ALLOWLIST = {
     "comicarr/app/system/router.py": set(),
     "comicarr/app/acquisition/maintenance.py": set(),
     "comicarr/weeklypullit.py": set(),
+    "comicarr/app/ai/enrichment.py": set(),
+    "comicarr/app/ai/parsing.py": set(),
+    "comicarr/app/ai/pull_list.py": set(),
+    "comicarr/app/ai/reconciliation.py": set(),
+    "comicarr/app/ai/search_expansion.py": set(),
+    "comicarr/app/ai/service.py": set(),
+    "comicarr/app/ai/story_arcs.py": set(),
 }
 
 
@@ -143,6 +150,8 @@ def test_runtime_factory_owns_and_projects_one_ai_client_bundle(_legacy_runtime_
     assert ctx.ai_async_client is async_client
     assert comicarr.AI_CLIENT is sync_client
     assert comicarr.AI_ASYNC_CLIENT is async_client
+    assert comicarr.AI_CIRCUIT_BREAKER is ctx.ai_circuit_breaker
+    assert comicarr.AI_RATE_LIMITER is ctx.ai_rate_limiter
 
 
 def test_runtime_access_fails_closed_before_initialization():

--- a/tests/unit/test_runtime_context.py
+++ b/tests/unit/test_runtime_context.py
@@ -1,0 +1,221 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Runtime-context ownership invariants.
+
+These tests deliberately exercise the process boundary rather than a copied
+``AppContext`` fixture.  Queue, lock, scheduler, and DDL set identities are
+the contract shared by worker, scheduler, and FastAPI code during the staged
+legacy migration.
+"""
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import comicarr
+from comicarr.app.core.context import AppContext, get_context
+from comicarr.app.core.runtime import RuntimeNotInitializedError, create_runtime, get_runtime
+
+RUNTIME_GLOBAL_ALLOWLIST = {
+    # These files are the first migrated system/acquisition ownership boundary.
+    # Keep the list explicit so a new mutable module-global read/write cannot
+    # creep back in while the larger legacy scheduler service drains later.
+    "comicarr/app/system/router.py": set(),
+    "comicarr/app/acquisition/maintenance.py": set(),
+    "comicarr/weeklypullit.py": set(),
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime(monkeypatch):
+    """Keep the process singleton isolated between factory tests."""
+    from comicarr.app.core import runtime
+
+    monkeypatch.setattr(runtime, "_runtime", None)
+    yield
+    monkeypatch.setattr(runtime, "_runtime", None)
+
+
+@pytest.fixture
+def _legacy_runtime_objects(monkeypatch):
+    """Install distinct legacy objects that the factory must adopt by identity."""
+    config = SimpleNamespace(SECURE_DIR=None, AI_BASE_URL=None, AI_API_KEY=None)
+    scheduler = MagicMock(name="scheduler")
+    ddl_queued = set()
+    search_queue = MagicMock(name="search_queue")
+    ddl_queue = MagicMock(name="ddl_queue")
+    search_lock = MagicMock(name="search_lock")
+    ddl_lock = MagicMock(name="ddl_lock")
+    acquisition_resume_lock = MagicMock(name="acquisition_resume_lock")
+    mass_add_pool = MagicMock(name="mass_add_pool")
+
+    values = {
+        "CONFIG": config,
+        "PROG_DIR": "/runtime/program",
+        "DATA_DIR": "/runtime/data",
+        "DB_FILE": "/runtime/data/comicarr.db",
+        "SCHED": scheduler,
+        "SEARCH_QUEUE": search_queue,
+        "DDL_QUEUE": ddl_queue,
+        "SEARCHLOCK": search_lock,
+        "DDL_LOCK": ddl_lock,
+        "ACQUISITION_RESUME_LOCK": acquisition_resume_lock,
+        "MASS_ADD": mass_add_pool,
+        "DDL_QUEUED": ddl_queued,
+        "PUBLISHER_IMPRINTS": {},
+        "PROVIDER_BLOCKLIST": [],
+        "DDL_STUCK_NOTIFIED": set(),
+        "PACK_ISSUEIDS_DONT_QUEUE": {},
+        "FORCE_STATUS": {},
+        "PROVIDER_STATUS": {},
+        "UPDATE_VALUE": {},
+        "ACQUISITION_SCHEMA_READY": True,
+        "ACQUISITION_SCHEMA_VERSION": 1,
+        "ACQUISITION_SCHEMA_ERROR": None,
+        "ACQUISITION_WORKERS_BLOCKED": False,
+        "ACQUISITION_BLOCK_REASON": None,
+    }
+    for name, value in values.items():
+        monkeypatch.setattr(comicarr, name, value, raising=False)
+
+    return SimpleNamespace(
+        scheduler=scheduler,
+        ddl_queued=ddl_queued,
+        search_queue=search_queue,
+        ddl_queue=ddl_queue,
+        search_lock=search_lock,
+        ddl_lock=ddl_lock,
+        acquisition_resume_lock=acquisition_resume_lock,
+        mass_add_pool=mass_add_pool,
+    )
+
+
+def test_runtime_factory_is_single_shot_and_adopts_identity_sensitive_objects(_legacy_runtime_objects):
+    """The bridge may project legacy aliases, but it must never snapshot them."""
+    from comicarr.app.core import runtime
+
+    with patch("comicarr.app.core.runtime.AppContext", wraps=AppContext) as context_type:
+        first = create_runtime()
+        second = create_runtime()
+
+    assert first is second
+    assert context_type.call_count == 1
+    assert first.scheduler is _legacy_runtime_objects.scheduler
+    assert first.search_queue is _legacy_runtime_objects.search_queue
+    assert first.ddl_queue is _legacy_runtime_objects.ddl_queue
+    assert first.search_lock is _legacy_runtime_objects.search_lock
+    assert first.ddl_lock is _legacy_runtime_objects.ddl_lock
+    assert first.acquisition_resume_lock is _legacy_runtime_objects.acquisition_resume_lock
+    assert first.mass_add_pool is _legacy_runtime_objects.mass_add_pool
+    assert first.ddl_queued is _legacy_runtime_objects.ddl_queued
+    assert first.acquisition_schema_ready is True
+    assert first.acquisition_workers_blocked is False
+
+    first.ddl_queued.add("issue-42")
+    assert "issue-42" in comicarr.DDL_QUEUED
+    assert runtime.get_runtime() is first
+
+
+def test_runtime_factory_owns_and_projects_one_ai_client_bundle(_legacy_runtime_objects):
+    """AI aliases are a compatibility view of the factory-created bundle."""
+    config = comicarr.CONFIG
+    config.AI_BASE_URL = "https://ai.example.test/v1"
+    config.AI_API_KEY = "test-key"
+    sync_client = MagicMock(name="sync_ai_client")
+    async_client = MagicMock(name="async_ai_client")
+
+    with patch("comicarr.app.ai.client.create_ai_clients", return_value=(sync_client, async_client)) as create_clients:
+        ctx = create_runtime()
+        assert create_runtime() is ctx
+
+    create_clients.assert_called_once_with(config)
+    assert ctx.ai_client is sync_client
+    assert ctx.ai_async_client is async_client
+    assert comicarr.AI_CLIENT is sync_client
+    assert comicarr.AI_ASYNC_CLIENT is async_client
+
+
+def test_runtime_access_fails_closed_before_initialization():
+    """Request code must not silently receive a partial or replacement context."""
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+
+    with pytest.raises(RuntimeNotInitializedError, match="not initialized"):
+        get_runtime()
+    with pytest.raises(RuntimeNotInitializedError, match="not initialized"):
+        get_context(request)
+
+
+def test_worker_bootstrap_refuses_to_start_before_a_runtime_exists(monkeypatch):
+    """A missing context is rejected before scheduler/worker bootstrap can run."""
+    scheduler = MagicMock(name="scheduler")
+    monkeypatch.setattr(comicarr, "SCHED", scheduler)
+    monkeypatch.setattr(comicarr, "_INITIALIZED", True)
+
+    with pytest.raises(RuntimeNotInitializedError, match="before an active runtime"):
+        comicarr.start(None)
+
+    scheduler.add_job.assert_not_called()
+    scheduler.start.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_attaches_the_factory_runtime_instance(_legacy_runtime_objects, monkeypatch):
+    """FastAPI receives the worker-created runtime rather than building a snapshot."""
+    from comicarr.app.acquisition.maintenance import RuntimeGateStatus
+    from comicarr.app.main import lifespan
+
+    ctx = create_runtime()
+    app = SimpleNamespace(state=SimpleNamespace())
+    gate = RuntimeGateStatus(
+        blocked=False,
+        reason=None,
+        schema_ready=True,
+        maintenance_active=False,
+        epoch=0,
+    )
+    monkeypatch.setattr("comicarr.app.acquisition.maintenance.refresh_runtime_state", lambda *_args: gate)
+    monkeypatch.setattr("comicarr.db.get_engine", lambda: None)
+
+    cm = lifespan(app)
+    await cm.__aenter__()
+    try:
+        assert app.state.ctx is ctx
+        assert app.state.ctx.ddl_queued is comicarr.DDL_QUEUED
+        assert get_runtime() is ctx
+    finally:
+        await cm.__aexit__(None, None, None)
+
+    with pytest.raises(RuntimeNotInitializedError, match="disposed"):
+        get_context(SimpleNamespace(app=app))
+
+
+def test_migrated_runtime_boundaries_have_no_unallowlisted_legacy_globals():
+    """Prevent a new direct mutable-global dependency in the first ownership wave."""
+    project_root = Path(__file__).resolve().parents[2]
+    pattern = re.compile(r"\bcomicarr\.([A-Z][A-Z0-9_]+)\b")
+
+    for relative_path, allowed in RUNTIME_GLOBAL_ALLOWLIST.items():
+        source = (project_root / relative_path).read_text(encoding="utf-8")
+        found = set(pattern.findall(source))
+        assert found <= allowed, "%s added direct legacy runtime access: %s" % (
+            relative_path,
+            sorted(found - allowed),
+        )
+
+
+def test_fastapi_lifespan_has_no_legacy_snapshot_builder():
+    """A future lifecycle change must attach the runtime rather than copy it."""
+    from comicarr.app import main
+
+    assert not hasattr(main, "_build_context_from_globals")
+    assert "_build_context_from_globals" not in Path(main.__file__).read_text(encoding="utf-8")

--- a/tests/unit/test_shutdown_drain.py
+++ b/tests/unit/test_shutdown_drain.py
@@ -58,7 +58,7 @@ import asyncio
 import inspect
 import threading
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import select
@@ -162,9 +162,9 @@ async def _run_shutdown(ctx, scheduler=None):
         # from globals). Replace app.state.ctx after entering.
         return None
 
-    # Enter the lifespan; its startup builds a context from globals which is
-    # heavy. Patch _build_context_from_globals to return our ctx.
-    with patch("comicarr.app.main._build_context_from_globals", return_value=ctx):
+    # Enter the lifespan with the canonical runtime that workers already use;
+    # lifespan must attach it rather than rebuilding a globals snapshot.
+    with patch("comicarr.app.main.get_runtime", return_value=ctx):
         await cm.__aenter__()
     await cm.__aexit__(None, None, None)
 
@@ -268,6 +268,49 @@ class TestHappyPath:
         assert ctx.refresh_queue.get_nowait() == "exit"
         # Idle-queue happy path leaves SIGNAL defaulting to shutdown.
         assert comicarr.SIGNAL == "shutdown"
+
+    @pytest.mark.asyncio
+    async def test_shutdown_closes_both_ai_client_variants_after_worker_drain(self, _isolated_db):
+        ctx = _make_ctx(scheduler=MagicMock())
+        ctx.ai_async_client = MagicMock()
+        ctx.ai_async_client.close = AsyncMock()
+        ctx.ai_client = MagicMock()
+
+        await _run_shutdown(ctx)
+
+        ctx.ai_async_client.close.assert_awaited_once()
+        ctx.ai_client.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_signals_and_drains_mass_add_before_dispose(self, _isolated_db):
+        ctx = _make_ctx(scheduler=MagicMock())
+        order = []
+        real_dispose = get_engine().dispose
+
+        class _MassAddPool(_FakePool):
+            def join(self, timeout=None):
+                order.append("mass-add-join")
+                super().join(timeout)
+
+        ctx.mass_add_pool = _MassAddPool()
+
+        def _track_dispose():
+            order.append("dispose")
+            return real_dispose()
+
+        with (
+            patch.object(comicarr, "SNPOOL", None, create=True),
+            patch.object(comicarr, "NZBPOOL", None, create=True),
+            patch.object(comicarr, "SEARCHPOOL", None, create=True),
+            patch.object(comicarr, "PPPOOL", None, create=True),
+            patch.object(comicarr, "DDLPOOL", None, create=True),
+            patch.object(comicarr, "MASS_REFRESH", None, create=True),
+            patch.object(get_engine(), "dispose", side_effect=_track_dispose),
+        ):
+            await _run_shutdown(ctx)
+
+        assert ctx.add_list.get_nowait() == "exit"
+        assert order.index("mass-add-join") < order.index("dispose")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_shutdown_drain.py
+++ b/tests/unit/test_shutdown_drain.py
@@ -37,8 +37,8 @@ worker journal write could therefore hit a disposed engine, and the
 ``os.execv``, degrading a restart to a plain stop.
 
 Post-U7 the lifespan owns the single ordered sequence:
-  1. scheduler.shutdown(wait=False)               (stop new pipeline work)
-  2. q.put('exit') for all 5 queues               (stop intake)
+  1. scheduler.shutdown(wait=True), OFF the loop  (quiesce scheduled work)
+  2. EventBus.close(), then q.put('exit')         (stop intake/late events)
   3. bounded pool.join, OFF the event loop, on a DEDICATED executor
      (final journal flush == workers fully drained)
   4. ai/cv client close
@@ -55,16 +55,19 @@ unconditional, non-blocking hard-kill backstop. The
 
 import ast
 import asyncio
+import datetime
 import inspect
 import threading
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from apscheduler.schedulers.background import BackgroundScheduler
 from sqlalchemy import select
 
 import comicarr
 from comicarr.app.core.context import AppContext
+from comicarr.app.core.events import EventBus
 from comicarr.app.downloads import journal
 from comicarr.app.main import lifespan
 from comicarr.db import get_engine, shutdown_engine
@@ -311,6 +314,126 @@ class TestHappyPath:
 
         assert ctx.add_list.get_nowait() == "exit"
         assert order.index("mass-add-join") < order.index("dispose")
+
+    @pytest.mark.asyncio
+    async def test_shutdown_waits_for_running_scheduler_job_before_dispose(self, _isolated_db):
+        """A real scheduled job must finish its durable write before disposal."""
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        disposed = threading.Event()
+        scheduler = BackgroundScheduler()
+        ctx = _make_ctx(scheduler=scheduler)
+        rkey = journal.release_key("scheduler-1", "test", nzbname="Scheduled Series")
+
+        def _scheduled_write():
+            started.set()
+            assert release.wait(timeout=2)
+            journal.record_transition(rkey, "snatched", issueid="scheduler-1", provider="test")
+            finished.set()
+
+        scheduler.add_job(
+            _scheduled_write,
+            "date",
+            run_date=datetime.datetime.now() + datetime.timedelta(milliseconds=20),
+        )
+        scheduler.start()
+        assert started.wait(timeout=2), "scheduled job did not start"
+
+        engine = get_engine()
+        real_dispose = engine.dispose
+
+        def _track_dispose():
+            disposed.set()
+            return real_dispose()
+
+        shutdown_task = None
+        try:
+            with patch.object(engine, "dispose", side_effect=_track_dispose):
+                shutdown_task = asyncio.create_task(_run_shutdown(ctx, scheduler))
+                await asyncio.sleep(0.05)
+                assert not disposed.is_set(), "engine disposed while a scheduler job was still running"
+                release.set()
+                await asyncio.wait_for(shutdown_task, timeout=2)
+
+            assert finished.is_set()
+            assert disposed.is_set()
+            assert journal.read_open()[0]["release_key"] == rkey
+        finally:
+            release.set()
+            if shutdown_task is not None and not shutdown_task.done():
+                await asyncio.wait_for(shutdown_task, timeout=2)
+            if scheduler.running:
+                scheduler.shutdown(wait=True)
+
+    @pytest.mark.asyncio
+    async def test_scheduler_drain_timeout_preserves_resources_for_terminal_exit(self, _isolated_db, monkeypatch):
+        """A hung scheduler job cannot make lifespan hang or dispose underneath it."""
+        from comicarr.app import main as appmain
+
+        scheduler_started = threading.Event()
+        release_scheduler = threading.Event()
+        scheduler = MagicMock()
+        ctx = _make_ctx(scheduler=scheduler)
+        disposed = threading.Event()
+        monkeypatch.setattr(appmain, "SCHEDULER_DRAIN_TIMEOUT", 0.05)
+
+        def _block_scheduler_shutdown(*, wait):
+            assert wait is True
+            scheduler_started.set()
+            assert release_scheduler.wait(timeout=2)
+
+        scheduler.shutdown.side_effect = _block_scheduler_shutdown
+        engine = get_engine()
+        real_dispose = engine.dispose
+
+        def _track_dispose():
+            disposed.set()
+            return real_dispose()
+
+        try:
+            started_at = time.monotonic()
+            with patch.object(engine, "dispose", side_effect=_track_dispose):
+                await _run_shutdown(ctx, scheduler)
+            elapsed = time.monotonic() - started_at
+
+            assert scheduler_started.is_set()
+            assert elapsed < 1.0
+            assert not disposed.is_set()
+            assert not ctx.disposed
+            assert ctx.snatched_queue.empty()
+        finally:
+            release_scheduler.set()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_rejects_late_event_bus_publication(self, _isolated_db):
+        """A worker publishing during the drain cannot enqueue a late SSE event."""
+        ctx = _make_ctx(scheduler=MagicMock())
+        bus = EventBus()
+        bus.set_loop(asyncio.get_running_loop())
+        _, events = bus.subscribe()
+        ctx.event_bus = bus
+
+        class _LatePublisherPool(_FakePool):
+            def join(self, timeout=None):
+                bus.publish_sync("late", {"source": "worker"})
+                super().join(timeout)
+
+        ctx.sn_pool = _LatePublisherPool()
+        with (
+            patch.object(comicarr, "SNPOOL", None, create=True),
+            patch.object(comicarr, "NZBPOOL", None, create=True),
+            patch.object(comicarr, "SEARCHPOOL", None, create=True),
+            patch.object(comicarr, "PPPOOL", None, create=True),
+            patch.object(comicarr, "DDLPOOL", None, create=True),
+            patch.object(comicarr, "MASS_ADD", None, create=True),
+            patch.object(comicarr, "MASS_REFRESH", None, create=True),
+        ):
+            await _run_shutdown(ctx)
+
+        await asyncio.sleep(0)
+        assert events.empty()
+        assert bus.publish_sync("after_shutdown", {}) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -720,6 +720,7 @@ class TestConfigService:
         job = MagicMock()
         job.next_run_time = datetime.datetime(2026, 7, 12, 0, 0, 0)
         ctx.scheduler.get_job.return_value = job
+        ctx.weekly_status = "Waiting"
         monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Waiting")
         monkeypatch.setattr(comicarr, "WEEKLY_MANUAL_NEXT_RUN", None)
 
@@ -730,6 +731,8 @@ class TestConfigService:
         assert result["state"] == "queued"
         job.modify.assert_called_once()
         upsert.assert_called_once_with("jobhistory", {"status": "Queued"}, {"JobName": "Weekly Pullist"})
+        assert ctx.weekly_manual_next_run == job.next_run_time
+        assert ctx.weekly_status == "Queued"
         assert comicarr.WEEKLY_MANUAL_NEXT_RUN == job.next_run_time
 
     def test_weekly_refresh_coalesces_an_already_queued_request(self, monkeypatch):
@@ -738,6 +741,7 @@ class TestConfigService:
         job = MagicMock()
         job.next_run_time = "2026-07-12T00:00:00Z"
         ctx.scheduler.get_job.return_value = job
+        ctx.weekly_status = "Queued"
         monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Queued")
 
         result = system_service.request_weekly_refresh(ctx)
@@ -755,6 +759,7 @@ class TestConfigService:
         job = MagicMock()
         job.next_run_time = "2026-07-12T00:00:00Z"
         ctx.scheduler.get_job.return_value = job
+        ctx.weekly_status = "Running"
         monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Running")
 
         result = system_service.request_weekly_refresh(ctx)

--- a/tests/unit/test_weekly_scheduler.py
+++ b/tests/unit/test_weekly_scheduler.py
@@ -1,7 +1,7 @@
 """Weekly scheduler lifecycle regression tests."""
 
 import datetime
-from types import SimpleNamespace
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,6 +10,8 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 import comicarr
 from comicarr import weeklypullit
+from comicarr.app.core import runtime
+from comicarr.app.core.context import AppContext
 from comicarr.app.system import service as system_service
 
 
@@ -69,6 +71,36 @@ def test_weekly_run_records_returned_pull_failure(monkeypatch):
     assert job_management.call_args_list[-1].kwargs["failure"] is True
 
 
+def test_weekly_run_projects_running_state_before_refresh_cannot_enqueue_again(monkeypatch):
+    """A manual refresh must observe the canonical Running state, not stale Queued state."""
+    scheduler = MagicMock()
+    scheduler.get_job.return_value = MagicMock(next_run_time=datetime.datetime.utcnow())
+    ctx = AppContext(scheduler=scheduler, weekly_status="Queued")
+    monkeypatch.setattr(runtime, "_runtime", ctx)
+    monkeypatch.setattr(system_service, "_fallback_weekly_refresh_lock", threading.RLock())
+    monkeypatch.setattr(weeklypullit.helpers, "job_management", MagicMock())
+    monkeypatch.setattr(weeklypullit.helpers, "utctimestamp", lambda: 123.0)
+    monkeypatch.setattr(weeklypullit.weeklypull, "future_check", MagicMock())
+
+    observed = []
+
+    def pullit_while_running():
+        observed.append(system_service.request_weekly_refresh(ctx))
+        return None
+
+    monkeypatch.setattr(weeklypullit.weeklypull, "pullit", pullit_while_running)
+
+    weeklypullit.Weekly().run()
+
+    assert observed == [
+        {
+            "accepted": False,
+            "state": "running",
+            "next_run_time": str(scheduler.get_job.return_value.next_run_time),
+        }
+    ]
+
+
 def test_manual_run_restores_the_original_future_schedule(monkeypatch):
     scheduled_run = datetime.datetime.utcnow() + datetime.timedelta(hours=4)
     job = MagicMock()
@@ -93,7 +125,7 @@ def test_manual_refresh_restores_a_real_interval_trigger_schedule(monkeypatch):
         id="weekly",
         next_run_time=original_next_run,
     )
-    ctx = SimpleNamespace(scheduler=scheduler, weekly_status="Waiting")
+    ctx = AppContext(scheduler=scheduler, weekly_status="Waiting")
     monkeypatch.setattr(comicarr, "WEEKLY_STATUS", "Waiting")
     monkeypatch.setattr(comicarr, "WEEKLY_MANUAL_NEXT_RUN", None)
     monkeypatch.setattr(system_service.db, "upsert", MagicMock())


### PR DESCRIPTION
## Summary

FastAPI AI, dashboard, and weekly domains now use domain-owned SQLAlchemy Core queries instead of the legacy `DBConnection` shim, while preserving their result and mutation contracts.

## Changes

- Added focused Core query modules for AI, dashboard, and weekly projections.
- Migrated all nine in-scope FastAPI callers and added a boundary regression that rejects `DBConnection(` under `comicarr/app`.
- Characterized cache, dashboard, weekly, and story-arc behavior, including legacy write retry and replacement semantics.

## Release Impact

- [x] No app release impact; no changeset needed

## Testing

- [x] `uv run --extra dev pytest tests/unit tests/integration -m 'not slow'` — 1,361 passed
- [x] `PATH="$PWD/.venv/bin:$PATH" npm run lint`
- [x] Focused AI/dashboard/weekly and query-boundary tests — 197 passed

## Screenshots

Not applicable; this is a backend persistence refactor with no UI change.

## Additional Notes

### Teaching note

Replacing a legacy SQL shim is more than translating syntax: empty results, ordering, retries, and replacement behavior are caller-visible contracts. The new query modules keep those contracts explicit at the Core boundary.

## Post-Deploy Monitoring & Validation

- **Signals:** Watch application errors and HTTP 5xx responses for AI persistence, dashboard projections, and weekly pull-list routes.
- **Expected healthy behavior:** Existing dashboard cards, AI activity/history, and weekly responses retain their current payloads and ordering without query errors.
- **Owner and window:** Release owner, during the first 24 hours after deployment.
- **Rollback trigger and action:** Revert this PR and redeploy if Core-query exceptions, missing dashboard activity, or AI/weekly persistence regressions appear.

---

[![Built with Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
