### PR TITLE
fix: Repair settings save and make interval changes take effect

### DIFF
--- a/.changeset/great-settings-persist.md
+++ b/.changeset/great-settings-persist.md
@@ -1,0 +1,13 @@
+---
+"comicarr": patch
+---
+
+Fix saving settings failing whenever the RSS check interval or database update
+interval was changed. Both fields were sent under names the configuration did
+not recognise, which rolled back the entire save — every other setting changed
+at the same time was discarded without a visible error.
+
+Interval changes now also reach the running scheduler, which they never did, so
+a new search or RSS cadence takes effect without a restart. The database update
+interval is a real setting now and survives a restart instead of resetting to 24
+hours.

--- a/.changeset/great-settings-persist.md
+++ b/.changeset/great-settings-persist.md
@@ -11,3 +11,9 @@ Interval changes now also reach the running scheduler, which they never did, so
 a new search or RSS cadence takes effect without a restart. The database update
 interval is a real setting now and survives a restart instead of resetting to 24
 hours.
+
+Setting an interval to zero and then correcting it no longer leaves that
+background job switched off. Jobs paused deliberately — from the jobs page, or
+by turning RSS off — still stay paused. A database update interval below an
+hour is raised to an hour, the way the search and RSS intervals already were,
+so a negative value can no longer schedule the updater to run without pause.

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -188,7 +188,6 @@ SCHED_MONITOR_LAST = None
 SCHED_SEARCH_LAST = None
 SCHED_VERSION_LAST = None
 SCHED_DBUPDATE_LAST = None
-DBUPDATE_INTERVAL = 1440  # 24hrs
 DB_BACKFILL = False
 DBLOCK = False
 DB_FILE = None
@@ -450,7 +449,6 @@ def initialize(config_file):
             VERSION_STATUS, \
             UPDATER_STATUS, \
             FORCE_STATUS, \
-            DBUPDATE_INTERVAL, \
             DB_BACKFILL, \
             LOG_LANG, \
             LOG_CHARSET, \
@@ -1006,7 +1004,7 @@ def start(ctx):
                 next_run_time=datetime.datetime.utcnow(),
                 name="DB Updater",
                 args=[None, True],
-                trigger=IntervalTrigger(hours=0, minutes=DBUPDATE_INTERVAL, timezone="UTC"),
+                trigger=IntervalTrigger(hours=0, minutes=CONFIG.DBUPDATE_INTERVAL, timezone="UTC"),
             )
             UPDATER_SCHEDULER.pause()
 
@@ -1139,19 +1137,19 @@ def start(ctx):
                         % helpers.utc_date_to_local(datetime.datetime.utcfromtimestamp(updater_timestamp))
                     )
                 else:
-                    updater_timestamp = helpers.utctimestamp() + (int(DBUPDATE_INTERVAL) * 60)
+                    updater_timestamp = helpers.utctimestamp() + (int(CONFIG.DBUPDATE_INTERVAL) * 60)
 
                 updater_diff = (helpers.utctimestamp() - updater_timestamp) / 60
-                if updater_diff >= int(DBUPDATE_INTERVAL):
+                if updater_diff >= int(CONFIG.DBUPDATE_INTERVAL):
                     logger.fdebug("[DB UPDATER] DB Updater scheduled to run immediately.")
                     UPDATER_SCHEDULER.modify(next_run_time=(datetime.datetime.utcnow()))
                 else:
                     updater_diff = datetime.datetime.utcfromtimestamp(
-                        helpers.utctimestamp() + ((int(DBUPDATE_INTERVAL) * 60) - (updater_diff * 60))
+                        helpers.utctimestamp() + ((int(CONFIG.DBUPDATE_INTERVAL) * 60) - (updater_diff * 60))
                     )
                     logger.fdebug(
                         "[DB UPDATER] Scheduling next run @ %s (every %s minutes)"
-                        % (helpers.utc_date_to_local(updater_diff), DBUPDATE_INTERVAL)
+                        % (helpers.utc_date_to_local(updater_diff), CONFIG.DBUPDATE_INTERVAL)
                     )
                     UPDATER_SCHEDULER.modify(next_run_time=updater_diff)
 

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -595,6 +595,46 @@ SCHEDULER_JOB_INTERVALS = {
     "dbupdater": "DBUPDATE_INTERVAL",
 }
 
