### PR TITLE
refactor(downloads): extract postprocess pipeline seams

### DIFF
--- a/comicarr/app/downloads/postprocess_pipeline.py
+++ b/comicarr/app/downloads/postprocess_pipeline.py
@@ -9,6 +9,7 @@
 
 """Restart-safe stages used by the legacy post-processing facade."""
 
+import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -39,6 +40,91 @@ class PostProcessTransitionResult:
     stage: str
     recorded: bool
     error: str | None = None
+
+
+@dataclass(frozen=True)
+class PostProcessInputContext:
+    """Downloader inputs needed to resolve the folder presented to PP."""
+
+    nzb_name: str
+    nzb_folder: str
+    module: str
+    ddl: bool
+    use_sabnzbd: bool
+    use_nzbget: bool
+    sab_direct_unpack: bool
+    sab_directory: str | None
+    nzbget_directory: str | None
+
+
+@dataclass(frozen=True)
+class PostProcessInputResult:
+    """Resolved input folder or a stop reason for the compatibility facade."""
+
+    folder: str
+    error: str | None = None
+
+
+class PostProcessInputStage:
+    """Resolve downloader-specific paths without mutating facade state."""
+
+    def __init__(self, path_exists=os.path.exists, log=logger):
+        self._path_exists = path_exists
+        self._log = log
+
+    def resolve(self, context: PostProcessInputContext) -> PostProcessInputResult:
+        folder = context.nzb_folder
+        if context.ddl:
+            self._log.fdebug(f"{context.module} Now performing post-processing of {context.nzb_name} sent from DDL")
+            return PostProcessInputResult(folder)
+
+        if context.use_sabnzbd:
+            if context.nzb_name != "Manual Run":
+                self._log.fdebug(f"{context.module} Using SABnzbd")
+                self._log.fdebug(f"{context.module} NZB name as passed from SABnzbd: {context.nzb_name}")
+
+            if context.nzb_name == "Manual Run":
+                self._log.fdebug(f"{context.module} Manual Run Post-Processing enabled.")
+            elif context.sab_direct_unpack and context.sab_directory not in (None, "None"):
+                if self._path_exists(os.path.join(folder, context.nzb_name)):
+                    self._log.fdebug(
+                        f"{context.module} SABnzbd Download folder option enabled. Using directory of : {folder}"
+                    )
+                else:
+                    job_folder = os.path.join(context.sab_directory, context.nzb_name)
+                    basename_folder = os.path.join(context.sab_directory, os.path.basename(folder))
+                    if self._path_exists(job_folder):
+                        folder = job_folder
+                        self._log.fdebug(
+                            f"{context.module} SABnzbd Download folder option enabled. Directory set to : {folder}"
+                        )
+                    elif self._path_exists(basename_folder):
+                        folder = basename_folder
+                        self._log.fdebug(
+                            f"{context.module} SABnzbd Download folder option enabled. Directory set to : {folder}"
+                        )
+                    else:
+                        error = (
+                            f"Unable to locate directory within {context.sab_directory} location. "
+                            "I have unsucessfully attempted to locate the following paths: "
+                            f"{job_folder} & {basename_folder}"
+                        )
+                        self._log.warn(error)
+                        return PostProcessInputResult(folder, error)
+
+        if context.use_nzbget:
+            if context.nzb_name != "Manual Run":
+                self._log.fdebug(f"{context.module} Using NZBGET")
+                self._log.fdebug(f"{context.module} NZB name as passed from NZBGet: {context.nzb_name}")
+
+            if context.nzb_name == "Manual Run":
+                self._log.fdebug(f"{context.module} Manual Run Post-Processing enabled.")
+            elif context.nzbget_directory not in (None, "None"):
+                self._log.fdebug(f"{context.module} NZB name as passed from NZBGet: {context.nzb_name}")
+                folder = os.path.join(context.nzbget_directory, context.nzb_name)
+                self._log.fdebug(f"{context.module} NZBGET Download folder option enabled. Directory set to : {folder}")
+
+        return PostProcessInputResult(folder)
 
 
 class PostProcessJournalStage:

--- a/comicarr/app/downloads/postprocess_pipeline.py
+++ b/comicarr/app/downloads/postprocess_pipeline.py
@@ -1,0 +1,122 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Restart-safe stages used by the legacy post-processing facade."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from comicarr import logger
+from comicarr.app.downloads import journal
+
+
+@dataclass(frozen=True)
+class PostProcessContext:
+    """Explicit state required to advance post-processing recovery."""
+
+    issue_id: str | None
+    issue_arc_id: str | None
+    comic_id: str | None
+    nzb_name: str
+    nzb_folder: str
+    api_call: bool
+    ddl: bool
+    canonical_release_key: str | None
+    log_module: str
+
+
+@dataclass(frozen=True)
+class PostProcessTransitionResult:
+    """Observable outcome of an attempted journal transition."""
+
+    release_key: str | None
+    stage: str
+    recorded: bool
+    error: str | None = None
+
+
+class PostProcessJournalStage:
+    """Advance the durable journal around irreversible post-processing work.
+
+    The injected collaborators make failure and idempotency behavior testable
+    without a database. The default journal module remains patchable by the
+    facade's existing integration tests.
+    """
+
+    def __init__(self, journal=journal, log=logger):
+        self._journal = journal
+        self._log = log
+
+    def release_key(
+        self,
+        context: PostProcessContext,
+        *,
+        issue_id: str | None = None,
+        issue_arc_id: str | None = None,
+    ) -> str:
+        explicit_arc_override = issue_arc_id is not None and issue_arc_id != context.issue_arc_id
+        if context.canonical_release_key and not explicit_arc_override:
+            return context.canonical_release_key
+
+        if explicit_arc_override:
+            identity = {
+                "issueid": issue_arc_id,
+                "IssueArcID": issue_arc_id,
+                "comicid": context.comic_id,
+                "nzbname": context.nzb_name,
+                "ddl": context.ddl,
+            }
+            return self._journal.derive_release_key(identity)
+
+        identity = {
+            "issueid": issue_id if issue_id is not None else context.issue_id,
+            "IssueArcID": issue_arc_id if issue_arc_id is not None else context.issue_arc_id,
+            "comicid": context.comic_id,
+            "nzbname": context.nzb_name,
+            "ddl": context.ddl,
+        }
+        return self._journal.derive_release_key(identity)
+
+    def transition(
+        self,
+        context: PostProcessContext,
+        stage: str,
+        *,
+        issue_id: str | None = None,
+        issue_arc_id: str | None = None,
+        payload: dict[str, Any] | None = None,
+        conn=None,
+    ) -> PostProcessTransitionResult:
+        release_key = None
+        try:
+            release_key = self.release_key(context, issue_id=issue_id, issue_arc_id=issue_arc_id)
+            if payload is None:
+                payload = {
+                    "issueid": issue_id if issue_id is not None else context.issue_id,
+                    "issuearcid": issue_arc_id if issue_arc_id is not None else context.issue_arc_id,
+                    "comicid": context.comic_id,
+                    "nzb_name": context.nzb_name,
+                    "nzb_folder": context.nzb_folder,
+                    "apicall": context.api_call,
+                    "ddl": context.ddl,
+                }
+            recorded = self._journal.record_transition(
+                release_key,
+                stage,
+                payload=payload,
+                conn=conn,
+                issueid=issue_id if issue_id is not None else context.issue_id,
+            )
+            self._log.fdebug(f"{context.log_module} [JOURNAL] {stage} for {release_key}")
+            return PostProcessTransitionResult(release_key, stage, bool(recorded))
+        except Exception as e:
+            if conn is not None:
+                raise
+            self._log.error(f"{context.log_module} [JOURNAL] {stage} transition failed (inert, continuing): {e}")
+            return PostProcessTransitionResult(release_key, stage, False, str(e))

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -32,6 +32,7 @@ from sqlalchemy import Integer, and_, delete, func, inspect, or_, select
 
 import comicarr
 from comicarr import db, filechecker, getimage, helpers, logger, notifiers, updater, weeklypull
+from comicarr.app.downloads.postprocess_pipeline import PostProcessContext, PostProcessJournalStage
 from comicarr.app.downloads.pp_commands import safe_walk
 from comicarr.config import get_manga_destination
 from comicarr.manga_parser import parse_manga_filename
@@ -45,6 +46,8 @@ from comicarr.tables import (
     storyarcs,
     weekly,
 )
+
+_POSTPROCESS_JOURNAL_STAGE = PostProcessJournalStage()
 
 
 class PostProcessor(object):
