### PR TITLE
fix(manga): restore MAL imports and inbox matching

### DIFF
--- a/.changeset/repair-manga-imports.md
+++ b/.changeset/repair-manga-imports.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Restore manga covers and chapter rows when adding MAL series, and fix library inbox matching so scanned manga files can be processed.

--- a/comicarr/filechecker.py
+++ b/comicarr/filechecker.py
@@ -2408,9 +2408,9 @@ def validateAndCreateDirectory(dir, create=False, module=None, dmode=None):
             logger.info("%s Found %s directory: %s" % (module, dirmode, dir))
             return True
         else:
-            logger.warn("%s Could not find %s directory: %s" % (module, dirmode, dir))
             if create:
                 if dir.strip():
+                    logger.info("%s %s directory does not exist yet: %s" % (module, dirmode.capitalize(), dir))
                     logger.info(
                         "%s Creating %s directory (%s) : %s" % (module, dirmode, comicarr.CONFIG.CHMOD_DIR, dir)
                     )
@@ -2438,6 +2438,8 @@ def validateAndCreateDirectory(dir, create=False, module=None, dmode=None):
                 else:
                     logger.warn("%s Provided directory [%s] is blank. Aborting." % (module, dir))
                     return False
+            else:
+                logger.warn("%s Could not find %s directory: %s" % (module, dirmode, dir))
     except OSError as e:
         logger.warn("%s Could not create directory: %s [%s]. Aborting." % (module, dir, e))
         return False

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -1082,6 +1082,50 @@ def addComictoDB(
 #                myDB.upsert("importresults", newValue, controlValue)
 
 
+def _upsert_placeholder_manga_chapters(mangaid, manga_name, total):
+    """Create deterministic placeholder rows for missing integer chapters."""
+    if total <= 0:
+        return 0
+
+    existing_chapters = set()
+    rows = db.select_all(
+        select(issues.c.Int_IssueNumber, issues.c.ChapterNumber, issues.c.Issue_Number).where(
+            issues.c.ComicID == mangaid
+        )
+    )
+    for row in rows:
+        int_issue_number = row.get("Int_IssueNumber")
+        if int_issue_number is None:
+            chapter_number = row.get("ChapterNumber") or row.get("Issue_Number")
+            if chapter_number is not None:
+                int_issue_number = helpers.issuedigits(str(chapter_number))
+        if int_issue_number is not None:
+            existing_chapters.add(int_issue_number)
+
+    created = 0
+    for chapter_number in range(1, total + 1):
+        chapter_number_str = str(chapter_number)
+        if helpers.issuedigits(chapter_number_str) in existing_chapters:
+            continue
+
+        placeholder_id = "%s-ch%s" % (mangaid, chapter_number_str)
+        placeholder_values = {
+            "IssueID": placeholder_id,
+            "ComicID": mangaid,
+            "ComicName": manga_name,
+            "Issue_Number": chapter_number_str,
+            "IssueName": "Chapter %s" % chapter_number_str,
+            "Status": "Skipped",
+            "Int_IssueNumber": helpers.issuedigits(chapter_number_str),
+            "ChapterNumber": chapter_number_str,
+            "DateAdded": helpers.now(),
+        }
+        db.upsert("issues", placeholder_values, {"IssueID": placeholder_id})
+        created += 1
+
+    return created
+
+
 def _populate_manga_chapters(mangaid, manga_name, mangadex_uuid, mal_num_chapters, controlValueDict):
     """Shared helper: fetch chapters and set Total/Have for a manga series.
 
@@ -1177,38 +1221,6 @@ def _populate_manga_chapters(mangaid, manga_name, mangadex_uuid, mal_num_chapter
         if total_from_aggregate > 0:
             total = max(total_from_aggregate, issue_count)
 
-            # Generate placeholder issues for chapters not in the language-filtered set
-            if total_from_aggregate > issue_count:
-                existing_chapters = set()
-                with db.get_engine().connect() as conn:
-                    stmt = select(issues.c.ChapterNumber).where(issues.c.ComicID == mangaid)
-                    for row in conn.execute(stmt):
-                        if row[0]:
-                            existing_chapters.add(str(row[0]))
-
-                for ch_num in range(1, total_from_aggregate + 1):
-                    ch_num_str = str(ch_num)
-                    if ch_num_str in existing_chapters:
-                        continue
-
-                    placeholder_id = "%s-ch%s" % (mangaid, ch_num_str)
-                    placeholder_values = {
-                        "IssueID": placeholder_id,
-                        "ComicID": mangaid,
-                        "ComicName": manga_name,
-                        "Issue_Number": ch_num_str,
-                        "IssueName": "Chapter %s" % ch_num_str,
-                        "Status": "Skipped",
-                        "Int_IssueNumber": helpers.issuedigits(ch_num_str),
-                        "ChapterNumber": ch_num_str,
-                        "DateAdded": helpers.now(),
-                    }
-                    db.upsert("issues", placeholder_values, {"IssueID": placeholder_id})
-
-                logger.info(
-                    "[MANGA-IMPORT] Generated %d placeholder chapters for %s (aggregate total: %d, language-filtered: %d)"
-                    % (total_from_aggregate - issue_count, manga_name, total_from_aggregate, issue_count)
-                )
         else:
             total = issue_count
     else:
@@ -1222,6 +1234,13 @@ def _populate_manga_chapters(mangaid, manga_name, mangadex_uuid, mal_num_chapter
             logger.info("[MANGA-IMPORT] Using MAL chapter count for %s: %d" % (manga_name, total))
         except (ValueError, TypeError):
             logger.error("[MANGA-IMPORT] Invalid MAL chapter count for %s: %s" % (manga_name, mal_num_chapters))
+
+    placeholder_count = _upsert_placeholder_manga_chapters(mangaid, manga_name, total)
+    if placeholder_count:
+        logger.info(
+            "[MANGA-IMPORT] Generated %d missing placeholder chapters for %s (total: %d, detailed: %d)"
+            % (placeholder_count, manga_name, total, issue_count)
+        )
 
     # Always set Total/Have — never leave as NULL
     update_values = {
@@ -1478,7 +1497,11 @@ def addMangaToDB_MAL(mangaid, imported=None, calledfrom=None):
     comic_published = status_mapping.get(md_status, "Unknown")
 
     # Resolve MangaDex UUID for chapter data
-    mangadex_uuid = mangadex.find_by_mal_id(mal_numeric_id, title_hint=manga_name)
+    mangadex_uuid = mangadex.find_by_mal_id(
+        mal_numeric_id,
+        title_hint=manga_name,
+        alternate_titles=manga.get("alt_titles", []),
+    )
 
     # Prepare comic values
     comic_values = {

--- a/comicarr/importinbox.py
+++ b/comicarr/importinbox.py
@@ -199,7 +199,7 @@ def _load_library_series():
                 comics.c.ComicID,
                 comics.c.ComicName,
                 comics.c.ComicSortName,
-                comics.c.DynamicName,
+                comics.c.DynamicComicName.label("DynamicName"),
             )
             for row in conn.execute(stmt):
                 series_list.append(dict(row._mapping))

--- a/comicarr/mangadex.py
+++ b/comicarr/mangadex.py
@@ -95,6 +95,17 @@ def _make_request(endpoint, params=None, method="GET"):
     except requests.exceptions.Timeout:
         logger.error("[MANGADEX] Request timeout for %s" % endpoint)
         return None
+    except requests.exceptions.HTTPError as e:
+        response = e.response
+        status_code = response.status_code if response is not None else "unknown"
+        request_id = response.headers.get("x-request-id", "unknown") if response is not None else "unknown"
+        detail = response.text if response is not None else str(e)
+        detail = " ".join(str(detail).split())[:400]
+        logger.error(
+            "[MANGADEX] HTTP %s for %s (request-id: %s): %s"
+            % (status_code, endpoint, request_id, detail or "No response body")
+        )
+        return None
     except requests.exceptions.RequestException as e:
         logger.error("[MANGADEX] Request failed: %s" % e)
         return None
@@ -489,15 +500,17 @@ def get_manga_details(manga_id):
     return details
 
 
-def find_by_mal_id(mal_id, title_hint=None):
+def find_by_mal_id(mal_id, title_hint=None, alternate_titles=None):
     """Find MangaDex manga UUID by its MyAnimeList ID.
 
-    Searches MangaDex by title and checks each result's links.mal field
-    to find the matching entry.
+    Searches MangaDex by the primary and alternate MAL titles, then checks
+    each result's links.mal field to find the matching entry.
 
     Args:
         mal_id: MAL numeric ID (string or int, without mal- prefix)
         title_hint: Manga title to search MangaDex with
+        alternate_titles: Optional alternate titles to try if the primary
+            lookup fails or does not return an exact MAL link match
 
     Returns:
         MangaDex manga UUID (string) or None if not found
@@ -506,56 +519,72 @@ def find_by_mal_id(mal_id, title_hint=None):
     if mal_id_str.startswith("mal-"):
         mal_id_str = mal_id_str[4:]
 
-    if not title_hint:
+    raw_titles = [title_hint]
+    if alternate_titles:
+        if isinstance(alternate_titles, str):
+            raw_titles.append(alternate_titles)
+        else:
+            raw_titles.extend(alternate_titles)
+
+    title_hints = []
+    seen_titles = set()
+    for title in raw_titles:
+        title = str(title).strip() if title else ""
+        normalized = title.casefold()
+        if not title or normalized in seen_titles:
+            continue
+        seen_titles.add(normalized)
+        title_hints.append(title)
+
+    title_hints = title_hints[:6]
+    if not title_hints:
         logger.warn("[MANGADEX] find_by_mal_id called without title_hint for MAL %s" % mal_id_str)
         return None
 
-    logger.info("[MANGADEX] Looking up MangaDex UUID for MAL ID %s (title: %s)" % (mal_id_str, title_hint))
+    logger.info("[MANGADEX] Looking up MangaDex UUID for MAL ID %s using %d title(s)" % (mal_id_str, len(title_hints)))
 
-    params = {
-        "title": title_hint,
-        "limit": 10,
-        "includes[]": ["cover_art"],
-        "contentRating[]": _get_content_ratings(),
-        "order[relevance]": "desc",
-    }
-
-    data = _make_request("/manga", params=params)
-    if not data or data.get("result") != "ok":
-        return None
-
-    # First pass: exact MAL ID match via links
-    for manga in data.get("data", []):
-        links = manga.get("attributes", {}).get("links", {})
-        if str(links.get("mal", "")) == mal_id_str:
-            manga_uuid = manga.get("id")
-            logger.info("[MANGADEX] Found MAL %s -> MangaDex %s (via links.mal)" % (mal_id_str, manga_uuid))
-            return manga_uuid
-
-    # Second pass: fuzzy title match as fallback
-    from comicarr.mangasync import _name_similarity
+    from comicarr.scanutil import name_similarity
 
     best_uuid = None
     best_score = 0.0
-    for manga in data.get("data", []):
-        attributes = manga.get("attributes", {})
-        candidate_title = _get_localized_string(attributes.get("title", {}))
-        if not candidate_title:
+    for search_title in title_hints:
+        params = {
+            "title": search_title,
+            "limit": 10,
+            "contentRating[]": _get_content_ratings(),
+            "order[relevance]": "desc",
+        }
+        data = _make_request("/manga", params=params)
+        if not data or data.get("result") != "ok":
+            logger.warn(
+                "[MANGADEX] MAL %s lookup failed for title '%s'; trying remaining titles" % (mal_id_str, search_title)
+            )
             continue
 
-        # Check primary title
-        score = _name_similarity(title_hint, candidate_title)
+        # Prefer an authoritative external-ID match over all title scoring.
+        for manga in data.get("data", []):
+            links = manga.get("attributes", {}).get("links", {})
+            if str(links.get("mal", "")) == mal_id_str:
+                manga_uuid = manga.get("id")
+                logger.info("[MANGADEX] Found MAL %s -> MangaDex %s (via links.mal)" % (mal_id_str, manga_uuid))
+                return manga_uuid
 
-        # Check alt titles too
-        for alt in attributes.get("altTitles", []):
-            alt_title = _get_localized_string(alt)
-            if alt_title:
-                alt_score = _name_similarity(title_hint, alt_title)
-                score = max(score, alt_score)
+        # Retain the best fuzzy candidate, but wait until every title has had
+        # a chance to produce an exact MAL link match before returning it.
+        for manga in data.get("data", []):
+            attributes = manga.get("attributes", {})
+            candidate_titles = [_get_localized_string(attributes.get("title", {}))]
+            candidate_titles.extend(_get_localized_string(alt) for alt in attributes.get("altTitles", []))
 
-        if score > best_score:
-            best_score = score
-            best_uuid = manga.get("id")
+            score = 0.0
+            for hint in title_hints:
+                for candidate_title in candidate_titles:
+                    if candidate_title:
+                        score = max(score, name_similarity(hint, candidate_title))
+
+            if score > best_score:
+                best_score = score
+                best_uuid = manga.get("id")
 
     if best_uuid and best_score >= 0.6:
         logger.info(

--- a/comicarr/myanimelist.py
+++ b/comicarr/myanimelist.py
@@ -301,7 +301,10 @@ def get_manga_details(mal_id):
 
     # Extract images
     main_picture = data.get("main_picture", {})
-    cover_url = _proxy_image_url(main_picture.get("large") or main_picture.get("medium") or "")
+    # Detail payloads are consumed by the backend importer, which needs an
+    # absolute provider URL to cache the image. Search payloads proxy this URL
+    # separately for browser display.
+    cover_url = main_picture.get("large") or main_picture.get("medium") or ""
 
     # Extract year
     start_date = data.get("start_date", "")

--- a/tests/unit/test_filechecker_directories.py
+++ b/tests/unit/test_filechecker_directories.py
@@ -1,3 +1,12 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
 """Directory creation logging regressions."""
 
 from unittest.mock import MagicMock, patch

--- a/tests/unit/test_filechecker_directories.py
+++ b/tests/unit/test_filechecker_directories.py
@@ -1,0 +1,40 @@
+"""Directory creation logging regressions."""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_missing_directory_requested_for_creation_is_not_warned(tmp_path):
+    from comicarr import filechecker
+
+    destination = tmp_path / "new-series"
+    config = MagicMock()
+    config.ENFORCE_PERMS = False
+    config.CHMOD_DIR = "0777"
+
+    with patch("comicarr.CONFIG", config), patch("comicarr.filechecker.logger") as mock_logger:
+        result = filechecker.validateAndCreateDirectory(str(destination), create=True)
+
+    assert result is True
+    assert destination.is_dir()
+    warning_text = " ".join(str(part) for call in mock_logger.warn.call_args_list for part in call.args)
+    assert "Could not find comic directory" not in warning_text
+
+
+def test_directory_creation_failure_still_warns(tmp_path):
+    from comicarr import filechecker
+
+    destination = tmp_path / "uncreatable"
+    config = MagicMock()
+    config.ENFORCE_PERMS = False
+    config.CHMOD_DIR = "0777"
+
+    with (
+        patch("comicarr.CONFIG", config),
+        patch("comicarr.filechecker.logger") as mock_logger,
+        patch("comicarr.filechecker.os.makedirs", side_effect=OSError("permission denied")),
+    ):
+        result = filechecker.validateAndCreateDirectory(str(destination), create=True)
+
+    assert result is False
+    warning_text = " ".join(str(part) for call in mock_logger.warn.call_args_list for part in call.args)
+    assert "Could not create directory" in warning_text

--- a/tests/unit/test_importinbox.py
+++ b/tests/unit/test_importinbox.py
@@ -125,6 +125,31 @@ class TestCollectFileGroups:
         assert result == {}
 
 
+class TestLoadLibrarySeries:
+    """Tests for loading the library fields used by inbox matching."""
+
+    def test_uses_dynamic_comic_name_as_dynamic_name(self, importinbox, _mock_globals):
+        mock_row = MagicMock()
+        mock_row._mapping = {
+            "ComicID": "mal-100",
+            "ComicName": "One Piece",
+            "ComicSortName": "One Piece",
+            "DynamicName": "one piece",
+        }
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value = [mock_row]
+        mock_engine = MagicMock()
+        mock_engine.connect.return_value.__enter__ = lambda _context: mock_conn
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+        _mock_globals["db"].get_engine.return_value = mock_engine
+
+        result = importinbox._load_library_series()
+
+        assert result == [dict(mock_row._mapping)]
+        stmt = mock_conn.execute.call_args.args[0]
+        assert stmt.selected_columns.DynamicName.element.name == "DynamicComicName"
+
+
 class TestMatchGroup:
     """Tests for _match_group — matching file groups against library."""
 

--- a/tests/unit/test_manga_import_regressions.py
+++ b/tests/unit/test_manga_import_regressions.py
@@ -1,0 +1,142 @@
+"""Regression coverage for manga import failures reported in issue #278."""
+
+from unittest.mock import MagicMock, patch
+
+import requests
+
+
+def _mal_payload():
+    return {
+        "id": 13,
+        "title": "One Piece",
+        "main_picture": {"large": "https://cdn.myanimelist.net/images/manga/2/253146l.jpg"},
+        "alternative_titles": {"en": "One Piece", "ja": "ONE PIECE", "synonyms": []},
+        "start_date": "1997-07-22",
+        "status": "currently_publishing",
+        "synopsis": "Pirates",
+        "num_chapters": 0,
+        "num_volumes": 0,
+        "authors": [],
+        "genres": [],
+        "media_type": "manga",
+    }
+
+
+class TestMalCoverUrls:
+    @patch("comicarr.myanimelist._make_request")
+    def test_detail_cover_url_stays_absolute_for_backend_caching(self, mock_request):
+        from comicarr import myanimelist
+
+        mock_request.return_value = _mal_payload()
+
+        result = myanimelist.get_manga_details("mal-13")
+
+        assert result["cover_url"] == "https://cdn.myanimelist.net/images/manga/2/253146l.jpg"
+
+    @patch("comicarr.myanimelist.listLibrary", return_value={})
+    @patch("comicarr.myanimelist._make_request")
+    def test_search_cover_url_remains_browser_proxied(self, mock_request, _mock_library):
+        from comicarr import myanimelist
+
+        mock_request.return_value = {"data": [{"node": _mal_payload()}], "paging": {}}
+
+        result = myanimelist.search_manga("One Piece")
+
+        assert result["results"][0]["comicimage"].startswith("/api/metadata/image-proxy?url=")
+
+
+class TestMangaDexMalMatching:
+    @patch("comicarr.mangadex._make_request")
+    def test_alternate_title_recovers_after_primary_lookup_failure(self, mock_request):
+        from comicarr import mangadex
+
+        mock_request.side_effect = [
+            None,
+            {
+                "result": "ok",
+                "data": [
+                    {
+                        "id": "a1c7c817-4e59-43b7-9365-09675a149a6f",
+                        "attributes": {"title": {"ja": "ワンピース"}, "altTitles": [], "links": {"mal": "13"}},
+                    }
+                ],
+            },
+        ]
+
+        result = mangadex.find_by_mal_id("13", title_hint="One Piece", alternate_titles=["ワンピース"])
+
+        assert result == "a1c7c817-4e59-43b7-9365-09675a149a6f"
+        assert [call.kwargs["params"]["title"] for call in mock_request.call_args_list] == ["One Piece", "ワンピース"]
+
+    @patch("comicarr.mangadex._make_request")
+    def test_exact_mal_link_outranks_earlier_fuzzy_title_match(self, mock_request):
+        from comicarr import mangadex
+
+        mock_request.side_effect = [
+            {
+                "result": "ok",
+                "data": [
+                    {
+                        "id": "fuzzy-candidate",
+                        "attributes": {"title": {"en": "One Piece"}, "altTitles": [], "links": {}},
+                    }
+                ],
+            },
+            {
+                "result": "ok",
+                "data": [
+                    {
+                        "id": "exact-candidate",
+                        "attributes": {"title": {"ja": "ワンピース"}, "altTitles": [], "links": {"mal": "13"}},
+                    }
+                ],
+            },
+        ]
+
+        result = mangadex.find_by_mal_id("13", title_hint="One Piece", alternate_titles=["ワンピース"])
+
+        assert result == "exact-candidate"
+
+    @patch("comicarr.mangadex._rate_limit")
+    @patch("comicarr.mangadex.logger")
+    @patch("comicarr.mangadex.requests.get")
+    def test_bad_request_logs_bounded_provider_details(self, mock_get, mock_logger, _mock_rate_limit):
+        from comicarr import mangadex
+
+        response = MagicMock()
+        response.status_code = 400
+        response.text = "invalid parameter: " + ("x" * 1000)
+        response.headers = {"x-request-id": "request-278"}
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("400 Client Error", response=response)
+        mock_get.return_value = response
+
+        result = mangadex._make_request("/manga", params={"title": "One Piece"})
+
+        assert result is None
+        message = " ".join(str(part) for call in mock_logger.error.call_args_list for part in call.args)
+        assert "request-278" in message
+        assert "invalid parameter" in message
+        assert len(message) < 800
+
+
+class TestMangaChapterFallback:
+    @patch("comicarr.importer.db")
+    @patch("comicarr.CONFIG")
+    def test_mal_total_creates_only_missing_placeholder_chapters(self, mock_config, mock_db):
+        from comicarr import importer
+
+        mock_config.MANGADEX_LANGUAGES = "en"
+        mock_db.select_all.return_value = [{"Int_IssueNumber": 1000, "ChapterNumber": "1.0", "Issue_Number": "1.0"}]
+
+        result = importer._populate_manga_chapters(
+            "mal-13",
+            "One Piece",
+            mangadex_uuid=None,
+            mal_num_chapters="3",
+            controlValueDict={"ComicID": "mal-13"},
+        )
+
+        issue_upserts = [call.args[1] for call in mock_db.upsert.call_args_list if call.args[0] == "issues"]
+        assert [values["IssueID"] for values in issue_upserts] == ["mal-13-ch2", "mal-13-ch3"]
+        assert all(values["Status"] == "Skipped" for values in issue_upserts)
+        assert result["total"] == 3

--- a/tests/unit/test_manga_import_regressions.py
+++ b/tests/unit/test_manga_import_regressions.py
@@ -1,3 +1,12 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
 """Regression coverage for manga import failures reported in issue #278."""
 
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary

MAL manga imports once again keep cacheable cover URLs, populate missing chapter rows for rescans, and match files from the import inbox. MangaDex matching now tries MAL alternate titles, favors authoritative MAL links over fuzzy candidates, and records bounded provider diagnostics when a lookup fails. Expected directory creation is logged as normal progress while real creation and permission failures remain warnings.

The chapter repair uses the final MangaDex or MAL total to fill only missing integer chapters, preserving detailed MangaDex rows and deterministic issue IDs.

## Validation

- Full backend unit suite in a clean worktree: 1,477 passed
- Focused manga, inbox, and directory regressions: 25 passed
- Repository-wide `npm run lint`
- `uv lock --check`
- `python3 Comicarr.py --help`
- Changeset status confirms a patch release

## Post-Deploy Monitoring & Validation

- For the first release cycle, review `[MANGADEX] HTTP`, `[MANGADEX] Found MAL`, and `[MANGA-IMPORT] Generated` log entries during MAL additions and rescans.
- Confirm imported MAL series retain a cover, contain the expected chapter total, and do not replace detailed MangaDex chapter metadata with placeholders.
- Review `[IMPORT-INBOX] Scan complete` and `[IMPORT-INBOX] Error loading library series` after the first scheduled and manual inbox scans.
- Healthy signal: MAL additions complete, missing rows are generated once, subsequent rescans are idempotent, and inbox scans match library series without database-column errors.
- Roll back this commit if chapter totals generate repeated placeholders, covers fail to cache, or inbox scans report library-loading failures. Repository maintainer owns validation during the first 24 hours after deployment.

Fixes #278.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored manga cover images and chapter rows when adding series from MyAnimeList.
  * Improved matching so scanned manga files are correctly associated with library entries.
  * Added missing placeholder chapters when imported series report more chapters than available details.
  * Improved MangaDex matching using alternate titles and exact MyAnimeList links.
  * Improved error reporting for MangaDex request failures.
  * Preserved appropriate image URLs for imports and search results.
  * Clarified directory creation warnings and failure handling.

* **Tests**
  * Added regression coverage for manga imports, title matching, chapter fallback, image URLs, directory handling, and library matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->