### PR TITLE
fix(config): secure provider credential persistence

### DIFF
--- a/.changeset/encrypted-provider-configuration.md
+++ b/.changeset/encrypted-provider-configuration.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Persist additional Newznab and Torznab credentials transactionally with encrypted API keys and truthful save failures, while scrubbing provider secrets from diagnostics and retained config backups.

--- a/comicarr/app/common/redaction.py
+++ b/comicarr/app/common/redaction.py
@@ -15,8 +15,10 @@ _PROVIDER_STRUCTURE_PATTERN = re.compile(r"(?i)(provider_list|newznab_info|torzn
 _AUTHORIZATION_PATTERN = re.compile(
     r"(?i)([\"']?authorization[\"']?\s*[:=]\s*[\"']?)(?:basic|bearer|token|digest)\s+[^\s,;\"'}\]]+"
 )
-_NAMED_SECRET_PATTERN = re.compile(r"(?i)(api[ _-]?key|authorization|password|passkey|authkey|token)\s*[=:]\s*[^\s,;]+")
-_QUERY_SECRET_PATTERN = re.compile(r"(?i)([?&](?:apikey|api_key|token|password|passkey|auth|authkey)=)[^&\s]+")
+_NAMED_SECRET_PATTERN = re.compile(
+    r"(?i)([\"']?(?:api[ _-]?key|authorization|password|passkey|authkey|token)[\"']?\s*[=:]\s*[\"']?)(?!\[redacted\])([^\s,;\"'}\]]+)([\"']?)"
+)
+_QUERY_SECRET_PATTERN = re.compile(r"(?i)([?&](?:apikey|api_key|r|token|password|passkey|auth|authkey)=)[^&\s]+")
 _URL_USERINFO_PATTERN = re.compile(r"(?i)(https?://)[^/@\s]+@")
 
 
@@ -32,6 +34,6 @@ def redact_sensitive_text(value, secrets=()):
 
     message = _PROVIDER_STRUCTURE_PATTERN.sub(r"\1: [redacted]", message)
     message = _AUTHORIZATION_PATTERN.sub(r"\1[redacted]", message)
-    message = _NAMED_SECRET_PATTERN.sub(r"\1=[redacted]", message)
+    message = _NAMED_SECRET_PATTERN.sub(r"\1[redacted]\3", message)
     message = _QUERY_SECRET_PATTERN.sub(r"\1[redacted]", message)
     return _URL_USERINFO_PATTERN.sub(r"\1[redacted]@", message)

--- a/comicarr/app/common/redaction.py
+++ b/comicarr/app/common/redaction.py
@@ -1,0 +1,37 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Shared secret redaction for operator-visible diagnostic text."""
+
+import re
+
+_PROVIDER_STRUCTURE_PATTERN = re.compile(r"(?i)(provider_list|newznab_info|torznab_info)\s*:\s*[^\r\n]*")
+_AUTHORIZATION_PATTERN = re.compile(
+    r"(?i)([\"']?authorization[\"']?\s*[:=]\s*[\"']?)(?:basic|bearer|token|digest)\s+[^\s,;\"'}\]]+"
+)
+_NAMED_SECRET_PATTERN = re.compile(r"(?i)(api[ _-]?key|authorization|password|passkey|authkey|token)\s*[=:]\s*[^\s,;]+")
+_QUERY_SECRET_PATTERN = re.compile(r"(?i)([?&](?:apikey|api_key|token|password|passkey|auth|authkey)=)[^&\s]+")
+_URL_USERINFO_PATTERN = re.compile(r"(?i)(https?://)[^/@\s]+@")
+
+
+def redact_sensitive_text(value, secrets=()):
+    """Redact known runtime secrets and common structured credential forms."""
+    message = str(value or "")
+    for secret in sorted(
+        (str(secret) for secret in secrets if secret not in (None, "", "None") and len(str(secret)) > 3),
+        key=len,
+        reverse=True,
+    ):
+        message = message.replace(secret, "[redacted]")
+
+    message = _PROVIDER_STRUCTURE_PATTERN.sub(r"\1: [redacted]", message)
+    message = _AUTHORIZATION_PATTERN.sub(r"\1[redacted]", message)
+    message = _NAMED_SECRET_PATTERN.sub(r"\1=[redacted]", message)
+    message = _QUERY_SECRET_PATTERN.sub(r"\1[redacted]", message)
+    return _URL_USERINFO_PATTERN.sub(r"\1[redacted]@", message)

--- a/comicarr/app/system/router.py
+++ b/comicarr/app/system/router.py
@@ -209,6 +209,9 @@ async def update_providers(request: Request, ctx: AppContext = Depends(get_conte
     """Update Newznab/Torznab provider configuration."""
     body = await request.json()
     result = await asyncio.to_thread(system_service.update_providers, ctx, body)
+    if not result["success"]:
+        status_code = 500 if result.get("error") == system_service.PROVIDER_CONFIG_PERSISTENCE_ERROR else 400
+        return JSONResponse(status_code=status_code, content=result)
     return result
 
 

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -41,6 +41,7 @@ import comicarr
 from comicarr import db, logger
 from comicarr.app.acquisition.models import DispatchState
 from comicarr.app.common.dates import normalize_utc_datetime
+from comicarr.app.common.redaction import redact_sensitive_text
 from comicarr.app.core.security import LoginRateLimiter
 from comicarr.tables import comics, jobhistory, storyarcs
 
@@ -62,6 +63,7 @@ SCHEDULER_JOB_NAMES = {
 
 SETUP_PERSISTENCE_ERROR = "Failed to persist initial credentials"
 CONFIG_PERSISTENCE_ERROR = "Failed to persist configuration"
+PROVIDER_CONFIG_PERSISTENCE_ERROR = "Failed to persist provider configuration"
 
 
 def get_weekly_refresh_lock():
@@ -555,14 +557,30 @@ def update_providers(ctx, provider_data):
     if not ctx.config:
         return {"success": False, "error": "Config not loaded"}
 
+    if not isinstance(provider_data, dict):
+        return {"success": False, "error": "Invalid provider payload"}
+
     provider_type = provider_data.get("type")
     providers = provider_data.get("providers", [])
 
     if provider_type not in ("newznab", "torznab"):
         return {"success": False, "error": "Invalid provider type"}
+    if not isinstance(providers, list):
+        return {"success": False, "error": "Invalid provider list"}
 
-    ctx.config.writeconfig_values({provider_type: providers})
-    ctx.config.configure(update=True, startup=False)
+    config_key = "EXTRA_NEWZNABS" if provider_type == "newznab" else "EXTRA_TORZNABS"
+    try:
+        ctx.config.validate_provider_extra_value(config_key, providers)
+    except (TypeError, ValueError):
+        return {"success": False, "error": "Invalid provider configuration"}
+    try:
+        persisted = ctx.config.apply_transaction({config_key: providers}, configure=False)
+    except Exception as e:
+        logger.error("[PROVIDERS] Failed to persist provider configuration: %s" % type(e).__name__)
+        persisted = False
+
+    if persisted is False:
+        return {"success": False, "error": PROVIDER_CONFIG_PERSISTENCE_ERROR}
 
     return {"success": True}
 
@@ -637,7 +655,13 @@ def get_recent_logs(ctx):
     try:
         with open(log_file, "r") as f:
             lines = f.readlines()
-        return {"logs": lines[-200:]}  # Last 200 lines
+        provider_secrets = []
+        if ctx.config:
+            for attr_name in ("EXTRA_NEWZNABS", "EXTRA_TORZNABS"):
+                for entry in getattr(ctx.config, attr_name, []) or []:
+                    if isinstance(entry, (list, tuple)) and len(entry) > 3:
+                        provider_secrets.append(entry[3])
+        return {"logs": [redact_sensitive_text(line, provider_secrets) for line in lines[-200:]]}
     except Exception as e:
         logger.error("[SYSTEM] Error reading logs: %s" % e)
         return {"logs": [], "error": str(e)}
@@ -793,12 +817,7 @@ def request_weekly_refresh(ctx):
 def sanitize_job_error(error):
     """Keep operational errors useful without persisting credentials or large tracebacks."""
     message = re.sub(r"\s+", " ", str(error or "")).strip()
-    message = re.sub(
-        r"(?i)(api[ _-]?key|authorization|password|token)\s*[=:]\s*[^\s,;]+",
-        r"\1=[redacted]",
-        message,
-    )
-    message = re.sub(r"(?i)(https?://)[^/@\s]+@", r"\1[redacted]@", message)
+    message = redact_sensitive_text(message)
     return message[:500] or "Scheduled job failed; check server logs for details."
 
 

--- a/comicarr/carepackage.py
+++ b/comicarr/carepackage.py
@@ -14,6 +14,7 @@ from glob import glob
 import comicarr
 from comicarr import config as config_module
 from comicarr import encrypted, logger, versioncheck
+from comicarr.app.common.redaction import redact_sensitive_text
 
 _LEGACY_32P_CREDENTIAL_LINE_PATTERN = re.compile(
     r"\buid\s*:\s*[^/\r\n]+\s*/\s*authkey\s*:\s*[^/\r\n]+\s*/\s*passkey\s*:\s*\S+",
@@ -246,74 +247,62 @@ class carePackage(object):
             except (configparser.NoSectionError, configparser.NoOptionError):
                 pass
 
-        extra_newznabs = list(zip(*[iter(tmpconfig.get("Newznab", "extra_newznabs").split(", "))] * 7, strict=False))
-        extra_torznabs = list(zip(*[iter(tmpconfig.get("Torznab", "extra_torznabs").split(", "))] * 7, strict=False))
-        cleaned_newznabs = []
-        cleaned_torznabs = []
-        for ens in extra_newznabs:
-            n_host = None
-            n_uid = None
-            n_api = None
-            if ens[1] is not None:
-                n_host = "xXX[REMOVED]XXx"
-            if ens[3] is not None:
-                nzkey = ens[3]
-                if nzkey[:5] == "^~$z$":
-                    nz = encrypted.Encryptor(nzkey)
-                    nz_stat = nz.decrypt_it()
-                    if nz_stat["status"] is True:
-                        nzkey = nz_stat["password"]
-                if nzkey not in self.keylist:
-                    self.keylist.append(nzkey)
-                n_api = "xXX[REMOVED]XXx"
-            if ens[4] is not None:
-                n_uid = "xXX[REMOVED]XXx"
-            newnewzline = (ens[0], n_host, ens[2], n_api, n_uid, ens[5], ens[6])
-            cleaned_newznabs.append(newnewzline)
+        config_version = tmpconfig.getint("General", "config_version", fallback=15)
+        secure_dir = tmpconfig.get(
+            "General",
+            "secure_dir",
+            fallback=None,
+        )
+        if secure_dir in (None, "", "None"):
+            secure_dir = os.path.join(comicarr.DATA_DIR, ".secure")
+        for section, option in (("Newznab", "extra_newznabs"), ("Torznab", "extra_torznabs")):
+            try:
+                entries = config_module.parse_provider_extras(
+                    tmpconfig.get(section, option),
+                    config_version=config_version,
+                )
+            except (configparser.NoSectionError, configparser.NoOptionError, ValueError):
+                if not tmpconfig.has_section(section):
+                    tmpconfig.add_section(section)
+                tmpconfig.set(section, option, "xXX[REMOVED]XXx")
+                continue
 
-        for ets in extra_torznabs:
-            n_host = None
-            n_uid = None
-            n_api = None
-            if ets[1] is not None:
-                n_host = "xXX[REMOVED]XXx"
-            if ets[3] is not None:
-                tzkey = ets[3]
-                if tzkey[:5] == "^~$z$":
-                    tz = encrypted.Encryptor(tzkey)
-                    tz_stat = tz.decrypt_it()
-                    if tz_stat["status"] is True:
-                        tzkey = tz_stat["password"]
-                if tzkey not in self.keylist:
-                    self.keylist.append(tzkey)
-                n_api = "xXX[REMOVED]XXx"
-            if ets[4] is not None:
-                n_uid = "xXX[REMOVED]XXx"
-            newtorline = (ets[0], n_host, ets[2], n_api, ets[4], ets[5], ets[6])
-            cleaned_torznabs.append(newtorline)
+            cleaned_entries = []
+            for entry in entries:
+                cleaned = list(entry)
+                host = cleaned[1]
+                if host not in (None, "", "None") and host not in self.keylist:
+                    self.keylist.append(host)
+                cleaned[1] = "xXX[REMOVED]XXx"
 
-        tmpconfig.set("Newznab", "extra_newznabs", ", ".join(self.write_extras(cleaned_newznabs)))
-        tmpconfig.set("Torznab", "extra_torznabs", ", ".join(self.write_extras(cleaned_torznabs)))
+                stored_key = cleaned[3]
+                if stored_key not in (None, "", "None"):
+                    if stored_key not in self.keylist:
+                        self.keylist.append(stored_key)
+                    try:
+                        runtime_key, _token, _migration = config_module.decrypt_provider_credential(
+                            stored_key,
+                            secure_dir,
+                        )
+                    except ValueError:
+                        runtime_key = None
+                    if runtime_key not in (None, "", "None") and runtime_key not in self.keylist:
+                        self.keylist.append(runtime_key)
+                    cleaned[3] = "xXX[REMOVED]XXx"
+
+                if section == "Newznab" and cleaned[4] not in (None, "", "None"):
+                    if cleaned[4] not in self.keylist:
+                        self.keylist.append(cleaned[4])
+                    cleaned[4] = "xXX[REMOVED]XXx"
+                cleaned_entries.append(tuple(cleaned))
+
+            tmpconfig.set(section, option, config_module.serialize_provider_extras(cleaned_entries))
         try:
             with codecs.open(self.cleanpath, encoding="utf8", mode="w+") as tmp_configfile:
                 tmpconfig.write(tmp_configfile)
             logger.fdebug("Configuration cleaned of keys/passwords and written to temporary location.")
         except IOError as e:
             logger.warn("Error writing configuration file: %s" % e)
-
-    def write_extras(self, value):
-        flattened = []
-        for item in value:
-            for i in item:
-                try:
-                    if '"' in i and ' "' in i:
-                        ib = str(i).replace('"', "").strip()
-                    else:
-                        ib = i
-                except:
-                    ib = i
-                flattened.append(str(ib))
-        return flattened
 
     def panicbutton(self):
         self._collect_runtime_secrets()
@@ -357,6 +346,7 @@ class carePackage(object):
                                     "uid:-REDACTED- / authkey:-REDACTED- / passkey:-REDACTED-", line
                                 )
                                 cnt += structured_redactions
+                                line = redact_sensitive_text(line, redaction_keys)
                                 for keyed in redaction_keys:
                                     if keyed in line:
                                         cnt += 1

--- a/comicarr/carepackage.py
+++ b/comicarr/carepackage.py
@@ -346,11 +346,8 @@ class carePackage(object):
                                     "uid:-REDACTED- / authkey:-REDACTED- / passkey:-REDACTED-", line
                                 )
                                 cnt += structured_redactions
+                                cnt += sum(1 for keyed in redaction_keys if keyed in line)
                                 line = redact_sensitive_text(line, redaction_keys)
-                                for keyed in redaction_keys:
-                                    if keyed in line:
-                                        cnt += 1
-                                        line = line.replace(keyed, "-REDACTED-")
                                 output.write(line)
                                 line = f.readline()
 

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -2034,11 +2034,14 @@ class Config(object):
         if not self.SECURE_DIR:
             self.SECURE_DIR = os.path.join(comicarr.DATA_DIR, ".secure")
 
-        if os.path.exists(self.SECURE_DIR):
-            return
         try:
-            os.makedirs(self.SECURE_DIR)
-            os.chmod(self.SECURE_DIR, 0o700)
+            if os.path.exists(self.SECURE_DIR):
+                if os.name != "nt":
+                    os.chmod(self.SECURE_DIR, 0o700)
+                return
+            os.makedirs(self.SECURE_DIR, mode=0o700)
+            if os.name != "nt":
+                os.chmod(self.SECURE_DIR, 0o700)
         except OSError:
             logger.error(
                 "[FATAL] Could not create secure directory at %s. "

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -40,6 +40,87 @@ config = configparser.ConfigParser()
 _CONFIG_TRANSACTION_LOCK = threading.RLock()
 _CONFIG_TEMP_PREFIX = ".comicarr-config-"
 _CONFIG_TEMP_SUFFIX = ".tmp"
+_PROVIDER_EXTRA_FIELDS = ("EXTRA_NEWZNABS", "EXTRA_TORZNABS")
+_PROVIDER_EXTRA_WIDTHS = (6, 7)
+_PROVIDER_CREDENTIAL_INDEX = 3
+_PROVIDER_BOOLEAN_VALUES = {"0", "1", "false", "true", "no", "yes", "off", "on"}
+
+
+def _provider_entry_is_structurally_valid(entry):
+    """Distinguish historical six- and seven-field provider records safely."""
+    if len(entry) not in _PROVIDER_EXTRA_WIDTHS:
+        return False
+    if str(entry[2]).strip().lower() not in _PROVIDER_BOOLEAN_VALUES:
+        return False
+    if str(entry[5]).strip().lower() not in _PROVIDER_BOOLEAN_VALUES:
+        return False
+    if len(entry) == 7:
+        try:
+            int(entry[6])
+        except (TypeError, ValueError):
+            return False
+    return True
+
+
+def parse_provider_extras(value, config_version=15):
+    """Parse provider extras without assuming one historical tuple width."""
+    if value in (None, "", "None"):
+        return []
+
+    if isinstance(value, (list, tuple)):
+        entries = value
+    elif isinstance(value, str):
+        parts = value.split(", ")
+        candidates = []
+        for width in _PROVIDER_EXTRA_WIDTHS:
+            if len(parts) % width:
+                continue
+            candidate = [parts[index : index + width] for index in range(0, len(parts), width)]
+            if all(_provider_entry_is_structurally_valid(entry) for entry in candidate):
+                candidates.append(candidate)
+        if len(candidates) != 1:
+            raise ValueError("Provider configuration has an invalid field count")
+        entries = candidates[0]
+    else:
+        raise ValueError("Provider configuration must be a list of entries")
+
+    parsed = []
+    for entry in entries:
+        if not isinstance(entry, (list, tuple)) or not _provider_entry_is_structurally_valid(entry):
+            raise ValueError("Provider entries must contain six or seven fields")
+        parsed.append(tuple(entry))
+    return parsed
+
+
+def serialize_provider_extras(entries):
+    """Serialize validated provider entries using the legacy flat INI format."""
+    flattened = []
+    for entry in parse_provider_extras(entries):
+        for index, value in enumerate(entry):
+            field = "" if value is None else str(value)
+            if index == 4:
+                field = field.replace(",", "#")
+            elif ", " in field:
+                raise ValueError("Provider fields cannot contain the INI delimiter")
+            flattened.append(field)
+    return ", ".join(flattened)
+
+
+def decrypt_provider_credential(value, secure_dir):
+    """Return a runtime provider credential and its reusable Fernet token."""
+    if value in (None, "", "None"):
+        return value, None, False
+    if not isinstance(value, str):
+        value = str(value)
+    if not value.startswith(("gAAAAA", "^~$z$")):
+        return value, None, True
+
+    result = encrypted.Encryptor(value, secure_dir=secure_dir).decrypt_it()
+    if not result.get("status"):
+        raise ValueError("Unable to decrypt provider credential")
+    token = value if value.startswith("gAAAAA") else None
+    return result["password"], token, token is None
+
 
 _CONFIG_DEFINITIONS = OrderedDict(
     {
@@ -559,6 +640,7 @@ class Config(object):
         # initalize the config...
         self._config_file = config_file
         self.WRITE_THE_CONFIG = False
+        self._provider_credential_tokens = {}
 
     def config_vals(self, update=False):
         if update is False:
@@ -709,6 +791,8 @@ class Config(object):
 
     def read(self, startup=False):
         self.config_vals()
+        self._ensure_secure_directory()
+        self._validate_existing_encryption_authority()
 
         if startup is True:
             if self.LOG_DIR is None:
@@ -751,6 +835,15 @@ class Config(object):
                     max_logfiles=self.MAX_LOGFILES,
                 )
 
+        # Validate the live provider authority before backup maintenance is
+        # allowed to encrypt historical plaintext with that same authority.
+        self.EXTRA_NEWZNABS, self.EXTRA_TORZNABS = self.get_extras()
+        provider_migration_needed = self._load_provider_extra_credentials()
+        self._validate_loaded_provider_extras()
+        if provider_migration_needed and self.writeconfig(startup=True) is False:
+            raise OSError("Unable to persist encrypted provider credentials")
+        self._sanitize_provider_backup_credentials()
+
         if any([self.CONFIG_VERSION == 0, self.CONFIG_VERSION < self.newconfig]):
             if not self.BACKUP_LOCATION:
                 # this is needed here since the configuration hasn't run to check the location value yet.
@@ -786,12 +879,18 @@ class Config(object):
         self.EXTRA_TORZNABS = extra_torznabs
         self.IGNORED_PUBLISHERS = self.get_ignored_pubs()
 
+        provider_migration_needed = self._load_provider_extra_credentials()
+        self._validate_loaded_provider_extras()
+        if provider_migration_needed and self.writeconfig(startup=True) is False:
+            raise OSError("Unable to persist encrypted provider credentials")
+
         if startup is False:
             # need to do provider sequence AFTER db check
             self.provider_sequence()
         self.configure(startup=startup)
         if self.WRITE_THE_CONFIG is True or startup is True:
-            self.writeconfig(startup=startup)
+            if self.writeconfig(startup=startup) is False:
+                raise OSError("Unable to persist configuration")
         return self
 
     def config_update(self):
@@ -889,7 +988,7 @@ class Config(object):
                 for chk_e in [self.OLD_VALUES["nzbsu_apikey"], self.OLD_VALUES["dognzb_apikey"]]:
                     if chk_e is not None:
                         if chk_e[:5] == "^~$z$":
-                            nz = encrypted.Encryptor(chk_e)
+                            nz = encrypted.Encryptor(chk_e, secure_dir=self.SECURE_DIR)
                             nz_stat = nz.decrypt_it()
                             if nz_stat["status"] is True:
                                 if chk_e == self.OLD_VALUES["nzbsu_apikey"]:
@@ -913,7 +1012,7 @@ class Config(object):
                         if n_name is None:
                             n_name = ""
                         if ben[3][:5] == "^~$z$":
-                            nz = encrypted.Encryptor(ben[3])
+                            nz = encrypted.Encryptor(ben[3], secure_dir=self.SECURE_DIR)
                             nz_stat = nz.decrypt_it()
                             if nz_stat["status"] is True:
                                 ben[3] = nz_stat["password"]
@@ -1116,6 +1215,278 @@ class Config(object):
             definition_type, section, _, default = definition
         return key, definition_type, section, ini_key, default
 
+    def _provider_max_id(self):
+        provider_ids = [getattr(comicarr, "PROVIDER_START_ID", 0)]
+        for attr_name in _PROVIDER_EXTRA_FIELDS:
+            try:
+                entries = parse_provider_extras(getattr(self, attr_name, []), self.CONFIG_VERSION)
+            except ValueError:
+                continue
+            for entry in entries:
+                if len(entry) == 7:
+                    try:
+                        provider_ids.append(int(entry[6]))
+                    except (TypeError, ValueError):
+                        pass
+        return max(provider_ids)
+
+    def _reserved_provider_ids(self):
+        reserved = set()
+        if self.EXPERIMENTAL:
+            reserved.add(101)
+        if self.ENABLE_DDL and self.ENABLE_GETCOMICS:
+            reserved.add(200)
+        if self.ENABLE_DDL and self.ENABLE_EXTERNAL_SERVER:
+            reserved.add(201)
+        return reserved
+
+    def _validate_existing_encryption_authority(self):
+        """Fail before any write when a live Fernet secret lacks its authority."""
+        for attr_name in ENCRYPTED_CONFIG_ITEMS:
+            value = getattr(self, attr_name, None)
+            if isinstance(value, (tuple, list)) and value:
+                value = value[0]
+            if not isinstance(value, str) or not value.startswith("gAAAAA"):
+                continue
+            result = encrypted.Encryptor(value, secure_dir=self.SECURE_DIR).decrypt_it()
+            if not result.get("status"):
+                raise ValueError("Unable to validate encrypted configuration authority")
+
+    def _reserved_provider_names(self):
+        reserved = set()
+        if self.ENABLE_TORRENT_SEARCH and self.ENABLE_32P:
+            reserved.add("32p")
+        if self.EXPERIMENTAL:
+            reserved.add("experimental")
+        if self.ENABLE_DDL and self.ENABLE_GETCOMICS:
+            reserved.add("ddl(getcomics)")
+        if self.ENABLE_DDL and self.ENABLE_EXTERNAL_SERVER:
+            reserved.add("ddl(external)")
+        return reserved
+
+    @staticmethod
+    def _validate_provider_names(entries, seen_names):
+        for entry in entries:
+            canonical_name = str(entry[0] or entry[1]).strip().casefold()
+            if not canonical_name:
+                raise ValueError("Provider name or host is required")
+            if canonical_name in seen_names:
+                raise ValueError("Provider names must be unique across enabled providers")
+            seen_names.add(canonical_name)
+
+    def _validate_loaded_provider_extras(self):
+        """Validate persisted provider identities before projection or backup work."""
+        seen_ids = self._reserved_provider_ids()
+        seen_names = self._reserved_provider_names()
+        next_id = self._provider_max_id()
+        for attr_name in _PROVIDER_EXTRA_FIELDS:
+            entries = parse_provider_extras(getattr(self, attr_name, []), self.CONFIG_VERSION)
+            normalized, next_id = self._assign_provider_ids(entries, next_id, seen_ids)
+            self._validate_provider_names(normalized, seen_names)
+
+    def _decode_provider_entries(self, entries, token_cache=None):
+        decoded = []
+        cache = dict(self._provider_credential_tokens if token_cache is None else token_cache)
+        migration_needed = False
+        for entry in entries:
+            runtime_entry = list(entry)
+            credential, token, migrate = decrypt_provider_credential(
+                runtime_entry[_PROVIDER_CREDENTIAL_INDEX],
+                self.SECURE_DIR,
+            )
+            runtime_entry[_PROVIDER_CREDENTIAL_INDEX] = credential
+            if token:
+                cache[credential] = token
+            elif migrate and credential in cache:
+                migrate = False
+            migration_needed = migration_needed or migrate
+            decoded.append(tuple(runtime_entry))
+        return decoded, cache, migration_needed
+
+    def _assign_provider_ids(self, entries, next_id=None, seen_ids=None):
+        """Normalize legacy widths and reject duplicate current provider IDs."""
+        next_id = self._provider_max_id() if next_id is None else next_id
+        normalized = []
+        seen_ids = set() if seen_ids is None else seen_ids
+        for entry in entries:
+            values = list(entry)
+            if len(values) == 6:
+                next_id += 1
+                while next_id in seen_ids:
+                    next_id += 1
+                values.append(next_id)
+            else:
+                try:
+                    values[6] = int(values[6])
+                except (TypeError, ValueError) as e:
+                    raise ValueError("Provider ID must be an integer") from e
+            if values[6] in seen_ids:
+                raise ValueError("Provider IDs must be unique across enabled providers")
+            seen_ids.add(values[6])
+            normalized.append(tuple(values))
+        return normalized, next_id
+
+    def _normalize_provider_extra_value(self, value):
+        entries = parse_provider_extras(value, self.CONFIG_VERSION)
+        decoded, token_cache, _migration_needed = self._decode_provider_entries(entries)
+        normalized, _next_id = self._assign_provider_ids(decoded, seen_ids=self._reserved_provider_ids())
+        self._validate_provider_names(normalized, self._reserved_provider_names())
+        self._provider_credential_tokens = token_cache
+        return normalized
+
+    def _load_provider_extra_credentials(self):
+        """Decrypt provider keys after secure-directory authority is available."""
+        decoded_fields = {}
+        token_cache = dict(self._provider_credential_tokens)
+        migration_needed = False
+        for attr_name in _PROVIDER_EXTRA_FIELDS:
+            entries = parse_provider_extras(getattr(self, attr_name, []), self.CONFIG_VERSION)
+            decoded, token_cache, migrate = self._decode_provider_entries(entries, token_cache)
+            decoded_fields[attr_name] = decoded
+            migration_needed = migration_needed or migrate
+
+        for attr_name, entries in decoded_fields.items():
+            setattr(self, attr_name, entries)
+        self._provider_credential_tokens = token_cache
+        if migration_needed:
+            self.ENCRYPT_PASSWORDS = True
+            if not config.has_section("General"):
+                config.add_section("General")
+            config.set("General", "encrypt_passwords", "True")
+            self.WRITE_THE_CONFIG = True
+        return migration_needed
+
+    def _sanitize_provider_backup_credentials(self):
+        """Encrypt provider keys retained in historical config backups."""
+        backup_dir = self.BACKUP_LOCATION
+        if backup_dir in (None, "", "None"):
+            backup_dir = os.path.join(comicarr.DATA_DIR, "backup")
+
+        for backup_name in glob.glob(os.path.join(backup_dir, "config.ini-v*.backup*")):
+            backup_path = Path(backup_name)
+            if backup_path.is_symlink():
+                raise OSError("Refusing to rewrite a symlinked config backup")
+            if not backup_path.is_file():
+                continue
+            backup_config = configparser.ConfigParser()
+            backup_config.read(backup_path)
+            config_version = backup_config.getint("General", "config_version", fallback=15)
+            changed = False
+
+            for section, option in (("Newznab", "extra_newznabs"), ("Torznab", "extra_torznabs")):
+                raw_value = backup_config.get(section, option, raw=True, fallback="")
+                if raw_value in ("", "None"):
+                    continue
+                section_changed = False
+                try:
+                    entries = parse_provider_extras(raw_value, config_version)
+                except ValueError:
+                    backup_config.set(section, option, "")
+                    changed = True
+                    continue
+
+                sanitized = []
+                for entry in entries:
+                    values = list(entry)
+                    credential = values[_PROVIDER_CREDENTIAL_INDEX]
+                    if credential not in (None, "", "None") and not str(credential).startswith("gAAAAA"):
+                        try:
+                            runtime_credential, _token, _migration = decrypt_provider_credential(
+                                credential,
+                                self.SECURE_DIR,
+                            )
+                        except ValueError:
+                            runtime_credential = None
+                        if runtime_credential in (None, "", "None"):
+                            values[_PROVIDER_CREDENTIAL_INDEX] = ""
+                        else:
+                            encrypted_value = encrypted.Encryptor(
+                                str(runtime_credential),
+                                secure_dir=self.SECURE_DIR,
+                            ).encrypt_it()
+                            if not encrypted_value.get("status"):
+                                raise OSError("Unable to sanitize provider credential backup")
+                            values[_PROVIDER_CREDENTIAL_INDEX] = encrypted_value["password"]
+                        section_changed = True
+                    sanitized.append(tuple(values))
+
+                if section_changed:
+                    backup_config.set(section, option, serialize_provider_extras(sanitized))
+                    changed = True
+
+            if changed:
+                backup_mode = stat.S_IMODE(backup_path.stat().st_mode)
+                self._atomic_replace_file(backup_path, backup_mode, backup_config.write)
+
+    def validate_provider_extra_value(self, attr_name, value):
+        """Validate an API provider payload without publishing it to readers."""
+        if attr_name not in _PROVIDER_EXTRA_FIELDS:
+            raise ValueError("Unknown provider configuration field")
+        seen_ids = self._reserved_provider_ids()
+        seen_names = self._reserved_provider_names()
+        next_id = self._provider_max_id()
+        for other_attr in _PROVIDER_EXTRA_FIELDS:
+            if other_attr == attr_name:
+                continue
+            other_entries = parse_provider_extras(getattr(self, other_attr, []), self.CONFIG_VERSION)
+            decoded_other, _token_cache, _migration_needed = self._decode_provider_entries(other_entries)
+            normalized_other, next_id = self._assign_provider_ids(decoded_other, next_id, seen_ids)
+            self._validate_provider_names(normalized_other, seen_names)
+        entries = parse_provider_extras(value, self.CONFIG_VERSION)
+        decoded, _token_cache, _migration_needed = self._decode_provider_entries(entries)
+        normalized, _next_id = self._assign_provider_ids(decoded, next_id, seen_ids)
+        self._validate_provider_names(normalized, seen_names)
+
+    def _prepare_provider_extras_for_write(self, overrides=None):
+        """Build encrypted storage copies while leaving runtime credentials plaintext."""
+        overrides = overrides or {}
+        storage = {}
+        runtime = {}
+        token_cache = dict(self._provider_credential_tokens)
+        next_id = self._provider_max_id()
+        seen_ids = self._reserved_provider_ids()
+        seen_names = self._reserved_provider_names()
+        has_credentials = False
+
+        for attr_name in _PROVIDER_EXTRA_FIELDS:
+            value = overrides.get(attr_name, getattr(self, attr_name, []))
+            entries = parse_provider_extras(value, self.CONFIG_VERSION)
+            decoded, token_cache, _migration_needed = self._decode_provider_entries(entries, token_cache)
+            normalized, next_id = self._assign_provider_ids(decoded, next_id, seen_ids)
+            self._validate_provider_names(normalized, seen_names)
+            encrypted_entries = []
+            for entry in normalized:
+                stored_values = list(entry)
+                credential = entry[_PROVIDER_CREDENTIAL_INDEX]
+                if credential not in (None, "", "None"):
+                    has_credentials = True
+                    token = token_cache.get(credential)
+                    if token is None:
+                        encrypted_value = encrypted.Encryptor(
+                            str(credential),
+                            secure_dir=self.SECURE_DIR,
+                        ).encrypt_it()
+                        if not encrypted_value.get("status"):
+                            raise ValueError("Unable to encrypt provider credential")
+                        token = encrypted_value["password"]
+                        token_cache[credential] = token
+                    stored_values[_PROVIDER_CREDENTIAL_INDEX] = token
+                encrypted_entries.append(tuple(stored_values))
+
+            runtime[attr_name] = normalized
+            storage[attr_name] = serialize_provider_extras(encrypted_entries)
+
+        active_credentials = {
+            entry[_PROVIDER_CREDENTIAL_INDEX]
+            for entries in runtime.values()
+            for entry in entries
+            if entry[_PROVIDER_CREDENTIAL_INDEX] not in (None, "", "None")
+        }
+        active_token_cache = {
+            credential: token_cache[credential] for credential in active_credentials if credential in token_cache
+        }
+        return storage, runtime, active_token_cache, has_credentials
+
     def process_kwargs(self, kwargs):
         """
         Given a big bunch of key value pairs, apply them to the ini.
@@ -1129,6 +1500,9 @@ class Config(object):
                 ]
             ):
                 key, definition_type, section, ini_key, default = self._define(name)
