### PR TITLE
refactor: Route Series kind decisions through one module

### DIFF
--- a/.changeset/olive-months-repeat.md
+++ b/.changeset/olive-months-repeat.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Route every "is this manga, and which provider owns it?" decision through a single `series_kind` module instead of 23 copied ID-prefix checks.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,3 +11,11 @@ The operator-confirmed workflow that binds pending Import Inbox records to a Ser
 ## Series
 
 A monitored comic or manga title and its library directory, issues or chapters, metadata, and acquisition state.
+
+## Series provider
+
+Who issued a Series' identifier: ComicVine, MangaDex (`md-` prefix), or MyAnimeList (`mal-` prefix). Distinct from whether the Series is manga — legacy manga rows predate the prefixes and are ComicVine-issued, so the provider answers routing questions while `ContentType` answers content questions. `comicarr/series_kind.py` reconciles the two.
+
+## Chapter source
+
+The MangaDex UUID a manga Series polls for new chapters. MangaDex Series carry it in their ComicID; MyAnimeList Series supply metadata from MAL but keep the chapter source in `MangaDexID`, and have none until it is resolved.

--- a/comicarr/app/imports/finalization.py
+++ b/comicarr/app/imports/finalization.py
@@ -20,7 +20,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 import comicarr
-from comicarr import logger
+from comicarr import logger, series_kind
 from comicarr.app.core.context import AppContext
 from comicarr.app.imports import queries as import_queries
 from comicarr.app.series import queries as series_queries
@@ -87,21 +87,18 @@ def _load_and_validate_rows(import_ids: Sequence[str]) -> list[dict]:
     return rows
 
 
-def _is_provider_series_id(series_id: str) -> bool:
-    return str(series_id).startswith(("md-", "mal-"))
-
-
 def _ensure_series(series_id: str, requested_name: str | None) -> str:
     existing_name = series_queries.get_comic_name(series_id)
     if existing_name:
         return existing_name
-    if not _is_provider_series_id(series_id):
+    provider = series_kind.provider_of(series_id)
+    if provider not in series_kind.MANGA_PROVIDERS:
         return requested_name or "Unknown"
 
     from comicarr import importer
 
     try:
-        if str(series_id).startswith("mal-"):
+        if provider is series_kind.SeriesProvider.MYANIMELIST:
             result = importer.addMangaToDB_MAL(series_id)
         else:
             result = importer.addMangaToDB(series_id)

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -160,15 +160,14 @@ def add_manga(ctx, manga_id):
         return {"success": False, "error": "Manga integration is not enabled"}
 
     try:
-        from comicarr import importer
+        from comicarr import importer, series_kind
 
-        if str(manga_id).startswith("mal-"):
+        if series_kind.provider_of(manga_id) is series_kind.SeriesProvider.MYANIMELIST:
             # MAL-sourced manga: fetch metadata from MAL, chapters from MangaDex
             result = importer.addMangaToDB_MAL(manga_id)
         else:
-            # MangaDex-sourced manga (existing flow)
-            if not str(manga_id).startswith("md-"):
-                manga_id = "md-" + manga_id
+            # An unprefixed id here is a raw MangaDex uuid.
+            manga_id = series_kind.add_prefix(manga_id, series_kind.SeriesProvider.MANGADEX)
             result = importer.addMangaToDB(manga_id)
 
         if result and result.get("status") == "complete":

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -23,7 +23,7 @@ from collections.abc import Mapping
 import sqlalchemy
 
 import comicarr
-from comicarr import db, logger
+from comicarr import db, logger, series_kind
 from comicarr.app.acquisition.evidence import has_verified_library_file
 from comicarr.app.acquisition.models import AcquisitionIntent, Fulfillment
 from comicarr.app.acquisition.policy import EligibilityInput, evaluate_eligibility, project_legacy_state
@@ -1542,10 +1542,12 @@ def listLibrary(comicid=None):
         try:
             mal_id = row.get("MalID")
             if mal_id:
-                library["mal-" + str(mal_id)] = {"comicid": row["ComicID"], "status": row["Status"]}
+                mal_key = series_kind.add_prefix(mal_id, series_kind.SeriesProvider.MYANIMELIST)
+                library[mal_key] = {"comicid": row["ComicID"], "status": row["Status"]}
             mangadex_id = row.get("MangaDexID")
             if mangadex_id:
-                library["md-" + str(mangadex_id)] = {"comicid": row["ComicID"], "status": row["Status"]}
+                mangadex_key = series_kind.add_prefix(mangadex_id, series_kind.SeriesProvider.MANGADEX)
+                library[mangadex_key] = {"comicid": row["ComicID"], "status": row["Status"]}
         except Exception as e:
             logger.fdebug("[SERIES] Cross-index by MAL/MangaDex ID failed for %s: %s" % (row.get("ComicID"), e))
 

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -48,6 +48,7 @@ from comicarr import (
     moveit,
     parseit,
     search,
+    series_kind,
     series_metadata,
     updater,
 )
@@ -250,12 +251,10 @@ def addComictoDB(
     suppress_addall=None,
 ):
 