@@ -161,43 +164,24 @@ class PostProcessor(object):
         the U4 single-derivation invariant — claim/markers/snatch all share
         the one key — is preserved unchanged.
         """
-        from comicarr.app.downloads import journal
+        return _POSTPROCESS_JOURNAL_STAGE.release_key(
+            self._journal_context(),
+            issue_id=issueid,
+            issue_arc_id=issuearcid,
+        )
 
-        # Secondary story-arc write: an explicit issuearcid override targets
-        # the ARC row (its own "S<IssueArcID>" nzblog entry is being deleted),
-        # not the primary claimed issue row — re-derive for that arc row.
-        explicit_arc_override = issuearcid is not None and issuearcid != self.issuearcid
-
-        # Prefer the canonical key threaded from the PP-consumer atomic claim
-        # (the row the claim advanced) for the PRIMARY item; re-derive for the
-        # secondary arc write and for unjournaled PP.
-        if self.journal_release_key and not explicit_arc_override:
-            return self.journal_release_key
-
-        # For an explicit story-arc override, the arc's durable `snatched`
-        # row is written with IssueID == IssueArcID (the bare arc id, NOT the
-        # "S"-prefixed nzblog form — updater.foundsearch, see recovery.py
-        # ~94-99), so the canonical arc release_key derives from the arc id.
-        # Anchor the derivation on the arc id so the re-derived key advances
-        # the ARC row, not the primary claimed issue row.
-        if explicit_arc_override:
-            ident = {
-                "issueid": issuearcid,
-                "IssueArcID": issuearcid,
-                "comicid": self.comicid,
-                "nzbname": self.nzb_name,
-                "ddl": getattr(self, "ddl", False),
-            }
-            return journal.derive_release_key(ident)
-
-        ident = {
-            "issueid": issueid if issueid is not None else self.issueid,
-            "IssueArcID": issuearcid if issuearcid is not None else self.issuearcid,
-            "comicid": self.comicid,
-            "nzbname": self.nzb_name,
-            "ddl": getattr(self, "ddl", False),
-        }
-        return journal.derive_release_key(ident)
+    def _journal_context(self):
+        return PostProcessContext(
+            issue_id=self.issueid,
+            issue_arc_id=self.issuearcid,
+            comic_id=self.comicid,
+            nzb_name=self.nzb_name,
+            nzb_folder=self.nzb_folder,
+            api_call=getattr(self, "apicall", False),
+            ddl=getattr(self, "ddl", False),
+            canonical_release_key=self.journal_release_key,
+            log_module=self.module,
+        )
 
     def _journal_pp(self, stage, issueid=None, issuearcid=None, payload=None, conn=None):
         """Record a PP-marker journal transition.
@@ -215,36 +199,14 @@ class PostProcessor(object):
         post_processing/moved. The swallow-and-continue contract applies ONLY
         to the own-transaction (conn is None) additive markers.
         """
-        from comicarr.app.downloads import journal
-
-        rkey = None
-        try:
-            rkey = self._journal_release_key(issueid=issueid, issuearcid=issuearcid)
-            if payload is None:
-                payload = {
-                    "issueid": issueid if issueid is not None else self.issueid,
-                    "issuearcid": issuearcid if issuearcid is not None else self.issuearcid,
-                    "comicid": self.comicid,
-                    "nzb_name": self.nzb_name,
-                    "nzb_folder": self.nzb_folder,
-                    "apicall": getattr(self, "apicall", False),
-                    "ddl": getattr(self, "ddl", False),
-                }
-            journal.record_transition(
-                rkey,
-                stage,
-                payload=payload,
-                conn=conn,
-                issueid=issueid if issueid is not None else self.issueid,
-            )
-            logger.fdebug("%s [JOURNAL] %s for %s" % (self.module, stage, rkey))
-        except Exception as e:
-            # conn-mode: must roll the whole block back (a swallowed failure
-            # would delete nzblog while the journal still said
-            # post_processing/moved). Own-txn additive markers swallow.
-            if conn is not None:
-                raise
-            logger.error("%s [JOURNAL] %s transition failed (inert, continuing): %s" % (self.module, stage, e))
+        _POSTPROCESS_JOURNAL_STAGE.transition(
+            self._journal_context(),
+            stage,
+            issue_id=issueid,
+            issue_arc_id=issuearcid,
+            payload=payload,
+            conn=conn,
+        )
 
     def _log(self, message, level=logger):  # .message):  #level=logger.MESSAGE):
         """

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -32,7 +32,12 @@ from sqlalchemy import Integer, and_, delete, func, inspect, or_, select
 
 import comicarr
 from comicarr import db, filechecker, getimage, helpers, logger, notifiers, updater, weeklypull
