### PR TITLE
fix: preserve library pagination state

### DIFF
--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -115,7 +115,12 @@ export default function SeriesTable({
   const progressFilter: ProgressFilter = params.progress ?? "all";
   const statusFilter: StatusFilter = params.status ?? "all";
 
-  const sorting: SortingState = params.sort ? [params.sort] : [];
+  const sortId = params.sort?.id;
+  const sortDesc = params.sort?.desc;
+  const sorting = useMemo<SortingState>(
+    () => (sortId ? [{ id: sortId, desc: sortDesc ?? false }] : []),
+    [sortDesc, sortId],
+  );
   const isGridView = params.view === "grid";
   const pageSize = isGridView ? 24 : 20;
 

--- a/frontend/tests/components/SeriesTable.test.tsx
+++ b/frontend/tests/components/SeriesTable.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { NuqsAdapter } from "nuqs/adapters/react-router/v7";
+import { render, screen } from "../test-utils";
+import SeriesTable from "@/components/series/SeriesTable";
+import type { Comic } from "@/types";
+
+function series(count: number): Comic[] {
+  return Array.from({ length: count }, (_, index) => {
+    const number = index + 1;
+    return {
+      ComicID: String(number),
+      ComicName: `Series ${number}`,
+      ComicPublisher: "Publisher",
+      ComicYear: "2024",
+      Status: "Active",
+      Have: 0,
+      Total: 1,
+    } as Comic;
+  });
+}
+
+describe("SeriesTable", () => {
+  it("shows the next page when pagination advances", async () => {
+    const user = userEvent.setup();
+    window.history.pushState({}, "", "/library");
+
+    render(
+      <NuqsAdapter>
+        <SeriesTable data={series(21)} />
+      </NuqsAdapter>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "next" }));
+
+    expect(screen.getByText("Series 21")).toBeTruthy();
+    expect(screen.queryByText("Series 1")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- keep Library table sorting state stable across pagination renders
- add regression coverage for navigating to the second Library page

## Validation
- npm run test:run -- tests/components/SeriesTable.test.tsx
- npm run lint
- npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved series table sorting behavior when sort direction or field values are missing.
  * Ensured sorting state updates reliably as sorting parameters change.

* **Tests**
  * Added coverage for series table pagination, verifying navigation displays the next page and removes the previous page’s content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->