-    # Check if this is a MangaDex manga ID (prefixed with 'md-')
-    if str(comicid).startswith("md-"):
+    provider = series_kind.provider_of(comicid)
+    if provider is series_kind.SeriesProvider.MANGADEX:
         return addMangaToDB(comicid, imported=imported, calledfrom=calledfrom)
-
-    # MAL-sourced manga (prefixed with 'mal-'): metadata from MAL, chapters from MangaDex
-    if str(comicid).startswith("mal-"):
+    if provider is series_kind.SeriesProvider.MYANIMELIST:
         return addMangaToDB_MAL(comicid, imported=imported, calledfrom=calledfrom)
 
     controlValueDict = {"ComicID": comicid}
@@ -1165,10 +1164,7 @@ def _populate_manga_chapters(mangaid, manga_name, mangadex_uuid, mal_num_chapter
     }
 
     if mangadex_uuid:
-        # Strip md- prefix if present for MangaDex API calls
-        mdex_id = mangadex_uuid
-        if mdex_id.startswith("md-"):
-            mdex_id = mdex_id[3:]
+        mdex_id = series_kind.strip_prefix(mangadex_uuid)
 
         # Track 1: Get language-filtered chapters for detailed issue rows
         logger.info("[MANGA-IMPORT] Fetching chapters for: %s" % manga_name)
@@ -1296,8 +1292,7 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
 
     logger.info("[MANGADEX] Adding manga with ID: %s" % mangaid)
 
-    # Get the raw MangaDex UUID (without md- prefix)
-    mangadex_uuid = mangadex.strip_manga_prefix(mangaid)
+    mangadex_uuid = series_kind.strip_prefix(mangaid)
 
     controlValueDict = {"ComicID": mangaid}
 
@@ -1458,9 +1453,8 @@ def addMangaToDB_MAL(mangaid, imported=None, calledfrom=None):
 
     logger.info("[MAL] Adding manga with ID: %s" % mangaid)
 
-    mal_numeric_id = myanimelist.strip_mal_prefix(str(mangaid))
-    if not str(mangaid).startswith("mal-"):
-        mangaid = "mal-%s" % mal_numeric_id
+    mal_numeric_id = series_kind.strip_prefix(mangaid)
+    mangaid = series_kind.add_prefix(mangaid, series_kind.SeriesProvider.MYANIMELIST)
 
     controlValueDict = {"ComicID": mangaid}
 

--- a/comicarr/mangadex.py
+++ b/comicarr/mangadex.py
@@ -32,7 +32,7 @@ from datetime import datetime
 import requests
 
 import comicarr
-from comicarr import logger
+from comicarr import logger, series_kind
 from comicarr.helpers import listLibrary
 
 # MangaDex API base URL
@@ -339,14 +339,14 @@ def search_manga(name, limit=None, offset=None, sort=None):
             links = attributes.get("links", {})
             mal_id = str(links.get("mal")) if links.get("mal") else None
 
-            # Check if we already have this manga (using md- prefix)
+            # Check if we already have this manga, by MangaDex id then MAL id
             haveit = "No"
-            mangadex_id = "md-" + manga_id
+            mangadex_id = series_kind.add_prefix(manga_id, series_kind.SeriesProvider.MANGADEX)
+            mal_key = series_kind.add_prefix(mal_id, series_kind.SeriesProvider.MYANIMELIST)
             if mangadex_id in comicLibrary:
                 haveit = comicLibrary[mangadex_id]
-            # Check by MAL ID
-            elif mal_id and ("mal-" + mal_id) in comicLibrary:
-                haveit = comicLibrary["mal-" + mal_id]
+            elif mal_key and mal_key in comicLibrary:
+                haveit = comicLibrary[mal_key]
             # Also check by name and year
             elif title and year:
                 name_key = "name:" + title.lower().strip() + ":" + str(year).strip()
@@ -423,9 +423,7 @@ def get_manga_details(manga_id):
     Returns:
         dict with manga details or None on error
     """
-    # Remove md- prefix if present
-    if manga_id.startswith("md-"):
-        manga_id = manga_id[3:]
+    manga_id = series_kind.strip_prefix(manga_id)
 
     # Check cache first
     cache_key = manga_id
@@ -469,7 +467,7 @@ def get_manga_details(manga_id):
     links = attributes.get("links", {})
 
     details = {
-        "id": "md-" + manga_id,
+        "id": series_kind.add_prefix(manga_id, series_kind.SeriesProvider.MANGADEX),
         "mangadex_id": manga_id,
         "name": title,
         "alt_titles": alt_titles,
@@ -515,9 +513,7 @@ def find_by_mal_id(mal_id, title_hint=None, alternate_titles=None):
     Returns:
         MangaDex manga UUID (string) or None if not found
     """
-    mal_id_str = str(mal_id)
-    if mal_id_str.startswith("mal-"):
-        mal_id_str = mal_id_str[4:]
+    mal_id_str = series_kind.strip_prefix(mal_id)
 
     raw_titles = [title_hint]
     if alternate_titles:
@@ -610,9 +606,7 @@ def get_manga_chapters(manga_id, languages=None, limit=100, offset=0):
     Returns:
         dict with 'chapters' list and 'pagination' metadata
     """
-    # Remove md- prefix if present
-    if manga_id.startswith("md-"):
-        manga_id = manga_id[3:]
+    manga_id = series_kind.strip_prefix(manga_id)
 
     logger.info("[MANGADEX] Fetching chapters for manga: %s (offset=%s, limit=%s)" % (manga_id, offset, limit))
 
@@ -695,9 +689,7 @@ def get_manga_aggregate(manga_id, languages=None):
     Returns:
         dict with volume/chapter structure
     """
-    # Remove md- prefix if present
-    if manga_id.startswith("md-"):
-        manga_id = manga_id[3:]
+    manga_id = series_kind.strip_prefix(manga_id)
 
     if languages is None:
         languages = _get_languages()
@@ -732,8 +724,7 @@ def get_total_chapter_count(manga_id):
     Returns:
         int: Total unique chapter count, or 0 if the API call fails
     """
-    if manga_id.startswith("md-"):
-        manga_id = manga_id[3:]
+    manga_id = series_kind.strip_prefix(manga_id)
 
     logger.info("[MANGADEX] Fetching language-unfiltered aggregate for manga: %s" % manga_id)
 
@@ -772,9 +763,7 @@ def get_all_chapters(manga_id, languages=None, include_unavailable=True):
     Returns:
         List of all chapters
     """
-    # Remove md- prefix if present
-    if manga_id.startswith("md-"):
-        manga_id = manga_id[3:]
+    manga_id = series_kind.strip_prefix(manga_id)
 
     # Check cache first
     cache_key = f"{manga_id}:{','.join(languages or _get_languages())}:{include_unavailable}"
@@ -881,9 +870,7 @@ def get_cover_image(manga_id):
     Returns:
         Cover URL string or None
     """
-    # Remove md- prefix if present
-    if manga_id.startswith("md-"):
-        manga_id = manga_id[3:]
+    manga_id = series_kind.strip_prefix(manga_id)
 
     # Check cache first
     if manga_id in _IMAGE_CACHE:
@@ -906,31 +893,3 @@ def clear_cache():
     _MANGA_CACHE = {}
     _CHAPTER_CACHE = {}
     logger.info("[MANGADEX] Caches cleared")
-
-
-def is_manga_id(comic_id):
-    """
-    Check if a comic ID is a MangaDex manga ID.
-
-    Args:
-        comic_id: Comic/Manga ID string
-
-    Returns:
-        True if it's a MangaDex ID (starts with 'md-')
-    """
-    return comic_id and str(comic_id).startswith("md-")
-
-
-def strip_manga_prefix(manga_id):
-    """
-    Remove the 'md-' prefix from a manga ID if present.
-
-    Args:
-        manga_id: Manga ID string
-
-    Returns:
-        Raw MangaDex UUID without prefix
-    """
-    if manga_id and str(manga_id).startswith("md-"):
-        return manga_id[3:]
-    return manga_id

--- a/comicarr/mangasync.py
+++ b/comicarr/mangasync.py
@@ -30,7 +30,7 @@ import time
 from sqlalchemy import select
 
 import comicarr
-from comicarr import db, logger
+from comicarr import db, logger, series_kind
 from comicarr.manga_parser import parse_manga_filename
 from comicarr.scanutil import COMIC_EXTENSIONS, find_best_match
 from comicarr.tables import comics, issues
@@ -465,7 +465,7 @@ def import_selected_manga(selected_ids, scan_id):
             continue
         try:
             logger.info("[MANGA-SCAN] Importing series: %s" % manga_id)
-            if str(manga_id).startswith("mal-"):
+            if series_kind.provider_of(manga_id) is series_kind.SeriesProvider.MYANIMELIST:
                 importer.addMangaToDB_MAL(manga_id)
             else:
                 importer.addMangaToDB(manga_id)

--- a/comicarr/myanimelist.py
+++ b/comicarr/myanimelist.py
@@ -30,7 +30,7 @@ from datetime import datetime
 import requests
 
 import comicarr
-from comicarr import logger
+from comicarr import logger, series_kind
 from comicarr.helpers import listLibrary
 
 # MAL API base URL
@@ -202,7 +202,7 @@ def search_manga(name, limit=None, offset=None, sort=None):
         score = node.get("mean")
 
         # Check if already in library
-        mal_comic_id = "mal-%s" % mal_id
+        mal_comic_id = series_kind.add_prefix(mal_id, series_kind.SeriesProvider.MYANIMELIST)
         haveit = "No"
         if mal_comic_id in comicLibrary:
             haveit = comicLibrary[mal_comic_id]
@@ -276,7 +276,7 @@ def get_manga_details(mal_id):
 
     Returns dict matching mangadex.get_manga_details() shape.
     """
-    numeric_id = strip_mal_prefix(str(mal_id))
+    numeric_id = series_kind.strip_prefix(mal_id)
     logger.info("[MAL] Fetching details for manga ID: %s" % numeric_id)
 
     params = {"fields": _MANGA_DETAIL_FIELDS}