-from comicarr.app.downloads.postprocess_pipeline import PostProcessContext, PostProcessJournalStage
+from comicarr.app.downloads.postprocess_pipeline import (
+    PostProcessContext,
+    PostProcessInputContext,
+    PostProcessInputStage,
+    PostProcessJournalStage,
+)
 from comicarr.app.downloads.pp_commands import safe_walk
 from comicarr.config import get_manga_destination
 from comicarr.manga_parser import parse_manga_filename
@@ -48,6 +53,7 @@ from comicarr.tables import (
 )
 
 _POSTPROCESS_JOURNAL_STAGE = PostProcessJournalStage()
+_POSTPROCESS_INPUT_STAGE = PostProcessInputStage()
 
 
 class PostProcessor(object):
@@ -586,71 +592,25 @@ class PostProcessor(object):
         self._log("nzb folder: %s" % self.nzb_folder)
         logger.fdebug("%s nzb name: %s" % (module, self.nzb_name))
         logger.fdebug("%s nzb folder: %s" % (module, self.nzb_folder))
-        if self.ddl is False:
-            if comicarr.USE_SABNZBD == 1:
-                if self.nzb_name != "Manual Run":
-                    logger.fdebug("%s Using SABnzbd" % module)
-                    logger.fdebug("%s NZB name as passed from SABnzbd: %s" % (module, self.nzb_name))
-
-                if self.nzb_name == "Manual Run":
-                    logger.fdebug("%s Manual Run Post-Processing enabled." % module)
-                else:
-                    # if the SAB Directory option is enabled, let's use that folder name and append the jobname.
-                    if all(
-                        [
-                            comicarr.CONFIG.SAB_DIRECT_UNPACK,
-                            comicarr.CONFIG.SAB_DIRECTORY is not None,
-                            comicarr.CONFIG.SAB_DIRECTORY != "None",
-                        ]
-                    ):
-                        if os.path.exists(os.path.join(self.nzb_folder, self.nzb_name)):
-                            logger.fdebug(
-                                "%s SABnzbd Download folder option enabled. Using directory of : %s"
-                                % (module, self.nzb_folder)
-                            )
-                        else:
-                            tmpchk = os.path.join(
-                                comicarr.CONFIG.SAB_DIRECTORY, self.nzb_name
-                            )  # .encode(comicarr.SYS_ENCODING)
-                            if os.path.exists(tmpchk):
-                                self.nzb_folder = tmpchk
-                                logger.fdebug(
-                                    "%s SABnzbd Download folder option enabled. Directory set to : %s"
-                                    % (module, self.nzb_folder)
-                                )
-                            else:
-                                tmpchk2 = os.path.join(comicarr.CONFIG.SAB_DIRECTORY, os.path.basename(self.nzb_folder))
-                                if os.path.exists(tmpchk2):
-                                    self.nzb_folder = tmpchk2
-                                    logger.fdebug(
-                                        "%s SABnzbd Download folder option enabled. Directory set to : %s"
-                                        % (module, self.nzb_folder)
-                                    )
-                                else:
-                                    logger.warn(
-                                        "Unable to locate directory within %s location. I have unsucessfully attempted to locate the following paths: %s & %s"
-                                        % (comicarr.CONFIG.SAB_DIRECTORY, tmpchk, tmpchk2)
-                                    )
-                                    self.valreturn.append({"self.log": self.log, "mode": "stop"})
-                                    return self.queue.put(self.valreturn)
-
-            if comicarr.USE_NZBGET == 1:
-                if self.nzb_name != "Manual Run":
-                    logger.fdebug("%s Using NZBGET" % module)
-                    logger.fdebug("%s NZB name as passed from NZBGet: %s" % (module, self.nzb_name))
-                # if the NZBGet Directory option is enabled, let's use that folder name and append the jobname.
-                if self.nzb_name == "Manual Run":
-                    logger.fdebug("%s Manual Run Post-Processing enabled." % module)
-                elif all([comicarr.CONFIG.NZBGET_DIRECTORY is not None, comicarr.CONFIG.NZBGET_DIRECTORY != "None"]):
-                    logger.fdebug("%s NZB name as passed from NZBGet: %s" % (module, self.nzb_name))
-                    self.nzb_folder = os.path.join(
-                        comicarr.CONFIG.NZBGET_DIRECTORY, self.nzb_name
-                    )  # .encode(comicarr.SYS_ENCODING)
-                    logger.fdebug(
-                        "%s NZBGET Download folder option enabled. Directory set to : %s" % (module, self.nzb_folder)
-                    )
-        else:
-            logger.fdebug("%s Now performing post-processing of %s sent from DDL" % (module, self.nzb_name))
+        use_sabnzbd = comicarr.USE_SABNZBD == 1
+        use_nzbget = comicarr.USE_NZBGET == 1
+        input_result = _POSTPROCESS_INPUT_STAGE.resolve(
+            PostProcessInputContext(
+                nzb_name=self.nzb_name,
+                nzb_folder=self.nzb_folder,
+                module=module,
+                ddl=self.ddl,
+                use_sabnzbd=use_sabnzbd,
+                use_nzbget=use_nzbget,
+                sab_direct_unpack=(comicarr.CONFIG.SAB_DIRECT_UNPACK if use_sabnzbd else False),
+                sab_directory=(comicarr.CONFIG.SAB_DIRECTORY if use_sabnzbd else None),
+                nzbget_directory=(comicarr.CONFIG.NZBGET_DIRECTORY if use_nzbget else None),
+            )
+        )
+        self.nzb_folder = input_result.folder
+        if input_result.error is not None:
+            self.valreturn.append({"self.log": self.log, "mode": "stop"})
+            return self.queue.put(self.valreturn)
 
         self.oneoffinlist = False
 