+# Scheduler job id -> a config attribute that must be set for the job to do
+# anything. Mirrors the CHECK_FOLDER / IMPORT_DIR guards in comicarr.start().
+SCHEDULER_JOB_REQUIRED_CONFIG = {
+    "monitor": "CHECK_FOLDER",
+    "importinbox": "IMPORT_DIR",
+}
+
+# Job ids this process parked because their interval was non-positive, so a
+# later positive interval can bring them back.
+#
+# APScheduler's pause_job() is just next_run_time=None, so a paused job cannot
+# say why it is paused -- and job_management() reads that same state back into
+# comicarr.<JOB>_STATUS, which means a job we parked starts looking exactly like
+# one the operator paused from the jobs UI. Remembering who did the parking is
+# what keeps the two apart. A job the operator paused is never in this set and
+# is therefore never resumed here.
+#
+# Process-scoped on purpose: a pause that outlives the process is replayed from
+# jobhistory by job_management(startup=True), and at that point nothing can say
+# why it was paused, so start() stays the authority.
+_INTERVAL_PARKED_JOBS = set()
+
+
+def _job_may_run(ctx, job_id):
+    """Whether job_id is allowed to run at all, mirroring comicarr.start()'s gates.
+
+    These are the conditions that have nothing to do with the interval, so they
+    still hold for a job this module parked itself.
+    """
+    if getattr(ctx, "acquisition_workers_blocked", False):
+        # Every job in SCHEDULER_JOB_INTERVALS is a producer or consumer of
+        # acquisition work; start() leaves them all paused behind this gate.
+        return False
+
+    required_key = SCHEDULER_JOB_REQUIRED_CONFIG.get(job_id)
+    if required_key and not getattr(ctx.config, required_key, None):
+        return False
+
+    return True
+
 
 def _reconfigure_schedulers(ctx):
     """Apply changed intervals to the running scheduler.
@@ -613,6 +653,10 @@ def _reconfigure_schedulers(ctx):
         try:
             minutes = int(getattr(ctx.config, config_key, None))
         except (TypeError, ValueError):
+            logger.error(
+                "[SYSTEM] Could not reschedule %s: %s is not a usable interval (%r)"
+                % (job_id, config_key, getattr(ctx.config, config_key, None))
+            )
             continue
 
         try:
@@ -621,21 +665,30 @@ def _reconfigure_schedulers(ctx):
                 continue
             if minutes <= 0:
                 scheduler.pause_job(job_id)
+                _INTERVAL_PARKED_JOBS.add(job_id)
                 continue
 
             trigger = IntervalTrigger(minutes=minutes, timezone="UTC")
-            if job.next_run_time is None:
-                # A paused job stays paused. job.modify(trigger=...) leaves
-                # next_run_time alone; scheduler.reschedule_job() recomputes it
-                # from the trigger and would silently resume the job.
-                job.modify(trigger=trigger)
+            pending = job.next_run_time
+            if pending is None:
+                if job_id in _INTERVAL_PARKED_JOBS and _job_may_run(ctx, job_id):
+                    # We parked this one for a non-positive interval; a positive
+                    # one is the operator asking for it back.
+                    job.modify(trigger=trigger, next_run_time=now + datetime.timedelta(minutes=minutes))
+                    _INTERVAL_PARKED_JOBS.discard(job_id)
+                else:
+                    # Paused by someone else, so it stays paused. job.modify(trigger=...)
+                    # leaves next_run_time alone; scheduler.reschedule_job() recomputes
+                    # it from the trigger and would silently resume the job.
+                    job.modify(trigger=trigger)
             else:
+                _INTERVAL_PARKED_JOBS.discard(job_id)
                 # Shortening an interval takes effect now; lengthening one takes
                 # effect after the run that is already scheduled. A pending run
                 # is never pushed later.
                 job.modify(
                     trigger=trigger,
-                    next_run_time=min(job.next_run_time, now + datetime.timedelta(minutes=minutes)),
+                    next_run_time=min(pending, now + datetime.timedelta(minutes=minutes)),
                 )
             rescheduled.append(job_id)
         except Exception as e:

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -35,6 +35,7 @@ from apscheduler.events import (
     EVENT_JOB_MAX_INSTANCES,
     EVENT_JOB_MISSED,
 )
+from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy import select
 
 import comicarr
@@ -227,7 +228,7 @@ def get_safe_config(ctx):
         "NZB_STARTUP_SEARCH",
         "SEARCH_INTERVAL",
         "SEARCH_DELAY",
-        "RSS_CHECK_INTERVAL",
+        "RSS_CHECKINTERVAL",
         "AUTO_UPDATE",
         "ANNUALS_ON",
         "WEEKFOLDER",
@@ -388,7 +389,7 @@ WRITABLE_CONFIG_KEYS = {
     "NZB_STARTUP_SEARCH",
     "SEARCH_INTERVAL",
     "SEARCH_DELAY",
-    "RSS_CHECK_INTERVAL",
+    "RSS_CHECKINTERVAL",
     "DBUPDATE_INTERVAL",
     "AUTO_UPDATE",
     "ANNUALS_ON",
@@ -511,8 +512,7 @@ def update_config(ctx, key_values):
     if not filtered:
         return {"success": False, "error": "No valid config keys provided"}
 
-    interval_keys = {"SEARCH_INTERVAL", "RSS_CHECK_INTERVAL", "DOWNLOAD_SCAN_INTERVAL", "DBUPDATE_INTERVAL"}
-    interval_changed = any(k in interval_keys for k in filtered)
+    interval_changed = any(k in set(SCHEDULER_JOB_INTERVALS.values()) for k in filtered)
 
     try:
         persisted = ctx.config.apply_transaction(filtered)
@@ -586,17 +586,64 @@ def update_providers(ctx, provider_data):
     return {"success": True}
 
 
+# Scheduler job id -> the config attribute that drives its cadence, in minutes.
+SCHEDULER_JOB_INTERVALS = {
+    "search": "SEARCH_INTERVAL",
+    "rss": "RSS_CHECKINTERVAL",
+    "monitor": "DOWNLOAD_SCAN_INTERVAL",
+    "importinbox": "IMPORT_SCAN_INTERVAL",
+    "dbupdater": "DBUPDATE_INTERVAL",
+}
+
+
 def _reconfigure_schedulers(ctx):
-    """Reconfigure scheduler intervals after config change."""
-    if not ctx.scheduler:
-        return
+    """Apply changed intervals to the running scheduler.
 
