### PR TITLE
fix(database): reject untrusted migration revisions

### DIFF
--- a/.changeset/trusted-database-revisions.md
+++ b/.changeset/trusted-database-revisions.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Reject empty, multiple, partial, unknown, and structurally spoofed Alembic revision states before schema mutation, and verify legacy adoption across every supported database dialect.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,12 +120,16 @@ jobs:
       - name: Install migration dependencies
         run: uv sync --locked --extra dev ${{ matrix.extra && format('--extra {0}', matrix.extra) || '' }}
 
-      - name: Upgrade and check reviewed schema
+      - name: Verify application fresh and legacy migration paths
+        env:
+          DATABASE_URL: ${{ matrix.database_url }}
+        run: uv run pytest tests/integration/test_schema_migration_dialects.py -q
+
+      - name: Check adopted schema
         env:
           DATABASE_URL: ${{ matrix.database_url }}
         run: |
-          uv run alembic upgrade head
-          uv run alembic current
+          uv run alembic current --check-heads
           uv run alembic check
 
   # ===========================================================================

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -11,6 +11,7 @@
 
 from alembic import context
 from comicarr import logger
+from comicarr.app.core.schema import autogenerate_include_object
 from comicarr.db import get_engine
 from comicarr.tables import metadata
 
@@ -35,7 +36,12 @@ def run_migrations_online():
 
     connection = config.attributes.get("connection")
     if connection is not None:
-        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            include_object=autogenerate_include_object(connection),
+        )
         with context.begin_transaction():
             context.run_migrations()
         return
@@ -43,11 +49,14 @@ def run_migrations_online():
     try:
         engine = config.attributes.get("engine") or get_engine()
     except TypeError as error:
-        raise RuntimeError(
-            "online migrations require DATABASE_URL or an initialized Comicarr configuration"
-        ) from error
+        raise RuntimeError("online migrations require DATABASE_URL or an initialized Comicarr configuration") from error
     with engine.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            include_object=autogenerate_include_object(connection),
+        )
         with context.begin_transaction():
             context.run_migrations()
 

--- a/comicarr/app/core/schema.py
+++ b/comicarr/app/core/schema.py
@@ -16,7 +16,9 @@ from pathlib import Path
 
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
-from sqlalchemy import Column, insert, inspect, select, text
+from alembic.script import ScriptDirectory
+from alembic.util.exc import CommandError
+from sqlalchemy import Column, UniqueConstraint, insert, inspect, select, text
 from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -78,9 +80,14 @@ def _application_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
-def _legacy_fingerprint_error(engine: Engine) -> str | None:
+def _legacy_fingerprint_error(
+    engine: Engine,
+    *,
+    require_control_row: bool = True,
+    require_complete_schema: bool = False,
+) -> str | None:
     inspector = inspect(engine)
-    table_names = set(inspector.get_table_names())
+    table_names = set(inspector.get_table_names()) - {_ALEMBIC_VERSION_TABLE}
     allowed_tables = set(metadata.tables) | _LEGACY_ONLY_TABLES
     unexpected = sorted(table_names - allowed_tables)
     if unexpected:
@@ -89,6 +96,11 @@ def _legacy_fingerprint_error(engine: Engine) -> str | None:
     missing = sorted(_REQUIRED_LEGACY_TABLES - table_names)
     if missing:
         return "is missing required Comicarr tables: %s" % ", ".join(missing)
+
+    if require_complete_schema:
+        missing = sorted(set(metadata.tables) - table_names)
+        if missing:
+            return "is missing tables required by its Comicarr revision: %s" % ", ".join(missing)
 
     for table_name, required_columns in _REQUIRED_LEGACY_COLUMNS.items():
         columns = {column["name"] for column in inspector.get_columns(table_name)}
@@ -103,10 +115,11 @@ def _legacy_fingerprint_error(engine: Engine) -> str | None:
         if unknown_columns:
             return "%s has unrecognized columns: %s" % (table_name, ", ".join(unknown_columns))
 
-    with engine.connect() as connection:
-        has_control_row = connection.execute(text("SELECT 1 FROM mylar_info LIMIT 1")).first() is not None
-    if not has_control_row:
-        return "is missing the mylar_info control row"
+    if require_control_row:
+        with engine.connect() as connection:
+            has_control_row = connection.execute(text("SELECT 1 FROM mylar_info LIMIT 1")).first() is not None
+        if not has_control_row:
+            return "is missing the mylar_info control row"
     return None
 
 