--- a/docs/architecture/postprocessing-migration-map.md
+++ b/docs/architecture/postprocessing-migration-map.md
@@ -59,10 +59,13 @@ completed journal stages rather than repeating irreversible file work.
 
 1. Journal transition stage with explicit context and an injectable journal
    adapter; `_journal_release_key()` and `_journal_pp()` remain facade methods.
-2. Filesystem operation/result stage, preserving the journal bracket and
+2. Downloader input-resolution stage with explicit SAB/NZBGet configuration
+   and an injectable path probe; `Process()` retains the historical queue-stop
+   facade for missing SAB paths.
+3. Filesystem operation/result stage, preserving the journal bracket and
    retry rule.
-3. Database reconciliation stage using downloads/series query boundaries.
-4. Cleanup and notification stages after durable completion.
+4. Database reconciliation stage using downloads/series query boundaries.
+5. Cleanup and notification stages after durable completion.
 
 Each stage must retain focused success, expected-failure, and
 side-effect/idempotency coverage before the next extraction begins.

--- a/docs/architecture/postprocessing-migration-map.md
+++ b/docs/architecture/postprocessing-migration-map.md
@@ -1,0 +1,68 @@
+# Post-processing migration map
+
+This map records the compatibility contract for strangling
+`comicarr.postprocessor.PostProcessor` one restart-safe stage at a time. The
+legacy class remains the public facade until its callers and operational
+recovery paths have migrated.
+
+## Entry points and callers
+
+| Entry point | First-party callers | Observable result |
+|---|---|---|
+| `PostProcessor.Process()` | `comicarr.process`, `comicarr.app.downloads.service`, tests | queue/API status, library file, issue state, notifications, cleanup |
+| `PostProcessor.Process_next()` | `Process()` and focused tests | one resolved issue processed or an error/status string |
+| `PostProcessor._process_manga()` | `Process()` and focused tests | chapter file moved, issue state updated, journal advanced |
+| Manual folder processing | `comicarr.app.common.filesystem`, `FolderCheck` | eligible files processed without deleting the selected root |
+
+## Inputs, outputs, and collaborators
+
+- Inputs: download name/path, optional issue/comic identity, manual/API/DDL
+  mode, queue, and an optional canonical recovery-journal release key.
+- Outputs: historical status strings/dicts, queue messages, logs, notifications,
+  and mutated instance fields used by later facade stages.
+- Filesystem: archive inspection, metadata staging, rename, copy/move, duplicate
+  handling, permissions, source/cache cleanup, and optional story-arc copies.
+- Persistence: comics, issues, annuals, story arcs, snatched/nzblog rows, weekly
+  and one-off history, plus the durable pipeline journal.
+- External collaborators: downloader cleanup, metadata tools, pre/post scripts,
+  image lookup, notifications, weekly/read-list projection, and runtime locks.
+- Mutable runtime state: configuration, API lock, cache/program directories,
+  current week/year, and user-visible global messages.
+
+## Failure and recovery contract
+
+The durable journal brackets irreversible work as
+`post_processing -> moved -> post_processed`. A primary download must reuse the
+canonical release key claimed by the queue consumer. A secondary story-arc copy
+must derive its own arc-scoped key. Additive pre-commit journal failures are
+logged and do not abort processing; the terminal transition joins the
+`nzblog` deletion transaction and must propagate so both changes roll back.
+Duplicate or regressing journal writes are monotonic no-ops. Manual processing
+may clean the selected file in move mode but must not delete the selected root.
+
+The durable journal/database facts are the recovery source of truth. Cleanup
+and notification happen only after durable move/status work; retries detect
+completed journal stages rather than repeating irreversible file work.
+
+## Characterization evidence
+
+- `test_pp_idempotency_guard.py`: atomic claim, retry, duplicate, manual, and
+  canonical-key threading.
+- `test_pp_complete_ordering.py`: move/cleanup ordering and transactional
+  journal completion.
+- `test_journal_pp_seam.py`: lifecycle, failure, story-arc, one-off, and manga
+  paths.
+- `test_manga_postprocessor.py`: manga filename, destination, and failure
+  behavior.
+
+## Extraction sequence
+
+1. Journal transition stage with explicit context and an injectable journal
+   adapter; `_journal_release_key()` and `_journal_pp()` remain facade methods.
+2. Filesystem operation/result stage, preserving the journal bracket and
+   retry rule.
+3. Database reconciliation stage using downloads/series query boundaries.
+4. Cleanup and notification stages after durable completion.
+
+Each stage must retain focused success, expected-failure, and
+side-effect/idempotency coverage before the next extraction begins.

