### PR TITLE
fix(runtime): gate teardown on worker liveness

### DIFF
--- a/.changeset/live-owner-shutdown.md
+++ b/.changeset/live-owner-shutdown.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Keep clients, database connections, and runtime context open for terminal process exit when a scheduler job or worker remains alive after its bounded shutdown drain.

--- a/comicarr/app/core/context.py
+++ b/comicarr/app/core/context.py
@@ -50,6 +50,8 @@ from dataclasses import dataclass, field
 
 from fastapi import Request
 
+from comicarr.app.core.workers import BackgroundWorkerRegistry
+
 
 @dataclass
 class AppContext:
@@ -92,6 +94,7 @@ class AppContext:
     ddl_pool: object = None
     mass_add_pool: object = None
     mass_refresh_pool: object = None
+    background_workers: object = field(default_factory=BackgroundWorkerRegistry)
 
     # SSE
     event_bus: object = None  # EventBus instance

--- a/comicarr/app/core/workers.py
+++ b/comicarr/app/core/workers.py
@@ -1,0 +1,149 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Process-owned registry for finite background threads."""
+
+from __future__ import annotations
+
+import threading
+import traceback
+from collections.abc import Callable
+from concurrent.futures import TimeoutError as FutureTimeoutError
+
+
+class _FutureWorker:
+    """Join-compatible view of work submitted to a shared executor."""
+
+    def __init__(self, future, name):
+        self.future = future
+        self.name = name
+
+    def is_alive(self):
+        return not self.future.done()
+
+    def join(self, timeout=None):
+        try:
+            self.future.result(timeout=timeout)
+        except FutureTimeoutError:
+            pass
+        except Exception:
+            # The submitted wrapper logs the original exception. Shutdown only
+            # needs the post-wait liveness state.
+            pass
+
+
+class BackgroundWorkerRegistry:
+    """Start finite workers and retain their identities until completion."""
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._workers = set()
+        self._accepting = True
+
+    def start(self, target: Callable, *, args=(), kwargs=None, name=None, daemon=None):
+        """Register a thread before starting it and retire it on completion."""
+
+        def run():
+            try:
+                target(*args, **(kwargs or {}))
+            except Exception:
+                from comicarr import logger
+
+                logger.error(
+                    "[BACKGROUND-WORKER] %s failed:\n%s" % (threading.current_thread().name, traceback.format_exc())
+                )
+            finally:
+                with self._lock:
+                    self._workers.discard(threading.current_thread())
+
+        worker = threading.Thread(target=run, name=name, daemon=daemon)
+        with self._lock:
+            if not self._accepting:
+                raise RuntimeError("background worker registry is closed for shutdown")
+            self._workers.add(worker)
+            try:
+                worker.start()
+            except Exception:
+                self._workers.discard(worker)
+                raise
+        return worker
+
+    def close(self):
+        """Atomically reject new work and return the workers to drain."""
+
+        with self._lock:
+            self._accepting = False
+            return self.snapshot()
+
+    def submit(self, executor, target: Callable, *, args=(), kwargs=None, name=None):
+        """Atomically admit executor work and retain it until completion."""
+
+        worker_name = name or getattr(target, "__name__", "background-future")
+
+        def run():
+            try:
+                return target(*args, **(kwargs or {}))
+            except Exception:
+                from comicarr import logger
+
+                logger.error("[BACKGROUND-WORKER] %s failed:\n%s" % (worker_name, traceback.format_exc()))
+                raise
+
+        with self._lock:
+            if not self._accepting:
+                raise RuntimeError("background worker registry is closed for shutdown")
+            future = executor.submit(run)
+            worker = _FutureWorker(future, worker_name)
+            self._workers.add(worker)
+            future.add_done_callback(lambda _future: self._discard(worker))
+        return future
+
+    def _discard(self, worker):
+        with self._lock:
+            self._workers.discard(worker)
+
+    def snapshot(self):
+        """Return the currently live registered workers."""
+
+        with self._lock:
+            stopped = {worker for worker in self._workers if not worker.is_alive()}
+            self._workers.difference_update(stopped)
+            return tuple(self._workers)
+
+
+def _runtime_registry():
+    from comicarr.app.core.runtime import get_runtime
+
+    return get_runtime().background_workers
+
+
+def start_background_thread(target: Callable, *, args=(), kwargs=None, name=None, daemon=None, registry=None):
+    """Start a finite process worker through the shutdown-owned registry."""
+
+    registry = registry if registry is not None else _runtime_registry()
+    return registry.start(
+        target,
+        args=args,
+        kwargs=kwargs,
+        name=name,
+        daemon=daemon,
+    )
+
+
+def submit_background_future(executor, target: Callable, *, args=(), kwargs=None, name=None, registry=None):
+    """Submit finite executor work through the shutdown-owned registry."""
+
+    registry = registry if registry is not None else _runtime_registry()
+    return registry.submit(
+        executor,
+        target,
+        args=args,
+        kwargs=kwargs,
+        name=name,
+    )

--- a/comicarr/app/main.py
+++ b/comicarr/app/main.py
@@ -15,6 +15,7 @@ import asyncio
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from apscheduler.schedulers.base import SchedulerNotRunningError
@@ -47,7 +48,8 @@ SHUTDOWN_DRAIN_TIMEOUT = 30.0
 
 # Scheduler jobs can own the same database and queues as workers. Give an
 # in-flight job a bounded grace period, then preserve live resources for the
-# terminal process exit rather than dispose underneath it.
+# terminal process exit rather than dispose underneath it. Worker drains use
+# the same preservation policy after their post-join liveness checks.
 SCHEDULER_DRAIN_TIMEOUT = 30.0
 
 # All pipeline worker pools. The bounded join below is RELOCATED here from
@@ -57,6 +59,17 @@ SCHEDULER_DRAIN_TIMEOUT = 30.0
 _WORKER_POOLS = tuple(POOL_CONTEXT_FIELDS)
 
 
+@dataclass(frozen=True)
+class DrainResult:
+    """Post-drain owners that can still touch shared runtime resources."""
+
+    live_owners: tuple[str, ...] = ()
+
+    @property
+    def all_stopped(self):
+        return not self.live_owners
+
+
 def _drain_worker_pools(timeout, ctx=None):
     """Bounded join of every live worker pool — runs OFF the event loop.
 
@@ -64,9 +77,13 @@ def _drain_worker_pools(timeout, ctx=None):
     bounded ``join(timeout)``; an unjoined pool is left for the terminal
     hard-kill backstop (a worker wedged in native code must never hang
     termination forever). An AssertionError from a join is swallowed here so
