### PR TITLE
fix: Stop manga post-processing destroying the source under link modes

### DIFF
--- a/.changeset/quiet-manga-keeps-source.md
+++ b/.changeset/quiet-manga-keeps-source.md
@@ -6,3 +6,8 @@ Fix manga post-processing deleting the downloaded file when the file operation
 is set to hardlink or softlink. Both modes are meant to leave the download in
 place; the manga path moved it regardless, so the original was destroyed. It now
 uses the same mode-aware file placement as the rest of post-processing.
+
+Manga chapters that are already in the library also import correctly again. A
+repack, a manual re-run, or a post-crash retry now replaces the existing file
+under every file operation mode, instead of failing on the hardlink and softlink
+modes and leaving the chapter unimported.

--- a/.changeset/quiet-manga-keeps-source.md
+++ b/.changeset/quiet-manga-keeps-source.md
@@ -1,0 +1,8 @@
+---
+"comicarr": patch
+---
+
+Fix manga post-processing deleting the downloaded file when the file operation
+is set to hardlink or softlink. Both modes are meant to leave the download in
+place; the manga path moved it regardless, so the original was destroyed. It now
+uses the same mode-aware file placement as the rest of post-processing.

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -4340,6 +4340,7 @@ class PostProcessor(object):
             # Clear the destination first, keeping all four modes on the same
             # replace-what-is-there policy the manga path had before file_ops.
             already_placed = False
+            displaced = None
             if os.path.lexists(dst):
                 try:
                     # same inode (hardlinked) or same target (softlinked) means an
@@ -4349,10 +4350,18 @@ class PostProcessor(object):
                 except OSError:
                     already_placed = False
                 if not already_placed:
+                    # Move the existing chapter aside instead of deleting it.
+                    # Placement can still fail (disk full, permissions), and the
+                    # copy/move modes truncate the destination as they write, so
+                    # deleting up front would leave the library with nothing while
+                    # the DB still reports the chapter as Downloaded. A rename
+                    # frees dst for every mode and keeps the old file restorable.
+                    displaced = "%s.comicarr-displaced" % dst
                     try:
-                        os.remove(dst)
+                        os.replace(dst, displaced)
                         logger.fdebug("%s Replacing existing manga file: %s" % (module, dst))
                     except OSError as e:
+                        displaced = None
                         logger.error("%s Failed to replace existing %s: %s" % (module, dst, e))
                         self._log("Failed to replace existing manga file: %s" % filename)
                         continue
@@ -4368,7 +4377,19 @@ class PostProcessor(object):
                 except Exception as e:
                     logger.error("%s Failed to place %s: %s" % (module, filename, e))
                     self._log("Failed to move/copy manga file: %s" % filename)
+                    if displaced is not None:
+                        try:
+                            os.replace(displaced, dst)
+                            logger.info("%s Restored the previous %s after a failed placement" % (module, dst))
+                        except OSError as restore_error:
+                            logger.error("%s Failed to restore the previous %s: %s" % (module, dst, restore_error))
                     continue
+
+                if displaced is not None:
+                    try:
+                        os.remove(displaced)
+                    except OSError as e:
+                        logger.warn("%s Failed to clean up %s: %s" % (module, displaced, e))
 
             # P1: do NOT emit per-file `moved` here. Every chapter in a manga
             # pack shares ONE release_key; advancing it to `moved` after

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -4329,15 +4329,46 @@ class PostProcessor(object):
             # four FILE_OPTS modes; shutil.move would destroy the source for the
             # two link modes.
             dst = os.path.join(series_folder, filename)
