### PR TITLE
fix: restore legacy MAL manga covers

### DIFF
--- a/.changeset/restore-mal-manga-covers.md
+++ b/.changeset/restore-mal-manga-covers.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Restore legacy MyAnimeList manga covers by normalizing provider image URLs to the MAL CDN.

--- a/comicarr/app/metadata/image_fetch.py
+++ b/comicarr/app/metadata/image_fetch.py
@@ -42,22 +42,33 @@ MAX_IMAGE_BYTES = 10 * 1024 * 1024  # 10 MiB
 _CHUNK_SIZE = 64 * 1024
 
 
-def is_allowed_image_url(url):
-    """Return True if url is http(s), no userinfo, and host is allowlisted."""
+def normalize_allowed_image_url(url):
+    """Return a normalized allowlisted image URL, or None when unsafe."""
     if not url or not isinstance(url, str):
-        return False
+        return None
     try:
         parsed = urlparse(url)
     except Exception as e:
         logger.fdebug("[METADATA-artwork] Invalid URL parse: %s" % e)
-        return False
+        return None
     if parsed.scheme not in ("http", "https"):
-        return False
+        return None
     if parsed.username or parsed.password:
-        return False
+        return None
     if not parsed.hostname:
-        return False
-    return parsed.hostname in ALLOWED_IMAGE_DOMAINS
+        return None
+    if parsed.hostname not in ALLOWED_IMAGE_DOMAINS:
+        return None
+
+    if parsed.hostname == "myanimelist.net" and parsed.path.startswith("/images/"):
+        return parsed._replace(scheme="https", netloc="cdn.myanimelist.net").geturl()
+
+    return url
+
+
+def is_allowed_image_url(url):
+    """Return True if url is http(s), no userinfo, and host is allowlisted."""
+    return normalize_allowed_image_url(url) is not None
 
 
 def fetch_allowed_image(url):
@@ -66,13 +77,14 @@ def fetch_allowed_image(url):
     Returns (content_bytes, content_type) or None on any failure.
     Streams the body and aborts once MAX_IMAGE_BYTES would be exceeded.
     """
-    if not is_allowed_image_url(url):
+    request_url = normalize_allowed_image_url(url)
+    if request_url is None:
         logger.fdebug("[METADATA-artwork] Rejected non-allowlisted image URL: %s" % url)
         return None
 
     try:
         resp = requests.get(
-            url,
+            request_url,
             timeout=(5, 10),
             headers={"User-Agent": "Comicarr/1.0"},
             allow_redirects=False,

--- a/tests/unit/test_metadata_domain.py
+++ b/tests/unit/test_metadata_domain.py
@@ -383,6 +383,18 @@ class TestImageFetch:
             assert is_allowed_image_url("https://%s/cover.jpg" % host) is True
 
     @patch("comicarr.app.metadata.image_fetch.requests.get")
+    def test_fetch_normalizes_legacy_mal_image_url_to_cdn(self, mock_get):
+        from comicarr.app.metadata.image_fetch import fetch_allowed_image
+
+        jpeg = _jpeg_bytes()
+        mock_get.return_value = _mock_image_response(jpeg)
+
+        result = fetch_allowed_image("https://myanimelist.net/images/manga/5/260006l.webp")
+
+        assert result == (jpeg, "image/jpeg")
+        assert mock_get.call_args.args[0] == "https://cdn.myanimelist.net/images/manga/5/260006l.webp"
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
     def test_fetch_rejects_non_200(self, mock_get):
         from comicarr.app.metadata.image_fetch import fetch_allowed_image
 


### PR DESCRIPTION
## Summary

Manga entries saved with older MyAnimeList artwork URLs now render covers again instead of broken-image placeholders. Comicarr recognizes only MAL's known `/images/` alias and rewrites it to the HTTPS `cdn.myanimelist.net` endpoint, while arbitrary redirects stay disabled so the image proxy remains fail-closed.

Related: #278

## Validation

- `pytest tests/unit/test_metadata_domain.py -q` — 41 passed
- `npm run lint` — passed
- A real legacy MAL image URL fetched successfully through the normalized CDN endpoint
- Full unit suite: 1,477 passed; the one unrelated existing failure comes from ignored `.worktrees/` content containing a Latin-1 file that the repository-wide source scan decodes as UTF-8

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored legacy MyAnimeList manga covers by automatically routing supported image URLs through the MyAnimeList CDN.
  * Improved image URL validation while preserving existing security and file-size checks.

* **Tests**
  * Added coverage verifying legacy MyAnimeList image URLs are normalized correctly before fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->