-    it can NOT short-circuit past the journal flush + engine.dispose() (the
-    removed ``except AssertionError: os._exit(0)`` landmine).
+    it can NOT short-circuit to process exit (the removed
+    ``except AssertionError: os._exit(0)`` landmine). Every pool is checked
+    again after its join; uncertain or live owners keep shared resources open
+    for the terminal process-exit path.
     """
+    import threading
+
     import comicarr
     from comicarr import logger
 
@@ -75,6 +92,13 @@ def _drain_worker_pools(timeout, ctx=None):
     # remaining until the deadline; once exhausted, remaining pools are left
     # for the terminal hard-kill backstop.
     deadline = time.monotonic() + timeout
+    live_owners = []
+    registry = getattr(ctx, "background_workers", None) if ctx is not None else None
+
+    def _record_live_owner(pool_attr, reason):
+        if pool_attr not in live_owners:
+            live_owners.append(pool_attr)
+        logger.warn("[SHUTDOWN] Worker pool %s remains live or uncertain after drain: %s" % (pool_attr, reason))
 
     for pool_attr in _WORKER_POOLS:
         pool = getattr(ctx, POOL_CONTEXT_FIELDS[pool_attr], None) if ctx is not None else None
@@ -88,21 +112,93 @@ def _drain_worker_pools(timeout, ctx=None):
             if pool.is_alive() is False:
                 continue
         except Exception as e:
-            logger.fdebug("[SHUTDOWN] pool.is_alive() check failed for %s: %s" % (pool_attr, e))
+            _record_live_owner(pool_attr, "initial liveness check failed: %s" % e)
             continue
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            logger.warn("[SHUTDOWN] Drain deadline exhausted; leaving %s for hard-kill backstop" % pool_attr)
+            _record_live_owner(pool_attr, "shared drain deadline exhausted")
             continue
         try:
             pool.join(remaining)
-            logger.fdebug("[SHUTDOWN] Drained worker pool %s" % pool_attr)
         except AssertionError as e:
-            # Must NOT short-circuit the drain — just log and continue so the
-            # journal flush + engine.dispose() still run.
             logger.warn("[SHUTDOWN] AssertionError joining %s: %s" % (pool_attr, e))
         except Exception as e:
             logger.error("[SHUTDOWN] Error joining %s: %s" % (pool_attr, e))
+
+        try:
+            still_alive = pool.is_alive() is not False
+        except Exception as e:
+            _record_live_owner(pool_attr, "post-join liveness check failed: %s" % e)
+            continue
+        if still_alive:
+            _record_live_owner(pool_attr, "still alive after bounded join")
+        else:
+            logger.fdebug("[SHUTDOWN] Drained worker pool %s" % pool_attr)
+
+    # Pipeline pools are admitted producers of finite child work. Close the
+    # registry only after those producers stop, then atomically snapshot and
+    # drain every child they handed off while joining.
+    registered_workers = registry.close() if registry is not None else ()
+    for worker in registered_workers:
+        owner = "background:%s" % worker.name
+        if worker is threading.current_thread():
+            continue
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            _record_live_owner(owner, "shared drain deadline exhausted")
+            continue
+        try:
+            worker.join(remaining)
+        except Exception as e:
+            logger.error("[SHUTDOWN] Error joining %s: %s" % (owner, e))
+        if worker.is_alive():
+            _record_live_owner(owner, "still alive after bounded join")
+        else:
+            logger.fdebug("[SHUTDOWN] Drained %s" % owner)
+
+    return DrainResult(tuple(live_owners))
+
+
+async def _drain_scheduler(loop, drain_executor, scheduler):
+    """Bound scheduler drain and report whether it can still own resources."""
+
+    from comicarr import logger
+
+    if not scheduler:
+        return DrainResult()
+    try:
+        scheduler_shutdown = loop.run_in_executor(drain_executor, lambda: scheduler.shutdown(wait=True))
+        await asyncio.wait_for(asyncio.shield(scheduler_shutdown), timeout=SCHEDULER_DRAIN_TIMEOUT)
+        if getattr(scheduler, "running", True) is not False:
+            logger.error("[SHUTDOWN] APScheduler liveness remains active or uncertain after shutdown")
+            return DrainResult(("APScheduler",))
+        logger.info("[SHUTDOWN] APScheduler stopped and running jobs drained")
+        return DrainResult()
+    except asyncio.TimeoutError:
+        logger.error("[SHUTDOWN] Scheduler drain timed out; APScheduler remains a live owner")
+    except SchedulerNotRunningError:
+        logger.info("[SHUTDOWN] APScheduler was already stopped")
+        return DrainResult()
+    except Exception as e:
+        logger.error("[SHUTDOWN] Error stopping scheduler; APScheduler liveness is uncertain: %s" % e)
+    return DrainResult(("APScheduler",))
+
+
+def _shutdown_executors(drain_executor, executor):
+    """Release shutdown executors exactly once on either terminal path."""
+
+    from comicarr import logger
+
+    try:
+        drain_executor.shutdown(wait=False)
+    except Exception as e:
+        logger.error("[SHUTDOWN] Error shutting down drain executor: %s" % e)
+
+    try:
+        executor.shutdown(wait=False)
+        logger.info("[SHUTDOWN] ThreadPoolExecutor shutdown requested without waiting")
+    except Exception as e:
+        logger.error("[SHUTDOWN] Error shutting down executor: %s" % e)
 
 
 @asynccontextmanager
@@ -161,8 +257,8 @@ async def lifespan(app: FastAPI):
     #   3. bounded pool.join OFF the loop, on a DEDICATED executor
     #      (== final journal flush: workers write the journal synchronously
     #       via the façade, so "drain workers fully" IS the flush guarantee)
-    #   4. ai/cv client close
-    #   5. engine.dispose()                — strictly AFTER the drain
+    #   4. recheck every pool's post-join liveness
+    #   5. ai/cv close + engine.dispose()  — ONLY after all owners stop
     #   6. executor / drain-executor shutdown — AFTER the drain
     #   7. default SIGNAL only if unset (never clobber restart/update/maint)
 
@@ -176,20 +272,7 @@ async def lifespan(app: FastAPI):
     # was already running to finish before queues or resources are retired. A
     # bounded wait preserves the terminal hard-kill liveness path for a hung
     # third-party call; in that case resource disposal is deliberately skipped.
-    scheduler_quiesced = True
-    if ctx.scheduler:
-        try:
-            scheduler_shutdown = loop.run_in_executor(drain_executor, lambda: ctx.scheduler.shutdown(wait=True))
-            await asyncio.wait_for(asyncio.shield(scheduler_shutdown), timeout=SCHEDULER_DRAIN_TIMEOUT)
-            logger.info("[SHUTDOWN] APScheduler stopped and running jobs drained")
-        except asyncio.TimeoutError:
-            scheduler_quiesced = False
-            logger.error("[SHUTDOWN] Scheduler drain timed out; preserving runtime resources for terminal process exit")
-        except SchedulerNotRunningError:
-            logger.info("[SHUTDOWN] APScheduler was already stopped")
-        except Exception as e:
-            scheduler_quiesced = False
-            logger.error("[SHUTDOWN] Error stopping scheduler; preserving runtime resources: %s" % e)
+    scheduler_result = await _drain_scheduler(loop, drain_executor, ctx.scheduler)
 
     # 2. Reject events from any worker that survives long enough to observe
     # shutdown. The EventBus close gate is synchronized with publisher
@@ -200,48 +283,54 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.error("[SHUTDOWN] Error closing event bus: %s" % e)
 
-    if not scheduler_quiesced:
-        # A job that failed to quiesce may still use the database, clients, or
-        # queues. Returning lets Comicarr.py take its terminal os._exit path;
-        # closing those resources here would recreate the shutdown race.
+    worker_result = DrainResult()
+    if scheduler_result.all_stopped:
+        # 3. Signal every worker queue to stop intake. Workers finish their
+        #    current item, then exit on the sentinel.
+        for q in [
+            ctx.snatched_queue,
+            ctx.nzb_queue,
+            ctx.pp_queue,
+            ctx.search_queue,
+            ctx.ddl_queue,
+            # MASS_ADD reads ADD_LIST as its shutdown sentinel. ISSUE_WATCH_LIST
+            # carries real issue IDs, so it is drained rather than poisoned with a
+            # value that could be treated as an issue during an in-flight loop.
+            ctx.add_list,
+            ctx.refresh_queue,
+        ]:
+            try:
+                q.put("exit")
+            except Exception:
+                pass
+
+        # 3. Bounded worker drain — relocated here from queue_schedule's
+        #    shutdown branch. pool.join(timeout) BLOCKS, so it runs off the
+        #    event loop on a DEDICATED single-thread executor.
         try:
-            drain_executor.shutdown(wait=False)
-            executor.shutdown(wait=False)
+            worker_result = await loop.run_in_executor(
+                drain_executor,
+                _drain_worker_pools,
+                SHUTDOWN_DRAIN_TIMEOUT,
+                ctx,
+            )
+            if worker_result.all_stopped:
+                logger.info("[SHUTDOWN] Worker drain complete; all pools stopped")
         except Exception as e:
-            logger.error("[SHUTDOWN] Error releasing timeout executors: %s" % e)
+            logger.error("[SHUTDOWN] Error during worker drain; liveness is uncertain: %s" % e)
+            worker_result = DrainResult(("worker-pool-state",))
+
+    live_owners = scheduler_result.live_owners + worker_result.live_owners
+    if live_owners:
+        # One preservation branch covers scheduler timeouts, worker timeouts,
+        # and uncertain liveness. Clients, the engine, and the runtime context
+        # remain usable until Comicarr.py reaches its terminal process exit.
+        logger.error(
+            "[SHUTDOWN] Preserving runtime resources for terminal process exit; live owners: %s"
+            % ", ".join(live_owners)
+        )
+        _shutdown_executors(drain_executor, executor)
         return
-
-    # 3. Signal every worker queue to stop intake. Workers finish their current
-    #    item, then exit on the sentinel.
-    for q in [
-        ctx.snatched_queue,
-        ctx.nzb_queue,
-        ctx.pp_queue,
-        ctx.search_queue,
-        ctx.ddl_queue,
-        # MASS_ADD reads ADD_LIST as its shutdown sentinel. ISSUE_WATCH_LIST
-        # carries real issue IDs, so it is drained rather than poisoned with a
-        # value that could be treated as an issue during an in-flight loop.
-        ctx.add_list,
-        ctx.refresh_queue,
-    ]:
-        try:
-            q.put("exit")
-        except Exception:
-            pass
-
-    # 3. Bounded worker drain — relocated here from queue_schedule's shutdown
-    #    branch. pool.join(timeout) BLOCKS, so it runs off the event loop on a
-    #    DEDICATED single-thread executor. It must NOT be scheduled onto
-    #    `executor` (the lifespan's default executor) because that is torn
-    #    down below; a dedicated executor keeps the drain independent of that
-    #    teardown. This MUST complete before engine.dispose() so an in-flight
-    #    worker journal write never hits a disposed engine (R7/R8/AE5).
-    try:
-        await loop.run_in_executor(drain_executor, _drain_worker_pools, SHUTDOWN_DRAIN_TIMEOUT, ctx)
-        logger.info("[SHUTDOWN] Worker drain complete")
-    except Exception as e:
-        logger.error("[SHUTDOWN] Error during worker drain: %s" % e)
 
     # 4. Close async/sync external clients (workers are drained now).
     if ctx.ai_async_client:
@@ -279,16 +368,7 @@ async def lifespan(app: FastAPI):
 
     # 6. Tear down executors — AFTER the drain (the drain used a dedicated
     #    executor, never `executor`, so this order is safe).
-    try:
-        drain_executor.shutdown(wait=False)
-    except Exception as e:
-        logger.error("[SHUTDOWN] Error shutting down drain executor: %s" % e)
-
-    try:
-        executor.shutdown(wait=False)
-        logger.info("[SHUTDOWN] ThreadPoolExecutor shut down")
-    except Exception as e:
-        logger.error("[SHUTDOWN] Error shutting down executor: %s" % e)
+    _shutdown_executors(drain_executor, executor)
 
     # 7. Default the signal ONLY if nothing else set it. Guarding with
     #    `if not comicarr.SIGNAL:` preserves restart/update/maintenance

--- a/comicarr/app/metadata/service.py
+++ b/comicarr/app/metadata/service.py
@@ -18,7 +18,6 @@ import json
 import os
 import re
 import shutil
-import threading
 import time
 import zipfile
 from pathlib import Path
@@ -28,6 +27,7 @@ from PIL import Image
 
 import comicarr
 from comicarr import db, getimage, logger, updater
+from comicarr.app.core.workers import start_background_thread
 
 
 def search_comics(
@@ -203,7 +203,7 @@ def manual_metatag(ctx, issue_id, comic_id=None):
 def bulk_metatag(ctx, comic_id, issue_ids):
     """Tag metadata for multiple issues."""
     try:
-        _do_bulk_metatag(comic_id, issue_ids)
+        _do_bulk_metatag(comic_id, issue_ids, registry=ctx.background_workers)
         return {"success": True, "count": len(issue_ids)}
     except Exception as e:
         logger.error("[METADATA] Bulk metatag error: %s" % e)
@@ -213,7 +213,7 @@ def bulk_metatag(ctx, comic_id, issue_ids):
 def group_metatag(ctx, comic_id):
     """Tag metadata for all issues in a series."""
     try:
-        _do_group_metatag(comic_id)
+        _do_group_metatag(comic_id, registry=ctx.background_workers)
         return {"success": True}
     except Exception as e:
         logger.error("[METADATA] Group metatag error: %s" % e)
@@ -467,7 +467,7 @@ def _thread_bulk_meta(comicinfo, issueinfo):
     }
 
 
-def _do_bulk_metatag(ComicID, IssueIDs, threaded=False):
+def _do_bulk_metatag(ComicID, IssueIDs, threaded=False, registry=None):
     """Tag metadata for selected issues. Extracted from WebInterface.bulk_metatag."""
     cinfo = db.raw_select_one(
         "SELECT ComicLocation, ComicVersion, ComicYear, ComicName, AgeRating FROM comics WHERE ComicID=?", [ComicID]
@@ -526,7 +526,12 @@ def _do_bulk_metatag(ComicID, IssueIDs, threaded=False):
         issueinfo.append({"IssueID": ginfo["IssueID"], "Location": ginfo["Location"]})
 
     if threaded is False:
-        threading.Thread(target=_thread_bulk_meta, args=[comicinfo, issueinfo]).start()
+        start_background_thread(
+            _thread_bulk_meta,
+            args=(comicinfo, issueinfo),
+            name="BulkMetadata",
+            registry=registry,
+        )
         return json.dumps({"status": "success"})
     else:
         _thread_bulk_meta(comicinfo, issueinfo)
@@ -556,7 +561,7 @@ def _thread_group_meta(comicinfo, issueinfo):
     }
 
 
-def _do_group_metatag(ComicID, threaded=False):
+def _do_group_metatag(ComicID, threaded=False, registry=None):
     """Tag metadata for all issues in a series. Extracted from WebInterface.group_metatag."""
     cinfo = db.raw_select_one(
         "SELECT ComicLocation, ComicVersion, ComicYear, ComicName, AgeRating FROM comics WHERE ComicID=?", [ComicID]
@@ -606,7 +611,12 @@ def _do_group_metatag(ComicID, threaded=False):
         issueinfo.append({"IssueID": ginfo["IssueID"], "Location": ginfo["Location"]})
 
     if threaded is False:
-        threading.Thread(target=_thread_group_meta, args=[comicinfo, issueinfo]).start()
+        start_background_thread(
+            _thread_group_meta,
+            args=(comicinfo, issueinfo),
+            name="GroupMetadata",
+            registry=registry,
+        )
         return json.dumps({"status": "success"})
     else:
         _thread_group_meta(comicinfo, issueinfo)

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -27,6 +27,7 @@ import requests
 import comicarr
 from comicarr import db, logger
 from comicarr.app.acquisition.models import DispatchState, ItemOutcome, RunState
+from comicarr.app.core.workers import start_background_thread
 from comicarr.app.search.commands import SearchCommand, SearchCommandError
 from comicarr.tables import issues, ref32p
 
@@ -308,11 +309,14 @@ def force_search(ctx):
 
 def force_rss(ctx):
     """Trigger an RSS feed check."""
-    import threading
-
     try:
         rss = comicarr.rsscheckit.tehMain()
-        threading.Thread(target=rss.run, args=(True,)).start()
+        start_background_thread(
+            rss.run,
+            args=(True,),
+            name="ManualRSS",
+            registry=ctx.background_workers,
+        )
         return {"success": True, "message": "RSS check initiated"}
     except Exception as e:
         logger.error("[SEARCH] Error starting RSS check: %s" % e)

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -28,6 +28,7 @@ from comicarr.app.acquisition.evidence import has_verified_library_file
 from comicarr.app.acquisition.models import AcquisitionIntent, Fulfillment
 from comicarr.app.acquisition.policy import EligibilityInput, evaluate_eligibility, project_legacy_state
 from comicarr.app.common.filesystem import is_path_within_allowed_dirs
+from comicarr.app.core.workers import start_background_thread
 from comicarr.app.series import queries as series_queries
 from comicarr.tables import annuals, comics, issues, oneoffhistory, storyarcs, weekly
 
@@ -218,7 +219,7 @@ def project_issue_collection(rows, *, series_status, today=None, annual=False, s
     return projected, _issue_summary(projected)
 
 
-def _start_library_scan(scanner, status_attr, worker, start_lock, scan_label, scan_dir, thread_name):
+def _start_library_scan(scanner, status_attr, worker, start_lock, scan_label, scan_dir, thread_name, registry):
     """Reserve and launch a scanner without allowing a second hand-off worker."""
     with start_lock:
         if getattr(scanner, status_attr) == "scanning" or scanner._SCAN_LOCK.locked():
@@ -228,7 +229,7 @@ def _start_library_scan(scanner, status_attr, worker, start_lock, scan_label, sc
         setattr(scanner, status_attr, "scanning")
         try:
             logger.info("[%s-SCAN] Starting %s library scan for: %s" % (scan_label.upper(), scan_label, scan_dir))
-            threading.Thread(target=worker, name=thread_name).start()
+            start_background_thread(worker, name=thread_name, registry=registry)
             return {"success": True, "message": "%s scan started for: %s" % (scan_label.capitalize(), scan_dir)}
         except Exception as e:
             setattr(scanner, status_attr, previous_status)
@@ -1250,7 +1251,11 @@ def refresh_import(ctx):
 
     try:
         logger.info("[IMPORT-INBOX] Starting import inbox scan for: %s" % import_dir)
-        threading.Thread(target=importinbox.inboxScan, name="API-InboxScan").start()
+        start_background_thread(
+            importinbox.inboxScan,
+            name="API-InboxScan",
+            registry=ctx.background_workers,
+        )
         return {"success": True, "message": "Import inbox scan started for: %s" % import_dir}
     except Exception as e:
         logger.error("[IMPORT-INBOX] Error: %s" % e)
@@ -1275,6 +1280,7 @@ def manga_library_scan(ctx):
         "manga",
         manga_dir,
         "API-MangaScan",
+        ctx.background_workers,
     )
 
 
@@ -1309,6 +1315,7 @@ def comic_library_scan(ctx):
         "comic",
         comic_dir,
         "API-ComicScan",
+        ctx.background_workers,
     )
 
 

--- a/comicarr/app/storyarcs/service.py
+++ b/comicarr/app/storyarcs/service.py
@@ -17,13 +17,13 @@ import datetime
 import os
 import random
 import re
-import threading
 import time
 
 import requests
 
 import comicarr
 from comicarr import db, helpers, logger
+from comicarr.app.core.workers import start_background_thread
 from comicarr.app.storyarcs import queries as arc_queries
 from comicarr.tables import comics, issues, storyarcs
 
@@ -109,7 +109,7 @@ def want_all_issues(arc_id):
 
     # Trigger search in background if any were queued
     if queued > 0:
-        threading.Thread(target=_read_get_wanted, args=(arc_id,)).start()
+        start_background_thread(_read_get_wanted, args=(arc_id,), name="StoryArcWantedSearch")
 
     return {"success": True, "data": {"queued": queued, "skipped": skipped}}
 
@@ -120,8 +120,8 @@ def refresh_arc(arc_id):
     if arc_row is None:
         return {"success": False, "error": "Story arc not found"}
 
-    threading.Thread(
-        target=_add_story_arc,
+    start_background_thread(
+        _add_story_arc,
         kwargs={
             "arcid": arc_row["StoryArcID"],
             "cvarcid": arc_row["CV_ArcID"],
@@ -130,7 +130,8 @@ def refresh_arc(arc_id):
             "arclist": None,
             "arcrefresh": True,
         },
-    ).start()
+        name="StoryArcRefresh",
+    )
 
     return {"success": True, "message": "Refreshing %s from ComicVine" % arc_row["StoryArc"]}
 

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -42,6 +42,7 @@ from comicarr import db, logger
 from comicarr.app.acquisition.models import DispatchState
 from comicarr.app.common.dates import normalize_utc_datetime
 from comicarr.app.core.security import LoginRateLimiter
+from comicarr.app.core.workers import start_background_thread
 from comicarr.tables import comics, jobhistory, storyarcs
 
 # Shared rate limiter instance for authentication endpoints.
@@ -931,7 +932,6 @@ def start_migration(ctx, path):
     if _comicarr.MIGRATION_IN_PROGRESS:
         return {"success": False, "error": "Migration already in progress"}
 
-    import threading
     import time
     import uuid
 
@@ -1022,9 +1022,12 @@ def start_migration(ctx, path):
                 _comicarr.ACQUISITION_BLOCK_REASON = "migration_reconciliation_gate_unavailable"
                 logger.error("[MIGRATION] Unable to refresh acquisition reconciliation gate: %s" % gate_error)
 
-    t = threading.Thread(target=_run_fenced_migration, name="MigrationThread")
-    t.daemon = True
-    t.start()
+    start_background_thread(
+        _run_fenced_migration,
+        name="MigrationThread",
+        daemon=True,
+        registry=ctx.background_workers,
+    )
     return {"status": "started", "run_id": run_id}
 
 

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -51,6 +51,7 @@ from comicarr import (
     series_metadata,
     updater,
 )
+from comicarr.app.core.workers import start_background_thread
 from comicarr.tables import annuals, comics, issues
 
 
@@ -993,7 +994,11 @@ def addComictoDB(
                             logger.fdebug("Status of : " + str(result["Status"]))
                             search_list.append(result["IssueID"])
                         if len(search_list) > 0:
-                            threading.Thread(target=search.searchIssueIDList, args=[search_list]).start()
+                            start_background_thread(
+                                search.searchIssueIDList,
+                                args=(search_list,),
+                                name="ImportWantedSearch",
+                            )
                     else:
                         logger.info("No issues marked as wanted for " + comic["ComicName"])
 

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -61,6 +61,7 @@ from comicarr.app.common.remote_artifacts import (
     safe_remote_filename,
     write_chunks_atomically,
 )
+from comicarr.app.core.workers import submit_background_future
 from comicarr.app.downloads import handoff
 from comicarr.downloaders import external_server as exs
 from comicarr.tables import (
@@ -128,7 +129,12 @@ def parallel_search_providers(scarios_list, timeout=120):
     # Submit all searches
     for scarios in scarios_list:
         provider_name = list(scarios.get("current_prov", {}).keys())[0] if scarios.get("current_prov") else "unknown"
-        future = executor.submit(search_the_matrix, scarios)
+        future = submit_background_future(
+            executor,
+            search_the_matrix,
+            args=(scarios,),
+            name="provider-search:%s" % provider_name,
+        )
         futures[future] = provider_name
 
     logger.fdebug(f"[PARALLEL-SEARCH] Submitted {len(futures)} provider searches in parallel")

--- a/comicarr/series_metadata.py
+++ b/comicarr/series_metadata.py
@@ -21,12 +21,12 @@ import datetime
 import json
 import os
 import re
-import threading
 
 from sqlalchemy import select
 
 import comicarr
 from comicarr import db, filechecker, helpers, logger, updater
+from comicarr.app.core.workers import start_background_thread
 from comicarr.tables import comics
 
 
@@ -41,7 +41,7 @@ class metadata_Series(object):
         self.refreshSeries = refreshSeries
 
     def update_metadata_thread(self):
-        threading.Thread(target=self.update_metadata).start()
+        start_background_thread(self.update_metadata, name="SeriesMetadata")
 
     def update_metadata(self):
         for cid in self.comiclist:

--- a/docs/architecture/runtime-context.md
+++ b/docs/architecture/runtime-context.md
@@ -12,7 +12,7 @@ instance to `app.state.ctx`; it does not construct a second view.
 | State category | Examples | Creation/writer | Reader/shutdown owner | Identity rule |
 | --- | --- | --- | --- | --- |
 | Immutable configuration | paths, `config`, build metadata | startup configuration | routes/services; no disposal | fixed after factory creation |
-| Long-lived services | scheduler, CV session/cache, Metron, AI bundle, event bus | runtime factory; event loop is attached in lifespan | workers/routes; lifespan quiesces jobs, closes the event bus, then closes clients after drain | one instance per process |
+| Long-lived services | scheduler, CV session/cache, Metron, AI bundle, event bus, background-worker registry | runtime factory; event loop is attached in lifespan | workers/routes; lifespan quiesces jobs, closes the event bus, then closes clients after drain | one instance per process |
 | Queues and locks | `ddl_queued`, all work queues, search/API/DDL locks, acquisition resume lock | existing bootstrap objects adopted by factory | workers, scheduler, routes; lifespan signals queues then drains pools | must be the exact same object, never a copy |
 | Request-visible state | scheduler status, setup/JWT state, import progress, version state | migrated services write with `set_runtime_field()` | system/API readers; discarded with process | bridge serializes migrated writes with `runtime_lock` |
 | Durable-acquisition projection | schema readiness, maintenance block reason, migration reconciliation | `MaintenanceController` database transactions/fences, then runtime projection | startup diagnostics and acquisition workers | durable DB fence is authoritative; context is its live projection |
@@ -23,7 +23,8 @@ instance to `app.state.ctx`; it does not construct a second view.
 - Immutable configuration: `prog_dir`, `data_dir`, `db_file`, `config`.
 - Long-lived services: `scheduler`, `event_bus`, `cv_session`,
   `cv_rate_limiter`, `cv_cache`, `metron_api`, `fernet`, `ai_client`,
-  `ai_async_client`, `ai_circuit_breaker`, `ai_rate_limiter`.
+  `ai_async_client`, `ai_circuit_breaker`, `ai_rate_limiter`,
+  `background_workers`.
 - Locks: `runtime_lock`, `init_lock`, `search_lock`, `api_lock`, `ddl_lock`,
   `acquisition_resume_lock`.
 - Queues: `snatched_queue`, `nzb_queue`, `pp_queue`, `search_queue`,
@@ -68,11 +69,13 @@ instance to `app.state.ctx`; it does not construct a second view.
    loop, and re-reads the durable acquisition gate.
 5. Lifespan shutdown quiesces running scheduler jobs off the event loop,
    closes the event bus to reject late publications, signals queues, joins
-   worker pools off the event loop, closes external clients, disposes the
-   database, then marks the context disposed. If scheduler quiescence times
-   out, it leaves the resources intact for Comicarr.py's terminal exit rather
-   than dispose them underneath the live job. `get_context()` fails closed
-   after normal teardown.
+   registered worker pools and finite background workers off the event loop,
+   closes external clients, disposes the database, then marks the context
+   disposed. Scheduler and worker drains recheck liveness and report every
+   live or uncertain owner. If any owner remains, one preservation path leaves
+   clients, the database, and the context intact for Comicarr.py's terminal
+   exit rather than disposing them underneath live work. `get_context()` fails
+   closed only after normal teardown.
 
 ## Transitional boundary
 

--- a/tests/unit/test_metadata_domain.py
+++ b/tests/unit/test_metadata_domain.py
@@ -203,7 +203,7 @@ class TestMetatag:
         result = metadata_service.bulk_metatag(ctx, "comic456", issue_ids)
         assert result["success"] is True
         assert result["count"] == 3
-        mock_do_bulk.assert_called_once_with("comic456", issue_ids)
+        mock_do_bulk.assert_called_once_with("comic456", issue_ids, registry=ctx.background_workers)
 
     @patch("comicarr.app.metadata.service._do_manual_metatag")
     def test_metatag_handles_error(self, mock_do_metatag):

--- a/tests/unit/test_runtime_context.py
+++ b/tests/unit/test_runtime_context.py
@@ -58,6 +58,7 @@ def _legacy_runtime_objects(monkeypatch):
     """Install distinct legacy objects that the factory must adopt by identity."""
     config = SimpleNamespace(SECURE_DIR=None, AI_BASE_URL=None, AI_API_KEY=None)
     scheduler = MagicMock(name="scheduler")
+    scheduler.running = False
     ddl_queued = set()
     search_queue = MagicMock(name="search_queue")
     ddl_queue = MagicMock(name="ddl_queue")
@@ -65,6 +66,7 @@ def _legacy_runtime_objects(monkeypatch):
     ddl_lock = MagicMock(name="ddl_lock")
     acquisition_resume_lock = MagicMock(name="acquisition_resume_lock")
     mass_add_pool = MagicMock(name="mass_add_pool")
+    mass_add_pool.is_alive.return_value = False
 
     values = {
         "CONFIG": config,

--- a/tests/unit/test_series_scan_start.py
+++ b/tests/unit/test_series_scan_start.py
@@ -27,14 +27,14 @@ from comicarr.app.series import service
 def test_library_scan_rejects_missing_mount(monkeypatch, scan, config_key, path, error):
     monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(**{config_key: path}))
     monkeypatch.setattr(service.os.path, "isdir", MagicMock(return_value=False))
-    thread = MagicMock()
-    monkeypatch.setattr(service.threading, "Thread", thread)
+    start_background_thread = MagicMock()
+    monkeypatch.setattr(service, "start_background_thread", start_background_thread)
 
-    result = scan(None)
+    result = scan(SimpleNamespace(background_workers=MagicMock()))
 
     assert result["success"] is False
     assert error in result["error"]
-    thread.assert_not_called()
+    start_background_thread.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -66,13 +66,13 @@ def test_library_scan_rejects_duplicate_request_before_starting_another_worker(
     monkeypatch.setattr(service.os.path, "isdir", MagicMock(return_value=True))
     monkeypatch.setattr(scanner_module, status_attr, None)
     monkeypatch.setattr(scanner_module, lock_attr, threading.Lock())
-    thread = MagicMock()
-    monkeypatch.setattr(service.threading, "Thread", thread)
+    start_background_thread = MagicMock()
+    monkeypatch.setattr(service, "start_background_thread", start_background_thread)
+    ctx = SimpleNamespace(background_workers=MagicMock())
 
-    first = scan(None)
-    duplicate = scan(None)
+    first = scan(ctx)
+    duplicate = scan(ctx)
 
     assert first["success"] is True
     assert duplicate == {"success": False, "error": "A library scan is already in progress"}
-    assert thread.call_count == 1
-    thread.return_value.start.assert_called_once()
+    start_background_thread.assert_called_once()

--- a/tests/unit/test_shutdown_drain.py
+++ b/tests/unit/test_shutdown_drain.py
@@ -41,8 +41,8 @@ Post-U7 the lifespan owns the single ordered sequence:
   2. EventBus.close(), then q.put('exit')         (stop intake/late events)
   3. bounded pool.join, OFF the event loop, on a DEDICATED executor
      (final journal flush == workers fully drained)
-  4. ai/cv client close
-  5. engine.dispose()                             (AFTER the drain)
+  4. recheck every pool's liveness after join
+  5. ai/cv client close and engine.dispose()      (ONLY when all stopped)
   6. executor.shutdown / drain-executor shutdown  (AFTER the drain)
   7. if not comicarr.SIGNAL: SIGNAL='shutdown'
 
@@ -59,6 +59,8 @@ import datetime
 import inspect
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -68,8 +70,14 @@ from sqlalchemy import select
 import comicarr
 from comicarr.app.core.context import AppContext
 from comicarr.app.core.events import EventBus
+from comicarr.app.core.runtime import RuntimeNotInitializedError
+from comicarr.app.core.workers import (
+    BackgroundWorkerRegistry,
+    start_background_thread,
+    submit_background_future,
+)
 from comicarr.app.downloads import journal
-from comicarr.app.main import lifespan
+from comicarr.app.main import _drain_worker_pools, lifespan
 from comicarr.db import get_engine, shutdown_engine
 from comicarr.tables import metadata, pipeline_journal
 
@@ -108,6 +116,9 @@ def _make_ctx(scheduler=None):
     clients are mocks.
     """
     import queue as _q
