### PR TITLE
fix: Treat MyAnimeList manga series like MangaDex ones

### DIFF
--- a/.changeset/olive-mal-series-work.md
+++ b/.changeset/olive-mal-series-work.md
@@ -1,0 +1,9 @@
+---
+"comicarr": patch
+---
+
+Fix MyAnimeList manga series being treated as comics in two places: downloads
+were post-processed down the ComicVine path instead of the manga path, and the
+scheduled chapter check skipped them entirely, so they never picked up new
+chapters. MangaDex-added series now also record their MangaDex id, which the
+"already in library" check on search results depends on.

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -1394,6 +1394,9 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
         "ReadingDirection": "rtl",
         "MetadataSource": "mangadex",
         "ExternalID": mangadex_uuid,
+        # Also recorded on the MAL path. Without it a MangaDex-added series is
+        # invisible to every cross-provider lookup keyed on MangaDexID.
+        "MangaDexID": mangadex_uuid,
         "LastUpdated": helpers.now(),
         "DateAdded": helpers.today() if dbmanga is None else dbmanga.get("DateAdded", helpers.today()),
     }

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -614,8 +614,10 @@ class PostProcessor(object):
 
         self.oneoffinlist = False
 
-        # --- Manga branch: if the comicid is a MangaDex ID, use manga-specific processing ---
-        if self.comicid is not None and str(self.comicid).startswith("md-"):
+        # --- Manga branch: MangaDex (md-) and MyAnimeList (mal-) series both
+        # need manga-specific processing. Omitting mal- sent every MAL download
+        # down the ComicVine path. ---
+        if self.comicid is not None and str(self.comicid).startswith(("md-", "mal-")):
             logger.fdebug(
                 "%s Manga series detected (ComicID: %s) - branching to manga post-processing" % (module, self.comicid)
             )

--- a/comicarr/rsscheck.py
+++ b/comicarr/rsscheck.py
@@ -31,7 +31,7 @@ import feedparser
 import requests
 from bs4 import BeautifulSoup
 from packaging.version import parse as parse_version
-from sqlalchemy import Column, Integer, MetaData, Table, Text, func, select
+from sqlalchemy import Column, Integer, MetaData, Table, Text, func, or_, select
 from sqlalchemy.exc import OperationalError
 
 import comicarr
@@ -1981,12 +1981,17 @@ def mangadexNewChapterCheck():
 
     logger.info("[MANGA-RSS] Starting MangaDex new-chapter check")
 
-    # Get all active manga series with MangaDex IDs
+    # Every active manga series MangaDex can supply chapters for. MAL-added
+    # series carry a resolved MangaDexID; restricting this to md- ComicIDs meant
+    # they never polled for new chapters at all.
     manga_series = db.select_all(
         select(t_comics).where(
             t_comics.c.ContentType == "manga",
             t_comics.c.Status != "Paused",
-            t_comics.c.ComicID.like("md-%"),
+            or_(
+                t_comics.c.ComicID.like("md-%"),
+                t_comics.c.MangaDexID.isnot(None),
+            ),
         )
     )
 
@@ -2001,6 +2006,11 @@ def mangadexNewChapterCheck():
     for series in manga_series:
         comic_id = series["ComicID"]
         comic_name = series["ComicName"]
