### PR TITLE
fix: Monitor torrents on every supported client

### DIFF
--- a/.changeset/brave-torrents-monitored.md
+++ b/.changeset/brave-torrents-monitored.md
@@ -8,3 +8,11 @@ forever: nothing polled them, post-processing never ran, and a restart could not
 pick them back up. All five torrent clients are now polled through one code
 path, and a client being unreachable is kept distinct from a torrent genuinely
 being gone, so an outage no longer looks like a lost download.
+
+The auto-snatch worker now also starts for uTorrent, Transmission and
+qBittorrent — and for a local-post-processing-only setup — so the releases those
+clients queue are actually consumed instead of piling up unread. Torrents paused
+for the local post-processing copy are resumed even when the copy fails, the
+on-snatch script keeps firing for the three newly monitored clients, and every
+qBittorrent and uTorrent WebUI call now has a timeout so one hung client can no
+longer stall monitoring for every download.

--- a/.changeset/brave-torrents-monitored.md
+++ b/.changeset/brave-torrents-monitored.md
@@ -1,0 +1,10 @@
+---
+"comicarr": patch
+---
+
+Fix torrents snatched through qBittorrent, Transmission or uTorrent never being
+monitored. They were sent to the client successfully and then left in Snatched
+forever: nothing polled them, post-processing never ran, and a restart could not
+pick them back up. All five torrent clients are now polled through one code
+path, and a client being unreachable is kept distinct from a torrent genuinely
+being gone, so an outage no longer looks like a lost download.

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -880,6 +880,7 @@ def resume_acquisition_runtime(config=None):
 
     from comicarr.app.acquisition.maintenance import refresh_runtime_state
     from comicarr.app.core.runtime import get_runtime_if_initialized, set_runtime_acquisition_status
+    from comicarr.torrent import monitor as torrent_monitor
 
     ctx = get_runtime_if_initialized()
     config = config or (ctx.config if ctx is not None else CONFIG)