-    try:
-        import comicarr
+    Returns the job ids that were rescheduled. Never raises: the durable config
+    write has already happened by the time this runs, so a scheduler failure
+    must not turn a successful save into a failed response.
+    """
+    scheduler = getattr(ctx, "scheduler", None)
+    if scheduler is None or not ctx.config:
+        return ()
 
-        comicarr.config.configure_schedulers()
-    except Exception as e:
-        logger.error("[SYSTEM] Error reconfiguring schedulers: %s" % e)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    rescheduled = []
+    for job_id, config_key in SCHEDULER_JOB_INTERVALS.items():
+        try:
+            minutes = int(getattr(ctx.config, config_key, None))
+        except (TypeError, ValueError):
+            continue
+
+        try:
+            job = scheduler.get_job(job_id)
+            if job is None:
+                continue
+            if minutes <= 0:
+                scheduler.pause_job(job_id)
+                continue
+
+            trigger = IntervalTrigger(minutes=minutes, timezone="UTC")
+            if job.next_run_time is None:
+                # A paused job stays paused. job.modify(trigger=...) leaves
+                # next_run_time alone; scheduler.reschedule_job() recomputes it
+                # from the trigger and would silently resume the job.
+                job.modify(trigger=trigger)
+            else:
+                # Shortening an interval takes effect now; lengthening one takes
+                # effect after the run that is already scheduled. A pending run
+                # is never pushed later.
+                job.modify(
+                    trigger=trigger,
+                    next_run_time=min(job.next_run_time, now + datetime.timedelta(minutes=minutes)),
+                )
+            rescheduled.append(job_id)
+        except Exception as e:
+            logger.error("[SYSTEM] Could not reschedule %s: %s" % (job_id, e))
+
+    if rescheduled:
+        logger.fdebug("[SYSTEM] Rescheduled jobs after config change: %s" % ", ".join(rescheduled))
+    return tuple(rescheduled)
 
 
 def get_version_info(ctx):
@@ -1906,7 +1953,7 @@ def job_management(
                                         " minutes until backlog is decimated." % (comicarr.CONFIG.BACKFILL_TIMESPAN)
                                     )
                                 else:
-                                    nextrun_stamp = utctimestamp() + (int(comicarr.DBUPDATE_INTERVAL) * 60)
+                                    nextrun_stamp = utctimestamp() + (int(comicarr.CONFIG.DBUPDATE_INTERVAL) * 60)
                             else:
                                 comicarr.SCHED.pause_job("dbupdater")
                             jobstore = jbst

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -215,6 +215,7 @@ _CONFIG_DEFINITIONS = OrderedDict(
         "RSS_CHECKINTERVAL": (int, "Scheduler", 20),
         "SEARCH_INTERVAL": (int, "Scheduler", 1440),
         "DOWNLOAD_SCAN_INTERVAL": (int, "Scheduler", 5),
+        "DBUPDATE_INTERVAL": (int, "Scheduler", 1440),  # 24hrs
         "CHECK_GITHUB_INTERVAL": (int, "Scheduler", 360),
         "BLOCKLIST_TIMER": (int, "Scheduler", 3600),
         "IMPORT_SCAN_INTERVAL": (int, "Scheduler", 30),

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -635,6 +635,40 @@ ENCRYPTED_CONFIG_ITEMS = OrderedDict(
     }
 )
 
+# Lower bound, in minutes, for the intervals that are handed to an
+# IntervalTrigger and whose job is then resumed regardless of the value. A
+# non-positive one builds a negative-length interval whose next fire time is
+# always in the past, so the job re-fires back to back forever.
+#
+# DOWNLOAD_SCAN_INTERVAL and IMPORT_SCAN_INTERVAL are deliberately absent: for
+# those, 0 is the documented way to disable the job, and comicarr.start() keeps
+# them paused rather than scheduling them.
+SCHEDULER_INTERVAL_MINIMUMS = {
+    "SEARCH_INTERVAL": (360, "Search interval too low. Resetting to 6 hour minimum"),
+    "RSS_CHECKINTERVAL": (20, "Minimum RSS Interval Check delay set for 20 minutes to avoid hammering."),
+    "DBUPDATE_INTERVAL": (60, "Minimum DB update interval set for 60 minutes to avoid hammering."),
+}
+
+
+def clamp_scheduler_intervals(cfg):
+    """Raise any scheduler interval that sits below its safe minimum.
+
+    Returns the keys that were clamped. Called from Config.configure(), which
+    apply_transaction() runs on every settings save, so this is the boundary a
+    value typed into the settings form has to cross.
+
+    A value that cannot be compared raises, as it did when these were three
+    inline checks: apply_transaction() rolls the save back rather than storing
+    an interval nothing downstream can use.
+    """
+    clamped = []
+    for key, (minimum, message) in SCHEDULER_INTERVAL_MINIMUMS.items():
+        if getattr(cfg, key) < minimum:
+            logger.fdebug(message)
+            setattr(cfg, key, minimum)
+            clamped.append(key)
+    return clamped
+
 
 class Config(object):
     def __init__(self, config_file):
@@ -2324,17 +2358,11 @@ class Config(object):
             # Set the actual API key, so comicarr does not appear broken from the start
             self.COMICVINE_API = self.COMICVINE_API[4:]
 
-        if self.SEARCH_INTERVAL < 360:
-            logger.fdebug("Search interval too low. Resetting to 6 hour minimum")
-            self.SEARCH_INTERVAL = 360
+        clamp_scheduler_intervals(self)
 
         if self.SEARCH_DELAY < 1:
             logger.fdebug("Minimum search delay set for 1 minute to avoid hammering.")
             self.SEARCH_DELAY = 1
-
-        if self.RSS_CHECKINTERVAL < 20:
-            logger.fdebug("Minimum RSS Interval Check delay set for 20 minutes to avoid hammering.")
-            self.RSS_CHECKINTERVAL = 20
 
         if self.ENABLE_RSS is True and comicarr.RSS_STATUS == "Paused":
             comicarr.RSS_STATUS = "Waiting"

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -300,7 +300,7 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
     if sched is True:
         logger.fdebug(
             "Refresh sequence set to fire every %s minutes for %s day(s)"
-            % (comicarr.DBUPDATE_INTERVAL, comicarr.CONFIG.REFRESH_CACHE)
+            % (comicarr.CONFIG.DBUPDATE_INTERVAL, comicarr.CONFIG.REFRESH_CACHE)
         )
 
     for comic in sorted(

--- a/frontend/src/components/settings/MediaManagementTab.tsx
+++ b/frontend/src/components/settings/MediaManagementTab.tsx
@@ -91,6 +91,7 @@ export function MediaManagementTab({
         <SettingField
           label="Search Interval"
           type="number"
+          min={1}
           value={formData.search_interval as number | undefined}
           onChange={(v) =>
             onChange("search_interval", parseInt(v as string) || 360)
@@ -100,6 +101,7 @@ export function MediaManagementTab({
         <SettingField
           label="RSS Check Interval"
           type="number"
+          min={1}
           value={formData.rss_checkinterval as number | undefined}
           onChange={(v) =>
             onChange("rss_checkinterval", parseInt(v as string) || 20)
@@ -109,6 +111,7 @@ export function MediaManagementTab({
         <SettingField
           label="Database Update Interval"
           type="number"
+          min={1}
           value={formData.dbupdate_interval as number | undefined}
           onChange={(v) =>
             onChange("dbupdate_interval", parseInt(v as string) || 1440)

--- a/frontend/src/components/settings/MediaManagementTab.tsx
+++ b/frontend/src/components/settings/MediaManagementTab.tsx
@@ -100,9 +100,9 @@ export function MediaManagementTab({
         <SettingField
           label="RSS Check Interval"
           type="number"
-          value={formData.rss_check_interval as number | undefined}
+          value={formData.rss_checkinterval as number | undefined}
           onChange={(v) =>
-            onChange("rss_check_interval", parseInt(v as string) || 20)
+            onChange("rss_checkinterval", parseInt(v as string) || 20)
           }
           helpText="How often to check RSS feeds (default: 20 min)"
         />

--- a/frontend/src/components/settings/SettingField.tsx
+++ b/frontend/src/components/settings/SettingField.tsx
@@ -25,6 +25,8 @@ interface SettingFieldProps {
   options?: SelectOption[];
   checked?: boolean;
   placeholder?: string;
+  /** Minimum accepted value. Number fields only. */
+  min?: number;
 }
 
 export function SettingField({
@@ -38,6 +40,7 @@ export function SettingField({
   options = [],
   checked,
   placeholder,
+  min,
 }: SettingFieldProps) {
   const fieldId = `field-${label.toLowerCase().replace(/\s+/g, "-")}`;
 
@@ -174,6 +177,7 @@ export function SettingField({
         value={value ?? ""}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        min={type === "number" ? min : undefined}
         className="mt-1.5"
       />
       {helpText && (

--- a/tests/unit/test_settings_intervals.py
+++ b/tests/unit/test_settings_intervals.py
@@ -1,0 +1,216 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Scheduling intervals: the settings surface, and applying a change.
+
+Two failures met here. The settings API advertised two keys that no config
+definition backs, so saving either raised KeyError inside apply_transaction and
+rolled back the entire payload -- every other setting in the same save was
+silently discarded. And the reconfiguration path called a function that has
+never existed in this repository, so an interval change never reached the
+running scheduler even when the save succeeded.
+
+The existing update_config tests use a MagicMock config, so apply_transaction
+never runs and neither failure was visible to them.
+"""
+
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from comicarr.app.system import service as system_service
+from comicarr.config import _CONFIG_DEFINITIONS, _PROVIDER_EXTRA_FIELDS
+
+
+def _readable_config_keys():
+    """The uppercase config keys get_safe_config reads off the config object."""
+    import inspect
+    import re
+
+    source = inspect.getsource(system_service.get_safe_config)
+    body = source.split("result = {}")[0]
+    return set(re.findall(r'"([A-Z][A-Z0-9_]+)"', body))
+
+
+class TestEveryAdvertisedKeyIsReal:
+    """A key on the settings surface with no definition poisons the whole save."""
+
+    def test_writable_keys_are_all_defined(self):
+        undefined = sorted(
+            key
+            for key in system_service.WRITABLE_CONFIG_KEYS
+            if key not in _CONFIG_DEFINITIONS and key not in _PROVIDER_EXTRA_FIELDS
+        )
+
+        assert undefined == [], "WRITABLE_CONFIG_KEYS advertises keys config cannot define: %s" % undefined
+
+    def test_readable_keys_are_all_defined(self):
+        undefined = sorted(
+            key
+            for key in _readable_config_keys()
+            if key not in _CONFIG_DEFINITIONS and key not in _PROVIDER_EXTRA_FIELDS
+        )
+
+        assert undefined == [], "get_safe_config reads keys config cannot define: %s" % undefined
+
+    def test_every_scheduled_interval_is_a_real_config_key(self):
+        for job_id, config_key in system_service.SCHEDULER_JOB_INTERVALS.items():
+            assert config_key in _CONFIG_DEFINITIONS, "%s drives job %s but is not defined" % (config_key, job_id)
+
+    def test_every_writable_key_survives_config_definition_lookup(self):
+        """The actual failure mechanism: _define raises KeyError on an unknown key,
+        apply_transaction catches BaseException and rolls the whole payload back, and
+        update_config reports a persistence failure for settings that were fine."""
+        from comicarr.config import Config
+
+        for key in sorted(set(system_service.WRITABLE_CONFIG_KEYS) - set(_PROVIDER_EXTRA_FIELDS)):
+            try:
+                Config._define(None, key)
+            except KeyError:
+                pytest.fail("saving %s would roll back the entire settings payload" % key)
+
+    def test_writable_intervals_are_the_ones_the_api_can_change(self):
+        """IMPORT_SCAN_INTERVAL drives a job but is deliberately read-only: it is
+        exposed by get_safe_config and has no settings field. Reconfiguration still
+        reads it, so a change made another way is picked up."""
+        writable = {
+            config_key
+            for config_key in system_service.SCHEDULER_JOB_INTERVALS.values()
+            if config_key in system_service.WRITABLE_CONFIG_KEYS
+        }
+
+        assert writable == {
+            "SEARCH_INTERVAL",
+            "RSS_CHECKINTERVAL",
+            "DOWNLOAD_SCAN_INTERVAL",
+            "DBUPDATE_INTERVAL",
+        }
+
+
+def _scheduler_with_jobs(**next_run_times):
+    scheduler = BackgroundScheduler(timezone="UTC")
+    for job_id in system_service.SCHEDULER_JOB_INTERVALS:
+        scheduler.add_job(
+            lambda: None,
+            id=job_id,
+            trigger=IntervalTrigger(minutes=1440, timezone="UTC"),
+            next_run_time=next_run_times.get(job_id),
+        )
+    return scheduler
+
+
+def _ctx(scheduler, **intervals):
+    defaults = {config_key: 1440 for config_key in system_service.SCHEDULER_JOB_INTERVALS.values()}
+    defaults.update(intervals)
+    return SimpleNamespace(scheduler=scheduler, config=SimpleNamespace(**defaults))
+
+
+def _now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+class TestReconfigureSchedulers:
+    def test_a_changed_interval_reaches_the_job(self):
+        scheduler = _scheduler_with_jobs(search=_now() + datetime.timedelta(minutes=1440))
+        ctx = _ctx(scheduler, SEARCH_INTERVAL=720)
+
+        rescheduled = system_service._reconfigure_schedulers(ctx)
+
+        assert "search" in rescheduled
+        assert scheduler.get_job("search").trigger.interval == datetime.timedelta(minutes=720)
+
+    def test_a_paused_job_stays_paused(self):
+        """scheduler.reschedule_job() would resume it; job.modify(trigger=...) does not."""
+        scheduler = _scheduler_with_jobs()  # every job added paused
+        ctx = _ctx(scheduler, RSS_CHECKINTERVAL=45)
+
+        system_service._reconfigure_schedulers(ctx)
+
+        job = scheduler.get_job("rss")
+        assert job.next_run_time is None
+        assert job.trigger.interval == datetime.timedelta(minutes=45)
+
+    def test_shortening_an_interval_takes_effect_immediately(self):
+        scheduler = _scheduler_with_jobs(monitor=_now() + datetime.timedelta(minutes=1440))
+        ctx = _ctx(scheduler, DOWNLOAD_SCAN_INTERVAL=5)
+
+        system_service._reconfigure_schedulers(ctx)
+
+        assert scheduler.get_job("monitor").next_run_time <= _now() + datetime.timedelta(minutes=5, seconds=5)
+
+    def test_a_pending_run_is_never_pushed_later(self):
+        pending = _now() + datetime.timedelta(minutes=10)
+        scheduler = _scheduler_with_jobs(search=pending)
+        ctx = _ctx(scheduler, SEARCH_INTERVAL=10080)
+
+        system_service._reconfigure_schedulers(ctx)
+
+        assert scheduler.get_job("search").next_run_time == pending
+
+    def test_a_non_positive_interval_pauses_rather_than_removes(self):
+        scheduler = _scheduler_with_jobs(importinbox=_now() + datetime.timedelta(minutes=30))
+        ctx = _ctx(scheduler, IMPORT_SCAN_INTERVAL=0)
+
+        system_service._reconfigure_schedulers(ctx)
+
+        job = scheduler.get_job("importinbox")
+        assert job is not None
+        assert job.next_run_time is None
+
+    def test_a_missing_job_is_skipped_not_fatal(self):
+        scheduler = BackgroundScheduler(timezone="UTC")
+        scheduler.add_job(
+            lambda: None,
+            id="search",
+            trigger=IntervalTrigger(minutes=1440, timezone="UTC"),
+            next_run_time=_now() + datetime.timedelta(minutes=1440),
+        )
+
+        assert system_service._reconfigure_schedulers(_ctx(scheduler, SEARCH_INTERVAL=720)) == ("search",)
+
+    def test_an_unusable_interval_is_skipped(self):
+        scheduler = _scheduler_with_jobs(search=_now() + datetime.timedelta(minutes=1440))
+        ctx = _ctx(scheduler)
+        ctx.config.SEARCH_INTERVAL = None
+
+        assert "search" not in system_service._reconfigure_schedulers(ctx)
+
+    def test_no_scheduler_is_not_an_error(self):
+        assert system_service._reconfigure_schedulers(SimpleNamespace(scheduler=None, config=MagicMock())) == ()
+
+    def test_a_scheduler_failure_never_raises_into_the_request(self):
+        """The durable config write already happened; a scheduler fault must not fail the save."""
+        scheduler = MagicMock()
+        scheduler.get_job.side_effect = RuntimeError("jobstore is wedged")
+
+        assert system_service._reconfigure_schedulers(_ctx(scheduler)) == ()
+
+
+class TestUpdateConfigTriggersReconfiguration:
+    @pytest.mark.parametrize(
+        "config_key",
+        sorted(set(system_service.SCHEDULER_JOB_INTERVALS.values()) & system_service.WRITABLE_CONFIG_KEYS),
+    )
+    def test_changing_any_interval_reconfigures(self, config_key, monkeypatch):
+        import comicarr
+
+        ctx = SimpleNamespace(config=MagicMock(), scheduler=MagicMock())
+        ctx.config.apply_transaction.return_value = True
+        monkeypatch.setattr(comicarr, "CONFIG", None, raising=False)
+        calls = []
+        monkeypatch.setattr(system_service, "_reconfigure_schedulers", lambda _ctx: calls.append(_ctx))
+
+        result = system_service.update_config(ctx, {config_key.lower(): 60})
+
+        assert result == {"success": True}
+        assert len(calls) == 1