@@ -327,7 +327,7 @@ def get_manga_details(mal_id):
     tags = [g.get("name", "") for g in data.get("genres", []) if g.get("name")]
 
     return {
-        "id": "mal-%s" % numeric_id,
+        "id": series_kind.add_prefix(numeric_id, series_kind.SeriesProvider.MYANIMELIST),
         "mal_id": str(numeric_id),
         "name": title,
         "alt_titles": alt_titles,
@@ -378,15 +378,3 @@ def _proxy_image_url(url):
     from urllib.parse import quote
 
     return "/api/metadata/image-proxy?url=%s" % quote(url, safe="")
-
-
-def is_mal_id(comic_id):
-    """Check if comic_id uses the MAL prefix."""
-    return bool(comic_id) and str(comic_id).startswith("mal-")
-
-
-def strip_mal_prefix(mal_id):
-    """Remove 'mal-' prefix from a MAL ID."""
-    if mal_id and str(mal_id).startswith("mal-"):
-        return str(mal_id)[4:]
-    return str(mal_id)

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -31,7 +31,7 @@ import time
 from sqlalchemy import Integer, and_, delete, func, inspect, or_, select
 
 import comicarr
-from comicarr import db, filechecker, getimage, helpers, logger, notifiers, updater, weeklypull
+from comicarr import db, filechecker, getimage, helpers, logger, notifiers, series_kind, updater, weeklypull
 from comicarr.app.downloads.postprocess_pipeline import (
     PostProcessContext,
     PostProcessInputContext,
@@ -609,10 +609,7 @@ class PostProcessor(object):
 
         self.oneoffinlist = False
 
-        # --- Manga branch: MangaDex (md-) and MyAnimeList (mal-) series both
-        # need manga-specific processing. Omitting mal- sent every MAL download
-        # down the ComicVine path. ---
-        if self.comicid is not None and str(self.comicid).startswith(("md-", "mal-")):
+        if self.comicid is not None and series_kind.is_manga(self.comicid):
             logger.fdebug(
                 "%s Manga series detected (ComicID: %s) - branching to manga post-processing" % (module, self.comicid)
             )

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -609,7 +609,10 @@ class PostProcessor(object):
 
         self.oneoffinlist = False
 
-        if self.comicid is not None and series_kind.is_manga(self.comicid):
+        # Provider-issued ids only: at this point the series row has not been
+        # loaded, so ContentType cannot participate. Legacy manga predating the
+        # prefixes take the ComicVine path here, as they always have.
+        if self.comicid is not None and series_kind.provider_of(self.comicid) in series_kind.MANGA_PROVIDERS:
             logger.fdebug(
                 "%s Manga series detected (ComicID: %s) - branching to manga post-processing" % (module, self.comicid)
             )

--- a/comicarr/rsscheck.py
+++ b/comicarr/rsscheck.py
@@ -1965,10 +1965,11 @@ def mangaCheck():
 def mangadexNewChapterCheck():
     """Poll MangaDex for new chapters not yet tracked in the database.
 
-    For each active manga series whose ComicID starts with 'md-', calls
-    the MangaDex API to retrieve the full chapter list and compares it
-    against existing issues in the database.  Any new chapters are inserted
-    as 'Wanted' issues.
+    For each active manga series with a resolvable MangaDex chapter source —
+    MangaDex-issued series, and MyAnimeList ones that have resolved a
+    MangaDexID — calls the MangaDex API to retrieve the full chapter list and
+    compares it against existing issues in the database.  Any new chapters are
+    inserted as 'Wanted' issues.
 
     Uses the built-in rate limiter in mangadex._rate_limit() to stay within
     the MangaDex 5 req/s limit.

--- a/comicarr/rsscheck.py
+++ b/comicarr/rsscheck.py
@@ -1975,7 +1975,7 @@ def mangadexNewChapterCheck():
 
     Callable from the scheduler or manually.
     """
-    from comicarr import mangadex
+    from comicarr import mangadex, series_kind
     from comicarr.tables import comics as t_comics
     from comicarr.tables import issues as t_issues
 
@@ -2006,9 +2006,7 @@ def mangadexNewChapterCheck():
     for series in manga_series:
         comic_id = series["ComicID"]
         comic_name = series["ComicName"]
-        # md- series carry the MangaDex uuid in the ComicID itself; mal- series
-        # keep it in MangaDexID.
-        mangadex_id = comic_id if str(comic_id).startswith("md-") else series["MangaDexID"]
+        mangadex_id = series_kind.chapter_source_id(series)
         if not mangadex_id:
             continue
 

--- a/comicarr/series_kind.py
+++ b/comicarr/series_kind.py
@@ -1,0 +1,136 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Deep module answering which provider owns a Series and where its chapters come from.
+
+Series identity is encoded two ways that must be read together:
+
+  * the ``ComicID`` prefix (``md-`` MangaDex, ``mal-`` MyAnimeList, otherwise
+    ComicVine), which says who issued the id, and
+  * the ``ContentType`` column, which says whether the Series is manga at all.
+
+They can disagree. A manga row added before the provider prefixes existed
+carries ``ContentType == 'manga'`` with an unprefixed ComicID, so a caller that
+consults only the prefix will treat it as a comic. Reconciling the two is what
+:func:`is_manga` is for; every caller should ask it rather than testing either
+signal directly.
+
+The load-bearing invariant is that **MyAnimeList supplies metadata but MangaDex
+always supplies chapters**. A MAL-sourced Series therefore fetches chapters
+against the MangaDex uuid recorded in its ``MangaDexID`` column, not against its
+own ComicID. :func:`chapter_source_id` is the only place that rule is written
+down.
+
+This module imports nothing from Comicarr so that it can be imported from both
+the legacy business modules and ``comicarr.app`` without cycles.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import Enum
+
+
+class SeriesProvider(str, Enum):
+    """Who issued a Series id."""
+
+    COMICVINE = "comicvine"
+    MANGADEX = "mangadex"
+    MYANIMELIST = "myanimelist"
+
+
+#: Providers whose Series are manga. ComicVine-issued ids may *also* be manga
+#: (see :func:`is_manga`) — membership here is about the id, not the content.
+MANGA_PROVIDERS = frozenset({SeriesProvider.MANGADEX, SeriesProvider.MYANIMELIST})
+
+_PROVIDER_PREFIXES: dict[SeriesProvider, str] = {
+    SeriesProvider.MANGADEX: "md-",
+    SeriesProvider.MYANIMELIST: "mal-",
+}
+
+_MANGA_CONTENT_TYPE = "manga"
+
+
+def _series_id_of(series: str | Mapping | None) -> str:
+    """Accept either a bare Series id or a Series row and return the id."""
+    if series is None:
+        return ""
+    if isinstance(series, Mapping):
+        return str(series.get("ComicID") or "")
+    return str(series)
+
+
+def provider_of(series: str | Mapping | None) -> SeriesProvider:
+    """Return the provider that issued this Series id.
+
+    Accepts a bare id or a Series row. Unprefixed and unknown ids are
+    ComicVine — including legacy manga rows, which is why callers asking
+    "is this manga?" must use :func:`is_manga` instead.
+    """
+    series_id = _series_id_of(series)
+    for provider, prefix in _PROVIDER_PREFIXES.items():
+        if series_id.startswith(prefix):
+            return provider
+    return SeriesProvider.COMICVINE
+
+
+def is_manga(series: str | Mapping | None) -> bool:
+    """Return whether this Series is manga, reconciling prefix and ContentType.
+
+    A provider prefix is sufficient on its own. For rows, ``ContentType`` is
+    also honoured, so legacy manga added before the prefixes existed still
+    answer True.
+    """
+    if provider_of(series) in MANGA_PROVIDERS:
+        return True
+    if isinstance(series, Mapping):
+        content_type = series.get("ContentType")
+        return str(content_type or "").strip().casefold() == _MANGA_CONTENT_TYPE
+    return False
+
+
+def chapter_source_id(series: str | Mapping | None) -> str | None:
+    """Return the MangaDex uuid to fetch this Series' chapters against.
+
+    MangaDex-issued Series carry the uuid in the ComicID itself. MyAnimeList
+    Series keep it in ``MangaDexID`` — MAL supplies metadata, MangaDex always
+    supplies chapters — so a bare ``mal-`` id cannot answer this and returns
+    None, as does a MAL Series whose uuid has not been resolved yet.
+
+    Returns a raw uuid with no prefix. ComicVine Series return None.
+    """
+    provider = provider_of(series)
+    if provider is SeriesProvider.MANGADEX:
+        return strip_prefix(_series_id_of(series)) or None
+    if provider is SeriesProvider.MYANIMELIST:
+        if not isinstance(series, Mapping):
+            return None
+        return strip_prefix(str(series.get("MangaDexID") or "")) or None
+    return None
+
+
+def strip_prefix(series_id: str | None) -> str:
+    """Return a Series id with any provider prefix removed."""
+    if not series_id:
+        return ""
+    series_id = str(series_id)
+    for prefix in _PROVIDER_PREFIXES.values():
+        if series_id.startswith(prefix):
+            return series_id[len(prefix) :]
+    return series_id
+
+
+def add_prefix(raw_id: str | None, provider: SeriesProvider) -> str:
+    """Return a Series id carrying ``provider``'s prefix, adding it if absent."""
+    if not raw_id:
+        return ""
+    prefix = _PROVIDER_PREFIXES.get(provider)
+    if prefix is None:
+        return str(raw_id)
+    return "%s%s" % (prefix, strip_prefix(raw_id))

--- a/comicarr/series_kind.py
+++ b/comicarr/series_kind.py
@@ -127,10 +127,17 @@ def strip_prefix(series_id: str | None) -> str:
 
 
 def add_prefix(raw_id: str | None, provider: SeriesProvider) -> str:
-    """Return a Series id carrying ``provider``'s prefix, adding it if absent."""
+    """Return a Series id carrying ``provider``'s prefix, adding it if absent.
+
+    An id that already names a provider is returned untouched, so this can
+    never relabel one provider's id as another's.
+    """
     if not raw_id:
         return ""
+    raw_id = str(raw_id)
+    if provider_of(raw_id) is not SeriesProvider.COMICVINE:
+        return raw_id
     prefix = _PROVIDER_PREFIXES.get(provider)
     if prefix is None:
-        return str(raw_id)
-    return "%s%s" % (prefix, strip_prefix(raw_id))
+        return raw_id
+    return "%s%s" % (prefix, raw_id)

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -30,7 +30,7 @@ from collections.abc import Mapping
 from sqlalchemy import bindparam, func, select, text, update
 
 import comicarr
-from comicarr import db, filechecker, helpers, logger
+from comicarr import db, filechecker, helpers, logger, series_kind
 from comicarr.tables import (
     annuals,
     comics,
@@ -353,7 +353,7 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
             lastupdated = datetime.datetime.strptime(comic["LastUpdated"], "%Y-%m-%d %H:%M:%S").strftime("%Y-%m-%d")
 
         mismatch = "no"
-        if str(ComicID).startswith(("md-", "mal-")):
+        if series_kind.provider_of(ComicID) in series_kind.MANGA_PROVIDERS:
             # Manga (MangaDex/MAL) refreshes entirely through the manga importer.
             # The CV_ONETIMER reconciliation below deletes issue rows and expects
             # CV issuedata that the manga add functions do not return, so route

--- a/tests/unit/test_mal_prefix_drift.py
+++ b/tests/unit/test_mal_prefix_drift.py
@@ -16,6 +16,10 @@ decision made somewhere else:
   * the chapter poll skipped MAL series entirely,
   * and the MangaDex add path never recorded MangaDexID, so a series added that
     way was invisible to every lookup keyed on it.
+
+The rule itself now lives in ``comicarr.series_kind`` and is tested against that
+interface in ``test_series_kind.py``. What remains here is the integration
+coverage: that each of these three call sites actually asks it.
 """
 
 from types import SimpleNamespace
@@ -120,7 +124,9 @@ class TestChapterPollCoversBothProviders:
             ],
         )
 
-        assert polled == ["md-uuid-1", "uuid-2"]
+        # Both providers resolve to a bare MangaDex uuid: md- series carry it in
+        # the ComicID, mal- series in MangaDexID.
+        assert polled == ["uuid-1", "uuid-2"]
 
     def test_a_mal_series_without_a_resolved_uuid_is_skipped(self, monkeypatch):
         polled = self._run(
@@ -200,7 +206,6 @@ class TestMangaDexAddRecordsItsId:
         monkeypatch.setattr(importer, "_populate_manga_chapters", lambda *a, **k: 0)
         monkeypatch.setattr(importer.helpers, "getImage", lambda *a, **k: None)
         monkeypatch.setattr(importer.helpers, "ComicSort", lambda **k: None)
-        monkeypatch.setattr(mangadex, "strip_manga_prefix", lambda mid: mid[3:] if mid.startswith("md-") else mid)
         monkeypatch.setattr(comicarr_config, "get_manga_destination", lambda: str(tmp_path))
 
         importer.addMangaToDB("md-uuid-42")

--- a/tests/unit/test_mal_prefix_drift.py
+++ b/tests/unit/test_mal_prefix_drift.py
@@ -125,8 +125,9 @@ class TestChapterPollCoversBothProviders:
         )
 
         # Both providers resolve to a bare MangaDex uuid: md- series carry it in
-        # the ComicID, mal- series in MangaDexID.
-        assert polled == ["uuid-1", "uuid-2"]
+        # the ComicID, mal- series in MangaDexID. The query has no ORDER BY, so
+        # compare without depending on row order.
+        assert sorted(polled) == ["uuid-1", "uuid-2"]
 
     def test_a_mal_series_without_a_resolved_uuid_is_skipped(self, monkeypatch):
         polled = self._run(

--- a/tests/unit/test_series_kind.py
+++ b/tests/unit/test_series_kind.py
@@ -1,0 +1,146 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""The single place that knows how Series identity is encoded.
+
+Before this module the answer was re-derived at 23 call sites in three
+spellings, and the copies drifted apart often enough to account for six
+consecutive fixes.
+"""
+
+import pytest
+
+from comicarr.series_kind import (
+    MANGA_PROVIDERS,
+    SeriesProvider,
+    add_prefix,
+    chapter_source_id,
+    is_manga,
+    provider_of,
+    strip_prefix,
+)
+
+
+class TestProviderOf:
+    @pytest.mark.parametrize(
+        ("series_id", "expected"),
+        (
+            ("md-uuid-1", SeriesProvider.MANGADEX),
+            ("mal-161890", SeriesProvider.MYANIMELIST),
+            ("12345", SeriesProvider.COMICVINE),
+            ("4050-12345", SeriesProvider.COMICVINE),
+        ),
+    )
+    def test_a_bare_id_is_read_from_its_prefix(self, series_id, expected):
+        assert provider_of(series_id) is expected
+
+    def test_a_row_is_read_from_its_comicid(self):
+        assert provider_of({"ComicID": "md-uuid-1"}) is SeriesProvider.MANGADEX
+
+    @pytest.mark.parametrize("series", (None, "", {}, {"ComicID": None}))
+    def test_an_absent_id_is_comicvine(self, series):
+        assert provider_of(series) is SeriesProvider.COMICVINE
+
+    def test_a_non_string_id_does_not_raise(self):
+        assert provider_of(12345) is SeriesProvider.COMICVINE
+
+    def test_the_manga_providers_are_the_prefixed_ones(self):
+        assert MANGA_PROVIDERS == {SeriesProvider.MANGADEX, SeriesProvider.MYANIMELIST}
+
+
+class TestIsManga:
+    @pytest.mark.parametrize("series_id", ("md-uuid-1", "mal-161890"))
+    def test_a_provider_prefix_is_sufficient(self, series_id):
+        assert is_manga(series_id) is True
+
+    def test_a_comicvine_id_is_not_manga(self):
+        assert is_manga("12345") is False
+
+    def test_content_type_covers_a_row_with_no_prefix(self):
+        """Manga added before the prefixes existed still answers True."""
+        assert is_manga({"ComicID": "999", "ContentType": "manga"}) is True
+
+    def test_content_type_is_matched_loosely(self):
+        assert is_manga({"ComicID": "999", "ContentType": " Manga "}) is True
+
+    def test_a_comic_row_is_not_manga(self):
+        assert is_manga({"ComicID": "999", "ContentType": "comic"}) is False
+
+    def test_a_row_with_neither_signal_is_not_manga(self):
+        assert is_manga({"ComicID": "999"}) is False
+
+    def test_a_bare_unprefixed_id_cannot_know_about_content_type(self):
+        """A string carries no ContentType — callers holding one must pass the row."""
+        assert is_manga("999") is False
+
+
+class TestChapterSourceId:
+    def test_a_mangadex_series_carries_its_uuid_in_the_comicid(self):
+        assert chapter_source_id("md-uuid-1") == "uuid-1"
+
+    def test_a_mangadex_row_is_read_the_same_way(self):
+        assert chapter_source_id({"ComicID": "md-uuid-1"}) == "uuid-1"
+
+    def test_a_mal_series_fetches_chapters_against_its_resolved_mangadex_uuid(self):
+        """MAL supplies metadata; MangaDex always supplies chapters."""
+        row = {"ComicID": "mal-161890", "MangaDexID": "uuid-2"}
+        assert chapter_source_id(row) == "uuid-2"
+
+    def test_a_mal_series_without_a_resolved_uuid_has_no_chapter_source(self):
+        assert chapter_source_id({"ComicID": "mal-999", "MangaDexID": None}) is None
+        assert chapter_source_id({"ComicID": "mal-999"}) is None
+
+    def test_a_bare_mal_id_cannot_answer(self):
+        """The uuid lives in a column, so the row is required."""
+        assert chapter_source_id("mal-161890") is None
+
+    def test_a_stored_uuid_keeps_working_if_it_was_written_with_a_prefix(self):
+        row = {"ComicID": "mal-161890", "MangaDexID": "md-uuid-2"}
+        assert chapter_source_id(row) == "uuid-2"
+
+    def test_a_comicvine_series_has_no_mangadex_chapter_source(self):
+        assert chapter_source_id("12345") is None
+        assert chapter_source_id({"ComicID": "999", "ContentType": "manga"}) is None
+
+
+class TestPrefixes:
+    @pytest.mark.parametrize(
+        ("series_id", "expected"),
+        (
+            ("md-uuid-1", "uuid-1"),
+            ("mal-161890", "161890"),
+            ("12345", "12345"),
+            ("", ""),
+            (None, ""),
+        ),
+    )
+    def test_strip_prefix(self, series_id, expected):
+        assert strip_prefix(series_id) == expected
+
+    @pytest.mark.parametrize(
+        ("raw_id", "provider", "expected"),
+        (
+            ("uuid-1", SeriesProvider.MANGADEX, "md-uuid-1"),
+            ("md-uuid-1", SeriesProvider.MANGADEX, "md-uuid-1"),
+            ("161890", SeriesProvider.MYANIMELIST, "mal-161890"),
+            ("mal-161890", SeriesProvider.MYANIMELIST, "mal-161890"),
+            ("12345", SeriesProvider.COMICVINE, "12345"),
+            (None, SeriesProvider.MANGADEX, ""),
+        ),
+    )
+    def test_add_prefix_is_idempotent(self, raw_id, provider, expected):
+        assert add_prefix(raw_id, provider) == expected
+
+    def test_add_prefix_reprefixes_across_providers(self):
+        assert add_prefix("md-uuid-1", SeriesProvider.MYANIMELIST) == "mal-uuid-1"
+
+    @pytest.mark.parametrize("series_id", ("md-uuid-1", "mal-161890", "12345"))
+    def test_strip_then_add_round_trips(self, series_id):
+        provider = provider_of(series_id)
+        assert add_prefix(strip_prefix(series_id), provider) == series_id

--- a/tests/unit/test_series_kind.py
+++ b/tests/unit/test_series_kind.py
@@ -137,8 +137,10 @@ class TestPrefixes:
     def test_add_prefix_is_idempotent(self, raw_id, provider, expected):
         assert add_prefix(raw_id, provider) == expected
 
-    def test_add_prefix_reprefixes_across_providers(self):
-        assert add_prefix("md-uuid-1", SeriesProvider.MYANIMELIST) == "mal-uuid-1"
+    def test_add_prefix_never_relabels_another_providers_id(self):
+        """Rewriting md- to mal- would invent a Series that does not exist."""
+        assert add_prefix("md-uuid-1", SeriesProvider.MYANIMELIST) == "md-uuid-1"
+        assert add_prefix("mal-13", SeriesProvider.MANGADEX) == "mal-13"
 
     @pytest.mark.parametrize("series_id", ("md-uuid-1", "mal-161890", "12345"))
     def test_strip_then_add_round_trips(self, series_id):


### PR DESCRIPTION
Closes #319.

## Why

"Is this Series manga, and which provider issued its id?" was re-derived inline at **23 non-test call sites** in three different spellings, alongside an orthogonal `ContentType == 'manga'` check that nothing reconciled against them. Six consecutive fixes — #279, #281, #298, #299, #303, #304 — were drift between those copies. The #304 commit message named the fix directly: *"The durable fix is one module that answers 'which kind of series is this'."*

## What

A new deep module, `comicarr/series_kind.py`, with a five-function interface:

```python
provider_of(series)       # SeriesProvider: COMICVINE | MANGADEX | MYANIMELIST
is_manga(series)          # reconciles ID prefix with ContentType
chapter_source_id(series)  # the MangaDex uuid to poll chapters against
strip_prefix(series_id)
add_prefix(raw_id, provider)
```

Each accepts either a bare Series id or a Series row. The module imports nothing from Comicarr, so both the legacy business modules and `comicarr/app/` can use it without cycles.

It also gives the load-bearing invariant a home for the first time: **MyAnimeList supplies metadata, but MangaDex always supplies chapters** — so a MAL Series resolves its chapter source from `MangaDexID`, not from its own ComicID. That rule previously existed only as an inline expression in `rsscheck.py` and a prefix-strip in `importer.py`.

### Deleted

Five shallow helpers, all wrappers over `startswith` whose only value was the name, and each too narrow for the sites that actually mattered:

- `mangadex.is_manga_id` · `mangadex.strip_manga_prefix`
- `myanimelist.is_mal_id` · `myanimelist.strip_mal_prefix`
- `finalization._is_provider_series_id`

### Migrated

`postprocessor.py` · `updater.py` · `importer.py` · `rsscheck.py` · `mangasync.py` · `mangadex.py` · `myanimelist.py` · `app/search/service.py` · `app/series/service.py` · `app/imports/finalization.py`

A grep for `startswith` with `md-`/`mal-` across `comicarr/` now returns nothing.

## One deliberate behaviour change

The chapter poll used to pass a **prefixed** id (`md-uuid-1`) for MangaDex Series and a **raw** uuid for MAL ones. `chapter_source_id` now returns raw uuids uniformly.

I verified first that all six MangaDex API entrypoints strip the prefix defensively at their own boundary, so the outbound request is byte-identical. `test_mal_prefix_drift.py` asserted the old inconsistency; that assertion is updated with a note on why it is now uniform.

## On `test_mal_prefix_drift.py`

Issue #319 predicted this file would become unnecessary. That turned out to be true only of its prefix knowledge. Its three integration assertions — post-processing routes both providers to the manga path, the poll covers both, the MangaDex add path records `MangaDexID` — are real regression coverage. The file stays, its docstring now points at `series_kind`, and rule-level testing moved to the new `test_series_kind.py` (41 tests).

## One literal left behind

`rsscheck.py:1992` still carries `ComicID.like("md-%")`. It is a SQL pre-filter to avoid loading every Series, not a discrimination decision — `chapter_source_id` remains the authority for every row that passes it — so routing it through the module would have grown the interface for no safety gain.

## Verification

- 1,717 unit tests pass
- `lint:modern`, `ruff check comicarr/`, and `ruff format --check comicarr/` all pass
- Every touched module imports cleanly

## Domain model

Adds **Series provider** and **Chapter source** to `CONTEXT.md`.

---

Candidate 1 of the architecture review. It also unblocks #320 and — via `_start_library_scan` — the scanner work in the review's candidate 6, both of which currently carry their own private copy of this discrimination logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbfD1uzrnEyG6j5CDteWax


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized handling for series providers, manga identification, and chapter-source resolution.
  * Improved support for MangaDex and MyAnimeList series identifiers across search, imports, library listings, updates, and chapter polling.
  * Added documentation explaining series providers and chapter sources.

* **Bug Fixes**
  * Improved consistency when recognizing and normalizing provider identifiers, including legacy series records.
  * Ensured chapter polling uses the correct MangaDex source for MyAnimeList-linked series.

* **Tests**
  * Added coverage for provider detection, manga classification, identifier normalization, and chapter-source resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->