+                if key in _PROVIDER_EXTRA_FIELDS:
+                    setattr(self, key, self._normalize_provider_extra_value(value))
+                    continue
                 if definition_type == str:
                     try:
                         if any([value == "", value is None, len(value) == 0]):
@@ -1214,11 +1588,26 @@ class Config(object):
             file_existed = config_path.is_file()
             file_contents = config_path.read_bytes() if file_existed else None
             file_mode = config_path.stat().st_mode if file_existed else None
+            provider_start_id = comicarr.PROVIDER_START_ID
 
             try:
-                self.process_kwargs(values)
+                provider_values = {key: value for key, value in values.items() if key in _PROVIDER_EXTRA_FIELDS}
+                scalar_values = {key: value for key, value in values.items() if key not in _PROVIDER_EXTRA_FIELDS}
+                if provider_values and scalar_values:
+                    raise ValueError("Provider and scalar settings require separate transactions")
+                if provider_values:
+                    # Provider values are fully normalized and published by
+                    # _writeconfig; the broad legacy configure pass adds no
+                    # provider state and cannot be rolled back safely.
+                    configure = False
+                if scalar_values:
+                    self.process_kwargs(scalar_values)
                 self._encrypt_config_for_write()
-                if self.writeconfig() is False:
+                if provider_values:
+                    persisted = self._writeconfig(provider_values=provider_values)
+                else:
+                    persisted = self.writeconfig()
+                if persisted is False:
                     raise OSError("config write failed")
                 if configure:
                     # configure() still owns legacy filesystem and queue side effects.