+
+    if isinstance(scheduler, MagicMock):
+        scheduler.running = False
 
     ctx = AppContext(
         scheduler=scheduler,
@@ -271,6 +282,7 @@ class TestHappyPath:
         assert ctx.refresh_queue.get_nowait() == "exit"
         # Idle-queue happy path leaves SIGNAL defaulting to shutdown.
         assert comicarr.SIGNAL == "shutdown"
+        assert ctx.disposed
 
     @pytest.mark.asyncio
     async def test_shutdown_closes_both_ai_client_variants_after_worker_drain(self, _isolated_db):
@@ -375,6 +387,11 @@ class TestHappyPath:
         release_scheduler = threading.Event()
         scheduler = MagicMock()
         ctx = _make_ctx(scheduler=scheduler)
+        ctx.event_bus = MagicMock()
+        ctx.ai_async_client = MagicMock()
+        ctx.ai_async_client.close = AsyncMock()
+        ctx.ai_client = MagicMock()
+        ctx.cv_session = MagicMock()
         disposed = threading.Event()
         monkeypatch.setattr(appmain, "SCHEDULER_DRAIN_TIMEOUT", 0.05)
 
@@ -402,6 +419,10 @@ class TestHappyPath:
             assert not disposed.is_set()
             assert not ctx.disposed
             assert ctx.snatched_queue.empty()
+            ctx.event_bus.close.assert_called_once()
+            ctx.ai_async_client.close.assert_not_awaited()
+            ctx.ai_client.close.assert_not_called()
+            ctx.cv_session.close.assert_not_called()
         finally:
             release_scheduler.set()
 
@@ -516,6 +537,240 @@ class TestAE5InFlightJournal:
 
 
 class TestBoundedDrainExceeded:
+    def test_drain_result_rechecks_liveness_and_names_only_live_owners(self):
+        ctx = _make_ctx()
+        stopped = _FakePool()
+        stuck = _FakePool(never_joins=True)
+        ctx.sn_pool = stopped
+        ctx.nzb_pool = stuck
+
+        with patch.object(comicarr.logger, "warn") as warn:
+            result = _drain_worker_pools(0.01, ctx)
+
+        assert stopped.join_calls
+        assert stuck.join_calls
+        assert result.live_owners == ("NZBPOOL",)
+        assert not result.all_stopped
+        assert any("NZBPOOL" in call.args[0] for call in warn.call_args_list)
+
+    def test_pool_can_handoff_registered_child_work_during_its_join(self, monkeypatch):
+        from comicarr.app.core import runtime
+
+        ctx = _make_ctx()
+        child_finished = threading.Event()
+        handoff_errors = []
+
+        class _ProducerPool(_FakePool):
+            def join(self, timeout=None):
+                try:
+                    start_background_thread(
+                        child_finished.set,
+                        name="ImportWantedSearch",
+                    )
+                except Exception as e:
+                    handoff_errors.append(e)
+                super().join(timeout)
+
+        ctx.sn_pool = _ProducerPool()
+        monkeypatch.setattr(runtime, "_runtime", ctx)
+
+        result = _drain_worker_pools(1, ctx)
+
+        assert not handoff_errors
+        assert child_finished.is_set()
+        assert result.all_stopped
+
+    @pytest.mark.asyncio
+    async def test_live_worker_preserves_clients_engine_and_runtime_context(self, _isolated_db, monkeypatch):
+        from comicarr.app import main as appmain
+
+        monkeypatch.setattr(appmain, "SHUTDOWN_DRAIN_TIMEOUT", 0.01)
+        ctx = _make_ctx(scheduler=MagicMock())
+        ctx.event_bus = MagicMock()
+        ctx.ai_async_client = MagicMock()
+        ctx.ai_async_client.close = AsyncMock()
+        ctx.ai_client = MagicMock()
+        ctx.cv_session = MagicMock()
+        ctx.sn_pool = _FakePool(never_joins=True)
+        engine = get_engine()
+
+        with (
+            patch.object(comicarr, "SNPOOL", None, create=True),
+            patch.object(comicarr, "NZBPOOL", None, create=True),
+            patch.object(comicarr, "SEARCHPOOL", None, create=True),
+            patch.object(comicarr, "PPPOOL", None, create=True),
+            patch.object(comicarr, "DDLPOOL", None, create=True),
+            patch.object(comicarr, "MASS_ADD", None, create=True),
+            patch.object(comicarr, "MASS_REFRESH", None, create=True),
+            patch.object(engine, "dispose") as dispose,
+        ):
+            await _run_shutdown(ctx)
+
+        ctx.event_bus.close.assert_called_once()
+        ctx.ai_async_client.close.assert_not_awaited()
+        ctx.ai_client.close.assert_not_called()
+        ctx.cv_session.close.assert_not_called()
+        dispose.assert_not_called()
+        assert not ctx.disposed
+
+    @pytest.mark.asyncio
+    async def test_live_registered_background_worker_prevents_resource_disposal(self, _isolated_db, monkeypatch):
+        from comicarr.app import main as appmain
+        from comicarr.app.core import runtime
+
+        monkeypatch.setattr(appmain, "SHUTDOWN_DRAIN_TIMEOUT", 0.01)
+        started = threading.Event()
+        release = threading.Event()
+        ctx = _make_ctx(scheduler=MagicMock())
+        ctx.background_workers = BackgroundWorkerRegistry()
+        ctx.ai_client = MagicMock()
+        engine = get_engine()
+        monkeypatch.setattr(runtime, "_runtime", ctx)
+
+        def _inbox_scan():
+            started.set()
+            release.wait(timeout=2)
+
+        worker = start_background_thread(_inbox_scan, name="API-InboxScan")
+        assert started.wait(timeout=1)
+        assert worker in ctx.background_workers.snapshot()
+        try:
+            with (
+                patch.object(comicarr.logger, "warn") as warn,
+                patch.object(engine, "dispose") as dispose,
+            ):
+                await _run_shutdown(ctx)
+
+            assert any("background:API-InboxScan" in call.args[0] for call in warn.call_args_list)
+            ctx.ai_client.close.assert_not_called()
+            dispose.assert_not_called()
+            assert not ctx.disposed
+        finally:
+            release.set()
+            worker.join(timeout=1)
+
+    @pytest.mark.asyncio
+    async def test_live_provider_future_prevents_resource_disposal(self, _isolated_db, monkeypatch):
+        from comicarr.app import main as appmain
+        from comicarr.app.core import runtime
+
+        monkeypatch.setattr(appmain, "SHUTDOWN_DRAIN_TIMEOUT", 0.01)
+        started = threading.Event()
+        release = threading.Event()
+        ctx = _make_ctx(scheduler=MagicMock())
+        ctx.background_workers = BackgroundWorkerRegistry()
+        engine = get_engine()
+        monkeypatch.setattr(runtime, "_runtime", ctx)
+        executor = ThreadPoolExecutor(max_workers=1)
+
+        def _provider_search():
+            started.set()
+            release.wait(timeout=2)
+
+        future = submit_background_future(
+            executor,
+            _provider_search,
+            name="provider-search:test",
+        )
+        assert started.wait(timeout=1)
+        try:
+            with (
+                patch.object(comicarr.logger, "warn") as warn,
+                patch.object(engine, "dispose") as dispose,
+            ):
+                await _run_shutdown(ctx)
+
+            assert any("background:provider-search:test" in call.args[0] for call in warn.call_args_list)
+            dispose.assert_not_called()
+            assert not ctx.disposed
+        finally:
+            release.set()
+            future.result(timeout=1)
+            executor.shutdown(wait=True)
+
+    def test_closed_background_registry_rejects_late_work(self):
+        registry = BackgroundWorkerRegistry()
+        ctx = _make_ctx()
+        ctx.background_workers = registry
+
+        result = _drain_worker_pools(0, ctx)
+
+        with pytest.raises(RuntimeError, match="closed for shutdown"):
+            registry.start(lambda: None, name="late-worker")
+
+        assert result.all_stopped
+        assert registry.snapshot() == ()
+
+    def test_background_work_is_rejected_before_runtime_initialization(self, monkeypatch):
+        from comicarr.app.core import runtime
+
+        monkeypatch.setattr(runtime, "_runtime", None)
+
+        with pytest.raises(RuntimeNotInitializedError, match="not initialized"):
+            start_background_thread(lambda: None, name="orphan-worker")
+
+    def test_background_worker_failure_is_logged_and_retired(self):
+        registry = BackgroundWorkerRegistry()
+
+        def _fail():
+            raise ValueError("worker failed")
+
+        with patch.object(comicarr.logger, "error") as log_error:
+            worker = registry.start(_fail, name="FailingWorker")
+            worker.join(timeout=1)
+
+        assert not worker.is_alive()
+        assert registry.snapshot() == ()
+        assert any("FailingWorker" in call.args[0] for call in log_error.call_args_list)
+
+    def test_detached_first_party_workers_use_the_shutdown_registry(self):
+        project_root = Path(__file__).resolve().parents[2]
+        allowed_thread_constructors = {
+            "comicarr/__init__.py": 2,
+            "comicarr/app/core/workers.py": 1,
+            "comicarr/app/downloads/service.py": 1,
+            "comicarr/importer.py": 2,
+        }
+        found = {}
+
+        for path in (project_root / "comicarr").rglob("*.py"):
+            if "_vendor" in path.parts:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            threading_modules = {"threading"}
+            thread_symbols = set()
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name == "threading":
+                            threading_modules.add(alias.asname or alias.name)
+                elif isinstance(node, ast.ImportFrom) and node.module == "threading":
+                    for alias in node.names:
+                        if alias.name == "Thread":
+                            thread_symbols.add(alias.asname or alias.name)
+
+            calls = 0
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if isinstance(node.func, ast.Name) and node.func.id in thread_symbols:
+                    calls += 1
+                elif (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "Thread"
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id in threading_modules
+                ):
+                    calls += 1
+            if calls:
+                found[str(path.relative_to(project_root))] = calls
+
+        assert found == allowed_thread_constructors
+
+        search_source = (project_root / "comicarr/search.py").read_text(encoding="utf-8")
+        assert "submit_background_future(" in search_source
+        assert "executor.submit(" not in search_source
+
     @pytest.mark.asyncio
     async def test_slow_worker_drain_returns_after_bound_process_still_exits(self, _isolated_db, monkeypatch):
         from comicarr.app import main as appmain
@@ -593,13 +848,13 @@ class TestRestartIntentPreserved:
 
 
 # ---------------------------------------------------------------------------
-# Error — AssertionError during the join does not short-circuit
+# Error — AssertionError during the join preserves live-owner resources
 # ---------------------------------------------------------------------------
 
 
 class TestAssertionLandmineRemoved:
     @pytest.mark.asyncio
-    async def test_assertion_in_join_does_not_skip_flush_and_dispose(self, _isolated_db):
+    async def test_assertion_in_join_preserves_resources_without_process_short_circuit(self, _isolated_db):
         scheduler = MagicMock()
         ctx = _make_ctx(scheduler=scheduler)
         dispose_called = []
@@ -621,10 +876,12 @@ class TestAssertionLandmineRemoved:
         ):
             await _run_shutdown(ctx, scheduler)
 
