### PR TITLE
fix: repair MAL manga refresh, rescan, and cover display (#298)

### DIFF
--- a/.changeset/mal-manga-refresh.md
+++ b/.changeset/mal-manga-refresh.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix MAL manga series: rescan no longer crashes on chapters without dates, Refresh routes `mal-` IDs through the MAL importer instead of ComicVine, and MAL cover images now display (CSP allowlist plus local cover caching).

--- a/comicarr/app/core/middleware.py
+++ b/comicarr/app/core/middleware.py
@@ -55,7 +55,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "default-src 'self'",
             "script-src 'self'",
             "style-src 'self' 'unsafe-inline'",
-            "img-src 'self' data: https://comicvine.gamespot.com https://static.metron.cloud https://uploads.mangadex.org",
+            "img-src 'self' data: https://comicvine.gamespot.com https://static.metron.cloud https://uploads.mangadex.org https://cdn.myanimelist.net",
             "font-src 'self'",
             "connect-src 'self'",
             "frame-ancestors 'none'",

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -254,6 +254,10 @@ def addComictoDB(
     if str(comicid).startswith("md-"):
         return addMangaToDB(comicid, imported=imported, calledfrom=calledfrom)
 
+    # MAL-sourced manga (prefixed with 'mal-'): metadata from MAL, chapters from MangaDex
+    if str(comicid).startswith("mal-"):
+        return addMangaToDB_MAL(comicid, imported=imported, calledfrom=calledfrom)
+
     controlValueDict = {"ComicID": comicid}
 
     with db.get_engine().connect() as conn:
@@ -1388,6 +1392,14 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
             covercheck = helpers.getImage(mangaid, cover_url)
             if covercheck["status"] == "retry":
                 logger.info("[MANGADEX] Retrying alternate cover image for: %s" % manga_name)
+            elif covercheck["status"] == "success":
+                # Point ComicImage at the local cached cover (matches the ComicVine
+                # add path); ComicImageURL keeps the external URL for the /art fallback.
+                db.upsert(
+                    "comics",
+                    {"ComicImage": helpers.replacetheslash(os.path.join("cache", str(mangaid) + ".jpg"))},
+                    controlValueDict,
+                )
         except Exception as e:
             logger.warn("[MANGADEX] Failed to cache cover for %s: %s" % (manga_name, e))
 
@@ -1543,6 +1555,14 @@ def addMangaToDB_MAL(mangaid, imported=None, calledfrom=None):
             covercheck = helpers.getImage(mangaid, cover_url)
             if covercheck["status"] == "retry":
                 logger.info("[MAL] Retrying alternate cover image for: %s" % manga_name)
+            elif covercheck["status"] == "success":
+                # Point ComicImage at the local cached cover (matches the ComicVine
+                # add path); ComicImageURL keeps the external URL for the /art fallback.
+                db.upsert(
+                    "comics",
+                    {"ComicImage": helpers.replacetheslash(os.path.join("cache", str(mangaid) + ".jpg"))},
+                    controlValueDict,
+                )
         except Exception as e:
             logger.warn("[MAL] Failed to cache cover for %s: %s" % (manga_name, e))
 

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -1139,6 +1139,11 @@ def _populate_manga_chapters(mangaid, manga_name, mangadex_uuid, mal_num_chapter
     3. MAL num_chapters as fallback (when MangaDex is unavailable)
     4. Explicit 0 as terminal default (never leaves Total/Have as NULL)
 
+    On refresh, existing chapter rows keep their Status and DateAdded so
+    Downloaded/Snatched/Wanted/etc. survive metadata updates; only new
+    chapters get the default Status. Have is reset to 0 here and
+    recalculated by forceRescan after a refresh.
+
     Args:
         mangaid: The comic ID used in the database (e.g. 'md-xxx' or 'mal-xxx')
         manga_name: Display name for logging
@@ -1151,6 +1156,13 @@ def _populate_manga_chapters(mangaid, manga_name, mangadex_uuid, mal_num_chapter
     issue_count = 0
     latest_chapter = None
     latest_date = None
+
+    # Snapshot existing IssueIDs so refresh does not wipe Status/DateAdded.
+    existing_issue_ids = {
+        row["IssueID"]
+        for row in db.select_all(select(issues.c.IssueID).where(issues.c.ComicID == mangaid))
+        if row.get("IssueID")
+    }
 
     if mangadex_uuid:
         # Strip md- prefix if present for MangaDex API calls
@@ -1170,10 +1182,6 @@ def _populate_manga_chapters(mangaid, manga_name, mangadex_uuid, mal_num_chapter
 
                 issue_id = "%s-ch%s" % (mangaid, chapter_num)
 
-                issue_status = "Skipped"
-                if comicarr.CONFIG.AUTOWANT_ALL:
-                    issue_status = "Wanted"
-
                 release_date = (
                     chapter.get("release_date") or chapter.get("publish_at", "")[:10]
                     if chapter.get("publish_at")
@@ -1188,12 +1196,18 @@ def _populate_manga_chapters(mangaid, manga_name, mangadex_uuid, mal_num_chapter
                     "IssueName": chapter.get("title") or ("Chapter %s" % chapter_num),
                     "ReleaseDate": release_date,
                     "IssueDate": release_date,
-                    "Status": issue_status,
                     "Int_IssueNumber": helpers.issuedigits(chapter_num),
                     "ChapterNumber": str(chapter_num),
                     "VolumeNumber": str(chapter.get("volume")) if chapter.get("volume") else None,
-                    "DateAdded": helpers.now(),
                 }
+                # Only set default Status/DateAdded for newly created rows.
+                # Refresh must not reset Downloaded/Snatched/Wanted/etc.
+                if issue_id not in existing_issue_ids:
+                    issue_status = "Skipped"
+                    if comicarr.CONFIG.AUTOWANT_ALL:
+                        issue_status = "Wanted"
+                    issue_values["Status"] = issue_status
+                    issue_values["DateAdded"] = helpers.now()
 
                 db.upsert("issues", issue_values, {"IssueID": issue_id})
                 issue_count += 1
@@ -1312,11 +1326,16 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
 
     if not manga:
         logger.error("[MANGADEX] Error fetching manga details for: %s" % mangaid)
-        db.upsert(
-            "comics",
-            {"ComicName": "Fetch failed, try refreshing. (%s)" % mangaid, "Status": "Active"},
-            controlValueDict,
-        )
+        if dbmanga is not None:
+            # Existing series: restore prior status, leave ComicName alone.
+            restore_status = series_status if series_status != "Loading" else "Active"
+            db.upsert("comics", {"Status": restore_status}, controlValueDict)
+        else:
+            db.upsert(
+                "comics",
+                {"ComicName": "Fetch failed, try refreshing. (%s)" % mangaid, "Status": "Active"},
+                controlValueDict,
+            )
         return {"status": "incomplete"}
 
     manga_name = manga.get("name", "Unknown")
@@ -1334,9 +1353,10 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
     # Generate dynamic name for matching
     dynamic_name = helpers.filesafe(re.sub(r"[\'\!\@\#\$\%\:\;\/\\]", "", manga_name).lower())
 
-    # Build folder path if destination directory is set
+    # Build folder path only for first-time add (or when no path is set yet).
+    # Refresh must not rewrite ComicLocation and send forceRescan to the wrong folder.
     manga_dest = get_manga_destination()
-    if manga_dest:
+    if manga_dest and not comlocation:
         folder_format = comicarr.CONFIG.FOLDER_FORMAT or "$Series ($Year)"
         folder_name = folder_format.replace("$Series", manga_name).replace("$Year", str(manga_year))
         folder_name = helpers.filesafe(folder_name)
@@ -1466,11 +1486,16 @@ def addMangaToDB_MAL(mangaid, imported=None, calledfrom=None):
 
     if not manga:
         logger.error("[MAL] Error fetching manga details for: %s" % mangaid)
-        db.upsert(
-            "comics",
-            {"ComicName": "Fetch failed, try refreshing. (%s)" % mangaid, "Status": "Active"},
-            controlValueDict,
-        )
+        if dbmanga is not None:
+            # Existing series: restore prior status, leave ComicName alone.
+            restore_status = series_status if series_status != "Loading" else "Active"
+            db.upsert("comics", {"Status": restore_status}, controlValueDict)
+        else:
+            db.upsert(
+                "comics",
+                {"ComicName": "Fetch failed, try refreshing. (%s)" % mangaid, "Status": "Active"},
+                controlValueDict,
+            )
         return {"status": "incomplete"}
 
     manga_name = manga.get("name", "Unknown")
@@ -1488,9 +1513,10 @@ def addMangaToDB_MAL(mangaid, imported=None, calledfrom=None):
     # Generate dynamic name for matching
     dynamic_name = helpers.filesafe(re.sub(r"[\'\!\@\#\$\%\:\;\/\\]", "", manga_name).lower())
 
-    # Build folder path if destination directory is set
+    # Build folder path only for first-time add (or when no path is set yet).
+    # Refresh must not rewrite ComicLocation and send forceRescan to the wrong folder.
     manga_dest = get_manga_destination()
-    if manga_dest:
+    if manga_dest and not comlocation:
         folder_format = comicarr.CONFIG.FOLDER_FORMAT or "$Series ($Year)"
         folder_name = folder_format.replace("$Series", manga_name).replace("$Year", str(manga_year))
         folder_name = helpers.filesafe(folder_name)

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -372,7 +372,19 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                     "message": "Failure refreshing %s (%s)" % (ComicName, dspyear),
                 }
                 return
-            forceRescan(ComicID)
+            try:
+                forceRescan(ComicID)
+            except Exception as e:
+                logger.error("[MANGA-REFRESH] forceRescan failed for %s: %s" % (ComicID, e))
+                comicarr.GLOBAL_MESSAGES = {
+                    "status": "failure",
+                    "comicname": ComicName,
+                    "seriesyear": dspyear,
+                    "comicid": ComicID,
+                    "tables": "both",
+                    "message": "Failure rescanning %s (%s) after refresh" % (ComicName, dspyear),
+                }
+                return
         elif not comicarr.CONFIG.CV_ONLY or ComicID[:1] == "G":
             # "exceptions" table is not in tables.py -- use text()
             CV_EXcomicid = db.select_one(text("SELECT * from exceptions WHERE ComicID=:cid").bindparams(cid=ComicID))

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -2090,7 +2090,15 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                                         )
                                         multiplechk = True
                                         break
-                                    if (mi["IssueYear"] in tmpfc["ComicFilename"]) and (issyear == mi["IssueYear"]):
+                                    # Empty year is not a discriminator: "" is a substring of
+                                    # every filename, so same-number NULL-date rows would match
+                                    # arbitrarily. Require a nonempty year on both sides.
+                                    if (
+                                        mi["IssueYear"]
+                                        and issyear
+                                        and mi["IssueYear"] in tmpfc["ComicFilename"]
+                                        and issyear == mi["IssueYear"]
+                                    ):
                                         logger.fdebug(module + " Matched to year within filename : " + str(issyear))
                                         multiplechk = False
                                         break
@@ -2321,7 +2329,15 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                                         )
                                         multiplechk = True
                                         break
-                                    if (ma["IssueYear"] in tmpfc["ComicFilename"]) and (issyear == ma["IssueYear"]):
+                                    # Empty year is not a discriminator: "" is a substring of
+                                    # every filename, so same-number NULL-date rows would match
+                                    # arbitrarily. Require a nonempty year on both sides.
+                                    if (
+                                        ma["IssueYear"]
+                                        and issyear
+                                        and ma["IssueYear"] in tmpfc["ComicFilename"]
+                                        and issyear == ma["IssueYear"]
+                                    ):
                                         # make sure that the IssueYear discovered is not preceded by a volume so it matches correctly
                                         vchk = tmpfc["ComicFilename"].find(ma["IssueYear"])
                                         if tmpfc["ComicFilename"][vchk - 1].lower() == "v":

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -353,7 +353,27 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
             lastupdated = datetime.datetime.strptime(comic["LastUpdated"], "%Y-%m-%d %H:%M:%S").strftime("%Y-%m-%d")
 
         mismatch = "no"
-        if not comicarr.CONFIG.CV_ONLY or ComicID[:1] == "G":
+        if str(ComicID).startswith(("md-", "mal-")):
+            # Manga (MangaDex/MAL) refreshes entirely through the manga importer.
+            # The CV_ONETIMER reconciliation below deletes issue rows and expects
+            # CV issuedata that the manga add functions do not return, so route
+            # these series around it and re-match files via forceRescan.
+            chkstatus = comicarr.importer.addComictoDB(ComicID, mismatch)
+            if chkstatus["status"] != "complete":
+                logger.warn(
+                    "There was an error when refreshing this series - Make sure directories are writable/exist, and check the logs for any errors/problems."
+                )
+                comicarr.GLOBAL_MESSAGES = {
+                    "status": "failure",
+                    "comicname": ComicName,
+                    "seriesyear": dspyear,
+                    "comicid": ComicID,
+                    "tables": "both",
+                    "message": "Failure refreshing %s (%s)" % (ComicName, dspyear),
+                }
+                return
+            forceRescan(ComicID)
+        elif not comicarr.CONFIG.CV_ONLY or ComicID[:1] == "G":
             # "exceptions" table is not in tables.py -- use text()
             CV_EXcomicid = db.select_one(text("SELECT * from exceptions WHERE ComicID=:cid").bindparams(cid=ComicID))
             if CV_EXcomicid is None:
@@ -1870,7 +1890,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                 mc_issue.append(
                     {
                         "Int_IssueNumber": mck["Int_IssueNumber"],
-                        "IssueYear": mck["IssueDate"][:4],
+                        "IssueYear": (mck["IssueDate"] or "")[:4],
                         "IssueID": mck["IssueID"],
                     }
                 )
@@ -1911,7 +1931,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                     mc_annual.append(
                         {
                             "Int_IssueNumber": ack["Int_IssueNumber"],
-                            "IssueYear": ack["IssueDate"][:4],
+                            "IssueYear": (ack["IssueDate"] or "")[:4],
                             "IssueID": ack["IssueID"],
                             "ReleaseComicID": ack["ReleaseComicID"],
                         }
@@ -1982,7 +2002,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                 except IndexError:
                     break
                 int_iss = helpers.issuedigits(reiss["Issue_Number"])
-                issyear = reiss["IssueDate"][:4]
+                issyear = (reiss["IssueDate"] or "")[:4]
                 old_status = reiss["Status"]
                 reiss["IssueName"]
 
@@ -2256,7 +2276,7 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
                     break
                 int_iss = helpers.issuedigits(reann["Issue_Number"])
                 # logger.fdebug(module + ' int_iss:' + str(int_iss))
-                issyear = reann["IssueDate"][:4]
+                issyear = (reann["IssueDate"] or "")[:4]
                 old_status = reann["Status"]
 
                 year_check = re.findall(r"(\d{4})(?=[\s]|annual\b|$)", temploc, flags=re.I)

--- a/tests/unit/test_manga_refresh_regressions.py
+++ b/tests/unit/test_manga_refresh_regressions.py
@@ -161,6 +161,92 @@ class TestForceRescanNullIssueDate:
                 pytest.fail("forceRescan crashed on NULL IssueDate: %s" % e)
             raise
 
+    def test_empty_year_does_not_resolve_duplicate_issue_numbers(self, monkeypatch, tmp_path):
+        """Same-number rows with NULL IssueDate must not year-match via empty substring.
+
+        ``"" in filename`` is always true, so without a nonempty-year guard the first
+        duplicate candidate would claim the file and overwrite its status/location.
+        """
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(
+                comics.insert(),
+                {
+                    "ComicID": "mal-161890",
+                    "ComicName": "Test Manga",
+                    "ComicPublisher": "Unknown",
+                    "ComicYear": "2020",
+                    "ComicLocation": str(tmp_path),
+                    "AlternateSearch": None,
+                    "Type": "Manga",
+                    "Corrected_Type": None,
+                    "Status": "Active",
+                },
+            )
+            for issue_id in ("issue-a", "issue-b"):
+                conn.execute(
+                    issues.insert(),
+                    {
+                        "IssueID": issue_id,
+                        "ComicID": "mal-161890",
+                        "Issue_Number": "1",
+                        "Int_IssueNumber": 1000,
+                        "IssueName": "Chapter 1",
+                        "IssueDate": None,
+                        "Status": "Skipped",
+                        "Location": None,
+                        "forced_file": None,
+                    },
+                )
+
+        monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(
+            comicarr,
+            "CONFIG",
+            SimpleNamespace(
+                ANNUALS_ON=False,
+                MULTIPLE_DEST_DIRS=None,
+                DUPECONSTRAINT="filesize",
+                IGNORE_HAVETOTAL=False,
+                IGNORE_TOTAL=False,
+                SNATCHED_HAVETOTAL=False,
+                ENFORCE_PERMS=False,
+                AUTOWANT_ALL=False,
+            ),
+            raising=False,
+        )
+
+        fake_filecheck = MagicMock()
+        fake_filecheck.listFiles.return_value = {
+            "comiccount": 1,
+            "comiclist": [
+                {
+                    "ComicFilename": "Test Manga 001.cbz",
+                    "ComicLocation": str(tmp_path),
+                    "ComicSize": 1234,
+                    "JusttheDigits": "1",
+                    "AnnualComicID": None,
+                    "SeriesVolume": None,
+                }
+            ],
+        }
+        monkeypatch.setattr(updater.filechecker, "FileChecker", lambda **kwargs: fake_filecheck)
+
+        updater.forceRescan("mal-161890")
+
+        with engine.connect() as conn:
+            rows = (
+                conn.execute(select(issues).where(issues.c.ComicID == "mal-161890").order_by(issues.c.IssueID))
+                .mappings()
+                .all()
+            )
+
+        assert len(rows) == 2
+        # Leave the duplicate unresolved rather than binding the file to an arbitrary row.
+        assert all(row["Status"] == "Skipped" for row in rows)
+        assert all(not row["Location"] for row in rows)
+
 
 def _mal_details(cover_url="https://cdn.myanimelist.net/images/manga/2/253146l.jpg"):
     return {

--- a/tests/unit/test_manga_refresh_regressions.py
+++ b/tests/unit/test_manga_refresh_regressions.py
@@ -307,3 +307,155 @@ class TestCspAllowsMalCdn:
         from comicarr.app.core.middleware import SecurityHeadersMiddleware
 
         assert "https://cdn.myanimelist.net" in SecurityHeadersMiddleware.CSP
+
+
+class TestMangaRefreshPreservesLibraryState:
+    """Review findings: Refresh must not destroy name, status, or location."""
+
+    def _seed_existing_mal(self, engine, *, status="Active", location="/library/One Piece (1997)"):
+        with engine.begin() as conn:
+            conn.execute(
+                comics.insert(),
+                {
+                    "ComicID": "mal-13",
+                    "ComicName": "One Piece",
+                    "ComicYear": "1997",
+                    "Status": status,
+                    "ComicLocation": location,
+                    "Type": "Manga",
+                },
+            )
+            conn.execute(
+                issues.insert(),
+                {
+                    "IssueID": "mal-13-ch1",
+                    "ComicID": "mal-13",
+                    "Issue_Number": "1",
+                    "Int_IssueNumber": 1000,
+                    "IssueName": "Chapter 1",
+                    "Status": "Downloaded",
+                    "Location": "One Piece 001.cbz",
+                    "forced_file": None,
+                },
+            )
+
+    def test_fetch_failure_preserves_existing_name_and_status(self, monkeypatch):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        self._seed_existing_mal(engine, status="Paused")
+        monkeypatch.setattr(importer.db, "get_engine", lambda: engine)
+        monkeypatch.setattr("comicarr.myanimelist.get_manga_details", lambda _id: None)
+
+        result = importer.addMangaToDB_MAL("mal-13")
+
+        assert result["status"] == "incomplete"
+        with engine.connect() as conn:
+            row = conn.execute(select(comics).where(comics.c.ComicID == "mal-13")).mappings().one()
+        assert row["ComicName"] == "One Piece"
+        assert row["Status"] == "Paused"
+
+    def test_fetch_failure_placeholder_only_for_new_series(self, monkeypatch):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        monkeypatch.setattr(importer.db, "get_engine", lambda: engine)
+        monkeypatch.setattr("comicarr.myanimelist.get_manga_details", lambda _id: None)
+
+        result = importer.addMangaToDB_MAL("mal-999")
+
+        assert result["status"] == "incomplete"
+        with engine.connect() as conn:
+            row = conn.execute(select(comics).where(comics.c.ComicID == "mal-999")).mappings().one()
+        assert "Fetch failed" in row["ComicName"]
+        assert row["Status"] == "Active"
+
+    def test_refresh_preserves_comiclocation_when_manga_dest_set(self, monkeypatch, tmp_path):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        existing = str(tmp_path / "existing-library")
+        self._seed_existing_mal(engine, location=existing)
+        monkeypatch.setattr(importer.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(comicarr, "COMICSORT", None, raising=False)
+        monkeypatch.setattr(
+            comicarr,
+            "CONFIG",
+            SimpleNamespace(CREATE_FOLDERS=False, FOLDER_FORMAT="$Series ($Year)"),
+            raising=False,
+        )
+        monkeypatch.setattr("comicarr.myanimelist.get_manga_details", lambda _id: _mal_details())
+        monkeypatch.setattr("comicarr.mangadex.find_by_mal_id", lambda *a, **k: None)
+        monkeypatch.setattr("comicarr.config.get_manga_destination", lambda: str(tmp_path / "manga-dest"))
+        monkeypatch.setattr(importer.helpers, "getImage", lambda *a, **k: {"status": "failed"})
+        monkeypatch.setattr(importer, "_populate_manga_chapters", lambda *a, **k: None)
+        monkeypatch.setattr(importer.helpers, "ComicSort", lambda **k: None)
+
+        importer.addMangaToDB_MAL("mal-13")
+
+        with engine.connect() as conn:
+            row = conn.execute(select(comics).where(comics.c.ComicID == "mal-13")).mappings().one()
+        assert row["ComicLocation"] == existing
+
+    def test_populate_preserves_existing_chapter_status(self, monkeypatch):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        self._seed_existing_mal(engine)
+        monkeypatch.setattr(importer.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(
+            comicarr,
+            "CONFIG",
+            SimpleNamespace(AUTOWANT_ALL=False, MANGADEX_LANGUAGES="en"),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "comicarr.mangadex.get_all_chapters",
+            lambda _id: [{"chapter": "1", "title": "Romance Dawn", "publish_at": "1997-07-22T00:00:00"}],
+        )
+        monkeypatch.setattr("comicarr.mangadex.get_total_chapter_count", lambda _id: 1)
+
+        importer._populate_manga_chapters(
+            "mal-13",
+            "One Piece",
+            mangadex_uuid="uuid-1",
+            mal_num_chapters=None,
+            controlValueDict={"ComicID": "mal-13"},
+        )
+
+        with engine.connect() as conn:
+            row = conn.execute(select(issues).where(issues.c.IssueID == "mal-13-ch1")).mappings().one()
+        assert row["Status"] == "Downloaded"
+        assert row["Location"] == "One Piece 001.cbz"
+        assert row["IssueName"] == "Romance Dawn"
+
+
+class TestMangaRefreshForceRescanErrors:
+    """#4: forceRescan exceptions must not report Refresh success."""
+
+    def test_forcerescan_exception_sets_failure_message(self, monkeypatch):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(
+                comics.insert(),
+                {
+                    "ComicID": "mal-161890",
+                    "ComicName": "Test Manga",
+                    "ComicYear": "2020",
+                    "Status": "Active",
+                    "LastUpdated": None,
+                },
+            )
+
+        monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(comicarr, "IMPORTLOCK", False, raising=False)
+        monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(CV_ONLY=True, CV_ONETIMER=1), raising=False)
+        monkeypatch.setattr(comicarr, "GLOBAL_MESSAGES", {}, raising=False)
+        monkeypatch.setattr(
+            comicarr.importer,
+            "addComictoDB",
+            MagicMock(return_value={"status": "complete", "comicid": "mal-161890"}),
+        )
+        monkeypatch.setattr(updater, "forceRescan", MagicMock(side_effect=RuntimeError("disk gone")))
+
+        updater.dbUpdate(["mal-161890"], calledfrom="refresh")
+
+        assert comicarr.GLOBAL_MESSAGES["status"] == "failure"
+        assert "rescanning" in comicarr.GLOBAL_MESSAGES["message"].lower()

--- a/tests/unit/test_manga_refresh_regressions.py
+++ b/tests/unit/test_manga_refresh_regressions.py
@@ -1,0 +1,223 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Regression coverage for MAL manga refresh/rescan/cover failures reported in issue #298."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, select
+
+import comicarr
+from comicarr import importer, updater
+from comicarr.tables import comics, issues, metadata
+
+
+class TestAddComictoDBMangaRouting:
+    """Defect 2a: addComictoDB must route mal-/md- IDs to the manga importer, not ComicVine."""
+
+    @patch("comicarr.importer.cv.getComic")
+    @patch("comicarr.importer.addMangaToDB_MAL")
+    def test_mal_id_routes_to_mal_importer(self, mock_mal, mock_getcomic):
+        sentinel = {"status": "complete", "comicid": "mal-161890"}
+        mock_mal.return_value = sentinel
+
+        result = importer.addComictoDB("mal-161890")
+
+        assert result is sentinel
+        mock_mal.assert_called_once_with("mal-161890", imported=None, calledfrom=None)
+        mock_getcomic.assert_not_called()
+
+    @patch("comicarr.importer.cv.getComic")
+    @patch("comicarr.importer.addMangaToDB")
+    def test_md_id_routes_to_mangadex_importer(self, mock_md, mock_getcomic):
+        sentinel = {"status": "complete", "comicid": "md-abc"}
+        mock_md.return_value = sentinel
+
+        result = importer.addComictoDB("md-abc")
+
+        assert result is sentinel
+        mock_md.assert_called_once_with("md-abc", imported=None, calledfrom=None)
+        mock_getcomic.assert_not_called()
+
+
+class TestDbUpdateMangaShortCircuit:
+    """Defect 2b: dbUpdate must refresh manga through the manga importer and skip the
+    CV issuedata reconciliation that deletes issue rows and expects issuedata."""
+
+    def test_manga_refresh_skips_cv_reconciliation(self, monkeypatch):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(
+                comics.insert(),
+                {
+                    "ComicID": "mal-161890",
+                    "ComicName": "Test Manga",
+                    "ComicYear": "2020",
+                    "Status": "Active",
+                    "LastUpdated": None,
+                },
+            )
+
+        monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(comicarr, "IMPORTLOCK", False, raising=False)
+        monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(CV_ONLY=True, CV_ONETIMER=1), raising=False)
+        monkeypatch.setattr(comicarr, "GLOBAL_MESSAGES", {}, raising=False)
+
+        mock_add = MagicMock(return_value={"status": "complete", "comicid": "mal-161890", "content_type": "manga"})
+        mock_rescan = MagicMock()
+        monkeypatch.setattr(comicarr.importer, "addComictoDB", mock_add)
+        monkeypatch.setattr(updater, "forceRescan", mock_rescan)
+
+        updater.dbUpdate(["mal-161890"], calledfrom="refresh")
+
+        # Manga branch calls addComictoDB positionally (no annload/csyear kwargs) and
+        # then re-matches files via forceRescan -- never the CV delete-and-reload path.
+        mock_add.assert_called_once_with("mal-161890", "no")
+        mock_rescan.assert_called_once_with("mal-161890")
+        assert comicarr.GLOBAL_MESSAGES["status"] == "success"
+
+
+class TestForceRescanNullIssueDate:
+    """Defect 1: forceRescan must not crash when a manga chapter row has a NULL IssueDate."""
+
+    def test_null_issuedate_does_not_crash(self, monkeypatch, tmp_path):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(
+                comics.insert(),
+                {
+                    "ComicID": "mal-161890",
+                    "ComicName": "Test Manga",
+                    "ComicPublisher": "Unknown",
+                    "ComicYear": "2020",
+                    "ComicLocation": str(tmp_path),
+                    "AlternateSearch": None,
+                    "Type": "Manga",
+                    "Corrected_Type": None,
+                    "Status": "Active",
+                },
+            )
+            conn.execute(
+                issues.insert(),
+                {
+                    "IssueID": "issue-1",
+                    "ComicID": "mal-161890",
+                    "Issue_Number": "1",
+                    "Int_IssueNumber": 1000,
+                    "IssueName": "Chapter 1",
+                    "IssueDate": None,  # the crash trigger
+                    "Status": "Skipped",
+                    "forced_file": None,
+                },
+            )
+
+        monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(
+            comicarr,
+            "CONFIG",
+            SimpleNamespace(
+                ANNUALS_ON=False,
+                MULTIPLE_DEST_DIRS=None,
+                DUPECONSTRAINT="filesize",
+                IGNORE_HAVETOTAL=False,
+                IGNORE_TOTAL=False,
+                SNATCHED_HAVETOTAL=False,
+                ENFORCE_PERMS=False,
+                AUTOWANT_ALL=False,
+            ),
+            raising=False,
+        )
+
+        fake_filecheck = MagicMock()
+        fake_filecheck.listFiles.return_value = {
+            "comiccount": 1,
+            "comiclist": [
+                {
+                    "ComicFilename": "Test Manga 001.cbz",
+                    "ComicLocation": str(tmp_path),
+                    "ComicSize": 1234,
+                    "JusttheDigits": "1",
+                    "AnnualComicID": None,
+                    "SeriesVolume": None,
+                }
+            ],
+        }
+        monkeypatch.setattr(updater.filechecker, "FileChecker", lambda **kwargs: fake_filecheck)
+
+        try:
+            updater.forceRescan("mal-161890")
+        except TypeError as e:
+            if "subscriptable" in str(e):
+                pytest.fail("forceRescan crashed on NULL IssueDate: %s" % e)
+            raise
+
+
+def _mal_details(cover_url="https://cdn.myanimelist.net/images/manga/2/253146l.jpg"):
+    return {
+        "name": "One Piece",
+        "alt_titles": [],
+        "description": "Pirates",
+        "year": "1997",
+        "status": "ongoing",
+        "last_chapter": None,
+        "author": "Oda",
+        "cover_url": cover_url,
+        "url": "https://myanimelist.net/manga/13",
+    }
+
+
+class TestMangaCoverCachePath:
+    """Defect 3b: a successful cover download repoints ComicImage at the local cache path
+    (CSP-safe), while ComicImageURL keeps the external URL for the /art fallback."""
+
+    def _add(self, monkeypatch, getimage_status):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        monkeypatch.setattr(importer.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(comicarr, "COMICSORT", None, raising=False)
+        monkeypatch.setattr(
+            comicarr,
+            "CONFIG",
+            SimpleNamespace(CREATE_FOLDERS=False, FOLDER_FORMAT="$Series ($Year)"),
+            raising=False,
+        )
+
+        monkeypatch.setattr("comicarr.myanimelist.get_manga_details", lambda _id: _mal_details())
+        monkeypatch.setattr("comicarr.mangadex.find_by_mal_id", lambda *a, **k: "uuid-1")
+        monkeypatch.setattr("comicarr.config.get_manga_destination", lambda: None)
+        monkeypatch.setattr(importer.helpers, "getImage", lambda *a, **k: {"status": getimage_status})
+        monkeypatch.setattr(importer, "_populate_manga_chapters", lambda *a, **k: None)
+        monkeypatch.setattr(importer.helpers, "ComicSort", lambda **k: None)
+
+        importer.addMangaToDB_MAL("mal-13")
+
+        with engine.connect() as conn:
+            return conn.execute(select(comics).where(comics.c.ComicID == "mal-13")).mappings().one()
+
+    def test_success_points_comicimage_at_cache(self, monkeypatch):
+        row = self._add(monkeypatch, "success")
+        assert row["ComicImage"] == "cache/mal-13.jpg"
+        assert row["ComicImageURL"] == "https://cdn.myanimelist.net/images/manga/2/253146l.jpg"
+
+    def test_failed_download_leaves_external_url(self, monkeypatch):
+        row = self._add(monkeypatch, "failed")
+        assert row["ComicImage"] == "https://cdn.myanimelist.net/images/manga/2/253146l.jpg"
+
+
+class TestCspAllowsMalCdn:
+    """Defect 3a: the MAL cover CDN must be in the CSP img-src allowlist."""
+
+    def test_mal_cdn_in_csp(self):
+        from comicarr.app.core.middleware import SecurityHeadersMiddleware
+
+        assert "https://cdn.myanimelist.net" in SecurityHeadersMiddleware.CSP


### PR DESCRIPTION
Fixes #298.

MAL-sourced manga (`mal-` IDs) suffered three separate defects, all fixed here.

## Defect 1 — rescan crash (`'NoneType' object is not subscriptable`)
`updater.forceRescan` sliced `IssueDate[:4]` with no guard at four sites. Manga chapter rows routinely have a `NULL` publish date, so manual-import matching crashed (surfaced via `finalization.py:finalize_manual_match` as a `phase="rescan"` failure). Guarded all four slices with `(row["IssueDate"] or "")[:4]`.

## Defect 2 — refresh queried ComicVine instead of MAL
`importer.addComictoDB` only routed `md-` IDs to the manga importer, so `mal-` series fell through to ComicVine during Refresh, producing the reporter's `cv.py` / `addComictoDB:336` / `dbUpdate:456` error cascade.

Fixed with **two coordinated changes**:
- Add the `mal-` routing branch to `addComictoDB` (mirrors `app/search/service.py`).
- Add a manga short-circuit at the top of `updater.dbUpdate`'s per-series branch. This is required: the default refresh path deletes all issue rows and expects ComicVine `issuedata` back — the manga add functions don't return `issuedata`, so routing alone would wipe the freshly repopulated chapters and raise `KeyError`. The short-circuit also fixes this latent hazard for existing `md-` series.

## Defect 3 — missing cover image
Manga adds stored the raw `cdn.myanimelist.net` URL in `ComicImage`, which the CSP `img-src` allowlist blocked (search previews worked because they route through the same-origin image proxy). Added `cdn.myanimelist.net` to the CSP and pointed `ComicImage` at the already-cached local file (`cache/<id>.jpg`, matching the ComicVine convention); `ComicImageURL` keeps the external URL for the `/art` fallback.

## Self-healing
Existing CV-corrupted `mal-` series heal after one **Refresh** — `addMangaToDB_MAL` rewrites the row and repopulates chapters, then the now-guarded `forceRescan` re-matches files. No migration needed.

## Tests
New `tests/unit/test_manga_refresh_regressions.py` covering all three defects (routing, `dbUpdate` short-circuit / no chapter wipe, NULL-date rescan, cover cache path, CSP). The 5 fix-dependent tests were verified to fail when the fixes are reverted. Adjacent suites and the full unit suite pass; ruff check, format, and the strict modern lane are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh/rescan stability for MyAnimeList and MangaDex manga, including cases with missing chapter dates.
  * MyAnimeList manga now refresh through the correct importer, with refresh behavior that preserves existing library metadata and chapter status/date values.
  * MyAnimeList covers now load reliably via local caching for successful downloads, while failed downloads keep using the external URL.
  * Updated security settings to allow the MyAnimeList CDN for cover images.
* **Tests**
  * Added regression coverage for MAL refresh/rescan/cover handling and state-preservation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->