### PR TITLE
fix: Derive cover CSP from the image host allowlist

### DIFF
--- a/.changeset/olive-covers-align.md
+++ b/.changeset/olive-covers-align.md
@@ -1,0 +1,8 @@
+---
+"comicarr": patch
+---
+
+Fix MyAnimeList cover art being blocked by the browser security policy. The
+list of hosts trusted to serve cover images and the Content-Security-Policy
+that permits the browser to load them are now derived from one source, so they
+cannot drift apart again.

--- a/comicarr/app/core/image_hosts.py
+++ b/comicarr/app/core/image_hosts.py
@@ -1,0 +1,40 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Canonical allowlist of third-party hosts trusted to serve cover art.
+
+One set, two derived views:
+
+- ``metadata.image_fetch`` compares bare hostnames, guarding server-side
+  fetches against SSRF.
+- ``core.middleware`` splices ``https://host`` tokens into the CSP img-src
+  directive, permitting the browser to load a cover directly.
+
+Both are needed because covers reach the browser two ways: proxied through
+``/api/metadata/art/{comic_id}``, and — when the cache-on-add fetch failed —
+as the raw external URL left in ``comics.ComicImage``, which the library grid
+renders with no proxy fallback. This module lives in ``core`` rather than
+``metadata`` because ``middleware`` may not import from a domain package.
+"""
+
+ALLOWED_IMAGE_DOMAINS = frozenset(
+    {
+        "comicvine.gamespot.com",
+        "static.metron.cloud",
+        "uploads.mangadex.org",
+        "myanimelist.net",
+        "cdn.myanimelist.net",
+        "api-cdn.myanimelist.net",
+    }
+)
+
+
+def csp_img_src_origins():
+    """Return the allowlist as space-joined ``https://host`` CSP source tokens."""
+    return " ".join("https://%s" % host for host in sorted(ALLOWED_IMAGE_DOMAINS))