@@ -1228,6 +1617,7 @@ class Config(object):
                     self.configure(update=True, startup=False)
                 return True
             except BaseException as e:
+                comicarr.PROVIDER_START_ID = provider_start_id
                 durable_write_happened = self._durable_write_changed(config_path, file_existed, file_contents)
                 runtime_ok = False
                 file_ok = False
@@ -1329,6 +1719,7 @@ class Config(object):
             )
         elif config_path.exists():
             config_path.unlink()
+            self._fsync_directory(config_path.parent)
 
     def _config_write_target(self):
         """Resolve a configured symlink target without replacing the link itself."""
@@ -1392,6 +1783,7 @@ class Config(object):
                 os.fsync(temp_file.fileno())
             os.replace(temp_path, target_path)
             temp_path = None
+            cls._fsync_directory(target_path.parent)
         finally:
             if temp_fd is not None:
                 os.close(temp_fd)
@@ -1402,6 +1794,17 @@ class Config(object):
                     pass
                 except OSError as cleanup_error:
                     logger.warn("[CONFIG] Unable to remove config temp file %s: %s" % (temp_path, cleanup_error))
+
+    @staticmethod
+    def _fsync_directory(directory):
+        """Make a replaced config directory entry crash-durable on POSIX."""
+        if os.name == "nt":
+            return
+        descriptor = os.open(directory, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
 
     def writeconfig(self, values=None, startup=False):
         """Serialize every parser mutation and atomic config-file replacement."""
@@ -1426,8 +1829,11 @@ class Config(object):
             parser_defaults = copy.deepcopy(config._defaults)
             parser_sections = copy.deepcopy(config._sections)
             try:
-                self.process_kwargs(values)
-                if self._writeconfig(startup=startup) is False:
+                provider_values = {key: value for key, value in values.items() if key in _PROVIDER_EXTRA_FIELDS}
+                scalar_values = {key: value for key, value in values.items() if key not in _PROVIDER_EXTRA_FIELDS}
+                if scalar_values:
+                    self.process_kwargs(scalar_values)
+                if self._writeconfig(startup=startup, provider_values=provider_values) is False:
                     raise OSError("config write failed")
                 return True
             except Exception as e:
@@ -1440,25 +1846,46 @@ class Config(object):
                 logger.error("[CONFIG] writeconfig_values failed: %s" % e)
                 return False
 
-    def _writeconfig(self, values=None, startup=False):
+    def _writeconfig(self, values=None, startup=False, provider_values=None):
         try:
             config_path = self._config_write_target()
         except (OSError, RuntimeError) as e:
             logger.warn("[CONFIG] Refusing unsafe configuration write target: %s" % e)
             return False
 
+        if values is not None:
+            value_providers = {key: value for key, value in values.items() if key in _PROVIDER_EXTRA_FIELDS}
+            provider_values = {**(provider_values or {}), **value_providers}
+            scalar_values = {key: value for key, value in values.items() if key not in _PROVIDER_EXTRA_FIELDS}
+            if scalar_values:
+                self.process_kwargs(scalar_values)
+
         logger.fdebug("Writing configuration to file")
-        config.set("Newznab", "extra_newznabs", ", ".join(self.write_extras(self.EXTRA_NEWZNABS)))
-        tmp_torz = self.write_extras(self.EXTRA_TORZNABS)
-        config.set("Torznab", "extra_torznabs", ", ".join(tmp_torz))
+        parser_defaults = copy.deepcopy(config._defaults)
+        parser_sections = copy.deepcopy(config._sections)
+        try:
+            provider_storage, provider_runtime, token_cache, has_provider_credentials = (
+                self._prepare_provider_extras_for_write(provider_values)
+            )
+        except Exception as e:
+            logger.warn("Unable to serialize provider configuration: %s" % type(e).__name__)
+            return False
 
-        # this needs to revert from , to # so that it is stored properly (multiple categories)
-        extra_newznabs, extra_torznabs = self.get_extras()
-        self.EXTRA_NEWZNABS = extra_newznabs
-        self.EXTRA_TORZNABS = extra_torznabs
+        config.set("Newznab", "extra_newznabs", provider_storage["EXTRA_NEWZNABS"])
+        config.set("Torznab", "extra_torznabs", provider_storage["EXTRA_TORZNABS"])
+        if has_provider_credentials:
+            self.ENCRYPT_PASSWORDS = True
+            config.set("General", "encrypt_passwords", "True")
 
-        if startup is False:
-            self.provider_sequence()
+        provider_order = None
+        if startup is False and provider_values:
+            provider_order, serialized_order = self._calculate_provider_order(
+                provider_runtime["EXTRA_NEWZNABS"],
+                provider_runtime["EXTRA_TORZNABS"],
+            )
+            if not config.has_section("Providers"):
+                config.add_section("Providers")
+            config.set("Providers", "PROVIDER_ORDER", serialized_order)
 
         ###this should be moved elsewhere...
         if type(self.IGNORED_PUBLISHERS) != list:
@@ -1475,9 +1902,6 @@ class Config(object):
         ###
         config.set("General", "dynamic_update", str(self.DYNAMIC_UPDATE))
 
-        if values is not None:
-            self.process_kwargs(values)
-
         # Atomic write: restrict the temporary file before making it visible.
         target_mode = 0o600
         try:
@@ -1485,11 +1909,39 @@ class Config(object):
         except FileNotFoundError:
             pass
 
+        file_existed = config_path.is_file()
+        original_file = config_path.read_bytes() if file_existed else None
+        original_mode = config_path.stat().st_mode if file_existed else None
+        durable_write_happened = False
         try:
             self._atomic_replace_file(config_path, target_mode, config.write)
+            durable_write_happened = True
+            if startup is False and provider_values:
+                self.write_out_provider_searches(
+                    provider_order=provider_order,
+                    extra_newznabs=provider_runtime["EXTRA_NEWZNABS"],
+                    extra_torznabs=provider_runtime["EXTRA_TORZNABS"],
+                )
+            self.EXTRA_NEWZNABS = provider_runtime["EXTRA_NEWZNABS"]
+            self.EXTRA_TORZNABS = provider_runtime["EXTRA_TORZNABS"]
+            self._provider_credential_tokens = token_cache
+            for entries in provider_runtime.values():
+                for entry in entries:
+                    comicarr.PROVIDER_START_ID = max(comicarr.PROVIDER_START_ID, int(entry[6]))
+            if provider_order is not None:
+                self.PROVIDER_ORDER = provider_order
             logger.fdebug("Configuration written to disk.")
             return True
         except Exception as e:
+            config._defaults = parser_defaults
+            config._sections = parser_sections
+            if durable_write_happened:
+                try:
+                    self._restore_config_file(config_path, file_existed, original_file, original_mode)
+                except Exception as rollback_error:
+                    logger.error(
+                        "[CONFIG] Failed to restore configuration after provider projection: %s" % rollback_error
+                    )
             logger.warn("Error writing configuration file: %s", e)
             return False
 
@@ -1520,7 +1972,7 @@ class Config(object):
             # Skip values already encrypted with Fernet
             if current_value.startswith("gAAAAA"):
                 if mode == "decrypt":
-                    hp = encrypted.Encryptor(current_value)
+                    hp = encrypted.Encryptor(current_value, secure_dir=self.SECURE_DIR)
                     decrypted = hp.decrypt_it()
                     if decrypted["status"]:
                         setattr(self, k, decrypted["password"])
@@ -1531,7 +1983,7 @@ class Config(object):
             # Legacy base64 encrypted values
             if current_value.startswith("^~$z$"):
                 if mode == "decrypt":
-                    hp = encrypted.Encryptor(current_value)
+                    hp = encrypted.Encryptor(current_value, secure_dir=self.SECURE_DIR)
                     decrypted = hp.decrypt_it()
                     if decrypted["status"]:
                         setattr(self, k, decrypted["password"])
@@ -1544,10 +1996,10 @@ class Config(object):
                         )
                 else:
                     # Re-encrypt legacy base64 → Fernet
-                    hp = encrypted.Encryptor(current_value)
+                    hp = encrypted.Encryptor(current_value, secure_dir=self.SECURE_DIR)
                     decrypted = hp.decrypt_it()
                     if decrypted["status"]:
-                        re_enc = encrypted.Encryptor(decrypted["password"])
+                        re_enc = encrypted.Encryptor(decrypted["password"], secure_dir=self.SECURE_DIR)
                         encrypted_password = re_enc.encrypt_it()
                         if encrypted_password["status"]:
                             config.set(section, ini_key, encrypted_password["password"])
@@ -1556,7 +2008,7 @@ class Config(object):
 
             # Plaintext — encrypt with Fernet
             if mode == "encrypt":
-                hp = encrypted.Encryptor(current_value)
+                hp = encrypted.Encryptor(current_value, secure_dir=self.SECURE_DIR)
                 encrypted_password = hp.encrypt_it()
                 if encrypted_password["status"]:
                     config.set(section, ini_key, encrypted_password["password"])
@@ -1576,6 +2028,23 @@ class Config(object):
             token = token[0]
         if token:
             self.GIT_TOKEN = (token, "x-oauth-basic")
+
+    def _ensure_secure_directory(self):
+        """Establish encryption authority before any configuration persistence."""
+        if not self.SECURE_DIR:
+            self.SECURE_DIR = os.path.join(comicarr.DATA_DIR, ".secure")
+
+        if os.path.exists(self.SECURE_DIR):
+            return
+        try:
+            os.makedirs(self.SECURE_DIR)
+            os.chmod(self.SECURE_DIR, 0o700)
+        except OSError:
+            logger.error(
+                "[FATAL] Could not create secure directory at %s. "
+                "Credential encryption will not work. Fix permissions and restart." % self.SECURE_DIR
+            )
+            raise SystemExit(1)
 
     def configure(self, update=False, startup=False):
 
@@ -1649,19 +2118,7 @@ class Config(object):
                     "[Cache Check] Could not create cache dir. Check permissions of datadir: %s" % comicarr.DATA_DIR
                 )
 
-        if not self.SECURE_DIR:
-            self.SECURE_DIR = os.path.join(comicarr.DATA_DIR, ".secure")
-
-        if not os.path.exists(self.SECURE_DIR):
-            try:
-                os.makedirs(self.SECURE_DIR)
-                os.chmod(self.SECURE_DIR, 0o700)
-            except OSError:
-                logger.error(
-                    "[FATAL] Could not create secure directory at %s. "
-                    "Credential encryption will not work. Fix permissions and restart." % self.SECURE_DIR
-                )
-                raise SystemExit(1)
+        self._ensure_secure_directory()
 
         # Encrypt plaintext credentials now that SECURE_DIR is available
         if self.ENCRYPT_PASSWORDS is True:
@@ -1919,6 +2376,7 @@ class Config(object):
 
         if self.ENCRYPT_PASSWORDS is True:
             self.encrypt_items(mode="decrypt")
+        self._load_provider_extra_credentials()
         if all([self.IGNORE_TOTAL is True, self.IGNORE_HAVETOTAL is True]):
             self.IGNORE_TOTAL = False
             self.IGNORE_HAVETOTAL = False
@@ -2243,30 +2701,8 @@ class Config(object):
         return KEYS_32P
 
     def get_extras(self):
-        cnt = 0
-        while cnt < 2:
-            if cnt == 0:
-                ex = self.EXTRA_NEWZNABS
-            else:
-                ex = self.EXTRA_TORZNABS
-
-            if type(ex) != list:
-                if self.CONFIG_VERSION < 11:
-                    if cnt == 0:
-                        extra_newznabs = list(zip(*[iter(ex.split(", "))] * 6, strict=False))
-                    else:
-                        extra_torznabs = list(zip(*[iter(ex.split(", "))] * 6, strict=False))
-                else:
-                    if cnt == 0:
-                        extra_newznabs = list(zip(*[iter(ex.split(", "))] * 7, strict=False))
-                    else:
-                        extra_torznabs = list(zip(*[iter(ex.split(", "))] * 7, strict=False))
-            else:
-                if cnt == 0:
-                    extra_newznabs = ex
-                else:
-                    extra_torznabs = ex
-            cnt += 1
+        extra_newznabs = parse_provider_extras(self.EXTRA_NEWZNABS, self.CONFIG_VERSION)
+        extra_torznabs = parse_provider_extras(self.EXTRA_TORZNABS, self.CONFIG_VERSION)
 
         x_newzcat = []
         x_torzcat = []
@@ -2327,12 +2763,7 @@ class Config(object):
         return xx_newzcat, xx_torzcat
 
     def get_extra_torznabs(self):
-        extra_torznabs = self.EXTRA_TORZNABS
-        if type(extra_torznabs) != list:
-            if self.CONFIG_VERSION < 11:
-                extra_torznabs = list(zip(*[iter(extra_torznabs.split(", "))] * 6, strict=False))
-            else:
-                extra_torznabs = list(zip(*[iter(extra_torznabs.split(", "))] * 7, strict=False))
+        extra_torznabs = parse_provider_extras(self.EXTRA_TORZNABS, self.CONFIG_VERSION)
         x_torcat = []
         for x in extra_torznabs:
             x_cat = x[4]
@@ -2368,7 +2799,10 @@ class Config(object):
             ignored_pubs = []
         return ignored_pubs
 
-    def provider_sequence(self):
+    def _calculate_provider_order(self, extra_newznabs=None, extra_torznabs=None):
+        """Calculate provider ordering without mutating runtime, disk, or the database."""
+        extra_newznabs = self.EXTRA_NEWZNABS if extra_newznabs is None else extra_newznabs
+        extra_torznabs = self.EXTRA_TORZNABS if extra_torznabs is None else extra_torznabs
         PR = []
         PR_NUM = 0
         if self.ENABLE_TORRENT_SEARCH:
@@ -2392,7 +2826,7 @@ class Config(object):
 
         PPR = ["Experimental", "DDL(GetComics)", "DDL(External)"]
         if self.NEWZNAB:
-            for ens in self.EXTRA_NEWZNABS:
+            for ens in extra_newznabs:
                 if str(ens[5]) == "1":  # if newznabs are enabled
                     if ens[0] == "":
                         en_name = ens[1]
@@ -2405,7 +2839,7 @@ class Config(object):
                     PR_NUM += 1
 
         if self.ENABLE_TORZNAB and self.ENABLE_TORRENT_SEARCH:
-            for ets in self.EXTRA_TORZNABS:
+            for ets in extra_torznabs:
                 if str(ets[5]) == "1":  # if torznabs are enabled
                     if ets[0] == "":
                         et_name = ets[1]