-        # An AssertionError in the bounded join must NOT short-circuit to
-        # os._exit before engine.dispose().
+        # An AssertionError must not short-circuit to os._exit. Because this
+        # pool still reports alive afterward, shared resources remain open for
+        # the terminal process-exit path.
         assert not m_exit.called, "no os._exit short-circuit during the drain"
-        assert dispose_called, "engine.dispose() still runs after a join AssertionError"
+        assert not dispose_called, "engine.dispose() must not run beneath a live pool"
+        assert not ctx.disposed
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Comicarr no longer tears down database connections, provider clients, or runtime context while work can still be running. Shutdown now proves that scheduler jobs, legacy pipeline pools, finite endpoint workers, and shared provider-search futures have all stopped; any live or uncertain owner selects the existing terminal-exit path with shared resources preserved.

The runtime also rejects background work before initialization and after the shutdown admission barrier, eliminating workers that could otherwise exist outside the lifecycle owner.

## Design decisions

- `AppContext` owns one background-worker registry for detached scans, imports, metadata jobs, RSS work, migrations, story-arc work, and provider futures.
- Scheduler jobs stop first, then pipeline pools drain while they may still hand off legitimate child work. Only after those producers stop does the registry atomically close admission and snapshot its finite children.
- Pools, threads, and futures share one bounded worker deadline and are rechecked after every join. Errors and indeterminate liveness fail closed.
- Client close, engine disposal, and `ctx.disposed` happen only when the aggregate result proves every owner stopped. The process hard-kill backstop remains unchanged.