@@ -909,10 +910,15 @@ def resume_acquisition_runtime(config=None):
         if all(
             [
                 bool(getattr(config, "ENABLE_TORRENTS", False)),
-                bool(getattr(config, "AUTO_SNATCH", False)),
+                any(
+                    [
+                        bool(getattr(config, "AUTO_SNATCH", False)),
+                        bool(getattr(config, "LOCAL_TORRENT_PP", False)),
+                    ]
+                ),
                 OS_DETECT != "Windows",
             ]
-        ) and getattr(config, "TORRENT_DOWNLOADER", None) in {2, 4}:
+        ) and torrent_monitor.is_monitorable_downloader(getattr(config, "TORRENT_DOWNLOADER", None)):
             schedule("snatched_queue")
             queues_started.append("snatched_queue")
         if bool(getattr(config, "POST_PROCESSING", False)) and (
@@ -981,6 +987,7 @@ def start(ctx):
     worker from starting against a copied queue/lock/scheduler view.
     """
     from comicarr.app.core.runtime import RuntimeNotInitializedError, set_runtime_acquisition_status, set_runtime_field
+    from comicarr.torrent import monitor as torrent_monitor
 
     if ctx is None or ctx.disposed:
         raise RuntimeNotInitializedError("Workers cannot start before an active runtime context exists")
@@ -1190,9 +1197,13 @@ def start(ctx):
             # thread queue control..
             queue_schedule("search_queue", "start", ctx=ctx)
 
-            if all([CONFIG.ENABLE_TORRENTS, CONFIG.AUTO_SNATCH, OS_DETECT != "Windows"]) and any(
-                [CONFIG.TORRENT_DOWNLOADER == 2, CONFIG.TORRENT_DOWNLOADER == 4]
-            ):
+            if all(
+                [
+                    CONFIG.ENABLE_TORRENTS,
+                    any([CONFIG.AUTO_SNATCH, CONFIG.LOCAL_TORRENT_PP]),
+                    OS_DETECT != "Windows",
+                ]
+            ) and torrent_monitor.is_monitorable_downloader(CONFIG.TORRENT_DOWNLOADER):
                 queue_schedule("snatched_queue", "start", ctx=ctx)
 
             if CONFIG.POST_PROCESSING is True and (
@@ -1347,6 +1358,7 @@ def start(ctx):
 def queue_schedule(queuetype, mode, ctx=None):
     """Start/stop legacy workers while preserving canonical pool identity."""
     from comicarr.app.core.runtime import POOL_CONTEXT_FIELDS, get_runtime_if_initialized, set_runtime_field
+    from comicarr.torrent import monitor as torrent_monitor
 
     ctx = ctx or get_runtime_if_initialized()
 
@@ -1483,10 +1495,10 @@ def queue_schedule(queuetype, mode, ctx=None):
                 [
                     mode != "shutdown",
                     comicarr.CONFIG.ENABLE_TORRENTS is True,
-                    comicarr.CONFIG.AUTO_SNATCH is True,
+                    any([comicarr.CONFIG.AUTO_SNATCH is True, comicarr.CONFIG.LOCAL_TORRENT_PP is True]),
                     OS_DETECT != "Windows",
                 ]
-            ) and any([comicarr.CONFIG.TORRENT_DOWNLOADER == 2, comicarr.CONFIG.TORRENT_DOWNLOADER == 4]):
+            ) and torrent_monitor.is_monitorable_downloader(comicarr.CONFIG.TORRENT_DOWNLOADER):
                 return
             shutdown(get_pool("SNPOOL"), comicarr.SNATCHED_QUEUE, "auto-snatch")
 

--- a/comicarr/_vendor/provenance.py
+++ b/comicarr/_vendor/provenance.py
@@ -194,8 +194,12 @@ VENDOR_PROVENANCE = {
         "partial_attributions": (),
         "redistribution_status": "evidence-recorded",
         "unresolved_reasons": (),
-        "local_modifications": "Bundled Web API client; exact upstream revision unidentified",
-        "packaged_snapshot_sha256": "708547733567cb9746641b198851e30fd36aec1bcc19643e80e4d4185df90970",
+        "local_modifications": (
+            "Bundled Web API client; exact upstream revision unidentified. "
+            "Comicarr adds a DEFAULT_TIMEOUT to every WebUI request so a hung "
+            "client cannot block the single-threaded torrent monitor."
+        ),
+        "packaged_snapshot_sha256": "b0251f4e6dd857e0f0a1107e30e851f8c524b15dd7b294bedbd2390d964f2b4f",
     },
     "rtorrent": {
         "integration_owner": "Comicarr",
@@ -290,7 +294,11 @@ VENDOR_PROVENANCE = {
             "the PyMOTW attribution covers only a helper and supplies no bundled license",
             "uTorrent 3.0+ is a compatibility target, not a client library version",
         ),
-        "local_modifications": "Ported to Python 3 and namespaced by Comicarr",
-        "packaged_snapshot_sha256": "725666a4b7029a1da28e253c38df9ad57a3c575be632164aec5e275b300973b0",
+        "local_modifications": (
+            "Ported to Python 3 and namespaced by Comicarr. Comicarr adds a "
+            "DEFAULT_TIMEOUT to every WebUI request so a hung client cannot "
+            "block the single-threaded torrent monitor."
+        ),
+        "packaged_snapshot_sha256": "c0cd1eeb3cae1068b081c2afeb113b16fb14de42b98bd7ad83d9ad9438e942f9",
     },
 }

--- a/comicarr/_vendor/qbittorrent/client.py
+++ b/comicarr/_vendor/qbittorrent/client.py
@@ -1,6 +1,11 @@
 import requests
 import json
 
+# Seconds to wait on any single WebUI call. The monitor polls this client from
+# a single-threaded worker, so an unbounded request would stall monitoring for
+# every download rather than failing one probe.
+DEFAULT_TIMEOUT = 30
+
 class LoginRequired(Exception):
     def __str__(self):
         return 'Please login first.'
@@ -14,7 +19,7 @@ class Client(object):
         self.url = url
 
         session = requests.Session()
-        check_prefs = session.get(url+'api/v2/app/preferences')
+        check_prefs = session.get(url+'api/v2/app/preferences', timeout=DEFAULT_TIMEOUT)
 
         if check_prefs.status_code == 200:
             self._is_authenticated = True
@@ -70,6 +75,8 @@ class Client(object):
         if not self._is_authenticated:
             raise LoginRequired
 
+        kwargs.setdefault('timeout', DEFAULT_TIMEOUT)
+
         rq = self.session
         if method == 'get':
             request = rq.get(final_url, **kwargs)
@@ -105,7 +112,8 @@ class Client(object):
         self.session = requests.Session()
         login = self.session.post(self.url+'api/v2/auth/login',
                                   data={'username': username,
-                                        'password': password})
+                                        'password': password},
+                                  timeout=DEFAULT_TIMEOUT)
         if login.text == 'Ok.':
             self._is_authenticated = True
         else:

--- a/comicarr/_vendor/utorrent/client.py
+++ b/comicarr/_vendor/utorrent/client.py
@@ -8,6 +8,11 @@ from urllib.request import HTTPBasicAuthHandler, HTTPCookieProcessor, Request, b
 
 from .upload import MultiPartForm
 
+# Seconds to wait on any single WebUI call. The monitor polls this client from
+# a single-threaded worker, so an unbounded request would stall monitoring for
+# every download rather than failing one probe.
+DEFAULT_TIMEOUT = 30
+
 class UTorrentClient(object):
 
     def __init__(self, base_url, username, password):
@@ -37,7 +42,7 @@ class UTorrentClient(object):
 
     def _get_token(self):
         url = urljoin(self.base_url, "token.html")
-        response = self.opener.open(url)
+        response = self.opener.open(url, timeout=DEFAULT_TIMEOUT)
         token_re = "<div id='token' style='display:none;'>([^<>]+)</div>"
         match = re.search(token_re, response.read().decode("utf-8"))
         return match.group(1)
@@ -133,7 +138,7 @@ class UTorrentClient(object):
             request.add_header("Content-type", content_type)
 
         try:
-            response = self.opener.open(request)
+            response = self.opener.open(request, timeout=DEFAULT_TIMEOUT)
             return response.code, json.loads(response.read())
         except HTTPError:
             raise

--- a/comicarr/app/downloads/handoff.py
+++ b/comicarr/app/downloads/handoff.py
@@ -47,7 +47,12 @@ _ROUTE_ALIASES = {
     "watchdir": "watchdir",
     "blackhole": "blackhole",
 }
-_RESTART_SAFE_ROUTES = frozenset({"sabnzbd", "nzbget", "ddl", "rtorrent", "deluge"})
+# Routes whose acceptance yields an identity the monitor can poll after a
+# restart. Every torrent client with a probe belongs here; watchdir and
+# blackhole produce no client-side identity and so stay out.
+_RESTART_SAFE_ROUTES = frozenset(
+    {"sabnzbd", "nzbget", "ddl", "rtorrent", "deluge", "qbittorrent", "transmission", "utorrent"}
+)
 
 
 def _record_route_health(route, success, error=None):

--- a/comicarr/app/search/health.py
+++ b/comicarr/app/search/health.py
@@ -157,7 +157,9 @@ def _downstream_readiness(config, route):
     }
     client, key, needs_path = clients.get(downloader, ("disabled", None, False))
     configured = getattr(config, key, None) if key else None
-    restart_safe = downloader in {2, 4}
+    # Every client with a monitor probe: uTorrent, rTorrent, Transmission,
+    # Deluge, qBittorrent. Watchfolder (0) has no identity to poll.
+    restart_safe = downloader in {1, 2, 3, 4, 5}
     client_ready = True if needs_path else bool(configured)
     path_keys = {
         2: "RTORRENT_DIRECTORY",

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -729,8 +729,16 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
                                 "Unable to create temporary directory to perform meta-tagging. Processing cannot continue with given item at this time."
                             )
                             torrent_info["copied_filepath"] = torrent_path
-                        else:
-                            torrent_monitor.resume(torrent_hash)
+                        finally:
+                            # The pause above must be undone on every exit path.
+                            # Resuming only on success left a failed copy's
+                            # torrent paused in the client with nothing to
+                            # restart it.
+                            if torrent_monitor.resume(torrent_hash) is False:
+                                logger.warn(
+                                    "Unable to resume torrent %s after the local copy - it may still be paused in the client."
+                                    % torrent_hash
+                                )
                 else:
                     logger.fdebug(
                         "%s has no pause API; skipping the local copy and leaving the torrent running."

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -30,6 +30,7 @@ from comicarr.app.acquisition.models import DispatchState, ItemOutcome, RunState
 from comicarr.app.core.workers import start_background_thread
 from comicarr.app.search.commands import SearchCommand, SearchCommandError
 from comicarr.tables import issues, ref32p
+from comicarr.torrent import monitor as torrent_monitor
 
 
 def find_comic(
@@ -604,63 +605,36 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
         logger.error("Torrent hash is missing, or an invalid hash value has been passed")
         return {"snatch_status": "MONITOR ERROR"}
 
-    if comicarr.USE_RTORRENT:
-        from comicarr import rtorrent_test_client
+    # One normalised snapshot for every client. Previously only rTorrent and
+    # Deluge were handled here and everything else fell through to MONITOR
+    # ERROR, so a torrent snatched via qBittorrent, Transmission or uTorrent
+    # could never be monitored or recovered.
+    snapshot = torrent_monitor.probe(torrent_hash)
+    logger.info("torrent_info: %s" % snapshot)
 
-        rp = rtorrent_test_client.RTorrent()
-        torrent_info = rp.main(torrent_hash, check=True)
-    elif comicarr.USE_DELUGE:
-        from comicarr.torrent.clients import deluge as delu
+    if not snapshot.get("reachable"):
+        # The client did not answer. NOT the same as "no such torrent" —
+        # recovery must not treat an outage as proof the download is gone.
+        logger.warn("torrent client unreachable for hash %s: %s" % (torrent_hash, snapshot.get("reason")))
+        return {"snatch_status": "MONITOR ERROR", "error": snapshot.get("reason")}
 
-        dp = delu.TorrentClient()
-        # connect() returns the RPC client on success, or {"status": False, "error": ...}
-        # on failure. Failure dicts are truthy — bare `if not conn` never catches them.
-        conn = dp.connect(comicarr.CONFIG.DELUGE_HOST, comicarr.CONFIG.DELUGE_USERNAME, comicarr.CONFIG.DELUGE_PASSWORD)
-        if conn is False or conn is None or (isinstance(conn, dict) and conn.get("status") is False):
-            logger.warn("Not connected to Deluge!")
-            return {"snatch_status": "MONITOR ERROR"}
-
-        torrent_info = dp.get_torrent(torrent_hash)
-    else:
-        return {"snatch_status": "MONITOR ERROR"}
-
-    logger.info("torrent_info: %s" % torrent_info)
-
-    # Falsy covers False (Deluge miss), None (rTorrent check-miss bare return), and {}.
-    # Use `not torrent_info` so None never hits len() and TypeErrors the worker.
-    if not torrent_info:
-        # The client was queried and returned no torrent for this hash. This
-        # is an EXPLICIT "hash not present in the client" signal — NOT the old
-        # silent fall-through (previously this set a lost local snatch_status
-        # and `return torrent_info` returned bare False, which made
-        # worker_main crash on snstat["snatch_status"] and gave U5 nothing
-        # authoritative to classify). Returning an explicit NOT-FOUND marker
-        # dict lets U5 recovery classification distinguish "absent from a
-        # reachable client" (→ gone, after the done-signal cross-check) from a
-        # transient client outage (MONITOR ERROR → unknown). Connection
-        # failures return MONITOR ERROR above and do not reach here.
+    if not snapshot.get("found"):
+        # The client was queried and returned no torrent for this hash. This is
+        # an EXPLICIT "hash not present in the client" signal, which lets U5
+        # recovery classification distinguish absent-from-a-reachable-client
+        # (→ gone, after the done-signal cross-check) from a transient outage
+        # (MONITOR ERROR → unknown).
         logger.warn("torrent not present in client for hash %s (explicit NOT FOUND)." % torrent_hash)
         return {"snatch_status": "NOT FOUND", "hash": torrent_hash}
     else:
-        if comicarr.USE_DELUGE:
-            torrent_status = torrent_info["is_finished"]
-            torrent_files = torrent_info["num_files"]
-            torrent_folder = torrent_info["save_path"]
-            torrent_info["total_filesize"] = torrent_info["total_size"]
-            torrent_info["upload_total"] = torrent_info["total_uploaded"]
-            torrent_info["download_total"] = torrent_info["total_payload_download"]
-            torrent_info["time_started"] = torrent_info["time_added"]
-
-        elif comicarr.USE_RTORRENT:
-            torrent_status = torrent_info["completed"]
-            torrent_files = len(torrent_info["files"])
-            torrent_folder = torrent_info["folder"]
+        torrent_info = dict(snapshot)
+        torrent_status = bool(snapshot.get("completed"))
+        torrent_files = snapshot.get("files") or []
+        torrent_folder = snapshot.get("folder")
 
         def resolve_torrent_path():
-            if torrent_files == 1:
-                if comicarr.USE_DELUGE:
-                    return os.path.join(torrent_folder, torrent_info["files"][0]["path"])
-                return torrent_info["files"][0]
+            if len(torrent_files) == 1:
+                return torrent_files[0]
             return torrent_folder
 
         if all([torrent_status is True, download is True]):
@@ -732,8 +706,12 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
             # explicit absent marker (returned above when the client has no hash).
             snatch_status = "IN PROGRESS"
             if monitor is True:
-                if comicarr.USE_DELUGE:
-                    pauseit = dp.stop_torrent(torrent_hash)
+                # Copying an in-flight torrent's files needs the client to hold
+                # off writing to them. Clients without a pause API simply skip
+                # this; the torrent is still monitored, it is just not copied
+                # early for local post-processing.
+                if snapshot.get("client") in torrent_monitor.PAUSABLE_ROUTES:
+                    pauseit = torrent_monitor.pause(torrent_hash)
                     if pauseit is False:
                         logger.warn("Unable to pause torrent - cannot run post-process on item at this time.")
                         snatch_status = "MONITOR FAIL"
@@ -752,7 +730,12 @@ def torrentinfo(issueid=None, torrent_hash=None, download=False, monitor=False):
                             )
                             torrent_info["copied_filepath"] = torrent_path
                         else:
-                            dp.start_torrent(torrent_hash)
+                            torrent_monitor.resume(torrent_hash)
+                else:
+                    logger.fdebug(
+                        "%s has no pause API; skipping the local copy and leaving the torrent running."
+                        % snapshot.get("client")
+                    )
             torrent_info["snatch_status"] = snatch_status
 
     return torrent_info

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -73,6 +73,7 @@ from comicarr.tables import (
     storyarcs,
     weekly,
 )
+from comicarr.torrent import monitor as torrent_monitor
 
 # ThreadPoolExecutor for parallel provider searches
 # Using a module-level executor allows connection reuse across searches
@@ -3562,7 +3563,12 @@ def searcher(
             # snatch-seam key (issueid|normalized-provider), orphaning the
             # snatched journal row. nzbprov here is the same raw provider label
             # foundsearch is given for this snatch.
-            if any([comicarr.USE_RTORRENT, comicarr.USE_DELUGE]) and comicarr.CONFIG.AUTO_SNATCH:
+            # Any client the monitor can poll is eligible. Restricting this to
+            # rTorrent and Deluge meant a qBittorrent, Transmission or uTorrent
+            # snatch never reached the queue at all, so it sat in Snatched
+            # forever regardless of what the monitor could see.
+            monitorable = torrent_monitor.configured_route() is not None
+            if monitorable and comicarr.CONFIG.AUTO_SNATCH:
                 comicarr.SNATCHED_QUEUE.put(
                     {
                         "issueid": IssueID,
@@ -3573,7 +3579,7 @@ def searcher(
                         "journal_release_key": journal_release_key,
                     }
                 )
-            elif any([comicarr.USE_RTORRENT, comicarr.USE_DELUGE]) and comicarr.CONFIG.LOCAL_TORRENT_PP:
+            elif monitorable and comicarr.CONFIG.LOCAL_TORRENT_PP:
                 comicarr.SNATCHED_QUEUE.put(
                     {
                         "issueid": IssueID,

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -3568,6 +3568,14 @@ def searcher(
             # snatch never reached the queue at all, so it sat in Snatched
             # forever regardless of what the monitor could see.
             monitorable = torrent_monitor.configured_route() is not None
+            # Widening `monitorable` moves qBittorrent, Transmission and
+            # uTorrent out of the else-branch below, which is where the
+            # on-snatch hook lives. Those users must not silently lose the
+            # hook, so it keeps its original gate: suppressed only for the
+            # rTorrent/Deluge queueing path, whose worker already performs the
+            # same pack lookup the hook does.
+            legacy_queue_route = any([comicarr.USE_RTORRENT, comicarr.USE_DELUGE])
+            queued_for_monitoring = comicarr.CONFIG.AUTO_SNATCH or comicarr.CONFIG.LOCAL_TORRENT_PP
             if monitorable and comicarr.CONFIG.AUTO_SNATCH:
                 comicarr.SNATCHED_QUEUE.put(
                     {
@@ -3590,7 +3598,7 @@ def searcher(
                         "journal_release_key": journal_release_key,
                     }
                 )
-            else:
+            if not (legacy_queue_route and queued_for_monitoring):
                 if comicarr.CONFIG.ENABLE_SNATCH_SCRIPT:
                     try:
                         if comicinfo[0]["pack"] is False:

--- a/comicarr/torrent/monitor.py
+++ b/comicarr/torrent/monitor.py
@@ -1,0 +1,346 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Read a torrent's state from whichever client is configured.
+
+One normalised shape for all five clients, so callers stop reading
+client-specific keys. Every client's own ``get_torrent`` returns something
+different -- Deluge speaks libtorrent field names, qBittorrent returns raw Web
+API payloads, uTorrent returns a subset -- and only rTorrent and Deluge were
+ever wired into the monitor path. A torrent snatched through any of the other
+three could not be monitored or recovered at all.
+
+The distinction this module exists to preserve is **unreachable** (the client
+did not answer) versus **absent** (the client answered and does not have this
+hash). Collapsing them makes recovery abandon live downloads, so every failure
+path here is explicit about which one it is.
+
+Note that all five adapters report a connection failure as a *truthy*
+``{"status": False, ...}`` mapping, so the common ``if not client.connect(...)``
+idiom silently treats a dead client as connected. Everything here routes through
+``normalize_connection_result``.
+"""
+
+import comicarr
+from comicarr import logger
+from comicarr.torrent.contracts import normalize_connection_result
+
+# Normalised keys every probe result carries when `found` is True. Clients that
+# cannot supply a field leave it None rather than omitting it, so callers can
+# read it unconditionally.
+_TORRENT_FIELDS = (
+    "hash",
+    "name",
+    "folder",
+    "completed",
+    "files",
+    "label",
+    "total_filesize",
+    "upload_total",
+    "download_total",
+    "ratio",
+    "time_started",
+)
+
+
+def unreachable(reason):
+    """The configured client could not be queried. Never means 'not present'."""
+    return {"reachable": False, "found": False, "reason": str(reason)}
+
+
+def absent(torrent_hash):
+    """The client answered and does not hold this hash."""
+    return {"reachable": True, "found": False, "hash": torrent_hash}
+
+
+def _found(torrent_hash, **fields):
+    result = {"reachable": True, "found": True, "hash": torrent_hash}
+    for key in _TORRENT_FIELDS:
+        result.setdefault(key, fields.get(key))
+    result.update({k: v for k, v in fields.items() if k in _TORRENT_FIELDS})
+    result["hash"] = torrent_hash
+    return result
+
+
+def configured_route():
+    """Return the torrent client route in use, or None when none is monitorable."""
+    if comicarr.USE_RTORRENT:
+        return "rtorrent"
+    if comicarr.USE_DELUGE:
+        return "deluge"
+    if comicarr.USE_QBITTORRENT:
+        return "qbittorrent"
+    if comicarr.USE_TRANSMISSION:
+        return "transmission"
+    if comicarr.USE_UTORRENT:
+        return "utorrent"
+    # Watch-folder handoff produces no client-side identity to poll.
+    return None
+
+
+def _probe_rtorrent(torrent_hash):
+    from comicarr import rtorrent_test_client
+
+    client = rtorrent_test_client.RTorrent()
+    info = client.main(torrent_hash, check=True)
+    if not info:
+        return absent(torrent_hash)
+    return _found(
+        torrent_hash,
+        name=info.get("name"),
+        folder=info.get("folder"),
+        completed=bool(info.get("completed")),
+        files=info.get("files") or [],
+        label=info.get("label"),
+        total_filesize=info.get("total_filesize"),
+        upload_total=info.get("upload_total"),
+        download_total=info.get("download_total"),
+        ratio=info.get("ratio"),
+        time_started=info.get("time_started"),
+    )
+
+
+def _probe_deluge(torrent_hash):
+    from comicarr.torrent.clients import deluge
+
+    client = deluge.TorrentClient()
+    conn = normalize_connection_result(
+        client.connect(
+            comicarr.CONFIG.DELUGE_HOST,
+            comicarr.CONFIG.DELUGE_USERNAME,
+            comicarr.CONFIG.DELUGE_PASSWORD,
+        )
+    )
+    if isinstance(conn, dict) and conn.get("status") is False:
+        return unreachable(conn.get("error", "deluge did not connect"))
+
+    info = client.get_torrent(torrent_hash)
+    if not info:
+        return absent(torrent_hash)
+
+    folder = info.get("save_path")
+    files = [f.get("path") for f in (info.get("files") or []) if isinstance(f, dict)]
+    return _found(
+        torrent_hash,
+        name=info.get("name"),
+        folder=folder,
+        completed=bool(info.get("is_finished")),
+        # Deluge reports paths relative to save_path; callers want absolute.
+        files=[_join(folder, path) for path in files],
+        label=info.get("label"),
+        total_filesize=info.get("total_size"),
+        upload_total=info.get("total_uploaded"),
+        download_total=info.get("total_payload_download"),
+        ratio=info.get("ratio"),
+        time_started=info.get("time_added"),
+    )
+
+
+def _probe_qbittorrent(torrent_hash):
+    from comicarr.torrent.clients import qbittorrent
+
+    client = qbittorrent.TorrentClient()
+    conn = normalize_connection_result(
+        client.connect(
+            comicarr.CONFIG.QBITTORRENT_HOST,
+            comicarr.CONFIG.QBITTORRENT_USERNAME,
+            comicarr.CONFIG.QBITTORRENT_PASSWORD,
+        )
+    )
+    if isinstance(conn, dict) and conn.get("status") is False:
+        return unreachable(conn.get("error", "qbittorrent did not connect"))
+
+    # get_torrent() hits /torrents/properties, which carries neither the name
+    # nor the progress. /torrents/info filtered by hash carries both.
+    try:
+        listing = client.conn.torrents(hashes=torrent_hash.lower())
+    except Exception as e:
+        return unreachable(e)
+
+    entry = next((t for t in listing or [] if str(t.get("hash", "")).lower() == torrent_hash.lower()), None)
+    if entry is None:
+        return absent(torrent_hash)
+
+    folder = entry.get("save_path") or entry.get("content_path")
+    try:
+        files = [
+            _join(folder, f.get("name"))
+            for f in client.conn.get_torrent_files(torrent_hash.lower()) or []
+            if f.get("name")
+        ]
+    except Exception:
+        # The torrent is present; only the file list is unavailable.
+        files = []
+
+    return _found(
+        torrent_hash,
+        name=entry.get("name"),
+        folder=folder,
+        completed=float(entry.get("progress") or 0) >= 1,
+        files=files,
+        label=entry.get("category"),
+        total_filesize=entry.get("size"),
+        upload_total=entry.get("uploaded"),
+        download_total=entry.get("downloaded"),
+        ratio=entry.get("ratio"),
+        time_started=entry.get("added_on"),
+    )
+
+
+def _probe_transmission(torrent_hash):
+    from comicarr.torrent.clients import transmission
+
+    client = transmission.TorrentClient()
+    conn = normalize_connection_result(
+        client.connect(
+            comicarr.CONFIG.TRANSMISSION_HOST,
+            comicarr.CONFIG.TRANSMISSION_USERNAME,
+            comicarr.CONFIG.TRANSMISSION_PASSWORD,
+        )
+    )
+    if isinstance(conn, dict) and conn.get("status") is False:
+        return unreachable(conn.get("error", "transmission did not connect"))
+
+    # Two calls: find_torrent returns the vendor object, get_torrent maps it.
+    torrent = client.find_torrent(torrent_hash)
+    if not torrent:
+        return absent(torrent_hash)
+    info = client.get_torrent(torrent)
+    if not info:
+        return absent(torrent_hash)
+    return _found(torrent_hash, **{k: info.get(k) for k in _TORRENT_FIELDS if k in info})
+
+
+def _probe_utorrent(torrent_hash):
+    from comicarr.torrent.clients import utorrent
+
+    client = utorrent.TorrentClient()
+    conn = normalize_connection_result(
+        client.connect(
+            comicarr.CONFIG.UTORRENT_HOST,
+            comicarr.CONFIG.UTORRENT_USERNAME,
+            comicarr.CONFIG.UTORRENT_PASSWORD,
+        )
+    )
+    if isinstance(conn, dict) and conn.get("status") is False:
+        return unreachable(conn.get("error", "utorrent did not connect"))
+
+    torrent = client.find_torrent(torrent_hash)
+    if not torrent:
+        return absent(torrent_hash)
+    info = client.get_torrent(torrent)
+    if not info:
+        return absent(torrent_hash)
+    # uTorrent reports no size, ratio or timing fields; they stay None.
+    return _found(torrent_hash, **{k: info.get(k) for k in _TORRENT_FIELDS if k in info})
+
+
+_PROBES = {
+    "rtorrent": _probe_rtorrent,
+    "deluge": _probe_deluge,
+    "qbittorrent": _probe_qbittorrent,
+    "transmission": _probe_transmission,
+    "utorrent": _probe_utorrent,
+}
+
+# Clients exposing start/stop, used by the local post-processing copy path.
+PAUSABLE_ROUTES = frozenset({"deluge", "transmission", "utorrent"})
+
+
+def _join(folder, path):
+    import os
+
+    if not path:
+        return path
+    if not folder or os.path.isabs(path):
+        return path
+    return os.path.join(folder, path)
+
+
+def _pausable_client():
+    """Return a connected client exposing start/stop, or None."""
+    route = configured_route()
+    if route not in PAUSABLE_ROUTES:
+        return None
+
+    if route == "deluge":
+        from comicarr.torrent.clients import deluge as module
+
+        host, user, password = (
+            comicarr.CONFIG.DELUGE_HOST,
+            comicarr.CONFIG.DELUGE_USERNAME,
+            comicarr.CONFIG.DELUGE_PASSWORD,
+        )
+    elif route == "transmission":
+        from comicarr.torrent.clients import transmission as module
+
+        host, user, password = (
+            comicarr.CONFIG.TRANSMISSION_HOST,
+            comicarr.CONFIG.TRANSMISSION_USERNAME,
+            comicarr.CONFIG.TRANSMISSION_PASSWORD,
+        )
+    else:
+        from comicarr.torrent.clients import utorrent as module
+
+        host, user, password = (
+            comicarr.CONFIG.UTORRENT_HOST,
+            comicarr.CONFIG.UTORRENT_USERNAME,
+            comicarr.CONFIG.UTORRENT_PASSWORD,
+        )
+
+    client = module.TorrentClient()
+    conn = normalize_connection_result(client.connect(host, user, password))
+    if isinstance(conn, dict) and conn.get("status") is False:
+        return None
+    return client
+
+
+def pause(torrent_hash):
+    """Pause a torrent so its files can be copied. False when unsupported."""
+    client = _pausable_client()
+    if client is None:
+        return False
+    try:
+        return client.stop_torrent(torrent_hash) is not False
+    except Exception as e:
+        logger.warn("[TORRENT-MONITOR] could not pause %s: %s" % (torrent_hash, e))
+        return False
+
+
+def resume(torrent_hash):
+    """Resume a torrent paused by :func:`pause`."""
+    client = _pausable_client()
+    if client is None:
+        return False
+    try:
+        return client.start_torrent(torrent_hash) is not False
+    except Exception as e:
+        logger.warn("[TORRENT-MONITOR] could not resume %s: %s" % (torrent_hash, e))
+        return False
+
+
+def probe(torrent_hash):
+    """Return a normalised view of ``torrent_hash`` from the configured client.
+
+    Always returns a mapping carrying ``reachable`` and ``found``. Raises
+    nothing: an adapter that throws is reported as unreachable, because a
+    thrown exception cannot distinguish a dead client from a missing torrent.
+    """
+    route = configured_route()
+    if route is None:
+        return unreachable("no monitorable torrent client is configured")
+
+    try:
+        result = _PROBES[route](torrent_hash)
+    except Exception as e:
+        logger.warn("[TORRENT-MONITOR] %s probe failed for %s: %s" % (route, torrent_hash, e))
+        return unreachable(e)
+
+    result["client"] = route
+    return result

--- a/comicarr/torrent/monitor.py
+++ b/comicarr/torrent/monitor.py
@@ -27,6 +27,8 @@ idiom silently treats a dead client as connected. Everything here routes through
 ``normalize_connection_result``.
 """
 
+import os
+
 import comicarr
 from comicarr import logger
 from comicarr.torrent.contracts import normalize_connection_result
@@ -63,9 +65,39 @@ def _found(torrent_hash, **fields):
     result = {"reachable": True, "found": True, "hash": torrent_hash}
     for key in _TORRENT_FIELDS:
         result.setdefault(key, fields.get(key))
-    result.update({k: v for k, v in fields.items() if k in _TORRENT_FIELDS})
+    # `hash` is itself a _TORRENT_FIELDS key and several adapters return their
+    # own copy of it, so the caller-supplied hash stays authoritative.
     result["hash"] = torrent_hash
     return result
+
+
+# TORRENT_DOWNLOADER value -> route. Mirrors the client map in
+# comicarr/app/search/health.py; 0 (watch folder) yields no identity to poll.
+_DOWNLOADER_ROUTES = {
+    1: "utorrent",
+    2: "rtorrent",
+    3: "transmission",
+    4: "deluge",
+    5: "qbittorrent",
+}
+
+
+def route_for_downloader(downloader):
+    """Route for a TORRENT_DOWNLOADER value, or None when nothing can be polled."""
+    try:
+        return _DOWNLOADER_ROUTES.get(int(downloader or 0))
+    except (TypeError, ValueError):
+        return None
+
+
+def is_monitorable_downloader(downloader):
+    """Whether a TORRENT_DOWNLOADER value yields an identity ``probe()`` can poll.
+
+    The snatched-queue producer (``comicarr/search.py``) and the consumer that
+    drains it (``SNPOOL`` in ``comicarr/__init__.py``) must agree on this, or
+    releases pile up on a queue nothing reads.
+    """
+    return route_for_downloader(downloader) is not None
 
 
 def configured_route():
@@ -120,8 +152,17 @@ def _probe_deluge(torrent_hash):
     if isinstance(conn, dict) and conn.get("status") is False:
         return unreachable(conn.get("error", "deluge did not connect"))
 
+    # deluge.get_torrent() catches every exception from core.get_torrent_status
+    # and returns False, so a daemon that dies after connect() succeeded is
+    # indistinguishable from a genuine miss. Ask the daemon whether it is still
+    # there before calling the torrent absent -- recovery treats absent as proof
+    # the download is gone and would mark a live torrent failed.
     info = client.get_torrent(torrent_hash)
     if not info:
+        try:
+            client.conn.call("daemon.info")
+        except Exception as e:
+            return unreachable(e)
         return absent(torrent_hash)
 
     folder = info.get("save_path")
@@ -217,13 +258,33 @@ def _probe_transmission(torrent_hash):
     return _found(torrent_hash, **{k: info.get(k) for k in _TORRENT_FIELDS if k in info})
 
 
+def utorrent_base_url(host):
+    """Normalise UTORRENT_HOST the way the uTorrent sender does.
+
+    ``UTORRENT_HOST`` is documented as ``URL:PORT`` and may or may not carry a
+    scheme or a trailing ``/gui``. The vendored client does
+    ``urljoin(base_url, "token.html")`` and ``base_url + "?token="`` with no
+    fix-up of its own, so an unnormalised host builds a URL that always fails.
+    This mirrors comicarr/utorrent.py, which is the form known to work.
+    """
+    if not host:
+        return host
+    if not host.startswith("http"):
+        host = "http://" + host
+    if host.endswith("/"):
+        host = host[:-1]
+    if host.endswith("/gui"):
+        host = host[:-4]
+    return "%s/gui/" % host
+
+
 def _probe_utorrent(torrent_hash):
     from comicarr.torrent.clients import utorrent
 
     client = utorrent.TorrentClient()
     conn = normalize_connection_result(
         client.connect(
-            comicarr.CONFIG.UTORRENT_HOST,
+            utorrent_base_url(comicarr.CONFIG.UTORRENT_HOST),
             comicarr.CONFIG.UTORRENT_USERNAME,
             comicarr.CONFIG.UTORRENT_PASSWORD,
         )
@@ -254,8 +315,6 @@ PAUSABLE_ROUTES = frozenset({"deluge", "transmission", "utorrent"})
 
 
 def _join(folder, path):
-    import os
-
     if not path:
         return path
     if not folder or os.path.isabs(path):
@@ -263,51 +322,83 @@ def _join(folder, path):
     return os.path.join(folder, path)
 
 
-def _pausable_client():
-    """Return a connected client exposing start/stop, or None."""
-    route = configured_route()
-    if route not in PAUSABLE_ROUTES:
-        return None
-
+def _pause_credentials(route):
+    """Return (client module, host, user, password) for a pausable route."""
     if route == "deluge":
         from comicarr.torrent.clients import deluge as module
 
-        host, user, password = (
+        return (
+            module,
             comicarr.CONFIG.DELUGE_HOST,
             comicarr.CONFIG.DELUGE_USERNAME,
             comicarr.CONFIG.DELUGE_PASSWORD,
         )
-    elif route == "transmission":
+    if route == "transmission":
         from comicarr.torrent.clients import transmission as module
 
-        host, user, password = (
+        return (
+            module,
             comicarr.CONFIG.TRANSMISSION_HOST,
             comicarr.CONFIG.TRANSMISSION_USERNAME,
             comicarr.CONFIG.TRANSMISSION_PASSWORD,
         )
-    else:
+    if route == "utorrent":
         from comicarr.torrent.clients import utorrent as module
 
-        host, user, password = (
-            comicarr.CONFIG.UTORRENT_HOST,
+        return (
+            module,
+            utorrent_base_url(comicarr.CONFIG.UTORRENT_HOST),
             comicarr.CONFIG.UTORRENT_USERNAME,
             comicarr.CONFIG.UTORRENT_PASSWORD,
         )
+    # A route added to PAUSABLE_ROUTES without wiring it here must fail loudly
+    # rather than quietly borrowing another client's credentials.
+    return None
 
+
+def _pausable_client():
+    """Return ``(route, connected client)`` exposing start/stop, or ``(None, None)``."""
+    route = configured_route()
+    if route not in PAUSABLE_ROUTES:
+        return None, None
+
+    credentials = _pause_credentials(route)
+    if credentials is None:
+        logger.warn("[TORRENT-MONITOR] %s is pausable but has no client wiring" % route)
+        return None, None
+
+    module, host, user, password = credentials
     client = module.TorrentClient()
     conn = normalize_connection_result(client.connect(host, user, password))
     if isinstance(conn, dict) and conn.get("status") is False:
-        return None
-    return client
+        logger.warn("[TORRENT-MONITOR] could not connect to %s to pause/resume" % route)
+        return None, None
+    return route, client
+
+
+def _pause_target(route, client, torrent_hash):
+    """Resolve what this client's start/stop expects for ``torrent_hash``.
+
+    Deluge and uTorrent take the hash. Transmission's ``stop_torrent``/
+    ``start_torrent`` call ``.stop()``/``.start()`` on a vendor torrent object,
+    so the hash has to be resolved to a handle first.
+    """
+    if route != "transmission":
+        return torrent_hash
+    return client.find_torrent(torrent_hash)
 
 
 def pause(torrent_hash):
     """Pause a torrent so its files can be copied. False when unsupported."""
-    client = _pausable_client()
+    route, client = _pausable_client()
     if client is None:
         return False
     try:
-        return client.stop_torrent(torrent_hash) is not False
+        target = _pause_target(route, client, torrent_hash)
+        if not target:
+            logger.warn("[TORRENT-MONITOR] %s has no torrent %s to pause" % (route, torrent_hash))
+            return False
+        return client.stop_torrent(target) is not False
     except Exception as e:
         logger.warn("[TORRENT-MONITOR] could not pause %s: %s" % (torrent_hash, e))
         return False
@@ -315,11 +406,15 @@ def pause(torrent_hash):
 
 def resume(torrent_hash):
     """Resume a torrent paused by :func:`pause`."""
-    client = _pausable_client()
+    route, client = _pausable_client()
     if client is None:
         return False
     try:
-        return client.start_torrent(torrent_hash) is not False
+        target = _pause_target(route, client, torrent_hash)
+        if not target:
+            logger.warn("[TORRENT-MONITOR] %s has no torrent %s to resume" % (route, torrent_hash))
+            return False
+        return client.start_torrent(target) is not False
     except Exception as e:
         logger.warn("[TORRENT-MONITOR] could not resume %s: %s" % (torrent_hash, e))
         return False

--- a/tests/unit/test_journal_snatch_seam.py
+++ b/tests/unit/test_journal_snatch_seam.py
@@ -156,15 +156,57 @@ def test_route_acceptance_persists_actual_top_level_sender_identity(route, respo
     assert "apikey" not in str(payload).lower()
 
 
-def test_unsupported_torrent_route_is_manual_review_not_restart_replayed():
+def test_route_without_an_identity_is_manual_review_not_restart_replayed():
+    """Watchdir drops the file in a folder and gets nothing back to poll, so
+    there is no identity to correlate after a restart."""
     key = journal.release_key("route-2", "torznab")
-    handoff.reserve(key, "qbittorrent", payload={"issueid": "route-2"}, issueid="route-2", provider="torznab")
+    handoff.reserve(key, "watchdir", payload={"issueid": "route-2"}, issueid="route-2", provider="torznab")
+
+    accepted = handoff.record_acceptance(
+        key,
+        "watchdir",
+        {"status": True},
+        issueid="route-2",
+        provider="torznab",
+    )
+
+    assert accepted.manual_review is True
+    assert _journal_row(key)["stage"] == journal.MANUAL_REVIEW
+
+
+@pytest.mark.parametrize("route", ("qbittorrent", "transmission", "utorrent"))
+def test_monitorable_torrent_routes_are_snatched_not_quarantined(route):
+    """These three senders all return a hash, and torrent.monitor.probe can now
+    poll it -- previously they were quarantined on acceptance because nothing
+    could read their state back."""
+    key = journal.release_key("route-%s" % route, "torznab")
+    handoff.reserve(key, route, payload={"issueid": "route-%s" % route}, issueid="route-%s" % route, provider="torznab")
+
+    accepted = handoff.record_acceptance(
+        key,
+        route,
+        {"status": True, "hash": "torrent-hash-%s" % route},
+        issueid="route-%s" % route,
+        provider="torznab",
+    )
+
+    assert accepted.manual_review is False
+    row = _journal_row(key)
+    assert row["stage"] == journal.SNATCHED
+    assert row["hash"] == "torrent-hash-%s" % route
+
+
+def test_a_monitorable_route_without_a_hash_is_still_quarantined():
+    """The route being supported is not enough; without an identity there is
+    nothing to poll, and the acceptance must not claim otherwise."""
+    key = journal.release_key("route-nohash", "torznab")
+    handoff.reserve(key, "qbittorrent", payload={"issueid": "route-nohash"}, issueid="route-nohash", provider="torznab")
 
     accepted = handoff.record_acceptance(
         key,
         "qbittorrent",
-        {"status": True, "hash": "torrent-hash"},
-        issueid="route-2",
+        {"status": True},
+        issueid="route-nohash",
         provider="torznab",
     )
 

--- a/tests/unit/test_migration_reconciliation.py
+++ b/tests/unit/test_migration_reconciliation.py
@@ -159,6 +159,45 @@ def test_runtime_resume_replays_obligations_starts_queues_and_resumes_jobs(monke
     assert all(job.resumed for job in scheduler.jobs.values())
 
 
+@pytest.mark.parametrize(
+    ("downloader", "expected"),
+    [
+        (0, False),  # watch folder -- no client-side identity to poll
+        (1, True),  # uTorrent
+        (2, True),  # rTorrent
+        (3, True),  # Transmission
+        (4, True),  # Deluge
+        (5, True),  # qBittorrent
+    ],
+)
+@pytest.mark.parametrize("flag", ("AUTO_SNATCH", "LOCAL_TORRENT_PP"))
+def test_snatched_queue_starts_for_every_client_the_searcher_enqueues(monkeypatch, downloader, expected, flag):
+    """The producer and consumer of SNATCHED_QUEUE must agree on eligibility.
+
+    comicarr/search.py enqueues whenever torrent_monitor can poll the client.
+    If this consumer gate is narrower, releases pile up on a queue nothing
+    reads -- silently, and for the life of the process.
+    """
+    config = SimpleNamespace(
+        ACQUISITION_MAINTENANCE=False,
+        ENABLE_TORRENTS=True,
+        AUTO_SNATCH=flag == "AUTO_SNATCH",
+        LOCAL_TORRENT_PP=flag == "LOCAL_TORRENT_PP",
+        TORRENT_DOWNLOADER=downloader,
+    )
+    queues = []
+    monkeypatch.setattr(comicarr, "ACQUISITION_SCHEMA_READY", True)
+    monkeypatch.setattr(comicarr, "OS_DETECT", "Linux")
+    monkeypatch.setattr(comicarr, "SCHED", SimpleNamespace(get_job=lambda _job_id: None))
+    monkeypatch.setattr(comicarr, "replay_acquisition_obligations", lambda: {"search": 0, "refresh": 0})
+    monkeypatch.setattr(comicarr, "queue_schedule", lambda queue_name, mode: queues.append(queue_name))
+
+    result = comicarr.resume_acquisition_runtime(config)
+
+    assert ("snatched_queue" in queues) is expected
+    assert ("snatched_queue" in result["queues_started"]) is expected
+
+
 def test_runtime_resume_failure_recloses_the_durable_gate(monkeypatch):
     ctx = AppContext(config=SimpleNamespace(ACQUISITION_MAINTENANCE=False))
     set_reconciliation_state("pending_preview", "repair review required", db.get_engine())

--- a/tests/unit/test_search_health.py
+++ b/tests/unit/test_search_health.py
@@ -88,8 +88,10 @@ def test_route_readiness_is_independent_and_never_exposes_credentials(tmp_path):
     assert routes["nzb"]["blocked"] is True
     assert routes["torrent"]["enabled"] is True
     assert routes["torrent"]["ready"] is False
-    assert routes["torrent"]["restart_safe"] is False
-    assert routes["torrent"]["reason"] == "unsupported_restart_correlation"
+    # qBittorrent can be monitored now, so the blocker is the missing host
+    # rather than the client being uncorrelatable.
+    assert routes["torrent"]["restart_safe"] is True
+    assert routes["torrent"]["reason"] == "client_not_ready"
     assert health.has_viable_route(routes) is True
     serialized = str(routes)
     assert "top-secret-key" not in serialized
@@ -151,19 +153,40 @@ def test_disabled_torrent_handoff_is_not_reported_as_executable(tmp_path):
     assert routes["torrent"]["executable_provider_count"] == 0
 
 
-@pytest.mark.parametrize(
-    ("downloader", "config_key"),
-    [(0, "LOCAL_WATCHDIR"), (1, "UTORRENT_HOST"), (3, "TRANSMISSION_HOST"), (5, "QBITTORRENT_HOST")],
-)
-def test_uncorrelatable_torrent_clients_are_never_reported_viable(tmp_path, downloader, config_key):
+def test_watchfolder_is_never_reported_viable(tmp_path):
+    """A watch folder hands the torrent off with no client-side identity to
+    poll, so a restart cannot correlate it with anything."""
     routes = health.build_route_readiness(
-        _config(tmp_path, TORRENT_DOWNLOADER=downloader, **{config_key: str(tmp_path)}),
+        _config(tmp_path, TORRENT_DOWNLOADER=0, LOCAL_WATCHDIR=str(tmp_path)),
     )
 
     assert routes["torrent"]["enabled"] is True
     assert routes["torrent"]["restart_safe"] is False
     assert routes["torrent"]["ready"] is False
     assert routes["torrent"]["reason"] == "unsupported_restart_correlation"
+
+
+@pytest.mark.parametrize(
+    ("downloader", "host_key", "path_key"),
+    [
+        (1, "UTORRENT_HOST", None),
+        (2, "RTORRENT_HOST", "RTORRENT_DIRECTORY"),
+        (3, "TRANSMISSION_HOST", "TRANSMISSION_DIRECTORY"),
+        (4, "DELUGE_HOST", "DELUGE_DOWNLOAD_DIRECTORY"),
+        (5, "QBITTORRENT_HOST", "QBITTORRENT_FOLDER"),
+    ],
+)
+def test_every_client_with_a_monitor_probe_is_restart_safe(tmp_path, downloader, host_key, path_key):
+    """Each of these clients yields a hash at acceptance and can be polled by
+    torrent.monitor.probe, so a restart can pick the download back up."""
+    overrides = {host_key: "https://client.test"}
+    if path_key:
+        overrides[path_key] = str(tmp_path)
+    routes = health.build_route_readiness(_config(tmp_path, TORRENT_DOWNLOADER=downloader, **overrides))
+
+    assert routes["torrent"]["enabled"] is True
+    assert routes["torrent"]["restart_safe"] is True
+    assert routes["torrent"]["reason"] != "unsupported_restart_correlation"
 
 
 def test_restart_safe_client_still_requires_a_mapped_postprocessing_path(tmp_path):

--- a/tests/unit/test_torrent_monitor.py
+++ b/tests/unit/test_torrent_monitor.py
@@ -1,0 +1,260 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""One normalised torrent snapshot for all five clients.
+
+The distinction under test is unreachable (the client did not answer) versus
+absent (it answered and does not hold this hash). Collapsing them makes recovery
+abandon a live download, and every adapter reports a connection failure as a
+*truthy* {"status": False} mapping, so the obvious `if not connect(...)` check
+does not catch it.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import comicarr
+from comicarr.torrent import monitor
+
+ROUTE_FLAGS = ("USE_RTORRENT", "USE_DELUGE", "USE_QBITTORRENT", "USE_TRANSMISSION", "USE_UTORRENT")
+
+
+@pytest.fixture(autouse=True)
+def _clients_off(monkeypatch):
+    for flag in ROUTE_FLAGS:
+        monkeypatch.setattr(comicarr, flag, False, raising=False)
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(
+            DELUGE_HOST="d",
+            DELUGE_USERNAME="u",
+            DELUGE_PASSWORD="p",
+            QBITTORRENT_HOST="q",
+            QBITTORRENT_USERNAME="u",
+            QBITTORRENT_PASSWORD="p",
+            TRANSMISSION_HOST="t",
+            TRANSMISSION_USERNAME="u",
+            TRANSMISSION_PASSWORD="p",
+            UTORRENT_HOST="ut",
+            UTORRENT_USERNAME="u",
+            UTORRENT_PASSWORD="p",
+        ),
+        raising=False,
+    )
+
+
+def _use(monkeypatch, flag):
+    monkeypatch.setattr(comicarr, flag, True, raising=False)
+
+
+class TestConfiguredRoute:
+    @pytest.mark.parametrize(
+        ("flag", "route"),
+        [
+            ("USE_RTORRENT", "rtorrent"),
+            ("USE_DELUGE", "deluge"),
+            ("USE_QBITTORRENT", "qbittorrent"),
+            ("USE_TRANSMISSION", "transmission"),
+            ("USE_UTORRENT", "utorrent"),
+        ],
+    )
+    def test_each_client_is_recognised(self, monkeypatch, flag, route):
+        _use(monkeypatch, flag)
+
+        assert monitor.configured_route() == route
+
+    def test_a_watch_folder_has_nothing_to_poll(self):
+        assert monitor.configured_route() is None
+
+    def test_probe_without_a_client_is_unreachable_not_absent(self):
+        result = monitor.probe("abc")
+
+        assert result["reachable"] is False
+        assert result["found"] is False
+
+
+class TestConnectionFailuresAreUnreachable:
+    """Every adapter returns a truthy {"status": False} on failure."""
+
+    @pytest.mark.parametrize(
+        ("flag", "module_path"),
+        [
+            ("USE_DELUGE", "comicarr.torrent.clients.deluge"),
+            ("USE_QBITTORRENT", "comicarr.torrent.clients.qbittorrent"),
+            ("USE_TRANSMISSION", "comicarr.torrent.clients.transmission"),
+            ("USE_UTORRENT", "comicarr.torrent.clients.utorrent"),
+        ],
+    )
+    def test_a_dead_client_is_never_reported_absent(self, monkeypatch, flag, module_path):
+        _use(monkeypatch, flag)
+        client = MagicMock()
+        client.connect.return_value = {"status": False, "error": "connection refused"}
+
+        with patch("%s.TorrentClient" % module_path, return_value=client):
+            result = monitor.probe("abc123")
+
+        assert result["reachable"] is False, "a client outage must not read as 'torrent gone'"
+        assert result["found"] is False
+
+    def test_an_adapter_that_raises_is_unreachable(self, monkeypatch):
+        _use(monkeypatch, "USE_DELUGE")
+        client = MagicMock()
+        client.connect.side_effect = RuntimeError("boom")
+
+        with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=client):
+            result = monitor.probe("abc123")
+
+        assert result["reachable"] is False
+
+
+class TestAbsence:
+    def test_a_reachable_client_without_the_hash_is_absent(self, monkeypatch):
+        _use(monkeypatch, "USE_DELUGE")
+        client = MagicMock()
+        client.connect.return_value = object()
+        client.get_torrent.return_value = False
+
+        with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=client):
+            result = monitor.probe("abc123")
+
+        assert result["reachable"] is True
+        assert result["found"] is False
+
+
+class TestNormalisation:
+    def test_deluge_fields_are_mapped_and_paths_absolute(self, monkeypatch):
+        _use(monkeypatch, "USE_DELUGE")
+        client = MagicMock()
+        client.connect.return_value = object()
+        client.get_torrent.return_value = {
+            "name": "Chainsaw Man 165",
+            "save_path": "/downloads",
+            "is_finished": True,
+            "files": [{"path": "Chainsaw Man 165.cbz"}],
+            "total_size": 1234,
+            "total_uploaded": 10,
+            "total_payload_download": 1234,
+            "ratio": 0.5,
+            "time_added": 111,
+        }
+
+        with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=client):
+            result = monitor.probe("abc123")
+
+        assert result["found"] is True
+        assert result["completed"] is True
+        assert result["folder"] == "/downloads"
+        assert result["files"] == ["/downloads/Chainsaw Man 165.cbz"]
+        assert result["total_filesize"] == 1234
+        assert result["time_started"] == 111
+
+    def test_qbittorrent_progress_becomes_completed(self, monkeypatch):
+        _use(monkeypatch, "USE_QBITTORRENT")
+        client = MagicMock()
+        client.connect.return_value = object()
+        client.conn.torrents.return_value = [
+            {
+                "hash": "abc123",
+                "name": "Chainsaw Man 165",
+                "save_path": "/downloads",
+                "progress": 1,
+                "size": 99,
+                "uploaded": 1,
+                "downloaded": 99,
+                "ratio": 0.1,
+                "added_on": 222,
+                "category": "comics",
+            }
+        ]
+        client.conn.get_torrent_files.return_value = [{"name": "Chainsaw Man 165.cbz"}]
+
+        with patch("comicarr.torrent.clients.qbittorrent.TorrentClient", return_value=client):
+            result = monitor.probe("ABC123")
+
+        assert result["found"] is True
+        assert result["completed"] is True
+        assert result["files"] == ["/downloads/Chainsaw Man 165.cbz"]
+        assert result["label"] == "comics"
+
+    def test_qbittorrent_incomplete_is_not_completed(self, monkeypatch):
+        _use(monkeypatch, "USE_QBITTORRENT")
+        client = MagicMock()
+        client.connect.return_value = object()
+        client.conn.torrents.return_value = [{"hash": "abc123", "progress": 0.42, "save_path": "/downloads"}]
+        client.conn.get_torrent_files.return_value = []
+
+        with patch("comicarr.torrent.clients.qbittorrent.TorrentClient", return_value=client):
+            result = monitor.probe("abc123")
+
+        assert result["found"] is True
+        assert result["completed"] is False
+
+    @pytest.mark.parametrize(
+        ("flag", "module_path"),
+        [
+            ("USE_TRANSMISSION", "comicarr.torrent.clients.transmission"),
+            ("USE_UTORRENT", "comicarr.torrent.clients.utorrent"),
+        ],
+    )
+    def test_two_call_clients_are_resolved_via_find_then_get(self, monkeypatch, flag, module_path):
+        """find_torrent returns a vendor handle, not a record; a one-call shim fails."""
+        _use(monkeypatch, flag)
+        handle = object()
+        client = MagicMock()
+        client.connect.return_value = object()
+        client.find_torrent.return_value = handle
+        client.get_torrent.return_value = {
+            "name": "Chainsaw Man 165",
+            "folder": "/downloads",
+            "completed": True,
+            "files": ["/downloads/Chainsaw Man 165.cbz"],
+        }
+
+        with patch("%s.TorrentClient" % module_path, return_value=client):
+            result = monitor.probe("abc123")
+
+        client.get_torrent.assert_called_once_with(handle)
+        assert result["found"] is True
+        assert result["completed"] is True
+
+    def test_utorrent_missing_fields_are_none_not_absent_keys(self, monkeypatch):
+        """uTorrent reports no size, ratio or timing; callers still read them."""
+        _use(monkeypatch, "USE_UTORRENT")
+        client = MagicMock()
+        client.connect.return_value = object()
+        client.find_torrent.return_value = object()
+        client.get_torrent.return_value = {
+            "hash": "abc123",
+            "name": "Chainsaw Man 165",
+            "folder": "/downloads",
+            "completed": False,
+            "files": [],
+            "label": "",
+        }
+
+        with patch("comicarr.torrent.clients.utorrent.TorrentClient", return_value=client):
+            result = monitor.probe("abc123")
+
+        for field in ("total_filesize", "upload_total", "download_total", "ratio", "time_started"):
+            assert field in result
+            assert result[field] is None
+
+
+class TestPauseCapability:
+    def test_clients_without_a_pause_api_report_it(self):
+        assert "qbittorrent" not in monitor.PAUSABLE_ROUTES
+        assert "rtorrent" not in monitor.PAUSABLE_ROUTES
+
+    def test_pause_is_false_when_unsupported(self, monkeypatch):
+        _use(monkeypatch, "USE_QBITTORRENT")
+
+        assert monitor.pause("abc123") is False

--- a/tests/unit/test_torrent_monitor.py
+++ b/tests/unit/test_torrent_monitor.py
@@ -16,8 +16,9 @@ abandon a live download, and every adapter reports a connection failure as a
 does not catch it.
 """
 
+import importlib
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
@@ -54,6 +55,16 @@ def _clients_off(monkeypatch):
 
 def _use(monkeypatch, flag):
     monkeypatch.setattr(comicarr, flag, True, raising=False)
+
+
+def _spec_client(module_path):
+    """A fake adapter that enforces the real TorrentClient's signatures.
+
+    A bare MagicMock accepts any call, so it cannot catch a wrong argument type
+    or a method the real adapter does not have. Autospec can.
+    """
+    real = importlib.import_module(module_path).TorrentClient
+    return create_autospec(real, instance=True)
 
 
 class TestConfiguredRoute:
@@ -122,6 +133,38 @@ class TestAbsence:
         client = MagicMock()
         client.connect.return_value = object()
         client.get_torrent.return_value = False
+
+        with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=client):
+            result = monitor.probe("abc123")
+
+        assert result["reachable"] is True
+        assert result["found"] is False
+
+    def test_a_deluge_rpc_failure_after_connect_is_unreachable_not_absent(self, monkeypatch):
+        """deluge.get_torrent() swallows every RPC exception and returns False.
+
+        Taking that as proof of absence lets recovery mark a live download
+        failed on nothing worse than a daemon hiccup, so the probe re-checks
+        that the daemon is still answering before calling the torrent gone.
+        """
+        _use(monkeypatch, "USE_DELUGE")
+        client = MagicMock()
+        client.connect.return_value = object()
+        client.get_torrent.return_value = False
+        client.conn.call.side_effect = ConnectionResetError("daemon went away")
+
+        with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=client):
+            result = monitor.probe("abc123")
+
+        assert result["reachable"] is False, "a mid-RPC outage must not read as 'torrent gone'"
+        assert result["found"] is False
+
+    def test_a_deluge_daemon_that_still_answers_confirms_absence(self, monkeypatch):
+        _use(monkeypatch, "USE_DELUGE")
+        client = MagicMock()
+        client.connect.return_value = object()
+        client.get_torrent.return_value = False
+        client.conn.call.return_value = "2.1.1"
 
         with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=client):
             result = monitor.probe("abc123")