@@ -2503,151 +2937,133 @@ class Config(object):
                 TMPPR_NUM += 1
             PROVIDER_ORDER = PROV_ORDER
 
-        ll = ", ".join(PROVIDER_ORDER)
+        serialized_order = ", ".join(PROVIDER_ORDER)
+        provider_order = dict(list(zip(*[PROVIDER_ORDER[i::2] for i in range(2)], strict=False)))
+        return provider_order, serialized_order
+
+    def provider_sequence(self):
+        """Publish the current provider order and reconcile its database projection."""
+        provider_order, serialized_order = self._calculate_provider_order()
         if not config.has_section("Providers"):
             config.add_section("Providers")
-        config.set("Providers", "PROVIDER_ORDER", ll)
-
-        PROVIDER_ORDER = dict(list(zip(*[PROVIDER_ORDER[i::2] for i in range(2)], strict=False)))
-        self.PROVIDER_ORDER = PROVIDER_ORDER
+        config.set("Providers", "PROVIDER_ORDER", serialized_order)
+        self.PROVIDER_ORDER = provider_order
         logger.fdebug("Provider Order is now set : %s " % self.PROVIDER_ORDER)
 
         self.write_out_provider_searches()
 
-    def write_extras(self, value):
-        flattened = []
-        for item in value:
-            for i in item:
-                try:
-                    if value.index(i) == 4:
-                        ib = i
-                        if "," in ib:
-                            ib = re.sub(",", "#", ib).strip()
-                    elif '"' in i and ' "' in i:
-                        ib = str(i).replace('"', "").strip()
-                    else:
-                        ib = i
-                except:
-                    ib = i
-                flattened.append(str(ib))
-        return flattened
+    @staticmethod
+    def _provider_search_identity(provider, extra_newznabs, extra_torznabs):
+        """Return the canonical database identity for a configured provider."""
+        if provider == "DDL(GetComics)":
+            return provider, "DDL", 200
+        if provider == "DDL(External)":
+            return provider, "DDL(External)", 201
+        if provider.lower() == "experimental":
+            return "experimental", "experimental", 101
+        for provider_type, entries in (("newznab", extra_newznabs), ("torznab", extra_torznabs)):
+            for entry in entries:
+                entry_name = entry[0] or entry[1]
+                if entry_name.lower() == provider.lower():
+                    return entry_name, provider_type, int(entry[6])
+        raise ValueError("Provider order contains an unknown provider")
 
-    def write_out_provider_searches(self):
-        # this is needed for rss to work since the provider table isn't written to
-        # until a search is performed
-        from sqlalchemy import delete, select
+    def write_out_provider_searches(self, provider_order=None, extra_newznabs=None, extra_torznabs=None):
+        """Reconcile the provider-search projection in one database transaction."""
+        from sqlalchemy import select, update
 
         from comicarr.tables import provider_searches
 
-        with db.get_engine().connect() as conn:
-            chk = [dict(row._mapping) for row in conn.execute(select(provider_searches))]
-        p_list = {}
-        write = False
-        if chk:
-            for ck in chk:
-                ck_hits = ck["hits"]
-                if ck_hits is None:
-                    ck_hits = 0
-                t_id = ck["id"]
-                prov_t = ck["provider"]
-                if t_id == "Experimental":
-                    prov_t = "experimental"
-                # logger.fdebug('[%s] t_id: %s' % (ck['provider'], t_id))
-                if any([t_id == 0, t_id is None]):
-                    # id of 0 means it hasn't been assigned - so we need to assign it before we build out the dict
-                    if "DDL(GetComics)" in prov_t:
-                        t_id = 200
-                    if "DDL(External)" in prov_t:
-                        t_id = 201
-                    elif any(["experimental" in prov_t, "Experimental" in prov_t]):
-                        t_id = 101
-                    else:
-                        nnf = False
-                        if self.EXTRA_NEWZNABS:
-                            for n in self.EXTRA_NEWZNABS:
-                                if n[0] == prov_t:
-                                    t_id = n[6]
-                                    nnf = True
-                                    break
-                        if nnf is False and self.EXTRA_TORZNABS:
-                            for n in self.EXTRA_TORZNABS:
-                                if n[0] == prov_t:
-                                    t_id = n[6]
-                                    nnf = True
-                                    break
+        provider_order = self.PROVIDER_ORDER if provider_order is None else provider_order
+        extra_newznabs = self.EXTRA_NEWZNABS if extra_newznabs is None else extra_newznabs
+        extra_torznabs = self.EXTRA_TORZNABS if extra_torznabs is None else extra_torznabs
 