@@ -123,12 +136,44 @@ def classify_database(engine: Engine | None = None) -> DatabaseState:
     if not table_names:
         return DatabaseState.FRESH
     if _ALEMBIC_VERSION_TABLE in table_names:
+        _validate_versioned_database(engine)
         return DatabaseState.VERSIONED
 
     error = _legacy_fingerprint_error(engine)
     if error:
         raise MigrationStateError("database is not a recognized Comicarr database and will not be adopted: %s" % error)
     return DatabaseState.LEGACY
+
+
+def _validate_versioned_database(engine: Engine) -> None:
+    """Fail closed unless the database records one exact Comicarr revision."""
+
+    with engine.connect() as connection:
+        revisions = MigrationContext.configure(connection).get_current_heads()
+
+    if not revisions:
+        raise MigrationStateError("Alembic version table is empty; refusing to mutate an untrusted database")
+    if len(revisions) != 1:
+        raise MigrationStateError(
+            "Alembic version table must contain exactly one revision for Comicarr's single-head migration graph"
+        )
+
+    revision = revisions[0]
+    scripts = ScriptDirectory.from_config(alembic_config(engine))
+    try:
+        resolved = scripts.get_revision(revision)
+    except CommandError as e:
+        raise MigrationStateError("Alembic version table contains an unknown Comicarr revision: %s" % revision) from e
+    if resolved is None or resolved.revision != revision:
+        raise MigrationStateError("Alembic version table contains an unknown Comicarr revision: %s" % revision)
+
+    error = _legacy_fingerprint_error(
+        engine,
+        require_control_row=False,
+        require_complete_schema=True,
+    )
+    if error:
+        raise MigrationStateError("versioned database is not a recognized Comicarr database: %s" % error)
 
 
 def alembic_config(engine: Engine | None = None, connection=None) -> Config:
@@ -141,6 +186,57 @@ def alembic_config(engine: Engine | None = None, connection=None) -> Config:
     if connection is not None:
         config.attributes["connection"] = connection
     return config