--- a/comicarr/app/core/middleware.py
+++ b/comicarr/app/core/middleware.py
@@ -18,6 +18,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
+from comicarr.app.core.image_hosts import csp_img_src_origins
+
 # Exempt only specific endpoints that cannot send the CSRF header
 # (OPDS uses HTTP Basic auth, not cookies, so CSRF is not applicable)
 CSRF_EXEMPT_PREFIXES = (
@@ -55,7 +57,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "default-src 'self'",
             "script-src 'self'",
             "style-src 'self' 'unsafe-inline'",
-            "img-src 'self' data: https://comicvine.gamespot.com https://static.metron.cloud https://uploads.mangadex.org https://cdn.myanimelist.net",
+            "img-src 'self' data: " + csp_img_src_origins(),
             "font-src 'self'",
             "connect-src 'self'",
             "frame-ancestors 'none'",

--- a/comicarr/app/metadata/image_fetch.py
+++ b/comicarr/app/metadata/image_fetch.py
@@ -20,15 +20,9 @@ import requests
 from comicarr import logger
 
 # Hosts allowed for server-side cover/image fetches (SSRF protection).
-# Keep in sync with CSP img-src in middleware when adding new CDNs.
-ALLOWED_IMAGE_DOMAINS = {
-    "comicvine.gamespot.com",
-    "static.metron.cloud",
-    "uploads.mangadex.org",
-    "myanimelist.net",
-    "cdn.myanimelist.net",
-    "api-cdn.myanimelist.net",
-}
+# Re-exported from core.image_hosts, which the CSP img-src directive is also
+# derived from — there is no second copy to keep in sync.
+from comicarr.app.core.image_hosts import ALLOWED_IMAGE_DOMAINS
 
 ALLOWED_IMAGE_CONTENT_TYPES = {
     "image/jpeg",

--- a/docs/solutions/ui-bugs/metron-search-broken-cover-images.md
+++ b/docs/solutions/ui-bugs/metron-search-broken-cover-images.md
@@ -149,9 +149,16 @@ if "apikey" not in kwargs and kwargs["cmd"] != "getAPI":
 
 ### 6. CSP `img-src` whitelist update
 
+At the time, the directive was hand-written:
+
 ```python
 "img-src 'self' data: https://comicvine.gamespot.com https://static.metron.cloud https://uploads.mangadex.org",
 ```
+
+> **Superseded — do not copy this shape.** Hand-maintaining the directive
+> alongside the SSRF allowlist is what let the two drift apart twice more
+> (#281, #298). As of PR #306 the CSP is derived from a single source; see
+> Prevention Strategy 4 below.
 
 ### 7. Page size 50 → 20
 
@@ -165,7 +172,7 @@ Reduces Metron API pressure from 50 concurrent image fetches to 20 (capped at 4 
 
 3. **Thread-safe bounded caches in CherryPy** — Always use `threading.Lock` + bounded `OrderedDict`. Never bare `dict` — CherryPy's 15-thread pool guarantees concurrent access.
 
-4. **Update CSP when adding image sources** — The `img-src` whitelist in `webstart.py` must be updated for any new provider. Add this to the provider integration checklist.
+4. **Add image hosts in one place — never hand-edit the CSP** — A new provider's host goes into `ALLOWED_IMAGE_DOMAINS` in `comicarr/app/core/image_hosts.py` and nowhere else. The CSP `img-src` directive is derived from that set by `csp_img_src_origins()` (`comicarr/app/core/middleware.py`), so it updates itself. Hand-writing hosts into the directive re-creates the second copy that drifted in #281 and #298; `tests/unit/test_image_hosts.py` fails if the CSP stops being derived. Note that membership grants two powers — the server may fetch from the host, and the browser may render images from it.
 
 5. **Browser-test the full auth flow** — Unit tests don't catch session/API key issues. The `getAPI` failure was only discoverable through actual browser testing.
 

--- a/tests/unit/test_image_hosts.py
+++ b/tests/unit/test_image_hosts.py
@@ -19,6 +19,28 @@ from comicarr.app.core.image_hosts import ALLOWED_IMAGE_DOMAINS, csp_img_src_ori
 from comicarr.app.core.middleware import SecurityHeadersMiddleware
 
 
+class TestAllowlistContents:
+    def test_allowlist_membership_is_pinned(self):
+        """Deriving the CSP proves the wiring, not the contents.
+
+        Every other test here iterates ALLOWED_IMAGE_DOMAINS, so the suite stays
+        green for any contents of the set -- including one with a provider host
+        dropped, which silently re-breaks that provider's covers. Pinning the set
+        literally makes a removal a deliberate test edit; an addition stays a
+        one-line change here alongside the one in image_hosts.
+        """
+        assert ALLOWED_IMAGE_DOMAINS == frozenset(
+            {
+                "comicvine.gamespot.com",
+                "static.metron.cloud",
+                "uploads.mangadex.org",
+                "myanimelist.net",
+                "cdn.myanimelist.net",
+                "api-cdn.myanimelist.net",
+            }
+        )
+
+
 class TestCspImgSrcOrigins:
     def test_every_allowed_host_becomes_an_https_origin(self):
         origins = csp_img_src_origins().split(" ")

--- a/tests/unit/test_image_hosts.py
+++ b/tests/unit/test_image_hosts.py
@@ -1,0 +1,57 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""The cover-host allowlist and the CSP img-src directive share one source.
+
+Two shipped fixes (#281, #298) were each a host added to one copy and not the
+other. Asserting that individual hosts appear in the CSP would not have caught
+the third drift, because a hand-written directive containing the right hosts
+passes that check. These tests pin the wiring instead.
+"""
+
+from comicarr.app.core.image_hosts import ALLOWED_IMAGE_DOMAINS, csp_img_src_origins
+from comicarr.app.core.middleware import SecurityHeadersMiddleware
+
+
+class TestCspImgSrcOrigins:
+    def test_every_allowed_host_becomes_an_https_origin(self):
+        origins = csp_img_src_origins().split(" ")
+
+        assert len(origins) == len(ALLOWED_IMAGE_DOMAINS)
+        for host in ALLOWED_IMAGE_DOMAINS:
+            assert "https://%s" % host in origins
+
+    def test_output_is_stable_across_calls(self):
+        assert csp_img_src_origins() == csp_img_src_origins()
+
+
+class TestCspDerivesFromTheAllowlist:
+    def test_csp_embeds_the_derived_fragment_verbatim(self):
+        """A hand-maintained second copy fails this even when its hosts are correct."""
+        assert csp_img_src_origins() in SecurityHeadersMiddleware.CSP
+
+    def test_img_src_directive_allows_self_and_data_uris(self):
+        directive = next(part for part in SecurityHeadersMiddleware.CSP.split("; ") if part.startswith("img-src "))
+
+        assert directive == "img-src 'self' data: " + csp_img_src_origins()
+
+
+class TestSsrfGuardSharesTheSource:
+    def test_image_fetch_reexports_the_canonical_allowlist(self):
+        from comicarr.app.metadata import image_fetch
+
+        assert image_fetch.ALLOWED_IMAGE_DOMAINS is ALLOWED_IMAGE_DOMAINS
+
+    def test_mal_hosts_reachable_by_both_consumers(self):
+        """The exact drift shipped today: allowed to fetch, blocked from rendering."""
+        from comicarr.app.metadata.image_fetch import is_allowed_image_url
+
+        for host in ("myanimelist.net", "cdn.myanimelist.net", "api-cdn.myanimelist.net"):
+            assert is_allowed_image_url("https://%s/images/manga/2/253146l.jpg" % host) is True
+            assert "https://%s" % host in SecurityHeadersMiddleware.CSP

--- a/tests/unit/test_manga_refresh_regressions.py
+++ b/tests/unit/test_manga_refresh_regressions.py
@@ -300,13 +300,10 @@ class TestMangaCoverCachePath:
         assert row["ComicImage"] == "https://cdn.myanimelist.net/images/manga/2/253146l.jpg"
 
 
-class TestCspAllowsMalCdn:
-    """Defect 3a: the MAL cover CDN must be in the CSP img-src allowlist."""
-
-    def test_mal_cdn_in_csp(self):
-        from comicarr.app.core.middleware import SecurityHeadersMiddleware
-
-        assert "https://cdn.myanimelist.net" in SecurityHeadersMiddleware.CSP
+# Defect 3a (the MAL cover CDN must be in the CSP img-src allowlist) is now
+# pinned structurally in tests/unit/test_image_hosts.py: the CSP is derived from
+# the same allowlist the SSRF guard uses, so a host can no longer be in one and
+# not the other.
 
 
 class TestMangaRefreshPreservesLibraryState:


### PR DESCRIPTION
## The bug

The set of hosts trusted to serve cover art was written twice: as `ALLOWED_IMAGE_DOMAINS` for the server-side SSRF guard, and again by hand in the CSP `img-src` directive. The copies had drifted — `myanimelist.net` and `api-cdn.myanimelist.net` were fetchable but not renderable.

**This is live, not latent.** When the cache-on-add fetch fails, the manga add path leaves the raw external URL in `comics.ComicImage` (`importer.py:1387,1554`), and `SeriesTable.tsx:663` / `SeriesCard.tsx:16-20` render it directly with no proxy fallback. Those covers were blocked outright. `tests/unit/test_manga_refresh_regressions.py:298` already asserts the raw URL persists on failure.

## The fix

Move the allowlist to `comicarr/app/core/image_hosts.py` — `middleware` may not import from a domain package — and derive the CSP fragment from it.

## The test shape matters

A test asserting "every allowed host appears in the CSP" would **still pass if someone hand-hardcodes the hosts again**, which is how this drifted twice (#281, #298). The test asserts the CSP contains `csp_img_src_origins()` *verbatim*, which proves the wiring rather than the contents. The old `TestCspAllowsMalCdn` is retired rather than kept alongside it.

## Worth a reviewer's eye

The derivation grants the browser direct-load permission to `myanimelist.net` itself. That host is in the SSRF list only to accept a legacy URL *shape* that `normalize_allowed_image_url` rewrites to the CDN before any request is made, so this is a deliberate slight widening, not an accident.

Separately, and not addressed here: `helpers.getImage` — the cache-on-add path — bypasses the allowlist entirely with a plain `requests.get`. That is the root cause of the raw URL persisting in the first place.

## Verification

`pytest tests/unit` (1508 passing), `ruff check`.

One of eight independent branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiHS1hJan2hwwyDkgFKJQj