## Release Impact

- [x] User-visible app change; patch changeset added
- [ ] No app release impact; no changeset needed

## Testing

- [x] 1,391 backend unit tests passed
- [x] 14 integration tests passed
- [x] `npm run lint` passed, including backend and frontend lint/format checks
- [x] Shutdown regressions cover live pools, mixed pool outcomes, scheduler timeout, pool-to-child handoff, live detached threads, live provider futures, late admission rejection, and failure logging
- [x] Repository-wide AST guard permits raw threads only at the managed pool, registry, and immediately-joined compatibility boundaries

## Post-Deploy Monitoring & Validation

- Watch `[SHUTDOWN]` logs during the first deployment and for 24 hours for named live owners, admission rejections, or repeated preservation-path exits.
- Healthy shutdown either reports all pools stopped and disposes resources once, or names the owner that forced resource preservation before terminal exit.
- An unexplained rise in `background:*` live owners, failed worker handoffs, or shutdowns that exceed the configured 60-second scheduler-plus-worker bound is a rollback trigger.
- Roll back to the previous application image if needed; this change does not alter durable data and retains the existing terminal-exit backstop.
- Owner: project maintainer during the first post-merge deployment.

## New concepts

### Two-phase quiescence barrier

A shutdown barrier must stop *producers* before it closes admission for the child work those producers are allowed to create. Closing too early loses valid handoffs; closing too late permits work to appear after the final empty check.

```mermaid
flowchart LR
    A["Stop scheduler producers"] --> B["Join pipeline pools"]
    B --> C["Atomically close child admission"]
    C --> D["Drain registered threads and futures"]
    D --> E{"Any owner still live?"}
    E -- Yes --> F["Preserve shared resources for terminal exit"]
    E -- No --> G["Close clients, dispose database and context"]
```

Here, the registry's close-and-snapshot operation is the barrier. Use this pattern when work can spawn finite child work during shutdown; do not use it as a substitute for cancellation or durable recovery when tasks must survive process exit.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