-                    t_ctrl = {"id": t_id, "provider": prov_t}
-                    t_vals = {"active": ck["active"], "lastrun": ck["lastrun"], "type": ck["type"], "hits": ck_hits}
-                    db.upsert("provider_searches", t_vals, t_ctrl)
-                p_list[prov_t] = {
-                    "id": t_id,
-                    "active": ck["active"],
-                    "lastrun": ck["lastrun"],
-                    "type": ck["type"],
-                    "hits": ck_hits,
-                }
-
-        # logger.fdebug('p_list: %s' % (p_list,))
-        for _k, v in self.PROVIDER_ORDER.items():
-            tmp_prov = v
-            if not any(p.lower() == tmp_prov.lower() for p, pv in p_list.items()):
-                write = True
-                # logger.fdebug('%s was not found in search db. Writing it..' % v)
-                if "DDL(GetComics)" in tmp_prov:
-                    t_type = "DDL"
-                    t_id = 200
-                if "DDL(External)" in tmp_prov:
-                    t_type = "DDL(External)"
-                    t_id = 201
-                elif any(["experimental" in tmp_prov, "Experimental" in tmp_prov]):
-                    tmp_prov = "experimental"
-                    t_type = "experimental"
-                    t_id = 101
-                else:
-                    nnf = False
-                    if self.EXTRA_NEWZNABS:
-                        for n in self.EXTRA_NEWZNABS:
-                            if n[0] == tmp_prov:
-                                t_type = "newznab"
-                                t_id = n[6]
-                                nnf = True
-                                break
-                    if nnf is False and self.EXTRA_TORZNABS:
-                        for n in self.EXTRA_TORZNABS:
-                            if n[0] == tmp_prov:
-                                t_type = "torznab"
-                                t_id = n[6]
-                                nnf = True
-                                break
-                ctrls = {"id": t_id, "provider": tmp_prov}
-                vals = {"active": False, "lastrun": 0, "type": t_type, "hits": 0}
-            else:
-                try:
-                    tprov = [p_list[x] for x, y in p_list.items() if x.lower() == tmp_prov.lower()][0]
-                except Exception:
-                    tprov = None
-
-                if tprov:
-                    if tmp_prov == "Experimental":
-                        # needed to ensure the type is set properly for this provider
-                        ptype = tprov["type"]
-                        if tmp_prov == "Experimental":
-                            stmt = delete(provider_searches).where(provider_searches.c.id == 101)
-                            with db.get_engine().begin() as conn:
-                                conn.execute(stmt)
-                            tmp_prov = "experimental"
-                        ctrls = {"id": tprov["id"], "provider": tmp_prov}
-                        vals = {
-                            "active": tprov["active"],
-                            "lastrun": tprov["lastrun"],
-                            "type": ptype,
-                            "hits": tprov["hits"],
+        with db.get_engine().begin() as conn:
+            rows = [dict(row._mapping) for row in conn.execute(select(provider_searches))]
+            existing = {}
+            existing_by_id = {}
+            for row in rows:
+                hits = row["hits"] or 0
+                provider = row["provider"]
+                provider_id = row["id"]
+                provider_type = row["type"]
+                if provider_id in (0, None):
+                    try:
+                        canonical, provider_type, provider_id = self._provider_search_identity(
+                            provider,
+                            extra_newznabs,
+                            extra_torznabs,
+                        )
+                    except ValueError:
+                        existing[provider.lower()] = {
+                            "id": provider_id,
+                            "provider": provider,
+                            "active": row["active"],
+                            "lastrun": row["lastrun"],
+                            "type": provider_type,
+                            "hits": hits,
                         }
-                        write = True
+                        if provider_id not in (0, None):
+                            existing_by_id[provider_id] = existing[provider.lower()]
+                        continue
+                    conn.execute(
+                        update(provider_searches)
+                        .where(provider_searches.c.provider == row["provider"])
+                        .values(id=provider_id, provider=canonical, type=provider_type, hits=hits)
+                    )
+                    provider = canonical
+                existing[provider.lower()] = {
+                    "id": provider_id,
+                    "provider": provider,
+                    "active": row["active"],
+                    "lastrun": row["lastrun"],
+                    "type": provider_type,
+                    "hits": hits,
+                }
+                if provider_id not in (0, None):
+                    existing_by_id[provider_id] = existing[provider.lower()]
 
-            if write is True:
-                logger.fdebug("writing: keys - %s: vals - %s" % (vals, ctrls))
-                db.upsert("provider_searches", vals, ctrls)
+            for provider in provider_order.values():
+                try:
+                    canonical, provider_type, provider_id = self._provider_search_identity(
+                        provider,
+                        extra_newznabs,
+                        extra_torznabs,
+                    )
+                except ValueError:
+                    if provider.lower() in {"32p", "public torrents"}:
+                        # Legacy torrent providers do not use provider_searches.
+                        continue
+                    raise
+                current = existing.get(canonical.lower())
+                if current:
+                    if current["id"] != provider_id or current["type"] != provider_type:
+                        previous_id = current["id"]
+                        conn.execute(
+                            update(provider_searches)
+                            .where(provider_searches.c.provider == current["provider"])
+                            .values(id=provider_id, provider=canonical, type=provider_type)
+                        )
+                        existing_by_id.pop(previous_id, None)
+                        current.update({"id": provider_id, "provider": canonical, "type": provider_type})
+                        existing_by_id[provider_id] = current
+                    continue
+                controls = {"id": provider_id, "provider": canonical}
+                values = {"active": False, "lastrun": 0, "type": provider_type, "hits": 0}
+                logger.fdebug("writing: keys - %s: vals - %s" % (values, controls))
+                id_collision = existing_by_id.get(provider_id)
+                if id_collision:
+                    conn.execute(
+                        update(provider_searches)
+                        .where(provider_searches.c.id == provider_id)
+                        .values(provider=canonical, **values)
+                    )
+                    existing.pop(id_collision["provider"].lower(), None)
+                    current = {"id": provider_id, "provider": canonical, **values}
+                    existing[canonical.lower()] = current
+                    existing_by_id[provider_id] = current
+                else:
+                    db.upsert_conn(conn, "provider_searches", values, controls)
 
 
 def get_manga_destination():

--- a/comicarr/encrypted.py
+++ b/comicarr/encrypted.py
@@ -18,7 +18,10 @@
 #  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
 
 import base64
+import errno
 import os
+import tempfile
+import threading
 
 import bcrypt
 from cryptography.fernet import Fernet
@@ -27,44 +30,179 @@ from comicarr import logger
 
 # Module-level cache for the Fernet instance (loaded once per process)
 _fernet_instance = None
+_fernet_secure_dir = None
+_fernet_lock = threading.RLock()
+_MASTER_KEY_TEMP_PREFIX = ".comicarr-master-key-"
+_MASTER_KEY_LOCK_NAME = ".master-key.lock"
 
 
-def _get_fernet():
-    """Get or create the Fernet instance using the master key from SECURE_DIR."""
-    global _fernet_instance
-    if _fernet_instance is not None:
-        return _fernet_instance
+def _fsync_directory(directory):
+    """Make a newly published key directory entry crash-durable on POSIX."""
+    if os.name == "nt":
+        return
+    descriptor = os.open(directory, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
-    import comicarr
 
-    if not comicarr.CONFIG or not comicarr.CONFIG.SECURE_DIR:
-        logger.error("[ENCRYPTION] SECURE_DIR not configured — cannot load master key")
-        return None
+def _publish_master_key_with_lock(key_path, temp_path):
+    """Publish atomically on filesystems that do not support hard links."""
+    lock_path = os.path.join(os.path.dirname(key_path), _MASTER_KEY_LOCK_NAME)
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    os.chmod(lock_path, 0o600)
+    if os.name == "nt":
+        import msvcrt
 
-    key_path = os.path.join(comicarr.CONFIG.SECURE_DIR, "master.key")
-
-    if os.path.exists(key_path):
-        with open(key_path, "rb") as f:
-            key = f.read().strip()
+        if os.fstat(lock_fd).st_size == 0:
+            os.write(lock_fd, b"\0")
+            os.fsync(lock_fd)
+        os.lseek(lock_fd, 0, os.SEEK_SET)
+        msvcrt.locking(lock_fd, msvcrt.LK_LOCK, 1)
     else:
-        # Generate a new Fernet key (direct random bytes, no PBKDF2 needed)
-        key = base64.urlsafe_b64encode(os.urandom(32))
-        try:
-            with open(key_path, "wb") as f:
-                f.write(key)
-            os.chmod(key_path, 0o600)
-            logger.info("[ENCRYPTION] Generated new master key at %s" % key_path)
-        except Exception as e:
-            logger.error("[ENCRYPTION] Failed to write master key: %s" % e)
-            return None
+        import fcntl
+
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
 
     try:
-        _fernet_instance = Fernet(key)
-    except Exception as e:
-        logger.error("[ENCRYPTION] Invalid master key: %s" % e)
-        return None
+        if os.path.exists(key_path):
+            return False
+        os.replace(temp_path, key_path)
+        os.chmod(key_path, 0o600)
+        _fsync_directory(os.path.dirname(key_path))
+        return True
+    finally:
+        if os.name == "nt":
+            os.lseek(lock_fd, 0, os.SEEK_SET)
+            msvcrt.locking(lock_fd, msvcrt.LK_UNLCK, 1)
+        else:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
 
-    return _fernet_instance
+
+def _publish_master_key(key_path, key):
+    """Publish a complete owner-only key without replacing a concurrent winner."""
+    temp_fd = None
+    temp_path = None
+    try:
+        temp_fd, temp_path = tempfile.mkstemp(
+            prefix=_MASTER_KEY_TEMP_PREFIX,
+            suffix=".tmp",
+            dir=os.path.dirname(key_path),
+        )
+        fchmod = getattr(os, "fchmod", None)
+        if callable(fchmod):
+            try:
+                fchmod(temp_fd, 0o600)
+            except (AttributeError, NotImplementedError):
+                os.chmod(temp_path, 0o600)
+            except OSError:
+                if os.name != "nt":
+                    raise
+                os.chmod(temp_path, 0o600)
+        else:
+            os.chmod(temp_path, 0o600)
+
+        with os.fdopen(temp_fd, "wb") as key_file:
+            temp_fd = None
+            key_file.write(key)
+            key_file.flush()
+            os.fsync(key_file.fileno())
+
+        try:
+            # A same-directory hard link publishes the fully written inode
+            # atomically and fails instead of replacing another process's key.
+            os.link(temp_path, key_path)
+        except FileExistsError:
+            return False
+        except (AttributeError, NotImplementedError):
+            return _publish_master_key_with_lock(key_path, temp_path)
+        except OSError as e:
+            unsupported = {errno.EACCES, errno.EPERM, errno.EXDEV}
+            if hasattr(errno, "ENOTSUP"):
+                unsupported.add(errno.ENOTSUP)
+            if hasattr(errno, "EOPNOTSUPP"):
+                unsupported.add(errno.EOPNOTSUPP)
+            if e.errno not in unsupported:
+                raise
+            return _publish_master_key_with_lock(key_path, temp_path)
+        os.chmod(key_path, 0o600)
+        _fsync_directory(os.path.dirname(key_path))
+        return True
+    finally:
+        if temp_fd is not None:
+            os.close(temp_fd)
+        if temp_path is not None:
+            try:
+                os.unlink(temp_path)
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                logger.warn("[ENCRYPTION] Unable to remove temporary master key: %s" % type(e).__name__)
+
+
+def _load_or_create_master_key(key_path, create):
+    """Load the durable key, atomically creating it on first use."""
+    try:
+        with open(key_path, "rb") as key_file:
+            key = key_file.read().strip()
+        if os.name != "nt":
+            os.chmod(key_path, 0o600)
+            if (os.stat(key_path).st_mode & 0o777) != 0o600:
+                raise PermissionError("Master key permissions are not owner-only")
+        return key
+    except FileNotFoundError:
+        if not create:
+            return None
+        key = Fernet.generate_key()
+        if _publish_master_key(key_path, key):
+            logger.info("[ENCRYPTION] Generated new master key at %s" % key_path)
+            return key
+
+        # A concurrent process published its complete key first.
+        with open(key_path, "rb") as key_file:
+            return key_file.read().strip()
+
+
+def _get_fernet(secure_dir=None, create=True):
+    """Get or create the Fernet instance using the master key from SECURE_DIR."""
+    global _fernet_instance, _fernet_secure_dir
+
+    if secure_dir is None:
+        import comicarr
+
+        if not comicarr.CONFIG or not comicarr.CONFIG.SECURE_DIR:
+            logger.error("[ENCRYPTION] SECURE_DIR not configured — cannot load master key")
+            return None
+        secure_dir = comicarr.CONFIG.SECURE_DIR
+
+    secure_dir = os.path.abspath(secure_dir)
+    with _fernet_lock:
+        key_path = os.path.join(secure_dir, "master.key")
+        if _fernet_instance is not None and _fernet_secure_dir == secure_dir:
+            if os.path.isfile(key_path):
+                return _fernet_instance
+            logger.error("[ENCRYPTION] Cached authority lost its durable master key")
+            return None
+
+        try:
+            key = _load_or_create_master_key(key_path, create)
+        except Exception as e:
+            logger.error("[ENCRYPTION] Failed to load or create master key: %s" % type(e).__name__)
+            return None
+        if key is None:
+            return None
+
+        try:
+            instance = Fernet(key)
+        except Exception as e:
+            logger.error("[ENCRYPTION] Invalid master key: %s" % e)
+            return None
+
+        _fernet_instance = instance
+        _fernet_secure_dir = secure_dir
+        return instance
 
 
 # --- bcrypt helpers for login passwords ---
@@ -106,7 +244,7 @@ def migrate_password(stored_password):
     if stored_password.startswith("^~$z$"):
         # Old base64 encoding — decode to get plaintext
         try:
-            decoded = base64.b64decode(stored_password[5:])
+            decoded = base64.b64decode(stored_password[5:], validate=True)
             if len(decoded) <= 8:
                 logger.error("[ENCRYPTION] Base64 payload too short to contain password + salt")
                 return None
@@ -129,13 +267,14 @@ class Encryptor(object):
     Handles migration from old base64 encoding (^~$z$ prefix) to Fernet (gAAAAA prefix).
     """
 
-    def __init__(self, password, logon=False):
+    def __init__(self, password, logon=False, secure_dir=None):
         self.password = password
         self.logon = logon
+        self.secure_dir = secure_dir
 
     def encrypt_it(self):
         """Encrypt a plaintext credential with Fernet."""
-        fernet = _get_fernet()
+        fernet = _get_fernet(self.secure_dir)
         if fernet is None:
             logger.error("[ENCRYPTION] Fernet not available — cannot encrypt. Check SECURE_DIR and master.key.")
             return {"status": False}
@@ -153,7 +292,7 @@ class Encryptor(object):
 
         # Already a Fernet token (starts with gAAAAA)
         if self.password.startswith("gAAAAA"):
-            fernet = _get_fernet()
+            fernet = _get_fernet(self.secure_dir, create=False)
             if fernet is None:
                 if self.logon is False:
                     logger.warn("[ENCRYPTION] Fernet not available — cannot decrypt")
@@ -168,7 +307,9 @@ class Encryptor(object):
         # Legacy base64 encoding (^~$z$ prefix)
         if self.password.startswith("^~$z$"):
             try:
-                passd = base64.b64decode(self.password[5:])
+                passd = base64.b64decode(self.password[5:], validate=True)
+                if len(passd) <= 8:
+                    raise ValueError("Base64 payload too short to contain password and salt")
                 return {"status": True, "password": passd[:-8].decode("utf-8")}
             except Exception as e:
                 logger.warn("Error when decrypting legacy password: %s" % e)

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -56,6 +56,7 @@ from comicarr import (
     search_filer,
     updater,
 )
+from comicarr.app.common.redaction import redact_sensitive_text
 from comicarr.app.common.remote_artifacts import (
     resolve_remote_artifact_path,
     safe_remote_filename,
@@ -119,7 +120,7 @@ def parallel_search_providers(scarios_list, timeout=120):
         try:
             return search_the_matrix(scarios_list[0])
         except Exception as e:
-            logger.warn(f"Search error: {e}")
+            logger.warn("Search error: %s" % redact_sensitive_text(e))
             return {"status": False}
 
     executor = get_search_executor()
@@ -147,7 +148,7 @@ def parallel_search_providers(scarios_list, timeout=120):
                             f.cancel()
                     return result
             except Exception as e:
-                logger.warn(f"[PARALLEL-SEARCH] Error from {provider_name}: {e}")
+                logger.warn("[PARALLEL-SEARCH] Error from %s: %s" % (provider_name, redact_sensitive_text(e)))
                 continue
     except TimeoutError:
         logger.warn("[PARALLEL-SEARCH] Search timeout exceeded")
@@ -160,6 +161,14 @@ def parallel_search_providers(scarios_list, timeout=120):
 # This reuses TCP connections across multiple requests, significantly
 # improving performance when making many requests to the same hosts
 _http_session = None
+
+
+def _rss_result_log_summary(result):
+    """Return useful RSS metadata without retaining provider-signed links."""
+    return "rss result: site=%s title=%s" % (
+        redact_sensitive_text(result.get("site", "unknown")),
+        redact_sensitive_text(result.get("title", "unknown")),
+    )
 
 
 def get_http_session():
@@ -2334,7 +2343,7 @@ def searchforissue(
                         }
                     ]
 
-                    logger.info("rss_results[x]: %s" % (x,))
+                    logger.info(_rss_result_log_summary(x))
                     try:
                         foundc = {}
                         foundc["status"] = False
@@ -2400,7 +2409,7 @@ def searchforissue(
                         if any([booktype == "TPB", booktype == "HC", booktype == "GN"]):
                             chktpb = 1
 
-                        logger.info("provider_list: %s" % (provider_list,))
+                        logger.info("provider order: %s" % provider_list["prov_order"])
 
                         intIss = helpers.issuedigits(xr["Issue_Number"])
 
@@ -3260,10 +3269,16 @@ def searcher(
 
         if filen is None:
             if payload is None:
-                logger.error("[PAYLOAD:NONE] Unable to download nzb from link: %s [%s]" % (down_url, link))
+                logger.error(
+                    "[PAYLOAD:NONE] Unable to download nzb from link: %s [%s]"
+                    % (redact_sensitive_text(down_url), redact_sensitive_text(link))
+                )
             else:
                 errorlink = down_url + "?" + urllib.parse.urlencode(payload)
-                logger.error("[PAYLOAD:PRESENT] Unable to download nzb from link: %s [%s]" % (errorlink, link))
+                logger.error(
+                    "[PAYLOAD:PRESENT] Unable to download nzb from link: %s [%s]"
+                    % (redact_sensitive_text(errorlink), redact_sensitive_text(link))
+                )
             return "sab-fail"
         else:
             # convert to a generic type of format to help with post-processing.

--- a/tests/unit/test_carepackage_security.py
+++ b/tests/unit/test_carepackage_security.py
@@ -128,7 +128,7 @@ def test_carepackage_redacts_fernet_provider_extras_without_runtime_config(tmp_p
     data_dir.mkdir()
     log_dir.mkdir()
     secure_dir.mkdir()
-    encrypted_module._fernet_instance = None
+    monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
 
     newznab_secret = "newznab-provider-secret"
     torznab_secret = "torznab-provider-secret"
@@ -215,8 +215,8 @@ def test_carepackage_missing_provider_key_redacts_without_creating_replacement(t
     with open(data_dir / "config.ini", "w") as config_file:
         parser.write(config_file)
 
-    encrypted_module._fernet_instance = None
-    encrypted_module._fernet_secure_dir = None
+    monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
+    monkeypatch.setattr(encrypted_module, "_fernet_secure_dir", None)
     monkeypatch.setattr(comicarr, "CONFIG", None)
     monkeypatch.setattr(comicarr, "DATA_DIR", str(data_dir))
     monkeypatch.setattr(comicarr, "PROG_DIR", str(tmp_path))
@@ -240,7 +240,7 @@ def test_encrypt_items_handles_git_token_auth_tuple(tmp_path, monkeypatch):
     config_path.write_text("")
 
     # Reset Fernet cache so master.key is loaded from this test's SECURE_DIR.
-    encrypted_module._fernet_instance = None
+    monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
 
     cfg = config_module.Config(str(config_path))
     for attr_name in config_module.ENCRYPTED_CONFIG_ITEMS:
@@ -264,5 +264,3 @@ def test_encrypt_items_handles_git_token_auth_tuple(tmp_path, monkeypatch):
     assert "ghp_test_token_value" not in encrypted_token
     # Runtime auth tuple shape is unchanged (encrypt writes the parser only).
     assert cfg.GIT_TOKEN == ("ghp_test_token_value", "x-oauth-basic")
-
-    encrypted_module._fernet_instance = None

--- a/tests/unit/test_carepackage_security.py
+++ b/tests/unit/test_carepackage_security.py
@@ -120,6 +120,115 @@ def test_carepackage_clean_config_and_logs_redact_newer_secrets(tmp_path, monkey
         assert zip_parser.get(section, option) == "xXX[REMOVED]XXx"
 
 
+def test_carepackage_redacts_fernet_provider_extras_without_runtime_config(tmp_path, monkeypatch):
+    """Maintenance bundles decrypt 6/7-field provider keys using explicit authority."""
+    data_dir = tmp_path / "data"
+    log_dir = tmp_path / "logs"
+    secure_dir = data_dir / ".secure"
+    data_dir.mkdir()
+    log_dir.mkdir()
+    secure_dir.mkdir()
+    encrypted_module._fernet_instance = None
+
+    newznab_secret = "newznab-provider-secret"
+    torznab_secret = "torznab-provider-secret"
+    newznab_token = encrypted_module.Encryptor(newznab_secret, secure_dir=str(secure_dir)).encrypt_it()["password"]
+    torznab_token = encrypted_module.Encryptor(torznab_secret, secure_dir=str(secure_dir)).encrypt_it()["password"]
+
+    parser = configparser.ConfigParser()
+    parser["General"] = {"config_version": "15", "secure_dir": "None"}
+    parser["Logs"] = {"log_dir": str(log_dir)}
+    parser["Git"] = {"git_user": "comicarr", "git_branch": "main", "git_token": "", "git_path": ""}
+    parser["Newznab"] = {
+        "extra_newznabs": ", ".join(["Newz", "https://newz.test", "1", newznab_token, "5030", "1", "101"])
+    }
+    parser["Torznab"] = {"extra_torznabs": ", ".join(["Torz", "https://torz.test", "1", torznab_token, "5070", "1"])}
+    config_path = data_dir / "config.ini"
+    with open(config_path, "w") as config_file:
+        parser.write(config_file)
+
+    bearer_secret = "diagnostic-bearer-secret"
+    basic_secret = "diagnostic-basic-secret"
+    token_secret = "diagnostic-token-secret"
+    query_secret = "diagnostic-query-secret"
+    (log_dir / "comicarr.log").write_text(
+        "%s %s\n" % (newznab_secret, torznab_secret)
+        + "provider_list: {'newznab_info': ('Newz', 'https://newz.test', '1', '%s')}\n" % newznab_secret
+        + "Authorization: Bearer %s\n" % bearer_secret
+        + "Authorization: Basic %s\n" % basic_secret
+        + "{'Authorization': 'Token %s'}\n" % token_secret
+        + "https://torz.test/api?apikey=%s\n" % query_secret
+    )
+    (data_dir / "comicarr.db").write_text("")
+
+    monkeypatch.setattr(comicarr, "CONFIG", None)
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(data_dir))
+    monkeypatch.setattr(comicarr, "PROG_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "KEYS_32P", {})
+
+    package = carePackage(maintenance=True)
+    package.cleaned_config()
+    clean_config = (log_dir / "clean_config.ini").read_text()
+    package.filename = str(log_dir / "ComicarrRunningEnvironment.txt")
+    package.panicfile = str(log_dir / "carepackage.zip")
+    with open(package.filename, "w") as environment_file:
+        environment_file.write("environment\n")
+    package.panicbutton()
+
+    with zipfile.ZipFile(package.panicfile, "r") as bundle:
+        redacted_log = bundle.read("comicarr.log").decode("utf-8")
+        zipped_config = bundle.read("clean_config.ini").decode("utf-8")
+
+    for secret in (
+        newznab_secret,
+        torznab_secret,
+        newznab_token,
+        torznab_token,
+        bearer_secret,
+        basic_secret,
+        token_secret,
+        query_secret,
+    ):
+        assert secret not in clean_config
+        assert secret not in zipped_config
+        assert secret not in redacted_log
+    assert "REDACTED" in redacted_log.upper()
+
+
+def test_carepackage_missing_provider_key_redacts_without_creating_replacement(tmp_path, monkeypatch):
+    """Reading diagnostics is side-effect free when Fernet authority is missing."""
+    from cryptography.fernet import Fernet
+
+    data_dir = tmp_path / "data"
+    log_dir = tmp_path / "logs"
+    secure_dir = data_dir / ".secure"
+    data_dir.mkdir()
+    log_dir.mkdir()
+    secure_dir.mkdir()
+    token = Fernet(Fernet.generate_key()).encrypt(b"unrecoverable-secret").decode()
+    parser = configparser.ConfigParser()
+    parser["General"] = {"config_version": "15", "secure_dir": str(secure_dir)}
+    parser["Logs"] = {"log_dir": str(log_dir)}
+    parser["Git"] = {"git_user": "comicarr", "git_branch": "main", "git_token": "", "git_path": ""}
+    parser["Newznab"] = {"extra_newznabs": ", ".join(["Newz", "https://newz.test", "1", token, "5030", "1", "101"])}
+    parser["Torznab"] = {"extra_torznabs": ""}
+    with open(data_dir / "config.ini", "w") as config_file:
+        parser.write(config_file)
+
+    encrypted_module._fernet_instance = None
+    encrypted_module._fernet_secure_dir = None
+    monkeypatch.setattr(comicarr, "CONFIG", None)
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(data_dir))
+    monkeypatch.setattr(comicarr, "PROG_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "KEYS_32P", {})
+
+    package = carePackage(maintenance=True)
+    package.cleaned_config()
+
+    assert token not in (log_dir / "clean_config.ini").read_text()
+    assert not (secure_dir / "master.key").exists()
+
+
 def test_encrypt_items_handles_git_token_auth_tuple(tmp_path, monkeypatch):
     """configure() rewrites GIT_TOKEN to a requests auth tuple before encrypt_items.
 

--- a/tests/unit/test_encrypted_security.py
+++ b/tests/unit/test_encrypted_security.py
@@ -1,0 +1,142 @@
+#  Copyright (C) 2025-2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Security regressions for durable Fernet key authority."""
+
+import errno
+import os
+import stat
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+
+from comicarr import encrypted
+
+
+@pytest.fixture(autouse=True)
+def reset_fernet_cache():
+    with encrypted._fernet_lock:
+        encrypted._fernet_instance = None
+        encrypted._fernet_secure_dir = None
+    yield
+    with encrypted._fernet_lock:
+        encrypted._fernet_instance = None
+        encrypted._fernet_secure_dir = None
+
+
+def test_concurrent_first_use_publishes_one_owner_only_master_key(tmp_path):
+    secure_dir = tmp_path / "secure"
+    secure_dir.mkdir()
+    workers = 16
+    barrier = threading.Barrier(workers)
+
+    def encrypt_after_barrier(index):
+        barrier.wait()
+        instance = encrypted._get_fernet(str(secure_dir))
+        token = instance.encrypt(("payload-%s" % index).encode())
+        return instance, token
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(encrypt_after_barrier, range(workers)))
+
+    instances = [instance for instance, _token in results]
+    assert len({id(instance) for instance in instances}) == 1
+
+    key_path = secure_dir / "master.key"
+    durable_fernet = Fernet(key_path.read_bytes())
+    for index, (_instance, token) in enumerate(results):
+        assert durable_fernet.decrypt(token) == ("payload-%s" % index).encode()
+
+    if os.name != "nt":
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+    assert list(secure_dir.glob("%s*" % encrypted._MASTER_KEY_TEMP_PREFIX)) == []
+
+
+def test_concurrent_explicit_directories_never_cross_key_authority(tmp_path):
+    secure_dirs = [tmp_path / "secure-a", tmp_path / "secure-b"]
+    for secure_dir in secure_dirs:
+        secure_dir.mkdir()
+
+    workers = 20
+    barrier = threading.Barrier(workers)
+
+    def encrypt_for_directory(index):
+        secure_dir = secure_dirs[index % len(secure_dirs)]
+        barrier.wait()
+        results = []
+        for iteration in range(20):
+            payload = ("%s:%s:%s" % (secure_dir.name, index, iteration)).encode()
+            token = encrypted._get_fernet(str(secure_dir)).encrypt(payload)
+            results.append((secure_dir, payload, token))
+        return results
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        batches = list(executor.map(encrypt_for_directory, range(workers)))
+
+    authorities = {secure_dir: Fernet((secure_dir / "master.key").read_bytes()) for secure_dir in secure_dirs}
+    for batch in batches:
+        for secure_dir, payload, token in batch:
+            assert authorities[secure_dir].decrypt(token) == payload
+            other_dir = next(candidate for candidate in secure_dirs if candidate != secure_dir)
+            with pytest.raises(InvalidToken):
+                authorities[other_dir].decrypt(token)
+
+
+@pytest.mark.parametrize("failure", ("missing", "not-implemented", "unsupported"))
+def test_first_use_falls_back_when_hard_links_are_unavailable(tmp_path, monkeypatch, failure):
+    secure_dir = tmp_path / "secure"
+    secure_dir.mkdir()
+    if failure == "missing":
+        monkeypatch.delattr(encrypted.os, "link")
+    else:
+        error = NotImplementedError() if failure == "not-implemented" else OSError(errno.EPERM, "unavailable")
+
+        def unavailable_link(*_args):
+            raise error
+
+        monkeypatch.setattr(encrypted.os, "link", unavailable_link)
+
+    authority = encrypted._get_fernet(str(secure_dir))
+    token = authority.encrypt(b"fallback-payload")
+
+    assert Fernet((secure_dir / "master.key").read_bytes()).decrypt(token) == b"fallback-payload"
+    if os.name != "nt":
+        assert stat.S_IMODE((secure_dir / "master.key").stat().st_mode) == 0o600
+
+
+def test_existing_master_key_permissions_are_repaired_before_use(tmp_path):
+    if os.name == "nt":
+        pytest.skip("POSIX permission bits are not authoritative on Windows")
+    secure_dir = tmp_path / "secure"
+    secure_dir.mkdir()
+    key_path = secure_dir / "master.key"
+    key_path.write_bytes(Fernet.generate_key())
+    key_path.chmod(0o644)
+
+    assert encrypted._get_fernet(str(secure_dir)) is not None
+
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize("token", ("^~$z$AAAA", "^~$z$!!!!"))
+def test_malformed_legacy_tokens_fail_instead_of_erasing_credentials(token):
+    assert encrypted.Encryptor(token).decrypt_it() == {"status": False}
+
+
+def test_decrypt_with_missing_master_key_does_not_create_replacement_authority(tmp_path):
+    secure_dir = tmp_path / "secure"
+    secure_dir.mkdir()
+    token = Fernet(Fernet.generate_key()).encrypt(b"unrecoverable").decode()
+
+    result = encrypted.Encryptor(token, secure_dir=str(secure_dir)).decrypt_it()
+
+    assert result == {"status": False}
+    assert not (secure_dir / "master.key").exists()

--- a/tests/unit/test_search_providers.py
+++ b/tests/unit/test_search_providers.py
@@ -111,6 +111,13 @@ def test_provider_search_exception_logs_redact_credentials(provider_count, monke
 
     monkeypatch.setattr(search, "search_the_matrix", fail_search)
     monkeypatch.setattr(search, "get_search_executor", lambda: executor)
+
+    def submit_background_future(executor, target, *, args=(), kwargs=None, name=None):
+        return executor.submit(target, *args, **(kwargs or {}))
+
+    # Main now routes provider work through the shutdown-owned registry. Keep
+    # this unit test focused on redaction by injecting its local executor.
+    monkeypatch.setattr(search, "submit_background_future", submit_background_future, raising=False)
     monkeypatch.setattr(
         search.logger, "warn", lambda message, *args: messages.append(message % args if args else message)
     )

--- a/tests/unit/test_search_providers.py
+++ b/tests/unit/test_search_providers.py
@@ -80,7 +80,7 @@ def test_encrypted_provider_key_is_plaintext_only_in_runtime_plan(tmp_path, monk
 
     secure_dir = tmp_path / "secure"
     secure_dir.mkdir()
-    encrypted_module._fernet_instance = None
+    monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
     secret = "runtime-provider-secret"
     token = encrypted_module.Encryptor(secret, secure_dir=str(secure_dir)).encrypt_it()["password"]
     runtime_config = config_module.Config(str(tmp_path / "config.ini"))
@@ -122,6 +122,13 @@ def test_provider_search_exception_logs_redact_credentials(provider_count, monke
     rendered = "\n".join(messages)
     assert secret not in rendered
     assert "[redacted]" in rendered.lower()
+
+
+def test_newznab_r_query_secret_is_redacted():
+    message = search.redact_sensitive_text("https://indexer.test/api?r=newznab-r-secret")
+
+    assert "newznab-r-secret" not in message
+    assert "r=[redacted]" in message
 
 
 def test_rss_result_log_summary_omits_provider_signed_link():

--- a/tests/unit/test_search_providers.py
+++ b/tests/unit/test_search_providers.py
@@ -1,4 +1,7 @@
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
+
+import pytest
 
 import comicarr
 from comicarr import search
@@ -69,3 +72,68 @@ def test_unnamed_provider_uses_safe_identity_during_legacy_execution(monkeypatch
 
     assert result["torznab_info"][0]["info"][0] == "Torznab 1"
     assert result["torznab_info"][0]["info"][1] == config.EXTRA_TORZNABS[0][1]
+
+
+def test_encrypted_provider_key_is_plaintext_only_in_runtime_plan(tmp_path, monkeypatch):
+    from comicarr import config as config_module
+    from comicarr import encrypted as encrypted_module
+
+    secure_dir = tmp_path / "secure"
+    secure_dir.mkdir()
+    encrypted_module._fernet_instance = None
+    secret = "runtime-provider-secret"
+    token = encrypted_module.Encryptor(secret, secure_dir=str(secure_dir)).encrypt_it()["password"]
+    runtime_config = config_module.Config(str(tmp_path / "config.ini"))
+    runtime_config.CONFIG_VERSION = 15
+    runtime_config.SECURE_DIR = str(secure_dir)
+    runtime_config.ENCRYPT_PASSWORDS = True
+    runtime_config.EXTRA_NEWZNABS = []
+    runtime_config.EXTRA_TORZNABS = [("Nyaa", "https://indexer.test", "1", token, "5070", "1", 101)]
+    monkeypatch.setattr(comicarr, "CONFIG", runtime_config)
+
+    runtime_config._load_provider_extra_credentials()
+    plan = effective_provider_plan(_config(EXTRA_TORZNABS=runtime_config.EXTRA_TORZNABS))
+
+    candidate = next(provider for provider in plan if provider.kind == "torznab")
+    assert candidate.entry[3] == secret
+    assert token not in repr(candidate)
+    assert secret not in repr(candidate)
+
+
+@pytest.mark.parametrize("provider_count", (1, 2))
+def test_provider_search_exception_logs_redact_credentials(provider_count, monkeypatch):
+    secret = "provider-exception-secret"
+    messages = []
+    executor = ThreadPoolExecutor(max_workers=2)
+
+    def fail_search(_scenario):
+        raise RuntimeError(f"request failed https://indexer.test/api?apikey={secret}")
+
+    monkeypatch.setattr(search, "search_the_matrix", fail_search)
+    monkeypatch.setattr(search, "get_search_executor", lambda: executor)
+    monkeypatch.setattr(
+        search.logger, "warn", lambda message, *args: messages.append(message % args if args else message)
+    )
+    try:
+        assert search.parallel_search_providers([{} for _ in range(provider_count)]) == {"status": False}
+    finally:
+        executor.shutdown(wait=True)
+
+    rendered = "\n".join(messages)
+    assert secret not in rendered
+    assert "[redacted]" in rendered.lower()
+
+
+def test_rss_result_log_summary_omits_provider_signed_link():
+    secret = "rss-signed-link-secret"
+    result = {
+        "site": "Indexer",
+        "title": "Example Comic",
+        "link": f"https://indexer.test/download?token={secret}",
+    }
+
+    summary = search._rss_result_log_summary(result)
+
+    assert summary == "rss result: site=Indexer title=Example Comic"
+    assert secret not in summary
+    assert "indexer.test" not in summary

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -1003,10 +1003,12 @@ class TestConfigService:
 
     def test_sanitize_job_error_redacts_credentials(self):
         message = system_service.sanitize_job_error(
-            "token=secret Authorization: Bearer bearer-secret https://user:pass@example.test failed"
+            "token=secret {'apikey': 'quoted-api-secret'} Authorization: Bearer bearer-secret "
+            "https://user:pass@example.test failed"
         )
 
         assert "secret" not in message
+        assert "quoted-api-secret" not in message
         assert "bearer-secret" not in message
         assert "user:pass" not in message
         assert "[redacted]" in message
@@ -1160,7 +1162,7 @@ def _make_real_config(tmp_path, monkeypatch):
     secure_dir.mkdir()
 
     monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
-    encrypted_module._fernet_instance = None
+    monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
 
     cfg = config_module.Config(str(config_path))
     cfg.config_vals()
@@ -1230,7 +1232,7 @@ class TestConfigTransactions:
             parser.write(config_file)
 
         monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
-        encrypted_module._fernet_instance = None
+        monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
         monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
         cfg = config_module.Config(str(config_path))
         monkeypatch.setattr(comicarr, "CONFIG", cfg)
@@ -1263,7 +1265,7 @@ class TestConfigTransactions:
             "[Torznab]\nextra_torznabs =\n" % secure_dir
         )
         monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
-        encrypted_module._fernet_instance = None
+        monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
         monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
         cfg = config_module.Config(str(config_path))
         cfg.configure = MagicMock()
@@ -1299,7 +1301,7 @@ class TestConfigTransactions:
             "[Torznab]\nextra_torznabs =\n" % secret
         )
         monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
-        encrypted_module._fernet_instance = None
+        monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
         monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
         monkeypatch.setattr(comicarr, "CONFIG_FILE", str(config_path))
         cfg = config_module.Config(str(config_path))
@@ -1330,7 +1332,7 @@ class TestConfigTransactions:
             "[Torznab]\nextra_torznabs =\n" % (secure_dir, malformed)
         )
         monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
-        encrypted_module._fernet_instance = None
+        monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
         monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
         cfg = config_module.Config(str(config_path))
         cfg.provider_sequence = MagicMock()
@@ -1368,8 +1370,8 @@ class TestConfigTransactions:
             "[Torznab]\nextra_torznabs =\n" % historical_secret
         )
         monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
-        encrypted_module._fernet_instance = None
-        encrypted_module._fernet_secure_dir = None
+        monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
+        monkeypatch.setattr(encrypted_module, "_fernet_secure_dir", None)
         monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
         cfg = config_module.Config(str(config_path))
         cfg.provider_sequence = MagicMock()
@@ -1408,8 +1410,8 @@ class TestConfigTransactions:
             "[Torznab]\nextra_torznabs =\n"
         )
         monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
