### PR TITLE
fix(ui): improve error recovery screen

### DIFF
--- a/.changeset/recovering-error-boundary.md
+++ b/.changeset/recovering-error-boundary.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Improve the application error recovery screen with clearer guidance and reload controls.

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface ErrorBoundaryProps {
@@ -45,24 +46,66 @@ class ErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      // Fallback UI
       return (
-        <div className="min-h-screen flex items-center justify-center bg-gray-50">
-          <div className="max-w-md w-full space-y-8 p-8 bg-white rounded-lg shadow-lg">
-            <div className="text-center">
-              <h1 className="text-3xl font-bold text-red-600 mb-4">
-                Something went wrong
+        <main className="relative grid min-h-screen place-items-center overflow-hidden bg-background px-5 py-8 sm:p-8">
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-[radial-gradient(circle_at_25%_10%,color-mix(in_oklab,var(--primary)_13%,transparent),transparent_32rem)]"
+          />
+          <section
+            aria-labelledby="error-heading"
+            className="relative grid w-full max-w-3xl overflow-hidden rounded-xl border border-border bg-card shadow-2xl shadow-black/10 md:grid-cols-[10.5rem_1fr]"
+          >
+            <div className="flex min-h-36 flex-col justify-between bg-[var(--primary)] px-6 py-5 text-primary-foreground md:min-h-full">
+              <div className="flex items-center justify-between md:block">
+                <span className="font-mono text-[10px] font-medium tracking-[0.18em] text-primary-foreground/80">
+                  COMICARR
+                </span>
+                <span className="font-mono text-[10px] font-medium tracking-[0.18em] text-primary-foreground/80 md:mt-2 md:block">
+                  RECOVERY
+                </span>
+              </div>
+              <AlertTriangle
+                aria-hidden="true"
+                className="hidden h-12 w-12 stroke-[1.5] md:block"
+              />
+              <span className="hidden font-mono text-[10px] tracking-[0.18em] text-primary-foreground/80 md:block">
+                SCREEN 01
+              </span>
+            </div>
+
+            <div className="p-6 sm:p-8 md:p-10">
+              <p className="mono-label text-[var(--status-error)]">App error</p>
+              <h1
+                id="error-heading"
+                className="mt-3 max-w-lg text-2xl font-semibold leading-tight text-foreground sm:text-3xl"
+              >
+                This screen needs a fresh start.
               </h1>
-              <p className="text-gray-600 mb-6">
-                An unexpected error occurred. Please try reloading the page.
+              <p className="mt-4 max-w-xl text-sm leading-6 text-muted-foreground sm:text-base">
+                Comicarr ran into a problem while rendering this page. Reload to
+                start it again; this action does not change your library or
+                settings.
               </p>
 
+              <div className="mt-7 border-y border-border py-4">
+                <p className="font-mono text-[11px] leading-5 text-muted-foreground">
+                  If this keeps happening, check the browser console or server
+                  logs for more information.
+                </p>
+              </div>
+
               {import.meta.env.DEV && this.state.error && (
-                <details className="text-left mb-6 p-4 bg-gray-100 rounded">
-                  <summary className="cursor-pointer font-semibold text-sm">
-                    Error details (development only)
+                <details className="group mt-6 rounded-md border border-border bg-muted/40 px-4 py-3 text-left">
+                  <summary className="cursor-pointer list-none font-mono text-[11px] font-medium text-foreground marker:content-none">
+                    <span className="inline-flex items-center gap-2">
+                      <span className="text-muted-foreground transition-transform group-open:rotate-90">
+                        ›
+                      </span>
+                      Development error details
+                    </span>
                   </summary>
-                  <pre className="mt-2 text-xs overflow-auto">
+                  <pre className="mt-3 max-h-48 overflow-auto whitespace-pre-wrap break-words border-t border-border pt-3 font-mono text-[11px] leading-5 text-muted-foreground">
                     {this.state.error.toString()}
                     {"\n\n"}
                     {this.state.errorInfo?.componentStack}
@@ -70,12 +113,17 @@ class ErrorBoundary extends React.Component<
                 </details>
               )}
 
-              <Button onClick={this.handleReload} className="w-full">
-                Reload Page
+              <Button
+                onClick={this.handleReload}
+                className="mt-7 w-full sm:w-auto"
+                size="lg"
+              >
+                <RefreshCw aria-hidden="true" />
+                Reload Comicarr
               </Button>
             </div>
-          </div>
-        </div>
+          </section>
+        </main>
       );
     }
 

--- a/frontend/tests/components/ErrorBoundary.test.tsx
+++ b/frontend/tests/components/ErrorBoundary.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderMinimal } from "../test-utils";
+import ErrorBoundary from "@/components/ErrorBoundary";
+
+function ThrowError(): never {
+  throw new Error("Unable to render issue shelf");
+}
+
+describe("ErrorBoundary", () => {
+  it("shows a clear recovery state when a child component fails", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    renderMinimal(
+      <ErrorBoundary>
+        <ThrowError />
+      </ErrorBoundary>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "This screen needs a fresh start." }),
+    ).toBeTruthy();
+    expect(screen.getByText("App error")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Reload Comicarr" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/does not change your library or settings/i),
+    ).toBeTruthy();
+  });
+
+  it("reloads the application from the recovery action", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const reload = vi.spyOn(window.location, "reload");
+    const user = userEvent.setup();
+
+    renderMinimal(
+      <ErrorBoundary>
+        <ThrowError />
+      </ErrorBoundary>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reload Comicarr" }));
+
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

When the app hits an unexpected rendering error, people now get a readable recovery screen instead of a low-contrast generic modal. The new screen explains the impact, provides a clear reload action, preserves development diagnostics, and does not imply that reloading changes library data or settings.

## Changes

- Rebuilt the global React error boundary with Comicarr's responsive theme and accessible recovery affordances.
- Added regression coverage for the fallback state and reload control.

## Release Impact

- [x] User-visible app change; patch changeset added.

## Testing

- [x] `cd frontend && npm run test:run` (115 tests)
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run format:check`
- [x] `cd frontend && npm run typecheck`
- [x] `cd frontend && npm run build`

## Screenshots

No screenshot captured; coverage exercises the error fallback and reload action.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a client-side presentation and recovery-flow update; validate by triggering an error boundary in a development environment and confirming the recovery action reloads the app.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned error recovery screen with clearer guidance and improved visual styling.
  * Added a prominent “Reload Comicarr” control to help recover from application errors.
  * Added development-only expandable error details for troubleshooting.

* **Tests**
  * Added coverage verifying the recovery screen and reload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->