### PR TITLE
fix: Repair Library filters and unify table action bar

### DIFF
--- a/.changeset/library-filters-action-bar.md
+++ b/.changeset/library-filters-action-bar.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix Library filters (empty dropdowns, double chevrons, broken search) and unify view toggle, search, and filter chips into one action bar.

--- a/frontend/src/components/series/SeriesFilters.tsx
+++ b/frontend/src/components/series/SeriesFilters.tsx
@@ -1,4 +1,3 @@
-import { ChevronDown } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -41,7 +40,7 @@ function FilterChip({
   return (
     <Select value={value} onValueChange={onValueChange}>
       <SelectTrigger
-        className={`h-auto py-[3px] px-2 rounded-full font-mono text-[11px] gap-1.5 w-auto shadow-none transition-colors ${
+        className={`h-auto py-[3px] px-2 rounded-full font-mono text-[11px] gap-1.5 w-auto shadow-none transition-colors [&_svg]:h-3 [&_svg]:w-3 ${
           active
             ? "border-primary/60 text-primary bg-primary/10"
             : "border-border text-muted-foreground hover:text-foreground"
@@ -49,7 +48,6 @@ function FilterChip({
       >
         <span className="text-muted-foreground/60">{label}:</span>
         <span>{display}</span>
-        <ChevronDown className="w-3 h-3 opacity-60" />
       </SelectTrigger>
       <SelectContent>
         {options.map((o) => (
@@ -81,10 +79,6 @@ export default function SeriesFilters({
 
   return (
     <div className="flex flex-wrap items-center gap-2 font-mono text-[11px]">
-      <span className="text-muted-foreground/60 uppercase tracking-wider pr-1">
-        filter
-      </span>
-
       {showTypeFilter && (
         <FilterChip
           label="type"

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -328,7 +328,8 @@ export default function SeriesTable({
           <button
             type="button"
             onClick={() => {
-              setParams({ view: null });
+              setLocalPage(0);
+              setParams({ view: null, page: null });
               setRowSelection({});
             }}
             className={`px-2 py-1.5 transition-colors ${

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -31,11 +31,11 @@ import {
   ChevronsUpDown,
   ImageOff,
 } from "lucide-react";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import EmptyState from "@/components/ui/EmptyState";
+import FilterField from "@/components/ui/FilterField";
 import SeriesFilters, {
   type TypeFilter,
   type ProgressFilter,
@@ -97,12 +97,7 @@ export default function SeriesTable({
       throttleMs: 300,
     }),
   );
-  const [searchInput, setSearchInput] = useState(search);
   const [localPage, setLocalPage] = useState(params.page);
-
-  useEffect(() => {
-    setSearchInput(search);
-  }, [search]);
 
   useEffect(() => {
     setLocalPage(params.page);
@@ -227,7 +222,7 @@ export default function SeriesTable({
   const table = useReactTable({
     data: filteredData,
     columns,
-    state: { sorting, globalFilter: searchInput, rowSelection, pagination },
+    state: { sorting, globalFilter: search, rowSelection, pagination },
     onSortingChange: (updaterOrValue) => {
       const newSorting =
         typeof updaterOrValue === "function"
@@ -327,39 +322,16 @@ export default function SeriesTable({
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      {/* Filter bar */}
-      <div className="px-5 py-2.5 border-b border-border flex items-center gap-3 min-h-[44px]">
-        <SeriesFilters
-          typeFilter={typeFilter}
-          progressFilter={progressFilter}
-          statusFilter={statusFilter}
-          onTypeChange={(value) => {
-            setLocalPage(0);
-            setParams({ type: value === "all" ? null : value, page: null });
-          }}
-          onProgressChange={(value) => {
-            setLocalPage(0);
-            setParams({ progress: value === "all" ? null : value, page: null });
-          }}
-          onStatusChange={(value) => {
-            setLocalPage(0);
-            setParams({ status: value === "all" ? null : value, page: null });
-          }}
-          resultCount={totalFiltered}
-          sortLabel={sortLabel}
-        />
-      </div>
-
-      {/* View toggle + search */}
-      <div className="px-5 py-2 border-b border-border flex items-center gap-2">
-        <div className="inline-flex rounded-md border border-border overflow-hidden">
+      {/* Unified action bar: view · search · filters · results */}
+      <div className="px-5 py-2 border-b border-border flex flex-wrap items-center gap-2 min-h-[44px]">
+        <div className="inline-flex shrink-0 rounded-md border border-border overflow-hidden">
           <button
             type="button"
             onClick={() => {
               setParams({ view: null });
               setRowSelection({});
             }}
-            className={`px-2 py-1 transition-colors ${
+            className={`px-2 py-1.5 transition-colors ${
               !isGridView
                 ? "bg-muted text-foreground"
                 : "text-muted-foreground hover:text-foreground"
@@ -375,7 +347,7 @@ export default function SeriesTable({
               setParams({ view: "grid", page: null });
               setRowSelection({});
             }}
-            className={`px-2 py-1 border-l border-border transition-colors ${
+            className={`px-2 py-1.5 border-l border-border transition-colors ${
               isGridView
                 ? "bg-muted text-foreground"
                 : "text-muted-foreground hover:text-foreground"
@@ -385,17 +357,50 @@ export default function SeriesTable({
             <LayoutGrid className="w-3.5 h-3.5" />
           </button>
         </div>
-        <Input
-          placeholder="Search series…"
-          value={searchInput}
-          onChange={(e) => {
-            setSearchInput(e.target.value);
-            setSearch(e.target.value || null);
-            setLocalPage(0);
-            setParams({ page: null });
-          }}
-          className="w-[220px] h-8 text-[12px]"
-        />
+
+        <div className="w-[min(220px,100%)] sm:w-[220px] shrink-0">
+          <FilterField
+            type="search"
+            placeholder="Filter series…"
+            aria-label="Filter series"
+            shortcut="/"
+            widthCap="full"
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value || null);
+              setLocalPage(0);
+              setParams({ page: null });
+            }}
+          />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <SeriesFilters
+            typeFilter={typeFilter}
+            progressFilter={progressFilter}
+            statusFilter={statusFilter}
+            onTypeChange={(value) => {
+              setLocalPage(0);
+              setParams({ type: value === "all" ? null : value, page: null });
+            }}
+            onProgressChange={(value) => {
+              setLocalPage(0);
+              setParams({
+                progress: value === "all" ? null : value,
+                page: null,
+              });
+            }}
+            onStatusChange={(value) => {
+              setLocalPage(0);
+              setParams({
+                status: value === "all" ? null : value,
+                page: null,
+              });
+            }}
+            resultCount={totalFiltered}
+            sortLabel={sortLabel}
+          />
+        </div>
       </div>
 
       {/* Bulk action bar */}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -109,6 +109,7 @@ const SelectContent = React.forwardRef<
   ) => (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Positioner
+        className="isolate z-50"
         side={side}
         sideOffset={sideOffset}
         align={align}
@@ -118,7 +119,7 @@ const SelectContent = React.forwardRef<
         <SelectPrimitive.Popup
           ref={ref}
           className={cn(
-            "relative isolate z-50 max-h-(--available-height) min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md transition-[opacity,transform] data-starting-style:scale-95 data-starting-style:opacity-0 data-ending-style:scale-95 data-ending-style:opacity-0 origin-(--transform-origin)",
+            "relative max-h-(--available-height) min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md transition-[opacity,transform] data-starting-style:scale-95 data-starting-style:opacity-0 data-ending-style:scale-95 data-ending-style:opacity-0 origin-(--transform-origin)",
             position === "popper" &&
               "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
             className,
@@ -129,8 +130,7 @@ const SelectContent = React.forwardRef<
           <SelectPrimitive.List
             className={cn(
               "p-1",
-              position === "popper" &&
-                "h-(--anchor-height) w-full min-w-(--anchor-width)",
+              position === "popper" && "w-full min-w-(--anchor-width)",
             )}
           >
             {children}

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -18,7 +18,7 @@ export function useKeyboardShortcuts(): void {
       if (e.key === "/" && !isTyping && !e.ctrlKey && !e.metaKey && !e.altKey) {
         e.preventDefault();
 
-        // Try to find and focus the search input
+        // Try to find and focus the page filter/search input
         const searchInput =
           document.querySelector<HTMLInputElement>('input[type="search"]') ||
           document.querySelector<HTMLInputElement>(
@@ -26,6 +26,12 @@ export function useKeyboardShortcuts(): void {
           ) ||
           document.querySelector<HTMLInputElement>(
             'input[placeholder*="search"]',
+          ) ||
+          document.querySelector<HTMLInputElement>(
+            'input[placeholder*="Filter"]',
+          ) ||
+          document.querySelector<HTMLInputElement>(
+            'input[placeholder*="filter"]',
           );
 
         if (searchInput) {

--- a/frontend/src/pages/SeriesListPage.tsx
+++ b/frontend/src/pages/SeriesListPage.tsx
@@ -3,7 +3,6 @@ import { Plus } from "lucide-react";
 import { useSeries } from "@/hooks/useSeries";
 import SeriesTable from "@/components/series/SeriesTable";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
-import FilterField from "@/components/ui/FilterField";
 import { Kbd } from "@/components/ui/kbd";
 
 export default function SeriesListPage() {
@@ -45,16 +44,6 @@ export default function SeriesListPage() {
         </div>
 
         <div className="ml-auto flex items-center gap-2">
-          <div className="hidden sm:flex w-[240px]">
-            <FilterField
-              placeholder="Filter series…"
-              aria-label="Filter series"
-              shortcut="/"
-              widthCap="full"
-              disabled
-            />
-          </div>
-
           <Link
             to="/search"
             className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[5px] text-[12px] font-semibold"


### PR DESCRIPTION
## Summary

- Fix Library filter dropdowns (clipped options), double chevrons, Select z-index over sticky headers, and non-working series search
- Unify list/grid toggle, search field, and status/progress chips into a single action bar under the page header

## Test plan

- [x] Library header shows title + Add only
- [x] One action bar contains view toggle, Filter series, status/progress chips, result count
- [x] Status/progress menus show full option lists and sit above table headers
- [x] Filter chips show a single chevron
- [x] Search updates `?search=` and filters the table; `/` focuses the filter field
- [ ] Spot-check Settings or Search selects still open with full options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed empty filter dropdowns and removed duplicate chevrons.
  * Improved library search behavior and `/` keyboard shortcut support.
  * Corrected dropdown sizing and layering issues.

* **UI Improvements**
  * Unified search, filters, filter chips, and view controls into one action bar.
  * Refined filter chip and grid view styling.
  * Removed redundant filter labeling and an unused header search control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->