-            try:
-                fileoperation = helpers.file_ops(filepath, dst)
-                if not fileoperation:
-                    raise OSError
-                logger.info("%s Placed manga file: %s -> %s" % (module, filename, series_folder))
-            except Exception as e:
-                logger.error("%s Failed to move %s: %s" % (module, filename, e))
-                self._log("Failed to move/copy manga file: %s" % filename)
-                continue
+
+            # An existing destination is not a failure. It happens on a repack of
+            # a chapter already in the library, on a manual re-run (under the
+            # non-move modes the download folder is never consumed, so the source
+            # stays there), and on the recovery finalizer's full re-drive after a
+            # mid-loop crash. shutil.move/copy overwrite silently, but os.link and
+            # os.symlink raise EEXIST and file_ops reports that as a bare False —
+            # so without this the link modes would skip the chapter on every pass.
+            # Clear the destination first, keeping all four modes on the same
+            # replace-what-is-there policy the manga path had before file_ops.
+            already_placed = False
+            if os.path.lexists(dst):
+                try:
+                    # same inode (hardlinked) or same target (softlinked) means an
+                    # earlier pass already placed this chapter — re-linking it
+                    # would only fail, and the source must survive either way.
+                    already_placed = os.path.samefile(filepath, dst)
+                except OSError:
+                    already_placed = False
+                if not already_placed:
+                    try:
+                        os.remove(dst)
+                        logger.fdebug("%s Replacing existing manga file: %s" % (module, dst))
+                    except OSError as e:
+                        logger.error("%s Failed to replace existing %s: %s" % (module, dst, e))
+                        self._log("Failed to replace existing manga file: %s" % filename)
+                        continue
+
+            if already_placed:
+                logger.fdebug("%s Manga file already placed, skipping placement: %s" % (module, filename))
+            else:
+                try:
+                    fileoperation = helpers.file_ops(filepath, dst)
+                    if not fileoperation:
+                        raise OSError("file_ops returned False for %s -> %s" % (filepath, dst))
+                    logger.info("%s Placed manga file: %s -> %s" % (module, filename, series_folder))
+                except Exception as e:
+                    logger.error("%s Failed to place %s: %s" % (module, filename, e))
+                    self._log("Failed to move/copy manga file: %s" % filename)
+                    continue
 
             # P1: do NOT emit per-file `moved` here. Every chapter in a manga
             # pack shares ONE release_key; advancing it to `moved` after
@@ -4346,10 +4377,12 @@ class PostProcessor(object):
             # — so a crash after chapter 1 but before the post-loop block
             # strands chapters 2..N. Keep the shared row at `post_processing`
             # (idempotent, monotonic no-op after the first write) so a mid-loop
-            # crash makes the finalizer re-drive the manga in FULL: chapter 1's
-            # source file is already gone (won't re-match/double-import) and
-            # only the unmoved chapters 2..N get processed. The single `moved`
-            # marker is written ONCE after the loop completes (below).
+            # crash makes the finalizer re-drive the manga in FULL. Re-driving is
+            # safe because placement above is idempotent: under `move` chapter 1's
+            # source is gone so it never re-matches, and under copy/hardlink/
+            # softlink the source survives but the destination-exists branch
+            # either recognises the already-placed chapter or replaces it. The
+            # single `moved` marker is written ONCE after the loop completes.
             self._journal_pp("post_processing")
 
             # --- Match to a chapter/issue in the database ---

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -113,11 +113,6 @@ class PostProcessor(object):
         else:
             self.ddl = False
 
-        if comicarr.CONFIG.FILE_OPTS == "copy":
-            self.fileop = shutil.copy
-        else:
-            self.fileop = shutil.move
-
         self.valreturn = []
         self.extensions = (".cbr", ".cbz", ".pdf", ".cb7")
 
@@ -4330,11 +4325,15 @@ class PostProcessor(object):
                 logger.warning("%s Skipping file outside download directory: %s" % (module, filepath))
                 continue
 
-            # Move/copy file to series folder
+            # Place the file in the series folder. helpers.file_ops honours all
+            # four FILE_OPTS modes; shutil.move would destroy the source for the
+            # two link modes.
             dst = os.path.join(series_folder, filename)
             try:
-                self.fileop(filepath, dst)
-                logger.info("%s Moved manga file: %s -> %s" % (module, filename, series_folder))
+                fileoperation = helpers.file_ops(filepath, dst)
+                if not fileoperation:
+                    raise OSError
+                logger.info("%s Placed manga file: %s -> %s" % (module, filename, series_folder))
             except Exception as e:
                 logger.error("%s Failed to move %s: %s" % (module, filename, e))
                 self._log("Failed to move/copy manga file: %s" % filename)
@@ -5224,12 +5223,6 @@ class PostProcessor(object):
                     logger.fdebug(
                         "%s Continuing post-processing but unable to change file permissions in %s" % (module, dst)
                     )
-
-        # let's reset the fileop to the original setting just in case it's a manual pp run
-        if comicarr.CONFIG.FILE_OPTS == "copy":
-            self.fileop = shutil.copy
-        else:
-            self.fileop = shutil.move
 
         # journal post_processed co-commits with the nzblog delete in one
         # begin() so the row is never terminal while nzblog is still present

