### PR TITLE
docs: Compress CLAUDE.md to what is not documented elsewhere

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,73 +6,23 @@ IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning for an
 
 ## Project Overview
 
-Comicarr is a Python 3 automated comic book (CBR/CBZ) downloader and library manager. It monitors comic series, downloads issues from NZB/torrent sources, handles post-processing with metadata tagging, and provides a modern React web interface for management.
-
 Comicarr is built on the foundation of Mylar3 with a completely rebuilt React 19 frontend and performance improvements. The HTTP layer is FastAPI + uvicorn (`comicarr.app.main`).
 
 ## Commands
 
 | Action | Command |
 |--------|---------|
-| Install (backend) | `uv sync` |
-| Install (dev) | `uv sync --extra dev` |
 | Validate dependency lock | `uv lock --check` |
-| Install with pip (unlocked) | `pip install .` |
-| Install (frontend) | `cd frontend && npm ci` |
 | Run app | `python3 Comicarr.py --nolaunch` |
-| Dev frontend | `cd frontend && npm run dev` |
-| Build frontend | `cd frontend && npm run build` |
 | Test backend | `pytest tests/unit -v` |
-| Test frontend | `cd frontend && npm run test:run` |
-| Lint backend | `ruff check comicarr/` |
 | Lint modern backend | `npm run lint:modern` (`comicarr/app` + `Comicarr.py`) |
-| Format check | `ruff format --check comicarr/` |
-| Format fix | `ruff format comicarr/` |
-| Lint frontend | `cd frontend && npm run lint` |
-| Format frontend | `cd frontend && npm run format` / `format:check` |
-| Typecheck | `cd frontend && npm run typecheck` |
 | Lint all (CI parity) | `npm run lint` |
-| Lint fix all | `npm run lint:fix` |
-| Install git hooks | `pre-commit install` (after `uv sync --extra dev`) |
-| Run hooks on tree | `pre-commit run --all-files` |
-| Add dependency | `uv add <package>` |
-| Add dev dep | `uv add --optional dev <package>` |
 
 Default HTTP port is **8090**. Vite dev proxy targets `http://localhost:8090` (override with `VITE_API_PROXY_TARGET`).
 
-## Architecture
-
-[Comicarr Code Index]|root: ./comicarr
-|Web Layer:{app/main.py:FastAPI app+lifespan,app/<domain>/router.py:HTTP routes,app/core/security.py:JWT+API key+OPDS auth,app/core/middleware.py:CSRF+headers+setup gate}
-|Business Logic:{search.py:provider search,postprocessor.py:post-processing,cv.py:ComicVine,metron.py:Metron,mangadex.py:MangaDex,importer.py:library scanning,rsscheck.py:RSS,weeklypull.py:pull list,app/downloads/:journal+recovery}
-|Config/Data:{config.py:INI config,encrypted.py:Fernet,db.py:SQLAlchemy Core,__init__.py:global state+scheduler,helpers.py:compat re-exports,migration.py:Mylar3 migration}
-|Downloaders:{downloaders/:Mega/MediaFire/Pixeldrain,torrent/clients/:qBittorrent/Deluge/Transmission/rTorrent/uTorrent,nzbget.py,sabnzbd.py}
-|Frontend:{frontend/src/pages,components,hooks,lib,contexts,types}
-|Tests:{tests/unit,tests/integration,frontend/tests}
-|Docs:{docs/solutions/:documented solutions (bugs, best practices, workflow patterns), organized by category with YAML frontmatter}
-
-IMPORTANT: Consult files in this index rather than relying on training data.
-
-FastAPI domain packages live under `comicarr/app/` (e.g. `series/`, `search/`, `downloads/`, `system/`, `dashboard/`, `metadata/`, `storyarcs/`, `weekly/`, `opds/`, `ai/`). Entry point is `Comicarr.py` → `uvicorn.run("comicarr.app.main:app", ...)`.
-
-## Framework Notes
-
-Python@3.10+|FastAPI + uvicorn, SQLAlchemy Core (not ORM), INI config via Config class
-React@19|Vite build, path alias @/ → src/, TanStack Query for data fetching, Base UI components
-Tailwind@4|postcss.config.js, tailwind.config.js in frontend/
-TypeScript@strict|noUnusedLocals, noUnusedParameters enabled
-
 ## Releases
 
-Releases are automated via Changesets. **Do NOT manually create tags, bump versions, or create GitHub Releases.**
-
-- Add a changeset with `npm run changeset` for user-visible app changes
-- Omit changesets for maintenance, docs, CI, dependency, and other non-app-impacting PRs
-- Pushes to `main` with pending changesets automatically maintain a `Version Packages` PR
-- Merging the `Version Packages` PR creates the GitHub Release, `vX.Y.Z` tag, and triggers Docker image build
-- Versions in `package.json`, `pyproject.toml`, `frontend/package.json`, and lockfiles are bumped by release automation — never edit these manually outside the release workflow
-- Config: `.changeset/config.json`; release sync scripts live in `scripts/release/`
-- Docker images publish to `ghcr.io/frankieramirez/comicarr`
+Releases are automated via Changesets. See the `releases` skill (`.claude/skills/releases/SKILL.md`) for the full workflow.
 
 ## Branch & PR Conventions
 
@@ -118,12 +68,6 @@ Conventional PR titles keep history readable, but they do not control releases. 
 - Import: `from comicarr import db`
 - Usage: `db.DBConnection().action("SELECT * FROM table WHERE id=?", [id])`
 - Always use parameterized queries
-
-### Import Ordering
-1. Standard library imports
-2. Third-party imports
-3. Local imports: `from comicarr import logger, helpers`
-4. Within packages use: `from . import logger`
 
 ### Adding New Features
 - Prefer `comicarr/app/<domain>/router.py` + `service.py` (+ `queries.py` when needed)


### PR DESCRIPTION
Compresses `CLAUDE.md` from 130 to 73 lines, removing content that is documented elsewhere.

## What was removed, and where it still lives

| Section | Status |
|---|---|
| Commands table (14 of 20 rows: install, frontend dev/build/test, individual ruff invocations, typecheck, pre-commit, `uv add`) | Duplicated in `AGENTS.md` |
| Architecture — the `[Comicarr Code Index]` module map and the `comicarr/app/` domain-package note | Duplicated in `AGENTS.md:46` |
| Releases — 8 detailed bullets | Replaced by a pointer to `.claude/skills/releases/SKILL.md`, which carries the same detail |

The commands table keeps the CI-parity subset: `npm run lint`, `npm run lint:modern`, `pytest tests/unit -v`, `uv lock --check`, and running the app.

## Deliberately accepted losses

Three items are removed from the repo entirely rather than relocated:

- **Framework Notes** — the Python/FastAPI/SQLAlchemy-Core-not-ORM, React 19 + TanStack Query + Base UI, Tailwind 4, and TypeScript `strict`/`noUnusedLocals` stack notes
- **Import Ordering** — stdlib → third-party → local convention
- **Release detail** — including the "never manually edit versions in `package.json` / `pyproject.toml` / `frontend/package.json`" warning

These were judged recoverable from the code itself (the stack is evident from imports and config; ruff enforces import ordering) or from the releases skill.

## Note

`CLAUDE.md` still opens with "Prefer retrieval-led reasoning… consult the actual codebase files." The code index that made retrieval cheap now lives only in `AGENTS.md`, so that instruction depends on the reading tool picking that file up.

Docs only — no changeset, per the convention that maintenance and docs PRs omit them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbfD1uzrnEyG6j5CDteWax