+        # md- series carry the MangaDex uuid in the ComicID itself; mal- series
+        # keep it in MangaDexID.
+        mangadex_id = comic_id if str(comic_id).startswith("md-") else series["MangaDexID"]
+        if not mangadex_id:
+            continue
 
         # Get existing chapter numbers from the database for this series
         existing_issues = db.select_all(
@@ -2019,7 +2029,7 @@ def mangadexNewChapterCheck():
 
         # Fetch chapters from MangaDex (rate-limited internally)
         try:
-            mdx_chapters = mangadex.get_all_chapters(comic_id)
+            mdx_chapters = mangadex.get_all_chapters(mangadex_id)
         except Exception as e:
             logger.error("[MANGA-RSS] Error fetching MangaDex chapters for %s: %s" % (comic_name, e))
             continue

--- a/tests/unit/test_mal_prefix_drift.py
+++ b/tests/unit/test_mal_prefix_drift.py
@@ -1,0 +1,211 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""MangaDex-added and MyAnimeList-added series must be treated alike.
+
+Three places knew about "md-" and not "mal-", each of them a copy of the same
+decision made somewhere else:
+
+  * post-processing sent every MAL download down the ComicVine path,
+  * the chapter poll skipped MAL series entirely,
+  * and the MangaDex add path never recorded MangaDexID, so a series added that
+    way was invisible to every lookup keyed on it.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine, select
+
+import comicarr
+from comicarr import rsscheck
+from comicarr.postprocessor import PostProcessor
+from comicarr.tables import comics, metadata
+
+
+def _make_pp(comicid):
+    lock = MagicMock()
+    lock.locked.return_value = False
+    config = MagicMock()
+    config.FILE_OPTS = "move"
+    config.IGNORE_SEARCH_WORDS = []
+    config.PRE_SCRIPTS = None
+    with patch.object(comicarr, "APILOCK", lock), patch.object(comicarr, "CONFIG", config):
+        return PostProcessor(
+            nzb_name="Chapter 1.cbz",
+            nzb_folder="/tmp/downloads",
+            comicid=comicid,
+            queue=MagicMock(),
+            apicall=True,
+        )
+
+
+class TestPostProcessingRoutesBothProviders:
+    @pytest.mark.parametrize("comicid", ("md-abc123", "mal-161890"))
+    def test_manga_ids_reach_the_manga_path(self, comicid):
+        pp = _make_pp(comicid)
+
+        with patch.object(pp, "_process_manga", return_value=None) as process_manga:
+            pp.Process()
+
+        process_manga.assert_called_once()
+
+    def test_a_comicvine_id_still_does_not(self):
+        pp = _make_pp("12345")
+
+        with (
+            patch.object(pp, "_process_manga") as process_manga,
+            patch("comicarr.postprocessor.filechecker") as filechecker,
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
+            mock_db.select_one.return_value = {"ComicID": "12345"}
+            filechecker.FileChecker.return_value.listFiles.return_value = {"comiccount": 0, "comiclist": []}
+            try:
+                pp.Process()
+            except Exception:
+                pass
+
+        process_manga.assert_not_called()
+
+
+def _seed(engine, rows):
+    with engine.begin() as conn:
+        for row in rows:
+            conn.execute(comics.insert(), row)
+
+
+class TestChapterPollCoversBothProviders:
+    def _run(self, monkeypatch, rows):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        _seed(engine, rows)
+        monkeypatch.setattr(rsscheck.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(rsscheck.db, "select_all", lambda stmt: _select_all(engine, stmt))
+
+        polled = []
+        import comicarr.mangadex as mangadex
+
+        monkeypatch.setattr(
+            mangadex,
+            "get_all_chapters",
+            lambda manga_id, *a, **k: polled.append(manga_id) or [],
+        )
+        rsscheck.mangadexNewChapterCheck()
+        return polled
+
+    def test_both_providers_are_polled_with_a_mangadex_id(self, monkeypatch):
+        polled = self._run(
+            monkeypatch,
+            [
+                {
+                    "ComicID": "md-uuid-1",
+                    "ComicName": "Chainsaw Man",
+                    "ContentType": "manga",
+                    "Status": "Active",
+                },
+                {
+                    "ComicID": "mal-161890",
+                    "ComicName": "Bleach",
+                    "ContentType": "manga",
+                    "Status": "Active",
+                    "MangaDexID": "uuid-2",
+                },
+            ],
+        )
+
+        assert polled == ["md-uuid-1", "uuid-2"]
+
+    def test_a_mal_series_without_a_resolved_uuid_is_skipped(self, monkeypatch):
+        polled = self._run(
+            monkeypatch,
+            [
+                {
+                    "ComicID": "mal-999",
+                    "ComicName": "Unresolved",
+                    "ContentType": "manga",
+                    "Status": "Active",
+                }
+            ],
+        )
+
+        assert polled == []
+
+    def test_paused_series_are_left_alone(self, monkeypatch):
+        polled = self._run(
+            monkeypatch,
+            [
+                {
+                    "ComicID": "md-uuid-3",
+                    "ComicName": "Paused",
+                    "ContentType": "manga",
+                    "Status": "Paused",
+                }
+            ],
+        )
+
+        assert polled == []
+
+
+def _select_all(engine, stmt):
+    with engine.connect() as conn:
+        return [dict(row) for row in conn.execute(stmt).mappings()]
+
+
+class TestMangaDexAddRecordsItsId:
+    def test_mangadex_add_writes_mangadexid(self, monkeypatch, tmp_path):
+        """The MAL path always recorded MangaDexID; the MangaDex path did not."""
+        from comicarr import importer
+
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        monkeypatch.setattr(importer.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(comicarr, "COMICSORT", None, raising=False)
+        monkeypatch.setattr(
+            comicarr,
+            "CONFIG",
+            SimpleNamespace(
+                MANGA_DIR=str(tmp_path),
+                FOLDER_FORMAT="$Series",
+                REPLACE_SPACES=False,
+                CREATE_FOLDERS=False,
+                ENFORCE_PERMS=False,
+            ),
+            raising=False,
+        )
+        import comicarr.mangadex as mangadex
+        from comicarr import config as comicarr_config
+
+        monkeypatch.setattr(
+            mangadex,
+            "get_manga_details",
+            lambda *a, **k: {
+                "id": "uuid-42",
+                "title": "Chainsaw Man",
+                "year": 2018,
+                "status": "ongoing",
+                "author": "Fujimoto",
+                "description": "",
+                "cover_url": None,
+                "url": "https://mangadex.org/title/uuid-42",
+                "alt_titles": [],
+            },
+        )
+        monkeypatch.setattr(importer, "_populate_manga_chapters", lambda *a, **k: 0)
+        monkeypatch.setattr(importer.helpers, "getImage", lambda *a, **k: None)
+        monkeypatch.setattr(importer.helpers, "ComicSort", lambda **k: None)
+        monkeypatch.setattr(mangadex, "strip_manga_prefix", lambda mid: mid[3:] if mid.startswith("md-") else mid)
+        monkeypatch.setattr(comicarr_config, "get_manga_destination", lambda: str(tmp_path))
+
+        importer.addMangaToDB("md-uuid-42")
+
+        with engine.connect() as conn:
+            row = conn.execute(select(comics).where(comics.c.ComicID == "md-uuid-42")).mappings().fetchone()
+
+        assert row["MangaDexID"] == "uuid-42"


### PR DESCRIPTION
## The bug

Three places knew about the `md-` prefix and not `mal-`, each a separate copy of a routing decision made elsewhere:

1. **`postprocessor.py:618`** branched to the manga path only for `md-`, so every MAL download went down the ComicVine path instead.
2. **`rsscheck.py:1989`** filtered on `ComicID LIKE 'md-%'`, so MAL series never polled for new chapters at all — even though they store a resolved `MangaDexID` for exactly this purpose.
3. **`addMangaToDB`** never wrote `MangaDexID`, while `addMangaToDB_MAL` always did. A MangaDex-added series was therefore invisible to lookups keyed on it, including the `in_library` flag on search results.

## The fix

- Post-processing accepts both prefixes.
- The chapter poll selects on a MangaDex id being present and hands *that* to MangaDex rather than the `ComicID`. A MAL series with no resolved uuid is skipped rather than polled with an id MangaDex cannot use.
- `addMangaToDB` records `MangaDexID`.

## Context

These are the same shape as #298, #281 and #278: one copy of a discriminator updated, the others left behind. The durable fix is one module that answers "which kind of series is this" — candidate 1 in the architecture review, which found four independent discriminators across ~35 sites. **This PR only closes the three live gaps**; it does not attempt the consolidation.

## Verification

`pytest tests/unit` (1508 passing), `ruff check`. Confirmed all three tests fail against the unfixed code before the change.

One of eight independent branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiHS1hJan2hwwyDkgFKJQj