-        encrypted_module._fernet_instance = None
-        encrypted_module._fernet_secure_dir = None
+        monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
+        monkeypatch.setattr(encrypted_module, "_fernet_secure_dir", None)
         monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
         cfg = config_module.Config(str(config_path))
         cfg.provider_sequence = MagicMock()
@@ -1443,8 +1445,8 @@ class TestConfigTransactions:
             % (secure_dir, torznab_name, torznab_id)
         )
         monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
-        encrypted_module._fernet_instance = None
-        encrypted_module._fernet_secure_dir = None
+        monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
+        monkeypatch.setattr(encrypted_module, "_fernet_secure_dir", None)
         monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
         cfg = config_module.Config(str(config_path))
         cfg.provider_sequence = MagicMock()
@@ -1489,7 +1491,7 @@ class TestConfigTransactions:
     def test_provider_transaction_encrypts_at_rest_and_reloads_plaintext(self, tmp_path, monkeypatch):
         cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
         encrypted_module = config_module.encrypted
-        encrypted_module._fernet_instance = None
+        monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
         existing_token = encrypted_module.Encryptor(
             "existing-secret",
             secure_dir=cfg.SECURE_DIR,
@@ -1538,7 +1540,7 @@ class TestConfigTransactions:
         first_newznab_storage = persisted.get("Newznab", "extra_newznabs")
         first_torznab_storage = persisted.get("Torznab", "extra_torznabs")
         monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
-        encrypted_module._fernet_instance = None
+        monkeypatch.setattr(encrypted_module, "_fernet_instance", None)
         fresh = config_module.Config(str(config_path))
         fresh.config_vals()
         fresh.EXTRA_NEWZNABS, fresh.EXTRA_TORZNABS = fresh.get_extras()

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -584,6 +584,89 @@ class TestConfigService:
         assert result == {"success": True}
         assert events == ["persist", "scheduler"]
 
+    @pytest.mark.parametrize(
+        ("provider_type", "config_key"),
+        (("newznab", "EXTRA_NEWZNABS"), ("torznab", "EXTRA_TORZNABS")),
+    )
+    def test_update_providers_uses_transactional_extra_provider_key(self, provider_type, config_key):
+        providers = [["Indexer", "https://indexer.test", "1", "secret", "5030", "1", 101]]
+        ctx = _make_test_ctx()
+
+        result = system_service.update_providers(ctx, {"type": provider_type, "providers": providers})
+
+        assert result == {"success": True}
+        ctx.config.apply_transaction.assert_called_once_with({config_key: providers}, configure=False)
+        ctx.config.configure.assert_not_called()
+        ctx.config.writeconfig_values.assert_not_called()
+
+    def test_update_providers_reports_transaction_failure_without_reconfigure(self):
+        old_providers = [("Old", "https://old.test", "1", "old-key", "5030", "1", 100)]
+        new_providers = [["New", "https://new.test", "1", "new-key", "5030", "1", 101]]
+        ctx = _make_test_ctx()
+        ctx.config.EXTRA_NEWZNABS = old_providers
+        ctx.config.apply_transaction.side_effect = None
+        ctx.config.apply_transaction.return_value = False
+
+        result = system_service.update_providers(ctx, {"type": "newznab", "providers": new_providers})
+
+        assert result == {"success": False, "error": "Failed to persist provider configuration"}
+        assert ctx.config.EXTRA_NEWZNABS is old_providers
+        ctx.config.apply_transaction.assert_called_once_with({"EXTRA_NEWZNABS": new_providers}, configure=False)
+        ctx.config.configure.assert_not_called()
+        ctx.config.writeconfig_values.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_providers_returns_bad_request_for_malformed_entry(self):
+        """Malformed provider tuples remain validation errors rather than storage failures."""
+        ctx = _make_test_ctx()
+        ctx.config.validate_provider_extra_value.side_effect = ValueError("invalid provider entry")
+        request = _JsonRequest({"type": "newznab", "providers": [["Too short", "https://short.test", "1"]]})
+
+        response = await system_router.update_providers(request, ctx)
+
+        assert response.status_code == 400
+        assert json.loads(response.body) == {"success": False, "error": "Invalid provider configuration"}
+        ctx.config.apply_transaction.assert_not_called()
+
+    @pytest.mark.parametrize("payload", ({"type": "invalid", "providers": []}, [], None))
+    def test_update_providers_rejects_invalid_payload_without_writing(self, payload):
+        ctx = _make_test_ctx()
+
+        result = system_service.update_providers(ctx, payload)
+
+        assert result["success"] is False
+        ctx.config.apply_transaction.assert_not_called()
+
+    def test_recent_logs_redact_runtime_provider_and_header_credentials(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        provider_secret = "provider-secret-value"
+        bearer_secret = "bearer-secret-value"
+        basic_secret = "basic-secret-value"
+        token_secret = "token-secret-value"
+        query_secret = "query-secret-value"
+        (log_dir / "comicarr.log").write_text(
+            "provider_list: {'info': ('Indexer', 'https://indexer.test', '1', 'provider-secret-value')}\n"
+            "Authorization: Bearer bearer-secret-value\n"
+            "Authorization: Basic basic-secret-value\n"
+            "{'Authorization': 'Token token-secret-value'}\n"
+            "download failed https://indexer.test/api?apikey=query-secret-value\n"
+        )
+        ctx = _make_test_ctx(data_dir=str(tmp_path))
+        ctx.config.LOG_DIR = str(log_dir)
+        ctx.config.EXTRA_NEWZNABS = [("Indexer", "https://indexer.test", "1", provider_secret, "5030", "1", 100)]
+        ctx.config.EXTRA_TORZNABS = []
+
+        result = system_service.get_recent_logs(ctx)
+
+        rendered = "".join(result["logs"])
+        assert provider_secret not in rendered
+        assert bearer_secret not in rendered
+        assert basic_secret not in rendered
+        assert token_secret not in rendered
+        assert query_secret not in rendered
+        assert "[redacted]" in rendered.lower()
+
     @patch("comicarr.app.system.service.secrets.token_hex", return_value="a" * 32)
     def test_regenerate_api_key_persists_new_key(self, mock_token_hex):
         """regenerate_api_key creates, persists, and returns a server-side key."""
@@ -919,9 +1002,12 @@ class TestConfigService:
         assert values["last_error"] == "Previous Auto-Search run was interrupted by restart."
 
     def test_sanitize_job_error_redacts_credentials(self):
-        message = system_service.sanitize_job_error("token=secret https://user:pass@example.test failed")
+        message = system_service.sanitize_job_error(
+            "token=secret Authorization: Bearer bearer-secret https://user:pass@example.test failed"
+        )
 
         assert "secret" not in message
+        assert "bearer-secret" not in message
         assert "user:pass" not in message
         assert "[redacted]" in message
 
@@ -978,6 +1064,28 @@ class _JsonRequest:
 
 
 class TestConfigRouter:
+    @pytest.mark.asyncio
+    async def test_update_providers_maps_persistence_failure_to_server_error(self):
+        failure = {"success": False, "error": "Failed to persist provider configuration"}
+        request = _JsonRequest({"type": "newznab", "providers": []})
+
+        with patch.object(system_router.system_service, "update_providers", return_value=failure):
+            response = await system_router.update_providers(request, _make_test_ctx())
+
+        assert response.status_code == 500
+        assert json.loads(response.body) == failure
+
+    @pytest.mark.asyncio
+    async def test_update_providers_maps_validation_failure_to_bad_request(self):
+        failure = {"success": False, "error": "Invalid provider type"}
+        request = _JsonRequest({"type": "invalid", "providers": []})
+
+        with patch.object(system_router.system_service, "update_providers", return_value=failure):
+            response = await system_router.update_providers(request, _make_test_ctx())
+
+        assert response.status_code == 400
+        assert json.loads(response.body) == failure
+
     @pytest.mark.asyncio
     async def test_setup_returns_server_error_when_persistence_fails(self):
         """The setup endpoint distinguishes storage failure from invalid input."""
@@ -1059,6 +1167,7 @@ def _make_real_config(tmp_path, monkeypatch):
     cfg.SECURE_DIR = str(secure_dir)
     config_module.config.set("General", "secure_dir", str(secure_dir))
     cfg.provider_sequence = MagicMock()
+    cfg.write_out_provider_searches = MagicMock()
     monkeypatch.setattr(comicarr, "CONFIG", cfg)
     monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
     return cfg, config_path, config_module
@@ -1072,6 +1181,605 @@ def _symlink_or_skip(link_path, target_path):
 
 
 class TestConfigTransactions:
+    @pytest.mark.parametrize(
+        ("config_version", "entry_width", "entry_count"),
+        ((15, 6, 7), (10, 7, 6)),
+    )
+    def test_ambiguous_flat_provider_count_uses_structural_width(self, config_version, entry_width, entry_count):
+        """A 42-field legacy payload never shifts API keys into another column."""
+        from comicarr import config as config_module
+
+        entries = []
+        for index in range(entry_count):
+            entry = [
+                f"Provider {index}",
+                f"https://provider-{index}.test",
+                "1",
+                f"secret-{index}",
+                "5030",
+                "1",
+            ]
+            if entry_width == 7:
+                entry.append(100 + index)
+            entries.append(entry)
+
+        parsed = config_module.parse_provider_extras(
+            ", ".join(str(field) for row in entries for field in row), config_version
+        )
+
+        assert len(parsed) == entry_count
+        assert all(len(entry) == entry_width for entry in parsed)
+        assert [entry[3] for entry in parsed] == [f"secret-{index}" for index in range(entry_count)]
+
+    def test_config_read_encrypts_plaintext_provider_before_projection(self, tmp_path, monkeypatch):
+        from comicarr import config as config_module
+        from comicarr import encrypted as encrypted_module
+
+        secure_dir = tmp_path / "secure"
+        secure_dir.mkdir()
+        config_path = tmp_path / "config.ini"
+        parser = configparser.ConfigParser()
+        parser["General"] = {
+            "config_version": "15",
+            "minimal_ini": "False",
+            "secure_dir": str(secure_dir),
+        }
+        parser["Newznab"] = {"extra_newznabs": "Legacy, https://legacy.test, 1, startup-secret, 5030, 1"}
+        parser["Torznab"] = {"extra_torznabs": ""}
+        with open(config_path, "w") as config_file:
+            parser.write(config_file)
+
+        monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
+        encrypted_module._fernet_instance = None
+        monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+        cfg = config_module.Config(str(config_path))
+        monkeypatch.setattr(comicarr, "CONFIG", cfg)
+        projections = []
+
+        def project_providers():
+            projections.append((cfg.EXTRA_NEWZNABS[0][3], config_path.read_text()))
+
+        cfg.provider_sequence = MagicMock(side_effect=project_providers)
+        cfg.configure = MagicMock()
+
+        assert cfg.read(startup=False) is cfg
+
+        assert projections
+        assert all(runtime_key == "startup-secret" for runtime_key, _file_text in projections)
+        assert all("startup-secret" not in file_text for _runtime_key, file_text in projections)
+        assert "gAAAAA" in config_path.read_text()
+
+    def test_config_read_fails_closed_when_plaintext_provider_migration_cannot_replace(self, tmp_path, monkeypatch):
+        """Startup never continues while a plaintext provider key remains on disk."""
+        from comicarr import config as config_module
+        from comicarr import encrypted as encrypted_module
+
+        secure_dir = tmp_path / "secure"
+        secure_dir.mkdir()
+        config_path = tmp_path / "config.ini"
+        config_path.write_text(
+            "[General]\nconfig_version = 15\nminimal_ini = False\nsecure_dir = %s\n"
+            "[Newznab]\nextra_newznabs = Legacy, https://legacy.test, 1, startup-secret, 5030, 1\n"
+            "[Torznab]\nextra_torznabs =\n" % secure_dir
+        )
+        monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
+        encrypted_module._fernet_instance = None
+        monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+        cfg = config_module.Config(str(config_path))
+        cfg.configure = MagicMock()
+        cfg.provider_sequence = MagicMock()
+        cfg._atomic_replace_file = MagicMock(side_effect=OSError("read-only config"))
+
+        with pytest.raises(OSError, match="encrypted provider credentials"):
+            cfg.read(startup=False)
+
+        assert "startup-secret" in config_path.read_text()
+        cfg.provider_sequence.assert_not_called()
+
+    def test_preupgrade_backup_never_copies_plaintext_provider_key(self, tmp_path, monkeypatch):
+        from comicarr import config as config_module
+        from comicarr import encrypted as encrypted_module
+
+        secure_dir = tmp_path / "secure"
+        backup_dir = tmp_path / "backup"
+        secure_dir.mkdir()
+        backup_dir.mkdir()
+        config_path = tmp_path / "config.ini"
+        secret = "preupgrade-provider-secret"
+        config_path.write_text(
+            "[General]\nconfig_version = 14\nminimal_ini = False\nsecure_dir = %s\n"
+            "[Backup]\nbackup_location = %s\nbackup_retention = 2\n"
+            "[Newznab]\nextra_newznabs = Legacy, https://legacy.test, 1, %s, 5030, 1, 301\n"
+            "[Torznab]\nextra_torznabs =\n" % (secure_dir, backup_dir, secret)
+        )
+        historical_backup = backup_dir / "config.ini-v13.backup"
+        historical_backup.write_text(
+            "[General]\nconfig_version = 13\n"
+            "[Newznab]\nextra_newznabs = Old, https://old.test, 1, %s, 5030, 1, 300\n"
+            "[Torznab]\nextra_torznabs =\n" % secret
+        )
+        monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
+        encrypted_module._fernet_instance = None
+        monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+        monkeypatch.setattr(comicarr, "CONFIG_FILE", str(config_path))
+        cfg = config_module.Config(str(config_path))
+        monkeypatch.setattr(comicarr, "CONFIG", cfg)
+        cfg.provider_sequence = MagicMock()
+        cfg.write_out_provider_searches = MagicMock()
+        cfg.configure = MagicMock()
+
+        assert cfg.read(startup=False) is cfg
+
+        backup_files = list(backup_dir.glob("config.ini-v*.backup*"))
+        assert backup_files
+        assert secret not in config_path.read_text()
+        assert all(secret not in backup.read_text() for backup in backup_files)
+        assert all("gAAAAA" in backup.read_text() for backup in backup_files)
+
+    def test_startup_rejects_malformed_legacy_provider_token_without_rewrite(self, tmp_path, monkeypatch):
+        from comicarr import config as config_module
+        from comicarr import encrypted as encrypted_module
+
+        secure_dir = tmp_path / "secure"
+        secure_dir.mkdir()
+        config_path = tmp_path / "config.ini"
+        malformed = "^~$z$!!!!"
+        config_path.write_text(
+            "[General]\nconfig_version = 15\nminimal_ini = False\nsecure_dir = %s\n"
+            "[Newznab]\nextra_newznabs = Legacy, https://legacy.test, 1, %s, 5030, 1, 301\n"
+            "[Torznab]\nextra_torznabs =\n" % (secure_dir, malformed)
+        )
+        monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
+        encrypted_module._fernet_instance = None
+        monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+        cfg = config_module.Config(str(config_path))
+        cfg.provider_sequence = MagicMock()
+        cfg.configure = MagicMock()
+
+        with pytest.raises(ValueError, match="decrypt provider credential"):
+            cfg.read(startup=False)
+
+        assert malformed in config_path.read_text()
+        cfg.provider_sequence.assert_not_called()
+
+    def test_startup_missing_provider_key_does_not_create_replacement_authority(self, tmp_path, monkeypatch):
+        from cryptography.fernet import Fernet
+
+        from comicarr import config as config_module
+        from comicarr import encrypted as encrypted_module
+
+        secure_dir = tmp_path / "secure"
+        backup_dir = tmp_path / "backup"
+        secure_dir.mkdir()
+        backup_dir.mkdir()
+        token = Fernet(Fernet.generate_key()).encrypt(b"unrecoverable-secret").decode()
+        historical_secret = "historical-plaintext-secret"
+        config_path = tmp_path / "config.ini"
+        config_path.write_text(
+            "[General]\nconfig_version = 15\nminimal_ini = False\nsecure_dir = %s\n"
+            "[Backup]\nbackup_location = %s\n"
+            "[Newznab]\nextra_newznabs = Legacy, https://legacy.test, 1, %s, 5030, 1, 301\n"
+            "[Torznab]\nextra_torznabs =\n" % (secure_dir, backup_dir, token)
+        )
+        historical_backup = backup_dir / "config.ini-v14.backup"
+        historical_backup.write_text(
+            "[General]\nconfig_version = 14\n"
+            "[Newznab]\nextra_newznabs = Old, https://old.test, 1, %s, 5030, 1, 300\n"
+            "[Torznab]\nextra_torznabs =\n" % historical_secret
+        )
+        monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
+        encrypted_module._fernet_instance = None
+        encrypted_module._fernet_secure_dir = None
+        monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+        cfg = config_module.Config(str(config_path))
+        cfg.provider_sequence = MagicMock()
+        cfg.configure = MagicMock()
+
+        with pytest.raises(ValueError, match="decrypt provider credential"):
+            cfg.read(startup=False)
+
+        assert not (secure_dir / "master.key").exists()
+        assert historical_secret in historical_backup.read_text()
+        cfg.provider_sequence.assert_not_called()
+
+    def test_startup_missing_scalar_key_blocks_provider_and_backup_rewrites(self, tmp_path, monkeypatch):
+        from cryptography.fernet import Fernet
+
+        from comicarr import config as config_module
+        from comicarr import encrypted as encrypted_module
+
+        secure_dir = tmp_path / "secure"
+        backup_dir = tmp_path / "backup"
+        secure_dir.mkdir()
+        backup_dir.mkdir()
+        scalar_token = Fernet(Fernet.generate_key()).encrypt(b"unrecoverable-comicvine-secret").decode()
+        config_path = tmp_path / "config.ini"
+        config_path.write_text(
+            "[General]\nconfig_version = 15\nminimal_ini = False\nsecure_dir = %s\n"
+            "[Backup]\nbackup_location = %s\n"
+            "[CV]\ncomicvine_api = %s\n"
+            "[Newznab]\nextra_newznabs = Legacy, https://legacy.test, 1, live-plaintext-secret, 5030, 1, 301\n"
+            "[Torznab]\nextra_torznabs =\n" % (secure_dir, backup_dir, scalar_token)
+        )
+        historical_backup = backup_dir / "config.ini-v14.backup"
+        historical_backup.write_text(
+            "[General]\nconfig_version = 14\n"
+            "[Newznab]\nextra_newznabs = Old, https://old.test, 1, backup-plaintext-secret, 5030, 1, 300\n"
+            "[Torznab]\nextra_torznabs =\n"
+        )
+        monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
+        encrypted_module._fernet_instance = None
+        encrypted_module._fernet_secure_dir = None
+        monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+        cfg = config_module.Config(str(config_path))
+        cfg.provider_sequence = MagicMock()
+        cfg.configure = MagicMock()
+
+        with pytest.raises(ValueError, match="encrypted configuration authority"):
+            cfg.read(startup=False)
+
+        assert not (secure_dir / "master.key").exists()
+        assert "live-plaintext-secret" in config_path.read_text()
+        assert "backup-plaintext-secret" in historical_backup.read_text()
+        cfg.provider_sequence.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("torznab_name", "torznab_id", "error"),
+        (("duplicate", 302, "Provider names must be unique"), ("Other", 301, "Provider IDs must be unique")),
+    )
+    def test_config_read_rejects_persisted_duplicate_provider_identity_before_projection(
+        self, tmp_path, monkeypatch, torznab_name, torznab_id, error
+    ):
+        from comicarr import config as config_module
+        from comicarr import encrypted as encrypted_module
+
+        secure_dir = tmp_path / "secure"
+        secure_dir.mkdir()
+        config_path = tmp_path / "config.ini"
+        config_path.write_text(
+            "[General]\nconfig_version = 15\nminimal_ini = False\nsecure_dir = %s\n"
+            "[Newznab]\nextra_newznabs = Duplicate, https://newz.test, 1, , 5030, 1, 301\n"
+            "[Torznab]\nextra_torznabs = %s, https://torz.test, 1, , 5070, 1, %s\n"
+            % (secure_dir, torznab_name, torznab_id)
+        )
+        monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
+        encrypted_module._fernet_instance = None
+        encrypted_module._fernet_secure_dir = None
+        monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+        cfg = config_module.Config(str(config_path))
+        cfg.provider_sequence = MagicMock()
+        cfg.configure = MagicMock()
+
+        with pytest.raises(ValueError, match=error):
+            cfg.read(startup=False)
+
+        cfg.provider_sequence.assert_not_called()
+        cfg.configure.assert_not_called()
+
+    def test_legacy_six_field_plaintext_provider_migrates_once(self, tmp_path, monkeypatch):
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.CONFIG_VERSION = 10
+        cfg.EXTRA_NEWZNABS = "Legacy, https://legacy.test, 1, legacy-secret, 5030, 1"
+        cfg.EXTRA_TORZNABS = ""
+        cfg.EXTRA_NEWZNABS, cfg.EXTRA_TORZNABS = cfg.get_extras()
+
+        cfg._load_provider_extra_credentials()
+
+        assert cfg.WRITE_THE_CONFIG is True
+        assert cfg.EXTRA_NEWZNABS[0][3] == "legacy-secret"
+        assert len(cfg.EXTRA_NEWZNABS[0]) == 7
+
+        cfg.CONFIG_VERSION = 15
+        config_module.config.set("General", "config_version", "15")
+        cfg.provider_sequence = MagicMock()
+        assert cfg.writeconfig(startup=True) is True
+        first = configparser.ConfigParser()
+        first.read(config_path)
+        first_storage = first.get("Newznab", "extra_newznabs")
+        first_entries = config_module.parse_provider_extras(first_storage, config_version=15)
+        assert first_entries[0][3].startswith("gAAAAA")
+        assert "legacy-secret" not in first_storage
+
+        assert cfg.writeconfig(startup=True) is True
+        second = configparser.ConfigParser()
+        second.read(config_path)
+        assert second.get("Newznab", "extra_newznabs") == first_storage
+        assert cfg.EXTRA_NEWZNABS[0][3] == "legacy-secret"
+
+    def test_provider_transaction_encrypts_at_rest_and_reloads_plaintext(self, tmp_path, monkeypatch):
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        encrypted_module = config_module.encrypted
+        encrypted_module._fernet_instance = None
+        existing_token = encrypted_module.Encryptor(
+            "existing-secret",
+            secure_dir=cfg.SECURE_DIR,
+        ).encrypt_it()["password"]
+        cfg.configure = MagicMock()
+        cfg.provider_sequence = MagicMock()
+        newznabs = [
+            ["Plain", "https://plain.test", "1", "plain-secret", "5030,5040", "1", 201],
+            ["Encrypted", "https://encrypted.test", "1", existing_token, "5070", "1", 202],
+            ["Empty", "https://empty.test", "1", "", "5000", "0", 203],
+        ]
+        torznabs = [["Legacy width", "https://tor.test", "1", "tor-secret", "5070", "1"]]
+
+        assert (
+            cfg.apply_transaction(
+                {
+                    "EXTRA_NEWZNABS": newznabs,
+                    "EXTRA_TORZNABS": torznabs,
+                }
+            )
+            is True
+        )
+        cfg.configure.assert_not_called()
+
+        persisted = configparser.ConfigParser()
+        persisted.read(config_path)
+        persisted_newznabs = config_module.parse_provider_extras(
+            persisted.get("Newznab", "extra_newznabs"),
+            config_version=cfg.CONFIG_VERSION,
+        )
+        persisted_torznabs = config_module.parse_provider_extras(
+            persisted.get("Torznab", "extra_torznabs"),
+            config_version=cfg.CONFIG_VERSION,
+        )
+        assert persisted_newznabs[0][3].startswith("gAAAAA")
+        assert persisted_newznabs[1][3] == existing_token
+        assert persisted_newznabs[2][3] == ""
+        assert persisted_newznabs[0][0:3] == ("Plain", "https://plain.test", "1")
+        assert persisted_newznabs[0][4:] == ("5030#5040", "1", "201")
+        assert persisted_torznabs[0][3].startswith("gAAAAA")
+        assert len(persisted_torznabs[0]) == 7
+        assert "plain-secret" not in config_path.read_text()
+        assert "existing-secret" not in config_path.read_text()
+        assert "tor-secret" not in config_path.read_text()
+
+        first_newznab_storage = persisted.get("Newznab", "extra_newznabs")
+        first_torznab_storage = persisted.get("Torznab", "extra_torznabs")
+        monkeypatch.setattr(config_module, "config", configparser.ConfigParser())
+        encrypted_module._fernet_instance = None
+        fresh = config_module.Config(str(config_path))
+        fresh.config_vals()
+        fresh.EXTRA_NEWZNABS, fresh.EXTRA_TORZNABS = fresh.get_extras()
+        fresh._load_provider_extra_credentials()
+
+        assert [entry[3] for entry in fresh.EXTRA_NEWZNABS] == ["plain-secret", "existing-secret", ""]
+        assert fresh.EXTRA_TORZNABS[0][3] == "tor-secret"
+        assert len(fresh.EXTRA_TORZNABS[0]) == 7
+        assert fresh.WRITE_THE_CONFIG is False
+
+        fresh.provider_sequence = MagicMock()
+        assert fresh.writeconfig(startup=True) is True
+        second = configparser.ConfigParser()
+        second.read(config_path)
+        assert second.get("Newznab", "extra_newznabs") == first_newznab_storage
+        assert second.get("Torznab", "extra_torznabs") == first_torznab_storage
+
+    def test_provider_transaction_persists_reconciled_order_in_same_write(self, tmp_path, monkeypatch):
+        cfg, config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.configure = MagicMock()
+        cfg.NEWZNAB = True
+        cfg.PROVIDER_ORDER = None
+        providers = [
+            ["First", "https://first.test", "1", "first-secret", "5030", "1", 201],
+            ["Second", "https://second.test", "1", "second-secret", "5030", "1", 202],
+        ]
+
+        assert cfg.apply_transaction({"EXTRA_NEWZNABS": providers}) is True
+
+        persisted = configparser.ConfigParser()
+        persisted.read(config_path)
+        assert persisted.get("Providers", "provider_order") == "0, First, 1, Second"
+        assert cfg.PROVIDER_ORDER == {"0": "First", "1": "Second"}
+
+        cfg.PROVIDER_ORDER = {"0": "Second", "1": "First"}
+        assert cfg.apply_transaction({"EXTRA_NEWZNABS": providers[1:]}) is True
+        persisted.read(config_path)
+        assert persisted.get("Providers", "provider_order") == "0, Second"
+        assert cfg.PROVIDER_ORDER == {"0": "Second"}
+
+    def test_failed_provider_write_never_publishes_candidate_to_concurrent_reader(self, tmp_path, monkeypatch):
+        cfg, _config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.configure = MagicMock()
+        old_providers = [("Old", "https://old.test", "1", "old-secret", "5030", "1", 100)]
+        new_providers = [["New", "https://new.test", "1", "new-secret", "5030", "1", 101]]
+        cfg.EXTRA_NEWZNABS = old_providers
+        entered_write = threading.Event()
+        release_write = threading.Event()
+        result = []
+
+        def fail_after_reader_observes(_target, _mode, _write_content, binary=False):
+            assert binary is False
+            entered_write.set()
+            assert release_write.wait(timeout=2)
+            raise OSError("replace failed")
+
+        cfg._atomic_replace_file = fail_after_reader_observes
+        worker = threading.Thread(
+            target=lambda: result.append(cfg.apply_transaction({"EXTRA_NEWZNABS": new_providers}))
+        )
+        worker.start()
+        assert entered_write.wait(timeout=2)
+        assert cfg.EXTRA_NEWZNABS is old_providers
+        release_write.set()
+        worker.join(timeout=2)
+
+        assert result == [False]
+        assert cfg.EXTRA_NEWZNABS == old_providers
+
+    def test_provider_projection_rolls_back_all_rows_when_later_upsert_fails(self, tmp_path, monkeypatch):
+        from sqlalchemy import create_engine, select
+
+        from comicarr import db as db_module
+        from comicarr.tables import provider_searches
+
+        engine = create_engine("sqlite:///:memory:")
+        provider_searches.create(engine)
+        monkeypatch.setattr(db_module, "_engine", engine)
+        cfg, _config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        del cfg.write_out_provider_searches
+        providers = [
+            ("First", "https://first.test", "1", "secret-1", "5030", "1", 201),
+            ("Second", "https://second.test", "1", "secret-2", "5030", "1", 202),
+        ]
+        real_upsert = db_module.upsert_conn
+        calls = 0
+
+        def fail_second_upsert(conn, table_name, values, controls):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise RuntimeError("second projection failed")
+            real_upsert(conn, table_name, values, controls)
+
+        monkeypatch.setattr(db_module, "upsert_conn", fail_second_upsert)
+
+        with pytest.raises(RuntimeError, match="second projection failed"):
+            cfg.write_out_provider_searches(
+                provider_order={"0": "First", "1": "Second"},
+                extra_newznabs=providers,
+                extra_torznabs=[],
+            )
+
+        with engine.connect() as conn:
+            assert conn.execute(select(provider_searches)).all() == []
+        engine.dispose()
+
+    def test_provider_projection_tolerates_stale_rows_skips_32p_and_refreshes_identity(self, tmp_path, monkeypatch):
+        from sqlalchemy import create_engine, select
+
+        from comicarr import db as db_module
+        from comicarr.tables import provider_searches
+
+        engine = create_engine("sqlite:///:memory:")
+        provider_searches.create(engine)
+        with engine.begin() as conn:
+            conn.execute(
+                provider_searches.insert(),
+                [
+                    {
+                        "id": 0,
+                        "provider": "Removed",
+                        "type": "newznab",
+                        "lastrun": 1,
+                        "active": False,
+                        "hits": 2,
+                    },
+                    {
+                        "id": 300,
+                        "provider": "Reused",
+                        "type": "newznab",
+                        "lastrun": 3,
+                        "active": True,
+                        "hits": 4,
+                    },
+                    {
+                        "id": 302,
+                        "provider": "Stale",
+                        "type": "newznab",
+                        "lastrun": 5,
+                        "active": True,
+                        "hits": 6,
+                    },
+                ],
+            )
+        monkeypatch.setattr(db_module, "_engine", engine)
+        cfg, _config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        del cfg.write_out_provider_searches
+        torznabs = [("Reused", "https://reused.test", "1", "secret", "5070", "1", 301)]
+        newznabs = [("New", "https://new.test", "1", "secret", "5030", "1", 302)]
+
+        cfg.write_out_provider_searches(
+            provider_order={"0": "32p", "1": "Reused", "2": "New"},
+            extra_newznabs=newznabs,
+            extra_torznabs=torznabs,
+        )
+
+        with engine.connect() as conn:
+            rows = {row.provider: row for row in conn.execute(select(provider_searches))}
+        assert rows["Removed"].id == 0
+        assert rows["Reused"].id == 301
+        assert rows["Reused"].type == "torznab"
+        assert rows["Reused"].lastrun == 3
+        assert rows["New"].id == 302
+        assert rows["New"].lastrun == 0
+        assert "Stale" not in rows
+        assert "32p" not in rows
+        engine.dispose()
+
+    @pytest.mark.parametrize("collision", ("cross-list", "reserved", "duplicate-name"))
+    def test_provider_transaction_rejects_global_id_collisions(self, tmp_path, monkeypatch, collision):
+        cfg, config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.configure = MagicMock()
+        newznabs = [["Newz", "https://newz.test", "1", "secret", "5030", "1", 301]]
+        values = {"EXTRA_NEWZNABS": newznabs}
+        if collision == "cross-list":
+            values["EXTRA_TORZNABS"] = [["Torz", "https://torz.test", "1", "secret", "5070", "1", 301]]
+        elif collision == "duplicate-name":
+            values["EXTRA_TORZNABS"] = [["newz", "https://torz.test", "1", "secret", "5070", "1", 302]]
+        else:
+            cfg.EXPERIMENTAL = True
+            newznabs[0][6] = 101
+        original_file = config_path.read_bytes()
+        original_runtime = cfg.EXTRA_NEWZNABS
+
+        assert cfg.apply_transaction(values) is False
+
+        assert config_path.read_bytes() == original_file
+        assert cfg.EXTRA_NEWZNABS == original_runtime
+        cfg.configure.assert_not_called()
+
+    def test_provider_transaction_rolls_back_before_projection_on_write_failure(self, tmp_path, monkeypatch):
+        cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
+        provider_events = []
+        cfg.configure = MagicMock()
+        cfg.write_out_provider_searches = MagicMock(side_effect=lambda **_kwargs: provider_events.append("projected"))
+        old_providers = [["Old", "https://old.test", "1", "old-secret", "5030", "1", 100]]
+        new_providers = [["New", "https://new.test", "1", "new-secret", "5030", "1", 101]]
+        assert cfg.apply_transaction({"EXTRA_NEWZNABS": old_providers}) is True
+        original_file = config_path.read_bytes()
+        original_runtime = cfg.EXTRA_NEWZNABS
+        cfg.configure.reset_mock()
+        cfg.write_out_provider_searches.reset_mock()
+        provider_events.clear()
+        real_replace = config_module.os.replace
+
+        def fail_config_replace(source, destination):
+            if config_module.Path(destination) == config_path:
+                raise OSError("replace failed")
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(config_module.os, "replace", fail_config_replace)
+
+        assert cfg.apply_transaction({"EXTRA_NEWZNABS": new_providers}) is False
+
+        assert cfg.EXTRA_NEWZNABS == original_runtime
+        assert config_path.read_bytes() == original_file
+        cfg.configure.assert_not_called()
+        assert provider_events == []
+
+    @pytest.mark.parametrize(
+        "providers",
+        (
+            [["Too short", "https://short.test", "1"]],
+            [["Bad token", "https://bad.test", "1", "gAAAAA-invalid", "5030", "1", 100]],
+            [["Bad legacy token", "https://bad.test", "1", "^~$z$!!!!", "5030", "1", 100]],
+            "not-a-provider-list",
+        ),
+    )
+    def test_provider_transaction_rejects_malformed_entries_without_mutation(self, tmp_path, monkeypatch, providers):
+        cfg, config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
+        cfg.configure = MagicMock()
+        original_file = config_path.read_bytes()
+        original_runtime = cfg.EXTRA_NEWZNABS
+
+        assert cfg.apply_transaction({"EXTRA_NEWZNABS": providers}) is False
+
+        assert cfg.EXTRA_NEWZNABS == original_runtime
+        assert config_path.read_bytes() == original_file
+        cfg.configure.assert_not_called()
+
     def test_legacy_cherrypy_logging_setting_is_ignored_but_preserved(self, tmp_path, monkeypatch):
         cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
         if not config_module.config.has_section("Interface"):
@@ -1087,8 +1795,8 @@ class TestConfigTransactions:
         persisted.read(config_path)
         assert persisted.getboolean("Interface", "cherrypy_logging") is True
 
-    def test_locked_value_write_processes_before_provider_sequence(self, tmp_path, monkeypatch):
-        """Provider payloads are applied before sequencing without releasing the write lock."""
+    def test_locked_scalar_write_does_not_reproject_provider_database(self, tmp_path, monkeypatch):
+        """Unrelated settings writes do not add provider database side effects."""
         cfg, _config_path, _config_module = _make_real_config(tmp_path, monkeypatch)
         events = []
         original_process = cfg.process_kwargs
@@ -1102,13 +1810,13 @@ class TestConfigTransactions:
             events.append("write")
 
         cfg.process_kwargs = tracked_process
-        cfg.provider_sequence = MagicMock(side_effect=lambda: events.append("provider_sequence"))
+        cfg.write_out_provider_searches = MagicMock(side_effect=lambda **_kwargs: events.append("provider_projection"))
         cfg._atomic_replace_file = tracked_atomic_replace
 
         assert cfg.writeconfig_values({"COMIC_DIR": "/ordered/library"}) is True
 
         assert cfg.COMIC_DIR == "/ordered/library"
-        assert events == ["process", "provider_sequence", "write"]
+        assert events == ["process", "write"]
 
     def test_writeconfig_values_restores_runtime_when_write_fails(self, tmp_path, monkeypatch):
         """Failed value writes must not leave process_kwargs mutations in memory."""


### PR DESCRIPTION
## Summary

Additional Newznab and Torznab configuration now has a truthful transactional save contract. Provider tuples are validated and staged privately, API keys are encrypted before persistence, provider order is included in the same atomic config write, the `provider_searches` projection commits in one database transaction, and runtime readers see the new providers only after both durable steps succeed. Validation and storage failures return distinct 400/500 responses instead of a false HTTP 200.

Legacy six- and seven-field provider records are parsed structurally, normalized without shifting credential columns, and migrated before provider projection or pre-upgrade backup creation. Retained config backups are sanitized, duplicate/reserved provider identities are rejected, stale projection rows are reconciled safely, and missing encryption authority fails closed without generating an unrelated replacement key.

Provider credentials are also removed from recent-log responses, carepackages, provider/search diagnostics, signed RSS/download URLs, and authorization headers through one shared redaction utility.

## Design decisions

- Provider saves use a staged file → database → runtime commit sequence. Failed file or database work restores the previous config and never publishes candidate credentials to search readers.
- Additional-provider API keys remain plaintext only in the live provider tuples; stable Fernet tokens are cached for deterministic no-op rewrites and persisted only at credential index 3.
- The master key is created mode 0600 through atomic no-replace publication, with a locked fallback for filesystems without hard-link support. File and directory metadata are fsynced before success is reported.
- Decryption is load-only: an absent `master.key` cannot silently create a replacement authority. Every existing Fernet-backed setting is validated before provider migration or historical-backup maintenance may write.
- Provider identities are unique across Newznab, Torznab, and enabled built-ins. Projection reconciliation preserves history when identities remain valid and repurposes stale ID rows explicitly when an ID is reused.
- Broad legacy `configure()` side effects are excluded from provider-only transactions; normalized provider runtime state is already the committed result.

## Release Impact

- [x] User-visible app change; patch changeset added
- [ ] No app release impact; no changeset needed

## Testing

- [x] 1,431 backend unit tests passed
- [x] 14 integration tests passed
- [x] 107 frontend tests passed
- [x] Repository-wide backend/frontend lint and format gate passed
- [x] Regressions cover 6/7-field ambiguity, plaintext/Fernet/empty values, atomic write and rollback failures, concurrent readers, durable ordering, database rollback, stale rows, duplicate/reserved identities, key concurrency/permissions/portability, missing authority, historical backups, carepackages, authorization headers, signed URLs, and correct 400/500 API responses
- [x] Independent security, transaction, and compatibility reviews found no remaining issues

## Post-Deploy Monitoring & Validation

- Save one Newznab and one Torznab provider, restart Comicarr, and confirm both providers retain their order and can search successfully.
- Inspect `config.ini` and retained `config.ini-v*.backup*` files to confirm provider API-key slots contain Fernet tokens rather than plaintext.
- Watch for `[CONFIG] Transactional update failed`, `[ENCRYPTION]`, or provider persistence 500 responses; these indicate unavailable config/database/key authority and should be resolved before retrying.
- Generate a carepackage and inspect recent logs to confirm provider tokens, authorization credentials, and signed query values are redacted.
- Roll back to the previous image if valid existing credentials fail authority preflight. Preserve `master.key` and the prior config together during rollback; never regenerate one independently.

## New concept

### Provider configuration commit boundary

A provider save is successful only after the encrypted file and provider-search database projection agree. Runtime publication is the final, non-fallible visibility step.

```mermaid
flowchart LR
    A["Validate and stage provider tuples"] --> B["Encrypt API keys"]
    B --> C["Atomic config replace and directory fsync"]
    C --> D["Single DB projection transaction"]
    D --> E{"Both durable steps succeed?"}
    E -- No --> F["Restore prior file and runtime; return 500"]
    E -- Yes --> G["Publish runtime providers and order"]
    G --> H["Return success"]
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Provider credentials are now encrypted during storage and redacted from logs, diagnostics, and configuration backups.
  * Maintenance packages safely remove sensitive provider tokens and secrets.

* **Bug Fixes**
  * Provider configuration updates now validate input and report persistence failures accurately.
  * Configuration writes offer improved transactional rollback and filesystem durability.
  * Missing encryption keys no longer trigger unintended replacement keys.

* **Reliability**
  * Provider credentials are handled more safely across migrations, concurrent access, and legacy configurations.
  * Search and download error logs no longer expose signed links or authentication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->