+
+
+def autogenerate_include_object(connection: Connection):
+    """Treat full unique indexes as equivalent to table unique constraints.
+
+    SQLite cannot add a table constraint without rebuilding the table, so the
+    reviewed legacy path restores equivalent enforcement with unique indexes.
+    This filter suppresses only the corresponding autogenerate representation
+    difference; absent, partial, or differently ordered enforcement remains a
+    schema diff.
+    """
+
+    metadata_unique_constraints = {
+        (table.name, tuple(column.name for column in constraint.columns))
+        for table in metadata.sorted_tables
+        for constraint in table.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
+    reflected_unique_indexes = None
+
+    def get_reflected_unique_indexes():
+        nonlocal reflected_unique_indexes
+        if reflected_unique_indexes is not None:
+            return reflected_unique_indexes
+
+        reflected_unique_indexes = set()
+        inspector = inspect(connection)
+        for table_name in set(inspector.get_table_names()) & set(metadata.tables):
+            for index in inspector.get_indexes(table_name):
+                dialect_options = index.get("dialect_options") or {}
+                is_partial = any(
+                    name.endswith("_where") and value is not None for name, value in dialect_options.items()
+                )
+                columns = tuple(index.get("column_names") or ())
+                if index.get("unique") and columns and not is_partial:
+                    reflected_unique_indexes.add((table_name, columns))
+        return reflected_unique_indexes
+
+    def include_object(schema_object, _name, object_type, reflected, compare_to):
+        if compare_to is not None:
+            return True
+        if object_type not in {"index", "unique_constraint"}:
+            return True
+        signature = (schema_object.table.name, tuple(column.name for column in schema_object.columns))
+        if object_type == "unique_constraint" and not reflected:
+            return signature not in get_reflected_unique_indexes()
+        if object_type == "index" and reflected and schema_object.unique:
+            return signature not in metadata_unique_constraints
+        return True
+
+    return include_object
 
 
 def current_revision(engine: Engine | None = None) -> str | None:

--- a/comicarr/app/core/schema.py
+++ b/comicarr/app/core/schema.py
@@ -350,8 +350,11 @@ def _migrate_readinglist_to_storyarcs(connection: Connection) -> None:
         raise MigrationStateError(
             "readinglist does not match the supported legacy layout; missing columns: %s" % ", ".join(missing_columns)
         )
-    columns = ", ".join(_READINGLIST_TO_STORYARCS_COLUMNS)
-    connection.execute(text("INSERT INTO storyarcs(%s) SELECT %s FROM readinglist" % (columns, columns)))
+    quote = connection.dialect.identifier_preparer.quote
+    columns = ", ".join(quote(column) for column in _READINGLIST_TO_STORYARCS_COLUMNS)
+    connection.execute(
+        text("INSERT INTO %s (%s) SELECT %s FROM %s" % (quote("storyarcs"), columns, columns, quote("readinglist")))
+    )
     connection.execute(text("DROP TABLE readinglist"))
 
 

--- a/docs/operations/schema-migrations.md
+++ b/docs/operations/schema-migrations.md
@@ -9,7 +9,11 @@ database.
 Startup classifies the configured database before it changes anything:
 
 - An empty database upgrades from base to the current Alembic head.
-- A database with `alembic_version` upgrades normally.
+- A database with `alembic_version` upgrades only when the table contains one
+  exact revision from Comicarr's reviewed, single-head migration graph and the
+  database contains the complete Comicarr schema required by that revision.
+  Empty, multiple, partial, unknown, or structurally spoofed revision states
+  fail before schema mutation.
 - A pre-Alembic Comicarr database is adopted only after it matches the
   conservative table, column, and `mylar_info` control-row fingerprint.
 - Any other nonempty database is left untouched and worker startup is blocked.
@@ -43,6 +47,10 @@ coordinate concurrent migration leaders across separate processes.
 4. If adoption refuses a nonempty database, do not run `stamp` manually.
    Collect its table/column inventory and use an explicit repair or migration
    path. Automatic adoption intentionally fails closed.
+   The same rule applies to an empty, multiple, partial, or unknown
+   `alembic_version` state: preserve the database, inspect why its revision does
+   not match Comicarr's graph, and use an explicit repair rather than forcing
+   startup past the check.
 5. If an upgrade is interrupted, leave workers blocked, restore the backup if
    needed, and rerun `upgrade head` only after confirming the database state.
 

--- a/tests/integration/test_schema_migration_dialects.py
+++ b/tests/integration/test_schema_migration_dialects.py
@@ -1,0 +1,224 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Service-backed legacy-adoption contract for every supported SQL dialect."""
+
+import os
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, inspect, select, text
+from sqlalchemy.exc import IntegrityError
+
+from alembic import command
+from comicarr.app.acquisition.maintenance import CONTROL_ID, RECONCILIATION_CONTROL_ID
+from comicarr.app.core.schema import MigrationStateError, alembic_config, current_revision, upgrade_database
+from comicarr.tables import (
+    acquisition_maintenance,
+    acquisition_reconciliation,
+    annuals,
+    comics,
+    issues,
+    metadata,
+    mylar_info,
+    storyarcs,
+)
+
+pytestmark = pytest.mark.slow
+
+
+def _reset_database(engine):
+    reflected = MetaData()
+    reflected.reflect(bind=engine)
+    reflected.drop_all(bind=engine)
+
+
+def _build_legacy_fixture(engine):
+    metadata.create_all(engine)
+
+    for table in reversed(metadata.sorted_tables):
+        if table.name.startswith("acquisition_"):
+            table.drop(engine, checkfirst=True)
+    comics.drop(engine, checkfirst=True)
+    storyarcs.drop(engine, checkfirst=True)
+
+    legacy = MetaData()
+    Table(
+        "comics_legacy",
+        legacy,
+        *(
+            Column(
+                column.name,
+                column.type,
+                nullable=column.nullable,
+                server_default=column.server_default.arg if column.server_default is not None else None,
+            )
+            for column in comics.columns
+            if column.name != "MetadataSource"
+        ),
+    )
+    readinglist = Table(
+        "readinglist",
+        legacy,
+        *(Column(column.name, column.type, nullable=True) for column in storyarcs.columns),
+    )
+    legacy.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(text("ALTER TABLE comics_legacy RENAME TO comics"))
+        connection.execute(mylar_info.insert().values(DatabaseVersion=0))
+        connection.execute(comics.insert().values(ComicID="dialect-comic", ComicName="Saga"))
+        connection.execute(issues.insert().values(IssueID="dialect-issue", ComicID="dialect-comic", ComicName="Saga"))
+        connection.execute(annuals.insert().values(IssueID="dialect-annual", Issue_Number="1"))
+        connection.execute(
+            readinglist.insert().values(
+                StoryArcID="dialect-arc",
+                ComicName="Saga",
+                IssueNumber="1",
+                StoryArc="The Arc",
+                IssueArcID="dialect-arc-issue",
+            )
+        )
+
+
+def test_fresh_database_uses_application_runner_and_is_idempotent():
+    database_url = os.environ["DATABASE_URL"]
+    engine = create_engine(database_url)
+    try:
+        _reset_database(engine)
+
+        assert upgrade_database(engine) == "0002_legacy_adoption"
+        assert upgrade_database(engine) == "0002_legacy_adoption"
+        assert current_revision(engine) == "0002_legacy_adoption"
+        assert set(metadata.tables).issubset(set(inspect(engine).get_table_names()))
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize(
+    ("revisions", "error_pattern"),
+    [
+        ((), "version table is empty"),
+        (("not_comicarr",), "unknown Comicarr revision"),
+        (("0001",), "unknown Comicarr revision"),
+        (("0001_baseline",), "versioned database is not a recognized Comicarr database"),
+        (("0001_baseline", "0002_legacy_adoption"), "exactly one revision"),
+    ],
+)
+def test_untrusted_revision_states_never_mutate_the_database(revisions, error_pattern):
+    database_url = os.environ["DATABASE_URL"]
+    engine = create_engine(database_url)
+    try:
+        _reset_database(engine)
+        untrusted = MetaData()
+        unrelated_data = Table("unrelated_data", untrusted, Column("id", Integer, primary_key=True))
+        version_table = Table(
+            "alembic_version",
+            untrusted,
+            Column("version_num", String(32), nullable=False),
+        )
+        untrusted.create_all(engine)
+        with engine.begin() as connection:
+            connection.execute(unrelated_data.insert().values(id=1))
+            if revisions:
+                connection.execute(version_table.insert(), [{"version_num": revision} for revision in revisions])
+
+        with pytest.raises(MigrationStateError, match=error_pattern):
+            upgrade_database(engine)
+
+        assert set(inspect(engine).get_table_names()) == {"alembic_version", "unrelated_data"}
+        with engine.connect() as connection:
+            assert tuple(connection.execute(select(version_table.c.version_num)).scalars()) == revisions
+            assert connection.execute(select(unrelated_data.c.id)).scalar_one() == 1
+    finally:
+        engine.dispose()
+
+
+def test_minimally_shaped_database_cannot_spoof_a_known_revision():
+    database_url = os.environ["DATABASE_URL"]
+    engine = create_engine(database_url)
+    try:
+        _reset_database(engine)
+        for table in (comics, issues, annuals, mylar_info):
+            table.create(engine)
+        version_table = Table(
+            "alembic_version",
+            MetaData(),
+            Column("version_num", String(32), nullable=False),
+        )
+        version_table.create(engine)
+        with engine.begin() as connection:
+            connection.execute(version_table.insert().values(version_num="0001_baseline"))
+
+        with pytest.raises(MigrationStateError, match="missing tables required by its Comicarr revision"):
+            upgrade_database(engine)
+
+        assert set(inspect(engine).get_table_names()) == {
+            "alembic_version",
+            "annuals",
+            "comics",
+            "issues",
+            "mylar_info",
+        }
+    finally:
+        engine.dispose()
+
+
+def test_legacy_adoption_preserves_data_and_is_idempotent_across_dialects():
+    database_url = os.environ["DATABASE_URL"]
+    engine = create_engine(database_url)
+    try:
+        _reset_database(engine)
+        _build_legacy_fixture(engine)
+
+        assert upgrade_database(engine) == "0002_legacy_adoption"
+        assert upgrade_database(engine) == "0002_legacy_adoption"
+        assert current_revision(engine) == "0002_legacy_adoption"
+
+        table_names = set(inspect(engine).get_table_names())
+        assert "readinglist" not in table_names
+        assert set(metadata.tables).issubset(table_names)
+        assert "MetadataSource" in {column["name"] for column in inspect(engine).get_columns("comics")}
+
+        unique_comic_ids = any(
+            constraint.get("column_names") == ["ComicID"]
+            for constraint in inspect(engine).get_unique_constraints("comics")
+        ) or any(
+            index.get("unique") and index.get("column_names") == ["ComicID"]
+            for index in inspect(engine).get_indexes("comics")
+        )
+        assert unique_comic_ids
+
+        with engine.connect() as connection:
+            assert (
+                connection.execute(select(comics.c.ComicName).where(comics.c.ComicID == "dialect-comic")).scalar_one()
+                == "Saga"
+            )
+            assert (
+                connection.execute(select(issues.c.ComicID).where(issues.c.IssueID == "dialect-issue")).scalar_one()
+                == "dialect-comic"
+            )
+            assert (
+                connection.execute(
+                    select(storyarcs.c.ComicName).where(storyarcs.c.IssueArcID == "dialect-arc-issue")
+                ).scalar_one()
+                == "Saga"
+            )
+            assert connection.execute(select(acquisition_maintenance.c.control_id)).scalar_one() == CONTROL_ID
+            assert (
+                connection.execute(select(acquisition_reconciliation.c.control_id)).scalar_one()
+                == RECONCILIATION_CONTROL_ID
+            )
+
+        with pytest.raises(IntegrityError):
+            with engine.begin() as connection:
+                connection.execute(comics.insert().values(ComicID="dialect-comic", ComicName="Duplicate"))
+
+        command.check(alembic_config(engine))
+    finally:
+        engine.dispose()

--- a/tests/integration/test_schema_migration_dialects.py
+++ b/tests/integration/test_schema_migration_dialects.py
@@ -133,7 +133,8 @@ def test_untrusted_revision_states_never_mutate_the_database(revisions, error_pa
 
         assert set(inspect(engine).get_table_names()) == {"alembic_version", "unrelated_data"}
         with engine.connect() as connection:
-            assert tuple(connection.execute(select(version_table.c.version_num)).scalars()) == revisions
+            actual_revisions = tuple(connection.execute(select(version_table.c.version_num)).scalars())
+            assert sorted(actual_revisions) == sorted(revisions)
             assert connection.execute(select(unrelated_data.c.id)).scalar_one() == 1
     finally:
         engine.dispose()

--- a/tests/unit/test_schema_migrations.py
+++ b/tests/unit/test_schema_migrations.py
@@ -10,7 +10,7 @@
 """Contract tests for the application-owned Alembic migration runner."""
 
 import pytest
-from sqlalchemy import Text, create_engine, inspect, text
+from sqlalchemy import Text, UniqueConstraint, create_engine, inspect, text
 from sqlalchemy.dialects import mysql
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.schema import CreateTable
@@ -19,6 +19,7 @@ import comicarr
 from comicarr.app.core.schema import (
     DatabaseState,
     MigrationStateError,
+    autogenerate_include_object,
     classify_database,
     current_revision,
     upgrade_database,
@@ -30,6 +31,33 @@ def test_classifier_identifies_a_fresh_database(tmp_path):
     engine = create_engine("sqlite:///%s" % (tmp_path / "fresh.db"))
 
     assert classify_database(engine) is DatabaseState.FRESH
+
+
+def test_autogenerate_only_equates_full_same_order_unique_indexes(tmp_path):
+    engine = create_engine("sqlite:///%s" % (tmp_path / "unique-index-equivalence.db"))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE comics (ComicID TEXT)"))
+        conn.execute(text("CREATE UNIQUE INDEX uq_comics_comicid ON comics (ComicID) WHERE ComicID IS NOT NULL"))
+        conn.execute(text("CREATE TABLE snatched (IssueID TEXT, Status TEXT, Provider TEXT)"))
+        conn.execute(text("CREATE UNIQUE INDEX uq_snatched_reversed ON snatched (Provider, Status, IssueID)"))
+
+    comic_id_unique = next(constraint for constraint in comics.constraints if isinstance(constraint, UniqueConstraint))
+    snatched_unique = next(
+        constraint for constraint in metadata.tables["snatched"].constraints if isinstance(constraint, UniqueConstraint)
+    )
+    with engine.connect() as connection:
+        include_object = autogenerate_include_object(connection)
+        assert include_object(comics, "comics", "table", False, None)
+        assert include_object(comic_id_unique, comic_id_unique.name, "unique_constraint", False, None)
+        assert include_object(snatched_unique, snatched_unique.name, "unique_constraint", False, None)
+
+    with engine.begin() as conn:
+        conn.execute(text("DROP INDEX uq_comics_comicid"))
+        conn.execute(text("CREATE UNIQUE INDEX uq_comics_comicid ON comics (ComicID)"))
+
+    with engine.connect() as connection:
+        include_object = autogenerate_include_object(connection)
+        assert not include_object(comic_id_unique, comic_id_unique.name, "unique_constraint", False, None)
 
 
 def test_schema_diagnostic_errors_redact_connection_credentials():
@@ -72,11 +100,104 @@ def test_classifier_identifies_a_known_unversioned_comicarr_database(tmp_path):
 
 def test_classifier_identifies_a_versioned_database(tmp_path):
     engine = create_engine("sqlite:///%s" % (tmp_path / "versioned.db"))
+    metadata.create_all(engine)
     with engine.begin() as conn:
+        conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
         conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
         conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0001_baseline')"))
 
     assert classify_database(engine) is DatabaseState.VERSIONED
+
+
+def test_classifier_rejects_an_empty_alembic_version_table(tmp_path):
+    engine = create_engine("sqlite:///%s" % (tmp_path / "empty-version.db"))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE unrelated_data (id INTEGER PRIMARY KEY)"))
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+
+    with pytest.raises(MigrationStateError, match="version table is empty"):
+        upgrade_database(engine)
+
+    assert set(inspect(engine).get_table_names()) == {"alembic_version", "unrelated_data"}
+
+
+@pytest.mark.parametrize("revision", ["not_comicarr", "0001"])
+def test_classifier_rejects_an_unknown_or_partial_alembic_revision(tmp_path, revision):
+    engine = create_engine("sqlite:///%s" % (tmp_path / ("untrusted-version-%s.db" % revision)))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE unrelated_data (id INTEGER PRIMARY KEY)"))
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+        conn.execute(text("INSERT INTO alembic_version(version_num) VALUES (:revision)"), {"revision": revision})
+
+    with pytest.raises(MigrationStateError, match="unknown Comicarr revision"):
+        upgrade_database(engine)
+
+    with engine.connect() as conn:
+        assert conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one() == revision
+    assert set(inspect(engine).get_table_names()) == {"alembic_version", "unrelated_data"}
+
+
+def test_classifier_rejects_multiple_alembic_revisions(tmp_path):
+    engine = create_engine("sqlite:///%s" % (tmp_path / "multiple-versions.db"))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+        conn.execute(
+            text("INSERT INTO alembic_version(version_num) VALUES ('0001_baseline'), ('0002_legacy_adoption')")
+        )
+
+    with pytest.raises(MigrationStateError, match="exactly one revision"):
+        upgrade_database(engine)
+
+    with engine.connect() as conn:
+        assert set(conn.execute(text("SELECT version_num FROM alembic_version")).scalars()) == {
+            "0001_baseline",
+            "0002_legacy_adoption",
+        }
+
+
+def test_classifier_rejects_a_known_revision_without_comicarr_provenance(tmp_path):
+    engine = create_engine("sqlite:///%s" % (tmp_path / "spoofed-version.db"))
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE unrelated_data (id INTEGER PRIMARY KEY)"))
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+        conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0001_baseline')"))
+
+    with pytest.raises(MigrationStateError, match="versioned database is not a recognized Comicarr database"):
+        upgrade_database(engine)
+
+    assert set(inspect(engine).get_table_names()) == {"alembic_version", "unrelated_data"}
+
+
+def test_classifier_rejects_a_known_revision_with_only_the_minimum_legacy_fingerprint(tmp_path):
+    engine = create_engine("sqlite:///%s" % (tmp_path / "minimally-shaped-spoof.db"))
+    for table_name in ("comics", "issues", "annuals", "mylar_info"):
+        metadata.tables[table_name].create(engine)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+        conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0001_baseline')"))
+
+    with pytest.raises(MigrationStateError, match="missing tables required by its Comicarr revision"):
+        upgrade_database(engine)
+
+    assert set(inspect(engine).get_table_names()) == {
+        "alembic_version",
+        "annuals",
+        "comics",
+        "issues",
+        "mylar_info",
+    }
+
+
+def test_upgrade_database_accepts_a_known_prior_comicarr_revision(tmp_path):
+    engine = create_engine("sqlite:///%s" % (tmp_path / "prior-version.db"))
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+        conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0001_baseline')"))
+
+    assert upgrade_database(engine) == "0002_legacy_adoption"
+    assert current_revision(engine) == "0002_legacy_adoption"
 
 
 def test_classifier_refuses_to_adopt_an_unknown_nonempty_database(tmp_path):


### PR DESCRIPTION
## Summary

Comicarr now refuses to migrate databases whose Alembic state cannot be proven to belong to the application. Empty, multiple, partial, unknown, and structurally spoofed revision states fail before any schema mutation, while verified fresh, legacy, and existing-head databases continue through the application-owned runner.

The migration matrix now exercises those paths against SQLite, PostgreSQL, and MySQL with representative legacy data, reading-list conversion, acquisition ledgers, missing-column repair, unique enforcement, and a second idempotent run.

## Design decisions

- A revision token is necessary but not sufficient: versioned databases must have exactly one exact revision from Comicarr's graph and the complete schema that revision requires.
- Legacy adoption remains conservative and requires its identifying tables, columns, and `mylar_info` control row before stamping.
- Alembic drift checks treat a full, same-ordered unique index as equivalent to a unique constraint. Partial or differently ordered indexes remain visible as drift.

## Release Impact

- [x] User-visible app change; patch changeset added
- [ ] No app release impact; no changeset needed

## Testing

- [x] 1,390 backend unit tests passed
- [x] 14 non-slow integration tests passed
- [x] 8 application migration-contract cases passed on SQLite locally
- [x] `npm run lint` passed, including backend and frontend lint/format checks
- [x] `alembic current --check-heads` and `alembic check` passed after legacy adoption
- [ ] PostgreSQL 16 and MySQL 8.4 migration-contract cases run in CI

## Post-Deploy Monitoring & Validation

- Watch startup logs for `[SCHEMA-MIGRATION]` refusals and unexpected revision or fingerprint errors during the first deployment and for 24 hours afterward.
- Healthy behavior is one exact Alembic head followed by normal worker startup; any unexplained rejection on a known Comicarr database or a dialect-matrix failure is a rollback trigger.
- Roll back to the previous application image if needed. The new trust checks are read-only and fail before migration commands mutate an untrusted database.
- Owner: project maintainer during the first post-merge deployment.

## Known residual

This proves the application-owned migration runner across the supported dialects. Full non-SQLite `comicarr.initialize()` coverage remains separate because the pre-existing legacy maintenance path still references the SQLite `DB_FILE` contract.

## New concepts

### Semantic schema-drift equivalence

Alembic normally compares database objects by representation, so a unique index and a unique constraint can appear different even when both enforce the same key.

| Database shape | Drift result |
|---|---|
| Full unique index, same columns and order | Equivalent to the declared constraint |
| Partial unique index | Reported as drift |
| Same columns in a different order | Reported as drift |
| Missing enforcement | Reported as drift |

This narrow equivalence lets SQLite legacy adoption avoid a destructive table rebuild without making `alembic check` noisy. It should not be generalized to predicates, reordered keys, or other objects where representation changes semantics or performance.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schema migrations now fail fast and never mutate data when the `alembic_version` state is empty, multiple, partial, unknown, or structurally spoofed.
  * Legacy database adoption now performs stricter version/schema validation, preserves seeded data, and is consistently idempotent across SQL dialects.
  * Improved migration autogeneration filtering to reduce equivalent unique-index noise.
* **Documentation**
  * Updated schema-migration operational guidance to include explicit handling of empty/multiple/partial/unknown revision states.
* **Tests**
  * Added integration and expanded unit coverage for multi-dialect migration, idempotency, and autogeneration behavior.
* **Chores**
  * Improved CI migration verification by adding schema consistency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->