@@ -250,6 +293,14 @@ class TestNormalisation:
 
 
 class TestPauseCapability:
+    """Pause/resume against *spec'd* adapters.
+
+    A bare MagicMock accepts any argument, so it agrees with the code even when
+    the real adapter would not -- which is exactly how the Transmission
+    signature mismatch below stayed green. create_autospec pins each adapter's
+    real signature, so what these tests assert is what the client receives.
+    """
+
     def test_clients_without_a_pause_api_report_it(self):
         assert "qbittorrent" not in monitor.PAUSABLE_ROUTES
         assert "rtorrent" not in monitor.PAUSABLE_ROUTES
@@ -258,3 +309,134 @@ class TestPauseCapability:
         _use(monkeypatch, "USE_QBITTORRENT")
 
         assert monitor.pause("abc123") is False
+
+    @pytest.mark.parametrize(
+        ("flag", "module_path"),
+        [
+            ("USE_DELUGE", "comicarr.torrent.clients.deluge"),
+            ("USE_UTORRENT", "comicarr.torrent.clients.utorrent"),
+        ],
+    )
+    def test_hash_taking_clients_are_paused_and_resumed_by_hash(self, monkeypatch, flag, module_path):
+        _use(monkeypatch, flag)
+        client = _spec_client(module_path)
+        client.stop_torrent.return_value = True
+        client.start_torrent.return_value = True
+
+        with patch("%s.TorrentClient" % module_path, return_value=client):
+            assert monitor.pause("abc123") is True
+            assert monitor.resume("abc123") is True
+
+        client.stop_torrent.assert_called_once_with("abc123")
+        client.start_torrent.assert_called_once_with("abc123")
+
+    def test_transmission_is_paused_with_the_handle_not_the_hash(self, monkeypatch):
+        """transmission's stop_torrent does `torrent.stop()`; a str has no .stop()."""
+        _use(monkeypatch, "USE_TRANSMISSION")
+        handle = object()
+        client = _spec_client("comicarr.torrent.clients.transmission")
+        client.find_torrent.return_value = handle
+        client.stop_torrent.return_value = True
+        client.start_torrent.return_value = True
+
+        with patch("comicarr.torrent.clients.transmission.TorrentClient", return_value=client):
+            assert monitor.pause("abc123") is True
+            assert monitor.resume("abc123") is True
+
+        client.stop_torrent.assert_called_once_with(handle)
+        client.start_torrent.assert_called_once_with(handle)
+
+    def test_transmission_without_the_torrent_does_not_pause(self, monkeypatch):
+        _use(monkeypatch, "USE_TRANSMISSION")
+        client = _spec_client("comicarr.torrent.clients.transmission")
+        client.find_torrent.return_value = False
+
+        with patch("comicarr.torrent.clients.transmission.TorrentClient", return_value=client):
+            assert monitor.pause("abc123") is False
+
+        client.stop_torrent.assert_not_called()
+
+    def test_a_client_that_will_not_connect_cannot_pause(self, monkeypatch):
+        _use(monkeypatch, "USE_DELUGE")
+        client = _spec_client("comicarr.torrent.clients.deluge")
+        client.connect.return_value = {"status": False, "error": "connection refused"}
+
+        with patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=client):
+            assert monitor.pause("abc123") is False
+            assert monitor.resume("abc123") is False
+
+        client.stop_torrent.assert_not_called()
+
+    def test_every_pausable_route_has_client_wiring(self):
+        """PAUSABLE_ROUTES and _pause_credentials must not drift apart."""
+        for route in monitor.PAUSABLE_ROUTES:
+            assert monitor._pause_credentials(route) is not None, route
+
+
+class TestDownloaderRoutes:
+    """The producer (search.py) and the consumer (SNPOOL) must agree on this."""
+
+    @pytest.mark.parametrize(
+        ("downloader", "route"),
+        [
+            (0, None),
+            (1, "utorrent"),
+            (2, "rtorrent"),
+            (3, "transmission"),
+            (4, "deluge"),
+            (5, "qbittorrent"),
+        ],
+    )
+    def test_each_downloader_value_maps_to_its_route(self, downloader, route):
+        assert monitor.route_for_downloader(downloader) == route
+        assert monitor.is_monitorable_downloader(downloader) is (route is not None)
+
+    @pytest.mark.parametrize("value", (None, "", "nonsense", 99, -1))
+    def test_unknown_downloader_values_are_not_monitorable(self, value):
+        assert monitor.is_monitorable_downloader(value) is False
+
+    def test_every_probe_route_is_reachable_from_a_downloader_value(self):
+        """A route with a probe but no downloader mapping could never be selected."""
+        mapped = {monitor.route_for_downloader(d) for d in range(1, 6)}
+        assert mapped == set(monitor._PROBES)
+
+
+class TestUtorrentHostNormalisation:
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [
+            ("utorrent.local:8080", "http://utorrent.local:8080/gui/"),
+            ("http://utorrent.local:8080", "http://utorrent.local:8080/gui/"),
+            ("http://utorrent.local:8080/", "http://utorrent.local:8080/gui/"),
+            ("http://utorrent.local:8080/gui", "http://utorrent.local:8080/gui/"),
+            ("http://utorrent.local:8080/gui/", "http://utorrent.local:8080/gui/"),
+        ],
+    )
+    def test_every_documented_host_form_reaches_the_same_gui_url(self, configured, expected):
+        assert monitor.utorrent_base_url(configured) == expected
+
+    def test_the_probe_connects_to_the_normalised_url(self, monkeypatch):
+        """The vendored client does urljoin(base_url, 'token.html') with no fix-up."""
+        _use(monkeypatch, "USE_UTORRENT")
+        comicarr.CONFIG.UTORRENT_HOST = "utorrent.local:8080"
+        client = _spec_client("comicarr.torrent.clients.utorrent")
+        client.find_torrent.return_value = False
+
+        with patch("comicarr.torrent.clients.utorrent.TorrentClient", return_value=client):
+            monitor.probe("abc123")
+
+        assert client.connect.call_args[0][0] == "http://utorrent.local:8080/gui/"
+
+
+class TestSnapshotShape:
+    def test_the_caller_supplied_hash_wins_over_the_clients_own(self, monkeypatch):
+        """Transmission and uTorrent return their own `hash`; the probe's is canonical."""
+        _use(monkeypatch, "USE_TRANSMISSION")
+        client = _spec_client("comicarr.torrent.clients.transmission")
+        client.find_torrent.return_value = object()
+        client.get_torrent.return_value = {"hash": "SOMETHING-ELSE", "name": "n", "completed": True}
+
+        with patch("comicarr.torrent.clients.transmission.TorrentClient", return_value=client):
+            result = monitor.probe("abc123")
+
+        assert result["hash"] == "abc123"