--- a/tests/unit/test_postprocess_input_resolution.py
+++ b/tests/unit/test_postprocess_input_resolution.py
@@ -1,0 +1,140 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import comicarr
+from comicarr.postprocessor import PostProcessor
+
+
+def _processor(folder, *, ddl=False, name="Saga.001", config, use_sab=0, use_nzbget=0):
+    queue = MagicMock()
+    queue.put.return_value = "queued"
+    apilock = MagicMock()
+    apilock.locked.return_value = False
+    with (
+        patch.object(comicarr, "APILOCK", apilock),
+        patch.object(comicarr, "CONFIG", config),
+        patch.object(comicarr, "USE_SABNZBD", use_sab),
+        patch.object(comicarr, "USE_NZBGET", use_nzbget),
+    ):
+        processor = PostProcessor(name, str(folder), comicid="md-saga", queue=queue, ddl=ddl)
+    return processor, queue
+
+
+def _config(tmp_path, **overrides):
+    values = {
+        "FILE_OPTS": "move",
+        "IGNORE_SEARCH_WORDS": [],
+        "SAB_DIRECT_UNPACK": True,
+        "SAB_DIRECTORY": str(tmp_path / "sab"),
+        "NZBGET_DIRECTORY": str(tmp_path / "nzbget"),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _run(processor, config, *, use_sab=0, use_nzbget=0):
+    with (
+        patch.object(comicarr, "CONFIG", config),
+        patch.object(comicarr, "USE_SABNZBD", use_sab),
+        patch.object(comicarr, "USE_NZBGET", use_nzbget),
+        patch.object(processor, "_process_manga", return_value="manga") as manga,
+    ):
+        result = processor.Process()
+    return result, manga
+
+
+def test_sab_resolution_prefers_configured_job_directory(tmp_path):
+    config = _config(tmp_path)
+    resolved = tmp_path / "sab" / "Saga.001"
+    resolved.mkdir(parents=True)
+    processor, _queue = _processor(tmp_path / "incoming", config=config, use_sab=1)
+
+    result, manga = _run(processor, config, use_sab=1)
+
+    assert result == "manga"
+    assert processor.nzb_folder == str(resolved)
+    manga.assert_called_once_with()
+
+
+def test_sab_resolution_keeps_passed_folder_when_job_is_nested_there(tmp_path):
+    config = _config(tmp_path)
+    incoming = tmp_path / "incoming"
+    (incoming / "Saga.001").mkdir(parents=True)
+    processor, _queue = _processor(incoming, config=config, use_sab=1)
+
+    result, _manga = _run(processor, config, use_sab=1)
+
+    assert result == "manga"
+    assert processor.nzb_folder == str(incoming)
+
+
+def test_sab_resolution_falls_back_to_incoming_basename(tmp_path):
+    config = _config(tmp_path)
+    incoming = tmp_path / "completed" / "random-job-id"
+    resolved = tmp_path / "sab" / incoming.name
+    resolved.mkdir(parents=True)
+    processor, _queue = _processor(incoming, config=config, use_sab=1)
+
+    result, _manga = _run(processor, config, use_sab=1)
+
+    assert result == "manga"
+    assert processor.nzb_folder == str(resolved)
+
+
+def test_missing_sab_paths_stop_before_processing(tmp_path):
+    config = _config(tmp_path)
+    processor, queue = _processor(tmp_path / "missing", config=config, use_sab=1)
+
+    result, manga = _run(processor, config, use_sab=1)
+
+    assert result == "queued"
+    assert processor.valreturn[-1]["mode"] == "stop"
+    queue.put.assert_called_once_with(processor.valreturn)
+    manga.assert_not_called()
+
+
+def test_nzbget_resolution_preserves_existing_override_order(tmp_path):
+    config = _config(tmp_path)
+    sab_path = tmp_path / "sab" / "Saga.001"
+    sab_path.mkdir(parents=True)
+    processor, _queue = _processor(tmp_path / "incoming", config=config, use_sab=1, use_nzbget=1)
+
+    result, _manga = _run(processor, config, use_sab=1, use_nzbget=1)
+
+    assert result == "manga"
+    assert processor.nzb_folder == str(tmp_path / "nzbget" / "Saga.001")
+
+
+def test_manual_and_ddl_runs_skip_downloader_path_resolution(tmp_path):
+    config = _config(tmp_path)
+    manual_folder = tmp_path / "manual"
+    manual, _queue = _processor(manual_folder, name="Manual Run", config=config, use_sab=1, use_nzbget=1)
+    ddl_folder = tmp_path / "ddl"
+    ddl, _queue = _processor(ddl_folder, ddl=True, config=config, use_sab=1, use_nzbget=1)
+
+    manual_result, _manga = _run(manual, config, use_sab=1, use_nzbget=1)
+    ddl_result, _manga = _run(ddl, config, use_sab=1, use_nzbget=1)
+
+    assert manual_result == "manga"
+    assert manual.nzb_folder == str(manual_folder)
+    assert ddl_result == "manga"
+    assert ddl.nzb_folder == str(ddl_folder)
+
+
+def test_disabled_downloaders_do_not_require_config_for_manga_branch(tmp_path):
+    config = _config(tmp_path)
+    processor, _queue = _processor(tmp_path / "incoming", config=config)
+
+    result, manga = _run(processor, None)
+
+    assert result == "manga"
+    manga.assert_called_once_with()

--- a/tests/unit/test_postprocess_pipeline.py
+++ b/tests/unit/test_postprocess_pipeline.py
@@ -1,0 +1,113 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from comicarr.app.downloads.postprocess_pipeline import (
+    PostProcessContext,
+    PostProcessJournalStage,
+)
+
+
+def _stage(*, release_key=None, recorded=True, error=None):
+    journal = MagicMock()
+    journal.derive_release_key.return_value = "derived-key"
+    if error is not None:
+        journal.record_transition.side_effect = error
+    else:
+        journal.record_transition.return_value = recorded
+    log = MagicMock()
+    context = PostProcessContext(
+        issue_id="I1",
+        issue_arc_id=None,
+        comic_id="C1",
+        nzb_name="Saga.001.cbz",
+        nzb_folder="/downloads/saga",
+        api_call=False,
+        ddl=False,
+        canonical_release_key=release_key,
+        log_module="[POST-PROCESSING]",
+    )
+    return PostProcessJournalStage(journal=journal, log=log), context, journal, log
+
+
+def test_canonical_release_key_is_reused_for_primary_transition():
+    stage, context, journal, _log = _stage(release_key="canonical-key")
+
+    assert stage.release_key(context, issue_id="I1") == "canonical-key"
+    journal.derive_release_key.assert_not_called()
+
+
+def test_story_arc_override_derives_a_distinct_release_key():
+    stage, context, journal, _log = _stage(release_key="canonical-key")
+
+    assert stage.release_key(context, issue_arc_id="ARC9") == "derived-key"
+    journal.derive_release_key.assert_called_once_with(
+        {
+            "issueid": "ARC9",
+            "IssueArcID": "ARC9",
+            "comicid": "C1",
+            "nzbname": "Saga.001.cbz",
+            "ddl": False,
+        }
+    )
+
+
+def test_transition_records_explicit_context_and_reports_success():
+    stage, context, journal, _log = _stage(release_key="canonical-key")
+
+    result = stage.transition(context, "moved", issue_id="I1")
+
+    assert result.release_key == "canonical-key"
+    assert result.stage == "moved"
+    assert result.recorded is True
+    assert result.error is None
+    journal.record_transition.assert_called_once_with(
+        "canonical-key",
+        "moved",
+        payload={
+            "issueid": "I1",
+            "issuearcid": None,
+            "comicid": "C1",
+            "nzb_name": "Saga.001.cbz",
+            "nzb_folder": "/downloads/saga",
+            "apicall": False,
+            "ddl": False,
+        },
+        conn=None,
+        issueid="I1",
+    )
+
+
+def test_duplicate_transition_is_an_explicit_idempotent_noop():
+    stage, context, _journal, _log = _stage(release_key="canonical-key", recorded=False)
+
+    result = stage.transition(context, "moved")
+
+    assert result.recorded is False
+    assert result.error is None
+
+
+def test_additive_transition_failure_is_inert_and_observable():
+    stage, context, _journal, log = _stage(error=RuntimeError("boom"))
+
+    result = stage.transition(context, "post_processing")
+
+    assert result.recorded is False
+    assert result.error == "boom"
+    log.error.assert_called_once()
+
+
+def test_transactional_transition_failure_propagates_for_caller_rollback():
+    stage, context, _journal, _log = _stage(error=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        stage.transition(context, "post_processed", conn=object())


### PR DESCRIPTION
## Summary

Post-processing can now advance durable recovery state and resolve downloader paths through tested downloads-domain boundaries while existing callers continue using `PostProcessor` unchanged. This establishes the first reversible strangler seams around the legacy engine without changing file-placement, retry, queue, or user-visible status behavior.

## Changes

- Isolates journal key derivation and stage transitions behind explicit context/result objects and an injectable journal adapter, preserving canonical-key reuse, story-arc separation, monotonic no-ops, and transaction-coupled rollback.
- Isolates SAB/NZBGet input resolution behind explicit configuration and path-probe dependencies while preserving provider precedence, manual/DDL behavior, and missing-path queue stops.
- Records callers, side effects, recovery rules, characterization evidence, and the remaining extraction sequence in the post-processing migration map.

## Release Impact

- [ ] User-visible app change; changeset added with `npm run changeset`
- [x] No app release impact; no changeset needed

## Testing

- [x] `uv run pytest tests/unit tests/integration -m 'not slow' -q` — 1,396 passed
- [x] `PATH="$PWD/.venv/bin:$PATH" npm run lint` — backend/frontend lint and format checks passed
- [x] Focused post-processing, recovery, and download-contract suite — 114 passed
- [x] Injected journal failure confirms terminal transition rollback remains coupled to `nzblog` deletion

## Additional Notes

This PR intentionally stops before destructive filesystem extraction. Duplicate-dump destination collisions cannot currently distinguish a completed retry from an unrelated pre-existing file, so Plan 009's recovery-rule guard requires an approved fingerprint/collision policy before that seam moves.

## Post-Deploy Monitoring & Validation

- Search logs for `[JOURNAL]`, `[POST-PROCESSING]`, and `Unable to locate directory within` during the first 24 hours after deployment.
- Healthy signals: journal rows continue advancing monotonically through `post_processing -> moved -> post_processed`, normal SAB/NZBGet jobs resolve without new queue stops, and recovery replay completes without duplicate processing.
- Failure signals: increased journal transition errors, rows accumulating in `post_processing`/`moved`, or a new rise in missing downloader-path warnings.
- Roll back these two commits if transition failures or path-resolution stops increase after deployment; existing callers remain behind the compatibility facade, so rollback is isolated.
- Owner: Comicarr maintainers during the first post-deploy day.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download folder detection for SABnzbd, NZBGet, DDL, and manual processing.
  * Prevented processing from continuing when required download paths cannot be resolved.
  * Improved restart safety and duplicate handling for post-processing journal updates.
  * Preserved canonical release keys and story-arc handling across processing stages.

* **Documentation**
  * Added documentation describing post-processing stages, recovery behavior, and compatibility requirements.

* **Tests**
  * Added coverage for downloader path resolution, manual runs, disabled downloaders, journal transitions, failures, and idempotent retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->