--- a/tests/unit/test_settings_intervals.py
+++ b/tests/unit/test_settings_intervals.py
@@ -21,6 +21,8 @@ never runs and neither failure was visible to them.
 """
 
 import datetime
+import inspect
+import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -28,18 +30,32 @@ import pytest
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
+import comicarr
 from comicarr.app.system import service as system_service
-from comicarr.config import _CONFIG_DEFINITIONS, _PROVIDER_EXTRA_FIELDS
+from comicarr.config import (
+    _CONFIG_DEFINITIONS,
+    _PROVIDER_EXTRA_FIELDS,
+    SCHEDULER_INTERVAL_MINIMUMS,
+    clamp_scheduler_intervals,
+)
 
 
 def _readable_config_keys():
     """The uppercase config keys get_safe_config reads off the config object."""
-    import inspect
-    import re
-
     source = inspect.getsource(system_service.get_safe_config)
     body = source.split("result = {}")[0]
-    return set(re.findall(r'"([A-Z][A-Z0-9_]+)"', body))
+    keys = set(re.findall(r'"([A-Z][A-Z0-9_]+)"', body))
+    # Without this the extraction could silently return nothing after a refactor
+    # and every assertion built on it would pass vacuously.
+    assert len(keys) > 50, "get_safe_config key extraction found almost nothing: %s" % sorted(keys)
+    return keys
+
+
+def _registered_job_ids():
+    """The job ids comicarr.start() actually registers with the scheduler."""
+    ids = set(re.findall(r'id="([a-z_]+)"', inspect.getsource(comicarr.start)))
+    assert ids, "no job registrations found in comicarr.start()"
+    return ids
 
 
 class TestEveryAdvertisedKeyIsReal:
@@ -66,6 +82,21 @@ class TestEveryAdvertisedKeyIsReal:
     def test_every_scheduled_interval_is_a_real_config_key(self):
         for job_id, config_key in system_service.SCHEDULER_JOB_INTERVALS.items():
             assert config_key in _CONFIG_DEFINITIONS, "%s drives job %s but is not defined" % (config_key, job_id)
+
+    def test_every_mapped_job_id_is_actually_registered(self):
+        """The other half of the mapping. SCHEDULER_JOB_INTERVALS duplicates the
+        job ids comicarr.start() registers, and _reconfigure_schedulers skips an
+        unknown id in silence -- so a rename there would quietly stop interval
+        changes from reaching the scheduler, the exact bug this module exists for."""
+        registered = _registered_job_ids()
+        unregistered = sorted(set(system_service.SCHEDULER_JOB_INTERVALS) - registered)
+
+        assert unregistered == [], "SCHEDULER_JOB_INTERVALS maps job ids nothing registers: %s" % unregistered
+
+    def test_the_job_tables_cover_the_same_jobs(self):
+        assert set(system_service.SCHEDULER_JOB_REQUIRED_CONFIG) <= set(system_service.SCHEDULER_JOB_INTERVALS)
+        for job_id, config_key in system_service.SCHEDULER_JOB_REQUIRED_CONFIG.items():
+            assert config_key in _CONFIG_DEFINITIONS, "%s gates job %s but is not defined" % (config_key, job_id)
 
     def test_every_writable_key_survives_config_definition_lookup(self):
         """The actual failure mechanism: _define raises KeyError on an unknown key,