--- a/tests/unit/test_journal_pp_seam.py
+++ b/tests/unit/test_journal_pp_seam.py
@@ -38,6 +38,7 @@ import comicarr
 from comicarr.app.acquisition.maintenance import ensure_acquisition_schema
 from comicarr.app.downloads import journal, service
 from comicarr.db import get_engine, shutdown_engine
+from comicarr import postprocessor
 from comicarr.postprocessor import PostProcessor
 from comicarr.tables import comics, ddl_info, issues, metadata, pipeline_journal
 
@@ -522,8 +523,9 @@ def test_manga_pp_writes_processing_moved_processed_in_order(tmp_path, monkeypat
     def _fake_fileop(s, d):
         moved_calls.append(("fileop", s, d))
         seen.append("__fileop__")
+        return True
 
-    pp.fileop = _fake_fileop
+    monkeypatch.setattr(postprocessor.helpers, "file_ops", _fake_fileop)
 
     with (
         patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
@@ -559,7 +561,7 @@ def test_manga_pp_failure_path_does_not_write_post_processed(tmp_path, monkeypat
     def _boom_fileop(s, d):
         raise OSError("disk full")
 
-    pp.fileop = _boom_fileop
+    monkeypatch.setattr(postprocessor.helpers, "file_ops", _boom_fileop)
 
     with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")):
         pp._process_manga()
@@ -633,8 +635,9 @@ def test_manga_multichapter_shared_key_not_terminalized_midloop(tmp_path, monkey
         import shutil
 
         shutil.copy(s, d)
+        return True
 
-    pp.fileop = _fileop
+    monkeypatch.setattr(postprocessor.helpers, "file_ops", _fileop)
     assert real_fileop_target.exists()
 
     with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")):
@@ -660,7 +663,7 @@ def test_manga_multichapter_shared_key_not_terminalized_midloop(tmp_path, monkey
     )
 
 
-def test_manga_multichapter_per_file_marker_is_post_processing_not_moved(tmp_path):
+def test_manga_multichapter_per_file_marker_is_post_processing_not_moved(tmp_path, monkeypatch):
     """P1: in the multi-chapter manga loop the per-file marker is
     `post_processing` (idempotent, monotonic no-op after the first), NOT
     `moved`. The single authoritative `moved` is written EXACTLY ONCE after
@@ -717,8 +720,9 @@ def test_manga_multichapter_per_file_marker_is_post_processing_not_moved(tmp_pat
         import shutil
 
         shutil.copy(s, d)
+        return True
 
-    pp.fileop = _fileop
+    monkeypatch.setattr(postprocessor.helpers, "file_ops", _fileop)
 
     with (
         patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
@@ -741,7 +745,7 @@ def test_manga_multichapter_per_file_marker_is_post_processing_not_moved(tmp_pat
     assert _stage_of(rkey) == "post_processed"
 
 
-def test_manga_multichapter_replay_redrives_in_full_after_midloop_crash(tmp_path):
+def test_manga_multichapter_replay_redrives_in_full_after_midloop_crash(tmp_path, monkeypatch):
     """P1: after a mid-loop crash the shared row is `post_processing` (not
     `moved`/`post_processed`); the replay finalizer therefore re-drives PP in
     FULL. Chapter 1's source file is already gone (moved on the first pass) so
@@ -802,8 +806,9 @@ def test_manga_multichapter_replay_redrives_in_full_after_midloop_crash(tmp_path
         import shutil
 
         shutil.move(s, d)
+        return True
 
-    pp1.fileop = _crashing_fileop
+    monkeypatch.setattr(postprocessor.helpers, "file_ops", _crashing_fileop)
     with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")):
         with pytest.raises(KeyboardInterrupt):
             pp1._process_manga()
@@ -840,7 +845,7 @@ def test_manga_multichapter_replay_redrives_in_full_after_midloop_crash(tmp_path
     assert len(_rows(nzblog)) == 2
 
 
-def test_manga_multichapter_terminalizes_once_after_full_loop(tmp_path):
+def test_manga_multichapter_terminalizes_once_after_full_loop(tmp_path, monkeypatch):
     """P2-6 happy path: when the full chapter loop completes, the shared
     release_key reaches `post_processed` exactly once and every matched
     chapter's nzblog row is deleted (U9 atomic co-commit preserved)."""
@@ -888,8 +893,9 @@ def test_manga_multichapter_terminalizes_once_after_full_loop(tmp_path):
         import shutil
 
         shutil.copy(s, d)
+        return True
 
-    pp.fileop = _fileop
+    monkeypatch.setattr(postprocessor.helpers, "file_ops", _fileop)
 
     with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")):
         pp._process_manga()

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -268,8 +268,18 @@ class TestProcessMangaFileMove:
         assert args[0] == str(cbz)
         assert "Bleach v1.cbz" in args[1]
 
-    def test_move_failure_continues(self, tmp_path):
-        """When file move fails, should log error and continue."""
+    # helpers.file_ops does not raise on a handled error -- it logs and returns
+    # False (comicarr/app/common/filesystem.py). The `if not fileoperation`
+    # bridge in _process_manga is the only thing turning that into the failure
+    # path, so the falsy return is the case that has to be pinned; an exception
+    # escaping file_ops is the rarer shape and is covered alongside it.
+    @pytest.mark.parametrize(
+        "file_ops_kwargs",
+        ({"return_value": False}, {"side_effect": OSError("Permission denied")}),
+        ids=("returns_false", "raises"),
+    )
+    def test_move_failure_continues(self, tmp_path, file_ops_kwargs):
+        """When placement fails, should log error and continue."""
         cbz = tmp_path / "Bleach v1.cbz"
         cbz.write_bytes(b"fake cbz")
 
@@ -289,12 +299,118 @@ class TestProcessMangaFileMove:
             patch("comicarr.postprocessor.db") as mock_db,
         ):
             mock_db.select_one.return_value = comic_row
-            with patch("comicarr.postprocessor.helpers.file_ops", side_effect=OSError("Permission denied")):
+            with patch("comicarr.postprocessor.helpers.file_ops", **file_ops_kwargs):
                 pp._process_manga()
 
         mock_queue.put.assert_called_once()
         result = mock_queue.put.call_args[0][0]
         assert "0 files matched" in result[0]["self.log"]
+
+    def test_falsy_file_ops_never_marks_the_chapter_downloaded(self, tmp_path):
+        """A False return means the file was NOT placed. Without the
+        `if not fileoperation` bridge the loop would upsert Status=Downloaded and
+        terminalize the journal for a file still sitting in the download folder,
+        which recovery would then never re-drive."""
+        cbz = tmp_path / "Bleach v1.cbz"
+        cbz.write_bytes(b"fake cbz")
+
+        dest_dir = tmp_path / "manga" / "Bleach"
+        dest_dir.mkdir(parents=True)
+
+        pp, _ = _make_pp(
+            nzb_name="Bleach v1.cbz",
+            nzb_folder=str(tmp_path),
+            comicid="md-bleach",
+        )
+
+        comic_row = {"ComicName": "Bleach", "ComicLocation": str(dest_dir)}
+        issue_row = {"IssueID": "md-bleach-v1", "Issue_Number": "1"}
+
+        with (
+            patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
+            # a chapter match IS available -- only the falsy placement stops it
+            mock_db.select_one.side_effect = [comic_row, issue_row, None, None]
+            with patch("comicarr.postprocessor.helpers.file_ops", return_value=False):
+                pp._process_manga()
+
+        assert mock_db.upsert.call_count == 0, "an unplaced chapter must not be marked Downloaded"
+
+
+class TestProcessMangaExistingDestination:
+    """os.link/os.symlink refuse an existing destination (EEXIST) and file_ops
+    reports that as a bare False, so an already-placed chapter would be skipped
+    on every pass. The manga loop clears/recognises the destination first."""
+
+    # The download folder and the manga destination are separate trees here: a
+    # destination nested inside the download folder would be picked up by the
+    # loop's own file walk as a second manga file.
+    def _run(self, tmp_path, file_opts, seed_dest=None, source_bytes=b"fresh grab"):
+        download_dir = tmp_path / "download"
+        download_dir.mkdir(exist_ok=True)
+        cbz = download_dir / "Chainsaw Man 165.cbz"
+        if not cbz.exists():
+            cbz.write_bytes(source_bytes)
+
+        dest_dir = tmp_path / "manga" / "Chainsaw Man"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        placed = dest_dir / "Chainsaw Man 165.cbz"
+        if seed_dest is not None:
+            placed.write_bytes(seed_dest)
+
+        pp, _ = _make_pp(
+            nzb_name="Chainsaw Man 165.cbz",
+            nzb_folder=str(download_dir),
+            comicid="md-csm",
+        )
+
+        config = MagicMock()
+        config.FILE_OPTS = file_opts
+        config.ARC_FILEOPS = file_opts
+        config.ARC_FILEOPS_SOFTLINK_RELATIVE = False
+        config.IGNORE_SEARCH_WORDS = []
+
+        comic_row = {"ComicName": "Chainsaw Man", "ComicLocation": str(dest_dir)}
+        with (
+            patch.object(comicarr, "CONFIG", config),
+            patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
+            mock_db.select_one.side_effect = [comic_row, None, None, None]
+            pp._process_manga()
+
+        return cbz, placed, pp
+
+    @pytest.mark.parametrize("file_opts", ("hardlink", "softlink", "copy", "move"))
+    def test_stale_destination_is_replaced(self, tmp_path, file_opts):
+        """A repack of a chapter already in the library replaces it, as it did
+        before placement moved to file_ops. Under hardlink/softlink the bare
+        os.link/os.symlink would have raised EEXIST and skipped the chapter."""
+        source, placed, pp = self._run(tmp_path, file_opts, seed_dest=b"stale copy")
+
+        assert placed.exists()
+        assert placed.read_bytes() == b"fresh grab", "%s must overwrite the stale library file" % file_opts
+        assert "Failed to move/copy manga file" not in pp.log
+
+    def test_hardlink_rerun_is_idempotent(self, tmp_path):
+        """The recovery finalizer re-drives a manga release in FULL. Under
+        hardlink the source survives the first pass, so the second pass must
+        recognise the already-linked chapter instead of failing on EEXIST."""
+        source, placed, _ = self._run(tmp_path, "hardlink")
+        assert source.exists() and placed.exists()
+        assert source.stat().st_ino == placed.stat().st_ino
+
+        # second pass over the same download folder, destination already linked
+        source_again, placed_again, pp_again = self._run(tmp_path, "hardlink")
+
+        # the re-drive must treat the already-linked chapter as placed, not as a
+        # failed placement -- a `continue` here would leave it unmatched forever
+        assert "Failed to move/copy manga file" not in pp_again.log
+        assert source_again.exists(), "the re-drive must not consume the download"
+        assert placed_again.exists(), "the re-drive must not lose the library file"
+        assert source_again.stat().st_ino == placed_again.stat().st_ino
+        assert placed_again.read_bytes() == b"fresh grab"
 
 
 class TestProcessMangaChapterMatch:

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -346,7 +346,7 @@ class TestProcessMangaExistingDestination:
     # The download folder and the manga destination are separate trees here: a
     # destination nested inside the download folder would be picked up by the
     # loop's own file walk as a second manga file.
-    def _run(self, tmp_path, file_opts, seed_dest=None, source_bytes=b"fresh grab"):
+    def _run(self, tmp_path, file_opts, seed_dest=None, source_bytes=b"fresh grab", file_ops=None):
         download_dir = tmp_path / "download"
         download_dir.mkdir(exist_ok=True)
         cbz = download_dir / "Chainsaw Man 165.cbz"
@@ -378,9 +378,39 @@ class TestProcessMangaExistingDestination:
             patch("comicarr.postprocessor.db") as mock_db,
         ):
             mock_db.select_one.side_effect = [comic_row, None, None, None]
-            pp._process_manga()
+            if file_ops is None:
+                pp._process_manga()
+            else:
+                with patch("comicarr.postprocessor.helpers.file_ops", **file_ops):
+                    pp._process_manga()
 
         return cbz, placed, pp
+
+    @pytest.mark.parametrize(
+        "file_ops",
+        ({"return_value": False}, {"side_effect": OSError("No space left on device")}),
+        ids=("returns_false", "raises"),
+    )
+    def test_failed_replacement_restores_the_previous_chapter(self, tmp_path, file_ops):
+        """The chapter already in the library is moved aside, not deleted, so a
+        placement that fails mid-replacement leaves the library intact. Deleting
+        first would strand the DB reporting Status=Downloaded for a chapter that
+        is physically gone."""
+        source, placed, pp = self._run(tmp_path, "copy", seed_dest=b"stale copy", file_ops=file_ops)
+
+        assert placed.exists(), "a failed replacement must not destroy the chapter already in the library"
+        assert placed.read_bytes() == b"stale copy"
+        assert source.exists(), "the download must survive a failed placement"
+        assert "Failed to move/copy manga file" in pp.log
+
+    def test_successful_replacement_leaves_no_displaced_file_behind(self, tmp_path):
+        """The moved-aside copy is cleaned up once placement succeeds, so it is
+        never picked up by a later library scan."""
+        _source, placed, _pp = self._run(tmp_path, "copy", seed_dest=b"stale copy")
+
+        assert placed.read_bytes() == b"fresh grab"
+        leftovers = sorted(p.name for p in placed.parent.iterdir())
+        assert leftovers == ["Chainsaw Man 165.cbz"], leftovers
 
     @pytest.mark.parametrize("file_opts", ("hardlink", "softlink", "copy", "move"))
     def test_stale_destination_is_replaced(self, tmp_path, file_opts):
@@ -392,6 +422,11 @@ class TestProcessMangaExistingDestination:
         assert placed.exists()
         assert placed.read_bytes() == b"fresh grab", "%s must overwrite the stale library file" % file_opts
         assert "Failed to move/copy manga file" not in pp.log
+        if file_opts != "move":
+            # replacing an existing chapter must not cost the download: under
+            # softlink the download path is a symlink into the library, so this
+            # also pins that it resolves to the file that actually landed.
+            assert source.exists(), "%s must not consume the download when replacing" % file_opts
 
     def test_hardlink_rerun_is_idempotent(self, tmp_path):
         """The recovery finalizer re-drives a manga release in FULL. Under

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -24,6 +24,8 @@ Tests cover the _process_manga() method and the manga branch in Process().
 import queue
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import comicarr
 
 # Ensure LOG_LEVEL is set for tests
@@ -44,8 +46,7 @@ def _make_pp(nzb_name, nzb_folder, comicid=None, issueid=None, apicall=False):
     mock_config.IGNORE_SEARCH_WORDS = []
     mock_config.PRE_SCRIPTS = None
 
-    with patch.object(comicarr, "APILOCK", mock_apilock), \
-         patch.object(comicarr, "CONFIG", mock_config):
+    with patch.object(comicarr, "APILOCK", mock_apilock), patch.object(comicarr, "CONFIG", mock_config):
         pp = PostProcessor(
             nzb_name=nzb_name,
             nzb_folder=nzb_folder,
@@ -55,6 +56,54 @@ def _make_pp(nzb_name, nzb_folder, comicid=None, issueid=None, apicall=False):
             apicall=apicall,
         )
     return pp, mock_queue
+
+
+class TestMangaPlacementHonoursFileOpts:
+    """The manga path used shutil.move for every mode except copy, so hardlink
+    and softlink -- both of which are supposed to leave the download in place --
+    destroyed the user's source file."""
+
+    def _run(self, tmp_path, file_opts):
+        cbz = tmp_path / "Chainsaw Man 165.cbz"
+        cbz.write_bytes(b"fake cbz")
+        dest_dir = tmp_path / "manga" / "Chainsaw Man"
+        dest_dir.mkdir(parents=True)
+
+        pp, _ = _make_pp(
+            nzb_name="Chainsaw Man 165.cbz",
+            nzb_folder=str(tmp_path),
+            comicid="md-csm",
+        )
+
+        config = MagicMock()
+        config.FILE_OPTS = file_opts
+        config.ARC_FILEOPS = file_opts
+        config.ARC_FILEOPS_SOFTLINK_RELATIVE = False
+        config.IGNORE_SEARCH_WORDS = []
+
+        comic_row = {"ComicName": "Chainsaw Man", "ComicLocation": str(dest_dir)}
+        with (
+            patch.object(comicarr, "CONFIG", config),
+            patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
+            mock_db.select_one.side_effect = [comic_row, None, None, None]
+            pp._process_manga()
+
+        return cbz, dest_dir / "Chainsaw Man 165.cbz"
+
+    @pytest.mark.parametrize("file_opts", ("hardlink", "softlink", "copy"))
+    def test_non_move_modes_leave_the_source_in_place(self, tmp_path, file_opts):
+        source, placed = self._run(tmp_path, file_opts)
+
+        assert source.exists(), "%s must not consume the downloaded file" % file_opts
+        assert placed.exists()
+
+    def test_move_mode_still_consumes_the_source(self, tmp_path):
+        source, placed = self._run(tmp_path, "move")
+
+        assert not source.exists()
+        assert placed.exists()
 
 
 class TestMangaBranchDetection:
@@ -81,13 +130,13 @@ class TestMangaBranchDetection:
             issueid="67890",
             apicall=True,
         )
-        with patch.object(pp, "_process_manga") as mock_pm, \
-             patch("comicarr.postprocessor.filechecker") as mock_fc, \
-             patch("comicarr.postprocessor.db") as mock_db:
+        with (
+            patch.object(pp, "_process_manga") as mock_pm,
+            patch("comicarr.postprocessor.filechecker") as mock_fc,
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
             mock_db.select_one.return_value = {"ComicID": "12345"}
-            mock_fc.FileChecker.return_value.listFiles.return_value = {
-                "comiccount": 0, "comiclist": []
-            }
+            mock_fc.FileChecker.return_value.listFiles.return_value = {"comiccount": 0, "comiclist": []}
             try:
                 pp.Process()
             except Exception:
@@ -172,8 +221,10 @@ class TestProcessMangaNoDestination:
 
         comic_row = {"ComicName": "Bleach", "ComicLocation": None}
 
-        with patch("comicarr.postprocessor.db") as mock_db, \
-             patch("comicarr.postprocessor.get_manga_destination", return_value=None):
+        with (
+            patch("comicarr.postprocessor.db") as mock_db,
+            patch("comicarr.postprocessor.get_manga_destination", return_value=None),
+        ):
             mock_db.select_one.return_value = comic_row
             pp._process_manga()
 
@@ -202,17 +253,18 @@ class TestProcessMangaFileMove:
 
         comic_row = {"ComicName": "Bleach", "ComicLocation": str(dest_dir)}
 
-        with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")), \
-             patch("comicarr.postprocessor.db") as mock_db:
+        with (
+            patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
             # First call: comic lookup. Remaining: chapter/issue lookups return None
             mock_db.select_one.side_effect = [comic_row, None, None, None]
-            pp.fileop = MagicMock()
+            with patch("comicarr.postprocessor.helpers.file_ops", return_value=True) as file_ops:
+                pp._process_manga()
 
-            pp._process_manga()
-
-        # fileop should have been called to move the file
-        pp.fileop.assert_called_once()
-        args = pp.fileop.call_args[0]
+        # the placement helper should have been called for the file
+        file_ops.assert_called_once()
+        args = file_ops.call_args[0]
         assert args[0] == str(cbz)
         assert "Bleach v1.cbz" in args[1]
 
@@ -232,12 +284,13 @@ class TestProcessMangaFileMove:
 
         comic_row = {"ComicName": "Bleach", "ComicLocation": str(dest_dir)}
 
-        with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")), \
-             patch("comicarr.postprocessor.db") as mock_db:
+        with (
+            patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
             mock_db.select_one.return_value = comic_row
-            pp.fileop = MagicMock(side_effect=OSError("Permission denied"))
-
-            pp._process_manga()
+            with patch("comicarr.postprocessor.helpers.file_ops", side_effect=OSError("Permission denied")):
+                pp._process_manga()
 
         mock_queue.put.assert_called_once()
         result = mock_queue.put.call_args[0][0]
@@ -274,14 +327,16 @@ class TestProcessMangaChapterMatch:
         # to a benign no-op here. This test pins the issues-upsert + success
         # log, not the journal seam (covered by test_pp_complete_ordering.py /
         # test_journal_pp_seam.py).
-        with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")), \
-             patch("comicarr.app.downloads.journal.record_transition", return_value=True), \
-             patch("comicarr.postprocessor.db") as mock_db:
+        with (
+            patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
+            patch("comicarr.app.downloads.journal.record_transition", return_value=True),
+            patch("comicarr.postprocessor.helpers.file_ops", return_value=True),
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
             # select_one calls: 1) comic lookup, 2) chapter match, 3) have count
             mock_db.select_one.side_effect = [comic_row, issue_row, have_count]
             mock_db.get_engine.return_value.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
             mock_db.get_engine.return_value.begin.return_value.__exit__ = MagicMock(return_value=False)
-            pp.fileop = MagicMock()
 
             pp._process_manga()
 
@@ -311,11 +366,13 @@ class TestProcessMangaChapterMatch:
 
         comic_row = {"ComicName": "Chainsaw Man", "ComicLocation": str(dest_dir)}
 
-        with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")), \
-             patch("comicarr.postprocessor.db") as mock_db:
+        with (
+            patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
+            patch("comicarr.postprocessor.helpers.file_ops", return_value=True),
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
             # comic lookup succeeds, all chapter/issue lookups return None
             mock_db.select_one.side_effect = [comic_row, None, None, None]
-            pp.fileop = MagicMock()
 
             pp._process_manga()
 

--- a/tests/unit/test_pp_complete_ordering.py
+++ b/tests/unit/test_pp_complete_ordering.py
@@ -43,7 +43,7 @@ Region B — Process_next MANUAL-RUN story-arc/oneoff path:
 Region C — _process_manga per-file loop (manga has NO tidyup; move IS the
 relocation):
   ~4358 post_processing (release-level identity)         [pre-loop / pre-move]
-  ~4376 self.fileop(filepath, dst)                       PER-FILE destructive
+  ~4376 helpers.file_ops(filepath, dst)                  PER-FILE placement
   ~4388 moved (release-level)                            [post per-file fileop]
   ~4440 db.upsert("issues" Status=Downloaded)            -> Status FIRST (inline)
   ~4449 begin(): single nzblog delete by issueid
@@ -96,6 +96,7 @@ from sqlalchemy import insert, select
 import comicarr
 from comicarr.app.downloads import journal
 from comicarr.db import get_engine, shutdown_engine
+from comicarr import postprocessor
 from comicarr.postprocessor import PostProcessor
 from comicarr.tables import comics, issues, metadata, nzblog, pipeline_journal
 
@@ -190,7 +191,7 @@ def _seed_manga(comicid="md-csm", issueid="md-csm-ch165"):
         )
 
 
-def test_characterization_manga_marker_ordering_around_destructive_move(tmp_path):
+def test_characterization_manga_marker_ordering_around_destructive_move(tmp_path, monkeypatch):
     """Region C (real _process_manga): post_processing STRICTLY before the
     per-file destructive fileop; moved STRICTLY after it; post_processed last.
     Pins the U3 bracket — unchanged by U9 (only nzblog<->post_processed
@@ -211,8 +212,9 @@ def test_characterization_manga_marker_ordering_around_destructive_move(tmp_path
 
     def _fake_fileop(s, d):
         seen.append("__fileop__")
+        return True
 
-    pp.fileop = _fake_fileop
+    monkeypatch.setattr(postprocessor.helpers, "file_ops", _fake_fileop)
 
     with (
         patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
@@ -226,7 +228,7 @@ def test_characterization_manga_marker_ordering_around_destructive_move(tmp_path
     assert seen[-1] == "post_processed"
 
 
-def test_characterization_manga_failed_move_stays_at_post_processing(tmp_path):
+def test_characterization_manga_failed_move_stays_at_post_processing(tmp_path, monkeypatch):
     """Region C error path: every per-file move fails -> 0 processed -> the
     release-level row stays at post_processing, NO moved/post_processed.
     Pinned: a failed move must NEVER write a terminal fact (replay re-drives
@@ -241,7 +243,7 @@ def test_characterization_manga_failed_move_stays_at_post_processing(tmp_path):
     def _boom_fileop(s, d):
         raise OSError("disk full")
 
-    pp.fileop = _boom_fileop
+    monkeypatch.setattr(postprocessor.helpers, "file_ops", _boom_fileop)
 
     with patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")):
         pp._process_manga()


### PR DESCRIPTION
## The bug

**Manga post-processing deleted the user's downloaded file when `FILE_OPTS` was `hardlink` or `softlink`.**

`self.fileop` was `shutil.copy` when `FILE_OPTS == "copy"` and `shutil.move` for everything else (`postprocessor.py:116-119`). `FILE_OPTS` also accepts `hardlink` and `softlink`, both of which are supposed to leave the download in place — so for those two modes the manga path destroyed the source.

It was the only placement site in post-processing not using `helpers.file_ops`, which handles all four modes and carries the EXDEV hardlink-to-copy fallback.

## Why the tests could not see it

Every test that reached the placement replaced `pp.fileop` with its own callable, so the real mover never ran. They now patch `helpers.file_ops`, which is also where a future regression would appear.

New tests drive `_process_manga` for real against each mode and assert the source survives for `hardlink`, `softlink` and `copy`, and is consumed for `move`.

## Also

`self.fileop` is deleted rather than fixed. It was bound in `__init__`, so it could not reflect a config change made later in the process, and the reset at the end of `Process_next` existed only to undo that. Reading the mode at placement time removes both.

## Verification

`pytest tests/unit` (1505 passing), `ruff check`. Confirmed the new tests fail against the unfixed mover before the change.

Found by the architecture review in this session; one of eight independent branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiHS1hJan2hwwyDkgFKJQj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manga downloads now remain available when using hardlink, softlink, or copy modes.
  * Reprocessing existing manga chapters now reliably replaces outdated files across all file operation modes.
  * Retried or repeated imports no longer fail because a chapter already exists.
  * Failed file operations no longer incorrectly mark chapters as successfully downloaded.
  * Manga processing is now safer and more consistent after interrupted or partially completed runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->