### PR TITLE
docs: Move backend patterns to comicarr/CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,28 +52,6 @@ Conventional PR titles keep history readable, but they do not control releases. 
 - **Do NOT manually bump versions** - Changesets release automation handles this
 - **Do NOT finish without linting** - Run `npm run lint` (or `npm run lint:fix` then re-check) before considering work done; do not bypass hooks with `--no-verify`
 
-## Common Patterns
-
-### Logging Pattern
-- Import: `from comicarr import logger`
-- Usage: `logger.fdebug('[MODULE-CONTEXT] message')` or `logger.error('[CONTEXT] Error: %s' % e)`
-- Always prefix with context in brackets
-
-### Configuration Access
-- Import: `import comicarr`
-- Usage: `comicarr.CONFIG.option_name`
-- Global config object is initialized at startup
-
-### Database Queries
-- Import: `from comicarr import db`
-- Usage: `db.DBConnection().action("SELECT * FROM table WHERE id=?", [id])`
-- Always use parameterized queries
-
-### Adding New Features
-- Prefer `comicarr/app/<domain>/router.py` + `service.py` (+ `queries.py` when needed)
-- Register/include the router from `comicarr/app/main.py`
-- Keep heavy provider/search/post-processing logic in existing business modules when it already lives there
-
 ## Gotchas
 
 - Config `SECURE_DIR` must be initialized before `encrypt_items()` or bcrypt migration — ordering matters in `config.py`

--- a/comicarr/CLAUDE.md
+++ b/comicarr/CLAUDE.md
@@ -1,0 +1,21 @@
+# Backend Patterns
+
+### Logging Pattern
+- Import: `from comicarr import logger`
+- Usage: `logger.fdebug('[MODULE-CONTEXT] message')` or `logger.error('[CONTEXT] Error: %s' % e)`
+- Always prefix with context in brackets
+
+### Configuration Access
+- Import: `import comicarr`
+- Usage: `comicarr.CONFIG.option_name`
+- Global config object is initialized at startup
+
+### Database Queries
+- Import: `from comicarr import db`
+- Usage: `db.DBConnection().action("SELECT * FROM table WHERE id=?", [id])`
+- Always use parameterized queries
+
+### Adding New Features
+- Prefer `comicarr/app/<domain>/router.py` + `service.py` (+ `queries.py` when needed)
+- Register/include the router from `comicarr/app/main.py`
+- Keep heavy provider/search/post-processing logic in existing business modules when it already lives there


### PR DESCRIPTION
## Summary

Moves the `## Common Patterns` section (logging, config access, DB queries, new-feature layout) out of the root `CLAUDE.md` and into a new `comicarr/CLAUDE.md`.

That section is Python-backend guidance — it only applies when working under `comicarr/`. In the root file it loaded into every session, including frontend and docs work where it never applied. Nested `CLAUDE.md` files load only when working with files under their directory, so the guidance still shows up exactly when it's relevant.

Root `CLAUDE.md` goes from 4,140 to 3,331 chars (~175 fewer always-resident tokens per session). No guidance was deleted — the content moved verbatim under a `# Backend Patterns` heading.

Gotchas, anti-patterns, and branch/PR conventions stay in the root file deliberately: those are safety rules that need to be loaded before you find out you needed them.

## Test plan

- [x] Docs-only change; no code, config, or dependency changes
- [x] No changeset — no release intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GusszWmRYrgSvEDZ6aMfpc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend development guidance with standards for logging, configuration access, database queries, and feature integration.
  * Removed the corresponding common-pattern guidance from the top-level documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->