@@ -97,6 +128,55 @@ class TestEveryAdvertisedKeyIsReal:
         }
 
 
+class TestSchedulerIntervalClamps:
+    """A non-positive interval must not reach IntervalTrigger. Config.configure()
+    runs on every save via apply_transaction, so this is where it gets caught."""
+
+    @pytest.mark.parametrize("config_key", sorted(SCHEDULER_INTERVAL_MINIMUMS))
+    def test_a_negative_interval_is_raised_to_the_minimum(self, config_key):
+        minimum = SCHEDULER_INTERVAL_MINIMUMS[config_key][0]
+        cfg = SimpleNamespace(**{key: value[0] for key, value in SCHEDULER_INTERVAL_MINIMUMS.items()})
+        setattr(cfg, config_key, -1)
+
+        assert clamp_scheduler_intervals(cfg) == [config_key]
+        assert getattr(cfg, config_key) == minimum
+
+    @pytest.mark.parametrize("config_key", sorted(SCHEDULER_INTERVAL_MINIMUMS))
+    def test_zero_is_also_clamped(self, config_key):
+        cfg = SimpleNamespace(**{key: value[0] for key, value in SCHEDULER_INTERVAL_MINIMUMS.items()})
+        setattr(cfg, config_key, 0)
+
+        clamp_scheduler_intervals(cfg)
+
+        assert getattr(cfg, config_key) == SCHEDULER_INTERVAL_MINIMUMS[config_key][0]
+
+    def test_an_acceptable_value_is_left_alone(self):
+        cfg = SimpleNamespace(**{key: value[0] * 2 for key, value in SCHEDULER_INTERVAL_MINIMUMS.items()})
+
+        assert clamp_scheduler_intervals(cfg) == []
+        assert cfg.DBUPDATE_INTERVAL == SCHEDULER_INTERVAL_MINIMUMS["DBUPDATE_INTERVAL"][0] * 2
+
+    def test_an_uncomparable_value_still_raises(self):
+        """Unchanged from the three inline checks this replaced: apply_transaction
+        rolls the save back rather than storing an interval nothing can use."""
+        cfg = SimpleNamespace(**{key: value[0] for key, value in SCHEDULER_INTERVAL_MINIMUMS.items()})
+        cfg.SEARCH_INTERVAL = "not-a-number"
+
+        with pytest.raises(TypeError):
+            clamp_scheduler_intervals(cfg)
+
+    def test_the_disable_by_zero_intervals_are_not_clamped(self):
+        """DOWNLOAD_SCAN_INTERVAL and IMPORT_SCAN_INTERVAL use 0 to mean 'off',
+        and comicarr.start() keeps those jobs paused rather than scheduling them.
+        Giving them a positive floor would remove the only way to disable them."""
+        assert "DOWNLOAD_SCAN_INTERVAL" not in SCHEDULER_INTERVAL_MINIMUMS
+        assert "IMPORT_SCAN_INTERVAL" not in SCHEDULER_INTERVAL_MINIMUMS
+
+    def test_every_clamped_key_is_a_real_config_key(self):
+        for config_key in SCHEDULER_INTERVAL_MINIMUMS:
+            assert config_key in _CONFIG_DEFINITIONS
+
+
 def _scheduler_with_jobs(**next_run_times):
     scheduler = BackgroundScheduler(timezone="UTC")
     for job_id in system_service.SCHEDULER_JOB_INTERVALS:
@@ -111,12 +191,27 @@ def _scheduler_with_jobs(**next_run_times):
 
 def _ctx(scheduler, **intervals):
     defaults = {config_key: 1440 for config_key in system_service.SCHEDULER_JOB_INTERVALS.values()}
+    # The jobs that carry a "is this even configured" guard are configured by
+    # default here, so a test that cares about that guard has to clear it.
+    defaults.update({config_key: "/tmp" for config_key in system_service.SCHEDULER_JOB_REQUIRED_CONFIG.values()})
     defaults.update(intervals)
-    return SimpleNamespace(scheduler=scheduler, config=SimpleNamespace(**defaults))
+    return SimpleNamespace(
+        scheduler=scheduler,
+        config=SimpleNamespace(**defaults),
+        acquisition_workers_blocked=False,
+    )
 
 
 def _now():
     return datetime.datetime.now(datetime.timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _clean_parked_jobs():
+    """_INTERVAL_PARKED_JOBS is process state; do not leak it between tests."""
+    system_service._INTERVAL_PARKED_JOBS.clear()
+    yield
+    system_service._INTERVAL_PARKED_JOBS.clear()
 
 
 class TestReconfigureSchedulers:
@@ -129,9 +224,11 @@ class TestReconfigureSchedulers:
         assert "search" in rescheduled
         assert scheduler.get_job("search").trigger.interval == datetime.timedelta(minutes=720)
 
-    def test_a_paused_job_stays_paused(self):
-        """scheduler.reschedule_job() would resume it; job.modify(trigger=...) does not."""
-        scheduler = _scheduler_with_jobs()  # every job added paused
+    def test_a_job_paused_by_someone_else_stays_paused(self):
+        """A job paused from the jobs UI, or by turning ENABLE_RSS off, keeps its
+        new interval but must not be resumed. scheduler.reschedule_job() would
+        resume it; job.modify(trigger=...) does not."""
+        scheduler = _scheduler_with_jobs()  # every job added paused, by nobody here
         ctx = _ctx(scheduler, RSS_CHECKINTERVAL=45)
 
         system_service._reconfigure_schedulers(ctx)
@@ -139,6 +236,61 @@ class TestReconfigureSchedulers:
         job = scheduler.get_job("rss")
         assert job.next_run_time is None
         assert job.trigger.interval == datetime.timedelta(minutes=45)
+
+    def test_a_job_parked_by_a_zero_interval_comes_back(self):
+        """The inverse of the pause below. Without it, setting an interval to 0 and
+        then correcting it left the job dark until the process restarted -- and the
+        pause is replayed from jobhistory, so a restart did not fix it either."""
+        scheduler = _scheduler_with_jobs(monitor=_now() + datetime.timedelta(minutes=30))
+
+        system_service._reconfigure_schedulers(_ctx(scheduler, DOWNLOAD_SCAN_INTERVAL=0))
+        assert scheduler.get_job("monitor").next_run_time is None
+
+        rescheduled = system_service._reconfigure_schedulers(_ctx(scheduler, DOWNLOAD_SCAN_INTERVAL=15))
+
+        job = scheduler.get_job("monitor")
+        assert "monitor" in rescheduled
+        assert job.next_run_time is not None
+        assert job.trigger.interval == datetime.timedelta(minutes=15)
+
+    def test_a_parked_job_comes_back_even_after_its_status_reads_paused(self, monkeypatch):
+        """job_management() derives comicarr.<JOB>_STATUS from the live scheduler, so
+        once it runs, a job we parked is indistinguishable from an operator-paused one
+        by status alone. Remembering who parked it is what makes the recovery work."""
+        monkeypatch.setattr(comicarr, "MONITOR_STATUS", "Paused")
+        scheduler = _scheduler_with_jobs(monitor=_now() + datetime.timedelta(minutes=30))
+
+        system_service._reconfigure_schedulers(_ctx(scheduler, DOWNLOAD_SCAN_INTERVAL=0))
+        system_service._reconfigure_schedulers(_ctx(scheduler, DOWNLOAD_SCAN_INTERVAL=15))
+
+        assert scheduler.get_job("monitor").next_run_time is not None
+
+    def test_a_job_missing_its_required_config_is_not_resumed(self):
+        """comicarr.start() refuses to run the folder monitor without CHECK_FOLDER;
+        a positive interval alone must not talk it into running here either."""
+        scheduler = _scheduler_with_jobs(monitor=_now() + datetime.timedelta(minutes=30))
+
+        system_service._reconfigure_schedulers(_ctx(scheduler, DOWNLOAD_SCAN_INTERVAL=0))
+        system_service._reconfigure_schedulers(_ctx(scheduler, DOWNLOAD_SCAN_INTERVAL=15, CHECK_FOLDER=None))
+
+        assert scheduler.get_job("monitor").next_run_time is None
+
+    def test_a_blocked_acquisition_gate_resumes_nothing(self):
+        scheduler = _scheduler_with_jobs(search=_now() + datetime.timedelta(minutes=30))
+
+        system_service._reconfigure_schedulers(_ctx(scheduler, SEARCH_INTERVAL=0))
+        ctx = _ctx(scheduler, SEARCH_INTERVAL=720)
+        ctx.acquisition_workers_blocked = True
+        system_service._reconfigure_schedulers(ctx)
+
+        assert scheduler.get_job("search").next_run_time is None
+
+    def test_a_job_that_was_never_parked_is_not_tracked(self):
+        scheduler = _scheduler_with_jobs(search=_now() + datetime.timedelta(minutes=30))
+
+        system_service._reconfigure_schedulers(_ctx(scheduler, SEARCH_INTERVAL=720))
+
+        assert "search" not in system_service._INTERVAL_PARKED_JOBS
 
     def test_shortening_an_interval_takes_effect_immediately(self):
         scheduler = _scheduler_with_jobs(monitor=_now() + datetime.timedelta(minutes=1440))
@@ -178,12 +330,22 @@ class TestReconfigureSchedulers:
 
         assert system_service._reconfigure_schedulers(_ctx(scheduler, SEARCH_INTERVAL=720)) == ("search",)
 
-    def test_an_unusable_interval_is_skipped(self):
+    def test_an_unusable_interval_is_skipped_and_logged(self, monkeypatch):
+        """A non-digit string survives Config.process_kwargs unchanged, so this is
+        reachable from the API. Skipping is right; skipping in silence is not --
+        every other failure in this loop says why."""
+        errors = []
+        monkeypatch.setattr(
+            system_service,
+            "logger",
+            SimpleNamespace(error=errors.append, fdebug=lambda _msg: None),
+        )
         scheduler = _scheduler_with_jobs(search=_now() + datetime.timedelta(minutes=1440))
         ctx = _ctx(scheduler)
-        ctx.config.SEARCH_INTERVAL = None
+        ctx.config.SEARCH_INTERVAL = "not-a-number"
 
         assert "search" not in system_service._reconfigure_schedulers(ctx)
+        assert any("search" in message and "SEARCH_INTERVAL" in message for message in errors), errors
 
     def test_no_scheduler_is_not_an_error(self):
         assert system_service._reconfigure_schedulers(SimpleNamespace(scheduler=None, config=MagicMock())) == ()


### PR DESCRIPTION
## The bug

**Editing the RSS check interval or the database update interval silently discarded the entire settings save.**

The settings API advertised `RSS_CHECK_INTERVAL` and `DBUPDATE_INTERVAL` as readable and writable keys. Neither is a config definition — the real key is `RSS_CHECKINTERVAL`, and the database update interval was only ever a module global. `Config._define` raises `KeyError` on an unknown key, `apply_transaction` catches `BaseException` and rolls the transaction back, and `update_config` reports a persistence failure. Since the settings form submits the whole payload, touching either field discarded every other change in the same save.

Second, `_reconfigure_schedulers` called `comicarr.config.configure_schedulers()`, **which has never existed in this repository** — `git log --all -S 'def configure_schedulers'` finds no commit that defined it. The `AttributeError` was swallowed one line down, so an interval change never reached the running scheduler even when the save succeeded.

## The fix

- Correct the two key names on the readable and writable surfaces.
- Give `DBUPDATE_INTERVAL` a real config definition. This also fixes it resetting to 1440 on every restart, which made the settings field a lie. Its module global is retired rather than mirrored.
- Implement `_reconfigure_schedulers` against the live jobs.

Two traps worth calling out in review, both verified against the pinned APScheduler 3.11.2:

- It uses `job.modify(trigger=...)`, **not** `scheduler.reschedule_job()`. The latter recomputes `next_run_time` from the trigger and would silently resume a job the operator had paused.
- A pending run is never pushed later. Shortening an interval applies immediately; lengthening one applies after the run already scheduled.

## Why the existing tests missed it

The `update_config` tests use a `MagicMock` config, so `apply_transaction` never runs. The new tests assert that every key the settings surface advertises survives `Config._define`, and drive `_reconfigure_schedulers` against a real unstarted `BackgroundScheduler` — pending jobs resolve while stopped, so no fake is needed.

## Verification

`pytest tests/unit` (1508 passing), `ruff check`, `npm run lint:modern`, frontend typecheck + eslint + vitest.

Found by the architecture review in this session; one of eight independent branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiHS1hJan2hwwyDkgFKJQj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings now save successfully when RSS and database update intervals are changed.
  * Interval changes are applied to the running scheduler without requiring an application restart.
  * Database update intervals now persist correctly instead of resetting to 24 hours.
  * Disabled or invalid scheduler intervals are handled safely without disrupting other settings.
* **Improvements**
  * Standardized RSS interval configuration handling across settings.
  * Scheduler timing updates now preserve pending runs when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->