### PR TITLE
fix: Decode queue table selection by row identity

### DIFF
--- a/.changeset/plain-bulk-selects.md
+++ b/.changeset/plain-bulk-selects.md
@@ -1,0 +1,7 @@
+---
+"comicarr": patch
+---
+
+Fix bulk actions on the Wanted and Upcoming lists doing nothing. Selecting rows
+never registered, so the action bar reported no selection and Search or Skip ran
+against an empty set.

--- a/.changeset/plain-bulk-selects.md
+++ b/.changeset/plain-bulk-selects.md
@@ -5,3 +5,9 @@
 Fix bulk actions on the Wanted and Upcoming lists doing nothing. Selecting rows
 never registered, so the action bar reported no selection and Search or Skip ran
 against an empty set.
+
+Clearing the selection, changing page, or a row disappearing now also unchecks
+the rows, so a later bulk action cannot skip issues you already cleared or that
+are no longer on screen. A bulk Skip or Mark Wanted that fails partway through
+now reports how many issues were applied and keeps only the failures selected,
+instead of reporting a total failure and retrying the ones that succeeded.

--- a/frontend/src/components/queue/UpcomingTable.tsx
+++ b/frontend/src/components/queue/UpcomingTable.tsx
@@ -191,9 +191,11 @@ export default function UpcomingTable({
       if (onSelectionChange) {
         const newSelection =
           typeof updater === "function" ? updater(rowSelection) : updater;
-        const selectedIds = Object.keys(newSelection)
-          .map((index) => issues[parseInt(index)]?.IssueID)
-          .filter(Boolean) as string[];
+        // getRowId returns IssueID, so the keys are already issue ids --
+        // indexing `issues` by them yields undefined and selects nothing.
+        const selectedIds = Object.entries(newSelection)
+          .filter(([, isSelected]) => isSelected)
+          .map(([issueId]) => issueId);
         onSelectionChange(selectedIds);
       }
     },

--- a/frontend/src/components/queue/UpcomingTable.tsx
+++ b/frontend/src/components/queue/UpcomingTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
   useReactTable,
   getCoreRowModel,
@@ -22,19 +22,39 @@ const columnHelper = createColumnHelper<UpcomingIssue>();
 
 interface UpcomingTableProps {
   issues?: UpcomingIssue[];
+  /** Controlled selection. The page owns it so Clear and paging reset the checkboxes too. */
+  selectedIds?: string[];
   onSelectionChange?: (selectedIds: string[]) => void;
 }
 
 export default function UpcomingTable({
   issues = [],
+  selectedIds = [],
   onSelectionChange,
 }: UpcomingTableProps) {
   const [sorting, setSorting] = useState<SortingState>([
     { id: "IssueDate", desc: false },
   ]);
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const queueIssueMutation = useQueueIssue();
   const unqueueIssueMutation = useUnqueueIssue();
+
+  // Derived, never stored: a second copy of the selection is what let the page
+  // clear `selectedIds` while the table kept its rows checked.
+  const rowSelection = useMemo<RowSelectionState>(
+    () => Object.fromEntries(selectedIds.map((id) => [id, true])),
+    [selectedIds],
+  );
+
+  // Rows can disappear under a live selection (refetch, view switch). Drop ids
+  // that are no longer rendered so a bulk action can't hit invisible issues.
+  useEffect(() => {
+    if (!onSelectionChange || selectedIds.length === 0) return;
+    const present = new Set(issues.map((issue) => issue.IssueID));
+    const stillVisible = selectedIds.filter((id) => present.has(id));
+    if (stillVisible.length !== selectedIds.length) {
+      onSelectionChange(stillVisible);
+    }
+  }, [issues, selectedIds, onSelectionChange]);
 
   const columns = useMemo(
     () => [
@@ -187,17 +207,16 @@ export default function UpcomingTable({
     state: { sorting, rowSelection },
     onSortingChange: setSorting,
     onRowSelectionChange: (updater: Updater<RowSelectionState>) => {
-      setRowSelection(updater);
-      if (onSelectionChange) {
-        const newSelection =
-          typeof updater === "function" ? updater(rowSelection) : updater;
-        // getRowId returns IssueID, so the keys are already issue ids --
-        // indexing `issues` by them yields undefined and selects nothing.
-        const selectedIds = Object.entries(newSelection)
+      if (!onSelectionChange) return;
+      const newSelection =
+        typeof updater === "function" ? updater(rowSelection) : updater;
+      // getRowId returns IssueID, so the keys are already issue ids --
+      // indexing `issues` by them yields undefined and selects nothing.
+      onSelectionChange(
+        Object.entries(newSelection)
           .filter(([, isSelected]) => isSelected)
-          .map(([issueId]) => issueId);
-        onSelectionChange(selectedIds);
-      }
+          .map(([issueId]) => issueId),
+      );
     },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/frontend/src/components/queue/WantedTable.tsx
+++ b/frontend/src/components/queue/WantedTable.tsx
@@ -168,9 +168,11 @@ export default function WantedTable({
       if (onSelectionChange) {
         const newSelection =
           typeof updater === "function" ? updater(rowSelection) : updater;
-        const selectedIds = Object.keys(newSelection)
-          .map((index) => issues[parseInt(index)]?.IssueID)
-          .filter(Boolean) as string[];
+        // getRowId returns IssueID, so the keys are already issue ids --
+        // indexing `issues` by them yields undefined and selects nothing.
+        const selectedIds = Object.entries(newSelection)
+          .filter(([, isSelected]) => isSelected)
+          .map(([issueId]) => issueId);
         onSelectionChange(selectedIds);
       }
     },

--- a/frontend/src/components/queue/WantedTable.tsx
+++ b/frontend/src/components/queue/WantedTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   useReactTable,
@@ -28,6 +28,8 @@ interface WantedTableProps {
   pagination?: PaginationMeta;
   onNextPage?: () => void;
   onPrevPage?: () => void;
+  /** Controlled selection. The page owns it so Clear and paging reset the checkboxes too. */
+  selectedIds?: string[];
   onSelectionChange?: (selectedIds: string[]) => void;
 }
 
@@ -36,14 +38,32 @@ export default function WantedTable({
   pagination,
   onNextPage,
   onPrevPage,
+  selectedIds = [],
   onSelectionChange,
 }: WantedTableProps) {
   const navigate = useNavigate();
   const [sorting, setSorting] = useState<SortingState>([
     { id: "DateAdded", desc: true },
   ]);
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const unqueueIssueMutation = useUnqueueIssue();
+
+  // Derived, never stored: a second copy of the selection is what let the page
+  // clear `selectedIds` while the table kept its rows checked.
+  const rowSelection = useMemo<RowSelectionState>(
+    () => Object.fromEntries(selectedIds.map((id) => [id, true])),
+    [selectedIds],
+  );
+
+  // Rows can disappear under a live selection (refetch, filtering). Drop ids
+  // that are no longer rendered so a bulk action can't hit invisible issues.
+  useEffect(() => {
+    if (!onSelectionChange || selectedIds.length === 0) return;
+    const present = new Set(issues.map((issue) => issue.IssueID));
+    const stillVisible = selectedIds.filter((id) => present.has(id));
+    if (stillVisible.length !== selectedIds.length) {
+      onSelectionChange(stillVisible);
+    }
+  }, [issues, selectedIds, onSelectionChange]);
 
   const columns = useMemo(
     () => [
@@ -164,17 +184,16 @@ export default function WantedTable({
     state: { sorting, rowSelection },
     onSortingChange: setSorting,
     onRowSelectionChange: (updater: Updater<RowSelectionState>) => {
-      setRowSelection(updater);
-      if (onSelectionChange) {
-        const newSelection =
-          typeof updater === "function" ? updater(rowSelection) : updater;
-        // getRowId returns IssueID, so the keys are already issue ids --
-        // indexing `issues` by them yields undefined and selects nothing.
-        const selectedIds = Object.entries(newSelection)
+      if (!onSelectionChange) return;
+      const newSelection =
+        typeof updater === "function" ? updater(rowSelection) : updater;
+      // getRowId returns IssueID, so the keys are already issue ids --
+      // indexing `issues` by them yields undefined and selects nothing.
+      onSelectionChange(
+        Object.entries(newSelection)
           .filter(([, isSelected]) => isSelected)
-          .map(([issueId]) => issueId);
-        onSelectionChange(selectedIds);
-      }
+          .map(([issueId]) => issueId),
+      );
     },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/frontend/src/hooks/useQueue.ts
+++ b/frontend/src/hooks/useQueue.ts
@@ -24,6 +24,65 @@ interface WantedSearchPreview {
   fingerprint: string;
 }
 
+/**
+ * Outcome of a bulk issue mutation. The requests run sequentially, so a failure
+ * partway through leaves earlier issues already applied -- callers need to know
+ * which ids landed rather than treating the whole batch as failed.
+ */
+export interface BulkIssueResult {
+  succeeded: string[];
+  failed: { id: string; error: string }[];
+}
+
+/**
+ * Turns a bulk outcome into what the page should show and keep selected, so
+ * both queue pages report partial failures the same way: the ids that failed
+ * stay selected and a retry does not repeat the requests that already landed.
+ */
+export function describeBulkResult(
+  { succeeded, failed }: BulkIssueResult,
+  verb: "queued" | "skipped",
+  failureVerb: "queue" | "skip",
+): { type: "success" | "info" | "error"; message: string; keep: string[] } {
+  const total = succeeded.length + failed.length;
+  if (failed.length === 0) {
+    return {
+      type: "success",
+      message: `${succeeded.length} issue${succeeded.length !== 1 ? "s" : ""} ${verb}`,
+      keep: [],
+    };
+  }
+  return {
+    type: succeeded.length > 0 ? "info" : "error",
+    message:
+      succeeded.length > 0
+        ? `${succeeded.length} of ${total} issues ${verb} — ${failed.length} failed: ${failed[0].error}`
+        : `Failed to ${failureVerb} issues: ${failed[0].error}`,
+    keep: failed.map(({ id }) => id),
+  };
+}
+
+export async function applySequentially(
+  issueIds: string[],
+  action: (id: string) => Promise<unknown>,
+): Promise<BulkIssueResult> {
+  const result: BulkIssueResult = { succeeded: [], failed: [] };
+  // Process sequentially to avoid rate limiting, but keep going past a failure
+  // so one bad issue cannot silently drop the rest of the batch.
+  for (const id of issueIds) {
+    try {
+      await action(id);
+      result.succeeded.push(id);
+    } catch (err) {
+      result.failed.push({
+        id,
+        error: err instanceof Error ? err.message : "Unknown error",
+      });
+    }
+  }
+  return result;
+}
+
 // Query Hooks
 export function useUpcoming(
   includeDownloaded = false,
@@ -99,15 +158,17 @@ export function useSearchWantedIssue(): UseMutationResult<
   });
 }
 
-export function useBulkQueueIssues(): UseMutationResult<void, Error, string[]> {
+export function useBulkQueueIssues(): UseMutationResult<
+  BulkIssueResult,
+  Error,
+  string[]
+> {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (issueIds: string[]) => {
-      // Process sequentially to avoid rate limiting
-      for (const id of issueIds) {
-        await apiRequest("PUT", `/api/series/issues/${id}/queue`);
-      }
-    },
+    mutationFn: (issueIds: string[]) =>
+      applySequentially(issueIds, (id) =>
+        apiRequest("PUT", `/api/series/issues/${id}/queue`),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["wanted"] });
       queryClient.invalidateQueries({ queryKey: ["upcoming"] });
@@ -117,18 +178,16 @@ export function useBulkQueueIssues(): UseMutationResult<void, Error, string[]> {
 }
 
 export function useBulkUnqueueIssues(): UseMutationResult<
-  void,
+  BulkIssueResult,
   Error,
   string[]
 > {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (issueIds: string[]) => {
-      // Process sequentially to avoid rate limiting
-      for (const id of issueIds) {
-        await apiRequest("PUT", `/api/series/issues/${id}/unqueue`);
-      }
-    },
+    mutationFn: (issueIds: string[]) =>
+      applySequentially(issueIds, (id) =>
+        apiRequest("PUT", `/api/series/issues/${id}/unqueue`),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["wanted"] });
       queryClient.invalidateQueries({ queryKey: ["upcoming"] });

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -6,6 +6,8 @@ import {
   useForceSearch,
   useBulkQueueIssues,
   useBulkUnqueueIssues,
+  describeBulkResult,
+  type BulkIssueResult,
 } from "@/hooks/useQueue";
 import { useRetrySearchRun } from "@/hooks/useSeries";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -276,14 +278,27 @@ function MyReleasesView() {
   const bulkUnqueueMutation = useBulkUnqueueIssues();
   const { addToast } = useToast();
 
+  const reportBulkResult = (
+    result: BulkIssueResult,
+    verb: "queued" | "skipped",
+    failureVerb: "queue" | "skip",
+  ) => {
+    const { type, message, keep } = describeBulkResult(
+      result,
+      verb,
+      failureVerb,
+    );
+    addToast({ type, message });
+    setSelectedIds(keep);
+  };
+
   const handleBulkQueue = async () => {
     try {
-      await bulkQueueMutation.mutateAsync(selectedIds);
-      addToast({
-        type: "success",
-        message: `${selectedIds.length} issue${selectedIds.length !== 1 ? "s" : ""} queued`,
-      });
-      setSelectedIds([]);
+      reportBulkResult(
+        await bulkQueueMutation.mutateAsync(selectedIds),
+        "queued",
+        "queue",
+      );
     } catch (err) {
       addToast({
         type: "error",
@@ -294,12 +309,11 @@ function MyReleasesView() {
 
   const handleBulkUnqueue = async () => {
     try {
-      await bulkUnqueueMutation.mutateAsync(selectedIds);
-      addToast({
-        type: "success",
-        message: `${selectedIds.length} issue${selectedIds.length !== 1 ? "s" : ""} skipped`,
-      });
-      setSelectedIds([]);
+      reportBulkResult(
+        await bulkUnqueueMutation.mutateAsync(selectedIds),
+        "skipped",
+        "skip",
+      );
     } catch (err) {
       addToast({
         type: "error",
@@ -439,7 +453,11 @@ function MyReleasesView() {
       )}
 
       {!isLoading && !error && issues.length > 0 && (
-        <UpcomingTable issues={issues} onSelectionChange={setSelectedIds} />
+        <UpcomingTable
+          issues={issues}
+          selectedIds={selectedIds}
+          onSelectionChange={setSelectedIds}
+        />
       )}
 
       <BulkActionBar

--- a/frontend/src/pages/WantedPage.tsx
+++ b/frontend/src/pages/WantedPage.tsx
@@ -5,6 +5,7 @@ import {
   useForceSearch,
   useBulkUnqueueIssues,
   useSearchWantedIssue,
+  describeBulkResult,
 } from "@/hooks/useQueue";
 import { useToast } from "@/components/ui/toast";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -40,12 +41,13 @@ export default function WantedPage() {
 
   const handleBulkUnqueue = async () => {
     try {
-      await bulkUnqueue.mutateAsync(selectedIds);
-      addToast({
-        type: "success",
-        message: `${selectedIds.length} issue${selectedIds.length !== 1 ? "s" : ""} skipped`,
-      });
-      setSelectedIds([]);
+      const { type, message, keep } = describeBulkResult(
+        await bulkUnqueue.mutateAsync(selectedIds),
+        "skipped",
+        "skip",
+      );
+      addToast({ type, message });
+      setSelectedIds(keep);
     } catch (err) {
       addToast({
         type: "error",
@@ -232,6 +234,7 @@ export default function WantedPage() {
             setPage((p) => Math.max(0, p - 1));
             setSelectedIds([]);
           }}
+          selectedIds={selectedIds}
           onSelectionChange={setSelectedIds}
         />
       )}

--- a/frontend/tests/components/QueueTableSelection.test.tsx
+++ b/frontend/tests/components/QueueTableSelection.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "../test-utils";
+import WantedTable from "@/components/queue/WantedTable";
+import UpcomingTable from "@/components/queue/UpcomingTable";
+import type { Issue } from "@/types";
+
+/**
+ * Both tables set getRowId to the IssueID, then decoded the resulting selection
+ * keys as array indices. issues[parseInt("md-csm-ch165")] is undefined, every id
+ * was filtered out, and the bulk action bar reported nothing selected -- so
+ * every bulk action silently ran on zero issues.
+ */
+
+function issues(count: number): Issue[] {
+  return Array.from({ length: count }, (_, index) => {
+    const number = index + 1;
+    return {
+      IssueID: `issue-${number}`,
+      ComicID: "series-1",
+      ComicName: "Chainsaw Man",
+      Issue_Number: String(number),
+      IssueName: `Chapter ${number}`,
+      IssueDate: "2026-01-01",
+      Status: "Wanted",
+    } as Issue;
+  });
+}
+
+async function selectFirstRow() {
+  const user = userEvent.setup();
+  const checkboxes = screen.getAllByRole("checkbox");
+  // checkboxes[0] is the header select-all toggle.
+  await user.click(checkboxes[1]);
+}
+
+describe("queue table selection", () => {
+  it("reports the selected WantedTable issue by id", async () => {
+    const onSelectionChange = vi.fn();
+    render(
+      <WantedTable issues={issues(3)} onSelectionChange={onSelectionChange} />,
+    );
+
+    await selectFirstRow();
+
+    expect(onSelectionChange).toHaveBeenCalled();
+    expect(onSelectionChange.mock.calls.at(-1)?.[0]).toEqual(["issue-1"]);
+  });
+
+  it("reports the selected UpcomingTable issue by id", async () => {
+    const onSelectionChange = vi.fn();
+    render(
+      <UpcomingTable issues={issues(3)} onSelectionChange={onSelectionChange} />,
+    );
+
+    await selectFirstRow();
+
+    expect(onSelectionChange).toHaveBeenCalled();
+    expect(onSelectionChange.mock.calls.at(-1)?.[0]).toEqual(["issue-1"]);
+  });
+
+  it("drops an issue from the selection when it is unchecked", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <WantedTable issues={issues(3)} onSelectionChange={onSelectionChange} />,
+    );
+
+    await selectFirstRow();
+    await user.click(screen.getAllByRole("checkbox")[1]);
+
+    expect(onSelectionChange.mock.calls.at(-1)?.[0]).toEqual([]);
+  });
+});

--- a/frontend/tests/components/QueueTableSelection.test.tsx
+++ b/frontend/tests/components/QueueTableSelection.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "../test-utils";
@@ -10,6 +11,10 @@ import type { Issue } from "@/types";
  * keys as array indices. issues[parseInt("md-csm-ch165")] is undefined, every id
  * was filtered out, and the bulk action bar reported nothing selected -- so
  * every bulk action silently ran on zero issues.
+ *
+ * Selection is now owned by the page and passed back down, so these tests drive
+ * the tables the way the pages do: a controlled harness that echoes each
+ * reported selection back as the `selectedIds` prop.
  */
 
 function issues(count: number): Issue[] {
@@ -27,48 +32,193 @@ function issues(count: number): Issue[] {
   });
 }
 
-async function selectFirstRow() {
-  const user = userEvent.setup();
-  const checkboxes = screen.getAllByRole("checkbox");
+type QueueTable = typeof WantedTable | typeof UpcomingTable;
+
+/**
+ * Stands in for WantedPage / MyReleasesView: holds the selection, feeds it back
+ * to the table, and exposes the page-side Clear button plus a data swap.
+ */
+function SelectionHarness({
+  table: Table,
+  rows,
+  onSelectionChange,
+}: {
+  table: QueueTable;
+  rows: Issue[];
+  onSelectionChange: (ids: string[]) => void;
+}) {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [data, setData] = useState(rows);
+
+  return (
+    <div>
+      <button type="button" onClick={() => setSelectedIds([])}>
+        Clear Selection
+      </button>
+      <button type="button" onClick={() => setData(data.slice(0, 1))}>
+        Drop rows
+      </button>
+      <Table
+        issues={data}
+        selectedIds={selectedIds}
+        onSelectionChange={(ids: string[]) => {
+          setSelectedIds(ids);
+          onSelectionChange(ids);
+        }}
+      />
+    </div>
+  );
+}
+
+function rowCheckboxes(): HTMLElement[] {
   // checkboxes[0] is the header select-all toggle.
-  await user.click(checkboxes[1]);
+  return screen.getAllByRole("checkbox").slice(1);
+}
+
+function lastSelection(spy: ReturnType<typeof vi.fn>): string[] | undefined {
+  return spy.mock.calls.at(-1)?.[0] as string[] | undefined;
 }
 
 describe("queue table selection", () => {
   it("reports the selected WantedTable issue by id", async () => {
+    const user = userEvent.setup();
     const onSelectionChange = vi.fn();
     render(
-      <WantedTable issues={issues(3)} onSelectionChange={onSelectionChange} />,
+      <SelectionHarness
+        table={WantedTable}
+        rows={issues(3)}
+        onSelectionChange={onSelectionChange}
+      />,
     );
 
-    await selectFirstRow();
+    await user.click(rowCheckboxes()[0]);
 
     expect(onSelectionChange).toHaveBeenCalled();
-    expect(onSelectionChange.mock.calls.at(-1)?.[0]).toEqual(["issue-1"]);
+    expect(lastSelection(onSelectionChange)).toEqual(["issue-1"]);
   });
 
   it("reports the selected UpcomingTable issue by id", async () => {
+    const user = userEvent.setup();
     const onSelectionChange = vi.fn();
     render(
-      <UpcomingTable issues={issues(3)} onSelectionChange={onSelectionChange} />,
+      <SelectionHarness
+        table={UpcomingTable}
+        rows={issues(3)}
+        onSelectionChange={onSelectionChange}
+      />,
     );
 
-    await selectFirstRow();
+    await user.click(rowCheckboxes()[0]);
 
     expect(onSelectionChange).toHaveBeenCalled();
-    expect(onSelectionChange.mock.calls.at(-1)?.[0]).toEqual(["issue-1"]);
+    expect(lastSelection(onSelectionChange)).toEqual(["issue-1"]);
+  });
+
+  it("reports ids, not row positions, for a non-adjacent multi-row selection", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <SelectionHarness
+        table={WantedTable}
+        rows={issues(4)}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await user.click(rowCheckboxes()[1]);
+    await user.click(rowCheckboxes()[3]);
+
+    // A position-based decode would report issue-1/issue-2 here.
+    expect(lastSelection(onSelectionChange)?.sort()).toEqual([
+      "issue-2",
+      "issue-4",
+    ]);
+  });
+
+  it("reports every id for the header select-all toggle", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <SelectionHarness
+        table={WantedTable}
+        rows={issues(3)}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await user.click(screen.getAllByRole("checkbox")[0]);
+
+    expect(lastSelection(onSelectionChange)?.sort()).toEqual([
+      "issue-1",
+      "issue-2",
+      "issue-3",
+    ]);
   });
 
   it("drops an issue from the selection when it is unchecked", async () => {
     const user = userEvent.setup();
     const onSelectionChange = vi.fn();
     render(
-      <WantedTable issues={issues(3)} onSelectionChange={onSelectionChange} />,
+      <SelectionHarness
+        table={WantedTable}
+        rows={issues(3)}
+        onSelectionChange={onSelectionChange}
+      />,
     );
 
-    await selectFirstRow();
-    await user.click(screen.getAllByRole("checkbox")[1]);
+    await user.click(rowCheckboxes()[0]);
+    await user.click(rowCheckboxes()[0]);
 
-    expect(onSelectionChange.mock.calls.at(-1)?.[0]).toEqual([]);
+    expect(lastSelection(onSelectionChange)).toEqual([]);
+  });
+
+  it("does not resurrect ids the page cleared", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <SelectionHarness
+        table={WantedTable}
+        rows={issues(4)}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await user.click(rowCheckboxes()[0]);
+    await user.click(rowCheckboxes()[1]);
+    expect(lastSelection(onSelectionChange)?.sort()).toEqual([
+      "issue-1",
+      "issue-2",
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "Clear Selection" }));
+    await user.click(rowCheckboxes()[3]);
+
+    // Before selection was lifted to the page, the table kept its own copy and
+    // reported issue-1 and issue-2 again -- skipping issues the user cleared.
+    expect(lastSelection(onSelectionChange)).toEqual(["issue-4"]);
+  });
+
+  it("drops selected ids whose rows are no longer rendered", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <SelectionHarness
+        table={WantedTable}
+        rows={issues(3)}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await user.click(rowCheckboxes()[0]);
+    await user.click(rowCheckboxes()[2]);
+    expect(lastSelection(onSelectionChange)?.sort()).toEqual([
+      "issue-1",
+      "issue-3",
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "Drop rows" }));
+
+    // issue-3 is gone from the data, so a bulk action must not still target it.
+    expect(lastSelection(onSelectionChange)).toEqual(["issue-1"]);
   });
 });

--- a/frontend/tests/lib/bulkIssueResult.test.ts
+++ b/frontend/tests/lib/bulkIssueResult.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import {
+  applySequentially,
+  describeBulkResult,
+  type BulkIssueResult,
+} from "@/hooks/useQueue";
+
+/**
+ * Bulk queue/unqueue applies one request per issue in sequence. A failure part
+ * way through leaves the earlier issues already applied, so reporting the whole
+ * batch as failed -- and keeping every id selected for the retry -- would tell
+ * the user nothing happened and then repeat the requests that succeeded.
+ */
+
+function result(overrides: Partial<BulkIssueResult> = {}): BulkIssueResult {
+  return { succeeded: [], failed: [], ...overrides };
+}
+
+describe("applySequentially", () => {
+  it("applies every id in order and reports them all as succeeded", async () => {
+    const applied: string[] = [];
+
+    const outcome = await applySequentially(
+      ["issue-1", "issue-2", "issue-3"],
+      async (id) => {
+        applied.push(id);
+      },
+    );
+
+    expect(applied).toEqual(["issue-1", "issue-2", "issue-3"]);
+    expect(outcome).toEqual({
+      succeeded: ["issue-1", "issue-2", "issue-3"],
+      failed: [],
+    });
+  });
+
+  it("keeps going after a failure instead of abandoning the rest of the batch", async () => {
+    const applied: string[] = [];
+
+    const outcome = await applySequentially(
+      ["issue-1", "issue-2", "issue-3"],
+      async (id) => {
+        applied.push(id);
+        if (id === "issue-2") throw new Error("Issue not found");
+      },
+    );
+
+    // The old loop threw on issue-2 and never attempted issue-3.
+    expect(applied).toEqual(["issue-1", "issue-2", "issue-3"]);
+    expect(outcome).toEqual({
+      succeeded: ["issue-1", "issue-3"],
+      failed: [{ id: "issue-2", error: "Issue not found" }],
+    });
+  });
+
+  it("records a non-Error rejection without losing the batch", async () => {
+    const outcome = await applySequentially(["issue-1"], () =>
+      Promise.reject("boom"),
+    );
+
+    expect(outcome.failed).toEqual([{ id: "issue-1", error: "Unknown error" }]);
+  });
+});
+
+describe("describeBulkResult", () => {
+  it("reports a clean batch as a success and clears the selection", () => {
+    expect(
+      describeBulkResult(
+        result({ succeeded: ["issue-1", "issue-2"] }),
+        "skipped",
+        "skip",
+      ),
+    ).toEqual({ type: "success", message: "2 issues skipped", keep: [] });
+  });
+
+  it("singularizes a one-issue batch", () => {
+    expect(
+      describeBulkResult(result({ succeeded: ["issue-1"] }), "queued", "queue")
+        .message,
+    ).toBe("1 issue queued");
+  });
+
+  it("reports partial progress and keeps only the failed ids selected", () => {
+    const { type, message, keep } = describeBulkResult(
+      result({
+        succeeded: ["issue-1", "issue-2"],
+        failed: [{ id: "issue-3", error: "Issue not found" }],
+      }),
+      "skipped",
+      "skip",
+    );
+
+    expect(type).toBe("info");
+    expect(message).toContain("2 of 3 issues skipped");
+    expect(message).toContain("Issue not found");
+    // A retry must not re-issue the two PUTs that already landed.
+    expect(keep).toEqual(["issue-3"]);
+  });
+
+  it("reports a total failure as an error and keeps the whole selection", () => {
+    const { type, message, keep } = describeBulkResult(
+      result({
+        failed: [
+          { id: "issue-1", error: "Unauthorized" },
+          { id: "issue-2", error: "Unauthorized" },
+        ],
+      }),
+      "queued",
+      "queue",
+    );
+
+    expect(type).toBe("error");
+    expect(message).toBe("Failed to queue issues: Unauthorized");
+    expect(keep).toEqual(["issue-1", "issue-2"]);
+  });
+});


### PR DESCRIPTION
## The bug

**Bulk actions on the Wanted and Upcoming lists silently ran on zero issues.**

Both tables set `getRowId` to the `IssueID`, so the keys of `RowSelectionState` are issue ids. Both then decoded those keys as array indices — `issues[parseInt("issue-1")]` is `undefined`, `.filter(Boolean)` removed every entry, and the selection handed up to the page was always empty.

The visible effect: the bulk action bar reported nothing selected no matter what the user checked, so **Search Selected** and **Skip Selected** appeared to do nothing.

`WantedTable.tsx:172`, `UpcomingTable.tsx:195`.

## The fix

Read the ids straight off the selection keys, which is also stable across sorting and pagination in a way the index lookup never was.

## Verification

New `tests/components/QueueTableSelection.test.tsx` selects a row and asserts the callback receives the issue id, plus deselection. Confirmed both fail against the unfixed tables before the change. Frontend typecheck, eslint and the full vitest suite (121 passing).

One of eight independent branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiHS1hJan2hwwyDkgFKJQj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed row selection on Wanted and Upcoming lists so bulk actions correctly recognize selected issues.
  * Selection now clears when changing pages, clearing selections, or when selected rows disappear.
  * Bulk Skip and Mark Wanted actions now continue processing after individual failures and report partial results.
  * Failed rows remain selected for retry, while successfully processed rows are removed from the selection.

* **Tests**
  * Added coverage for controlled selection, select-all behavior, disappearing rows, and partial bulk-action outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->