--- a/tests/unit/test_torrentinfo.py
+++ b/tests/unit/test_torrentinfo.py
@@ -169,6 +169,55 @@ def test_deluge_monitor_copies_the_resolved_incomplete_file(monkeypatch):
     fake_client.start_torrent.assert_called_once_with(HASH40)
 
 
+def test_a_failed_copy_still_resumes_the_paused_torrent(monkeypatch):
+    """The pause must be undone on every exit path.
+
+    Resuming only in the try's else arm left a failed copy's torrent paused in
+    the client with nothing to restart it, so the download stalled forever.
+    """
+    monkeypatch.setattr(comicarr, "USE_DELUGE", True)
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", False)
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = True
+    fake_client.get_torrent.return_value = _deluge_torrent(finished=False)
+
+    with (
+        patch("comicarr.torrent.clients.deluge.TorrentClient", return_value=fake_client),
+        patch("shutil.copy", side_effect=OSError("disk full")),
+    ):
+        result = service.torrentinfo(torrent_hash=HASH40, download=False, monitor=True)
+
+    assert result["snatch_status"] == "IN PROGRESS"
+    fake_client.stop_torrent.assert_called_once_with(HASH40)
+    fake_client.start_torrent.assert_called_once_with(HASH40)
+
+
+def test_a_non_pausable_client_is_monitored_without_being_paused(monkeypatch):
+    """qBittorrent has no pause API; that must not block monitoring."""
+    monkeypatch.setattr(comicarr, "USE_DELUGE", False)
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", False)
+    monkeypatch.setattr(comicarr, "USE_QBITTORRENT", True, raising=False)
+    comicarr.CONFIG.QBITTORRENT_HOST = "qb"
+    comicarr.CONFIG.QBITTORRENT_USERNAME = "u"
+    comicarr.CONFIG.QBITTORRENT_PASSWORD = "p"
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = True
+    fake_client.conn.torrents.return_value = [{"hash": HASH40, "progress": 0.5, "save_path": "/downloads"}]
+    fake_client.conn.get_torrent_files.return_value = [{"name": "Saga.cbz"}]
+
+    with (
+        patch("comicarr.torrent.clients.qbittorrent.TorrentClient", return_value=fake_client),
+        patch("shutil.copy") as copy,
+    ):
+        result = service.torrentinfo(torrent_hash=HASH40, download=False, monitor=True)
+
+    assert result["snatch_status"] == "IN PROGRESS", "an unpausable client must not read as MONITOR FAIL"
+    copy.assert_not_called()
+    fake_client.stop_torrent.assert_not_called()
+
+
 def test_deluge_connect_failure_dict_is_monitor_error_not_not_found(monkeypatch):
     """Deluge connect returns truthy {status: False}; must not fall through to NOT FOUND."""
     monkeypatch.setattr(comicarr, "USE_DELUGE", True)


### PR DESCRIPTION
## The bug

**A torrent snatched through qBittorrent, Transmission or uTorrent was sent successfully and then abandoned.** It sat in `Snatched` forever: nothing polled it, post-processing never ran, and a restart could not pick it back up.

The gap was double-gated, so fixing either half alone changes nothing:

- `searcher` only put an item on `SNATCHED_QUEUE` for rTorrent and Deluge (`search.py:3565,3576`).
- `torrentinfo` only knew how to query those same two, returning `MONITOR ERROR` for anything else (`app/search/service.py:607-625`).

## The fix

New `comicarr/torrent/monitor.py` with one `probe()` returning a normalised snapshot for all five clients; `torrentinfo` routes through it. Previously it reassigned Deluge's libtorrent field names inline and rTorrent's separately, which is why adding a third client meant adding a third branch.

The invariant the module exists to hold is **unreachable** (client did not answer) versus **absent** (client answered, no such hash). Recovery treats absent as proof the download is gone, so conflating them abandons live downloads. Note that every adapter signals a connection failure with a *truthy* `{"status": False}` mapping, so the usual `if not connect(...)` check misses it — everything here goes through `normalize_connection_result`.

## Two tests asserted the old limitation as policy

`unsupported_restart_correlation` in health, and manual-review-on-acceptance for qbittorrent in the handoff seam. That policy existed because nothing could read those clients' state back.

All three senders do return a hash — qBittorrent computes it from the magnet or torrent file, Transmission takes `hashString`, uTorrent gets it from `addurl`/`addfile` — so with a probe they correlate like any other. `record_acceptance` already guards with `and bool(identity)`, so a missing hash still quarantines.

Both tests are rewritten to pin what is actually true: **watchdir** has no identity to poll, and a supported route without a hash is still quarantined.

## Please note

The rTorrent and Deluge paths are exercised by the existing `torrentinfo` tests. **The three new client branches are written against the client APIs and covered by fakes; they have not been run against live servers.** Transmission and uTorrent need two calls (`find_torrent` returns a vendor handle, `get_torrent` maps it) and uTorrent reports no size, ratio or timing fields — both are pinned by tests.

## Verification

`pytest tests/unit` (1528 passing), `ruff check`, `npm run lint:modern`.

Found by the architecture review in this session; one of eight independent branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiHS1hJan2hwwyDkgFKJQj