### PR TITLE
fix: Report the real reason a search is blocked

### DIFF
--- a/.changeset/loud-pumas-search.md
+++ b/.changeset/loud-pumas-search.md
@@ -1,0 +1,14 @@
+---
+"comicarr": patch
+---
+
+Surface the actual reason a search is blocked instead of a generic placeholder.
+
+When no acquisition route was handoff-ready, the search-missing preview and the
+Wanted force-search both read a `reason` key that `get_search_health()` never
+returns, so every blocked search reported `no_viable_acquisition_route` no matter
+the cause. Route readiness already computes a specific blocker per route
+(`path_not_ready`, `client_not_ready`, `disabled`, `providers_temporarily_blocked`,
+a maintenance hold); the blocked response now reports the one closest to ready,
+and the series search dialog explains it in plain language while keeping the raw
+code visible for support.

--- a/comicarr/app/search/health.py
+++ b/comicarr/app/search/health.py
@@ -25,6 +25,24 @@ WORKER_PREFIX = "Worker: "
 ROUTE_PREFIX = "Acquisition Route: "
 _ROUTES = ("ddl", "nzb", "torrent")
 
+# Last-resort reason when no route reported anything usable.
+NO_VIABLE_ROUTE = "no_viable_acquisition_route"
+
+# Blockers ordered from nearest-to-ready to furthest, so the reason surfaced to
+# operators names the smallest remaining gap.
+_ROUTE_REASON_RANK = {
+    reason: rank
+    for rank, reason in enumerate(
+        (
+            "providers_temporarily_blocked",
+            "path_not_ready",
+            "client_not_ready",
+            "unsupported_restart_correlation",
+            "disabled",
+        )
+    )
+}
+
 
 def _truthy(value):
     return str(value or "").strip().lower() in {"1", "true", "yes", "on", "running"}
@@ -326,6 +344,25 @@ def build_route_readiness(
 def has_viable_route(routes):
     """Return whether at least one centralized route is currently handoff-ready."""
     return any(bool(route.get("ready")) for route in routes.values())
+
+
+def blocking_route_reason(routes):
+    """Return the most actionable reason no route is handoff-ready.
+
+    Routes report why they individually fall short; callers gate on the fleet.
+    Rank the blockers so the operator sees the route closest to ready rather
+    than whichever one happens to sort first, and let an unrecognized reason
+    (a maintenance hold, which suppresses every route at once) outrank the
+    per-route ones because it is the true cause.
+    """
+    reasons = [
+        reason
+        for route in _ROUTES
+        if (reason := str((routes.get(route) or {}).get("reason") or "").strip()) and reason != "ready"
+    ]
+    if not reasons:
+        return NO_VIABLE_ROUTE
+    return min(reasons, key=lambda reason: _ROUTE_REASON_RANK.get(reason, -1))
 
 
 def get_acquisition_health(engine=None):

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -187,7 +187,7 @@ def force_search(ctx):
     """Trigger a full search for all wanted issues with a durable outcome."""
     from comicarr import search
     from comicarr.app.acquisition.runs import RunLedger
-    from comicarr.app.search.health import get_search_health
+    from comicarr.app.search.health import blocking_route_reason, get_search_health
 
     health = get_search_health(
         ctx.config,
@@ -198,11 +198,11 @@ def force_search(ctx):
         bool((routes.get(name) or {}).get("ready") or (routes.get(name) or {}).get("viable"))
         for name in ("ddl", "nzb", "torrent")
     )
-    if health.get("blocked") or not viable:
+    if not viable:
         return {
             "success": False,
             "status": "blocked",
-            "error": health.get("reason") or "no_viable_acquisition_route",
+            "error": blocking_route_reason(routes),
             "message": "Search blocked: no complete acquisition route is ready",
         }
 

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -622,7 +622,7 @@ def _search_missing_preview_state(ctx, comic_id):
 
     route = {"viable": True, "reason": None}
     try:
-        from comicarr.app.search.health import get_search_health
+        from comicarr.app.search.health import blocking_route_reason, get_search_health
 
         health = get_search_health(
             ctx.config,
@@ -633,11 +633,8 @@ def _search_missing_preview_state(ctx, comic_id):
             bool((routes.get(name) or {}).get("ready") or (routes.get(name) or {}).get("viable"))
             for name in ("ddl", "nzb", "torrent")
         )
-        if health.get("blocked") or not viable:
-            route = {
-                "viable": False,
-                "reason": health.get("reason") or "no_viable_acquisition_route",
-            }
+        if not viable:
+            route = {"viable": False, "reason": blocking_route_reason(routes)}
     except Exception as e:
         logger.warn("[SERIES] Route readiness unavailable for bulk search preview: %s" % e)
         route = {"viable": False, "reason": "route_health_unavailable"}

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -75,9 +75,29 @@ function getSeparateIntent(issue: Issue): string | null {
   return getIssueStatus(issue).toLowerCase() === intent ? null : intent;
 }
 
+const ROUTE_REASON_COPY: Record<string, string> = {
+  no_viable_acquisition_route:
+    "No download route is configured yet. Enable a DDL, Usenet, or torrent route in Settings.",
+  route_health_unavailable:
+    "Route health could not be read. Check the server logs, then refresh this preview.",
+  disabled:
+    "Every download route is disabled. Enable one in Settings, along with at least one provider.",
+  client_not_ready:
+    "The download client is missing its host or API key. Finish configuring it in Settings.",
+  path_not_ready:
+    "The configured download directory does not exist on the server. Check the path and any container mounts.",
+  providers_temporarily_blocked:
+    "Every provider is in a temporary backoff. This clears on its own — try again shortly.",
+  unsupported_restart_correlation:
+    "The selected download client cannot correlate downloads across a restart. Choose a client that can.",
+};
+
 function formatRouteReason(reason?: string | null): string {
   if (!reason) return "No safe acquisition route is currently ready.";
-  return reason.replace(/_/g, " ");
+  return (
+    ROUTE_REASON_COPY[reason] ??
+    `Search is blocked: ${reason.replace(/_/g, " ")}.`
+  );
 }
 
 function errorMessage(error: unknown): string {
@@ -784,15 +804,14 @@ export default function SeriesDetailPage() {
                       className="mt-1"
                       style={{ color: "var(--muted-foreground)" }}
                     >
-                      Configure a safe download route, then refresh this
-                      preview.
+                      {formatRouteReason(preview.route?.reason)}
                     </div>
                     {preview.route?.reason && (
                       <div
                         className="mt-2 font-mono text-[10px]"
                         style={{ color: "var(--text-muted)" }}
                       >
-                        {formatRouteReason(preview.route.reason)}
+                        {preview.route.reason}
                       </div>
                     )}
                   </div>

--- a/frontend/tests/pages/SeriesDetailPage.test.tsx
+++ b/frontend/tests/pages/SeriesDetailPage.test.tsx
@@ -335,7 +335,7 @@ describe("SeriesDetailPage", () => {
           comicId: "1",
           eligibleCount: 2,
           excludedCount: 8,
-          route: { viable: false, reason: "no_viable_acquisition_route" },
+          route: { viable: false, reason: "path_not_ready" },
           canSearch: false,
         }),
       ),
@@ -353,9 +353,10 @@ describe("SeriesDetailPage", () => {
     ).toBeTruthy();
     expect(
       screen.getByText(
-        "Configure a safe download route, then refresh this preview.",
+        "The configured download directory does not exist on the server. Check the path and any container mounts.",
       ),
     ).toBeTruthy();
+    expect(screen.getByText("path_not_ready")).toBeTruthy();
     expect(
       screen
         .getByRole("button", { name: "Confirm search" })

--- a/tests/integration/test_acquisition_pipeline.py
+++ b/tests/integration/test_acquisition_pipeline.py
@@ -84,7 +84,6 @@ def _ready_search_route(monkeypatch):
     monkeypatch.setattr(
         "comicarr.app.search.health.get_search_health",
         lambda *_args, **_kwargs: {
-            "blocked": False,
             "viable_route": True,
             "routes": {"nzb": {"ready": True}, "torrent": {}, "ddl": {}},
         },

--- a/tests/unit/test_search_domain.py
+++ b/tests/unit/test_search_domain.py
@@ -27,10 +27,12 @@ def test_force_search_reports_blocked_when_no_viable_route(monkeypatch):
     monkeypatch.setattr(
         "comicarr.app.search.health.get_search_health",
         lambda *_args, **_kwargs: {
-            "blocked": False,
             "viable_route": False,
-            "routes": {"ddl": {"ready": False}, "nzb": {"ready": False}, "torrent": {"ready": False}},
-            "reason": "no_viable_acquisition_route",
+            "routes": {
+                "ddl": {"ready": False, "reason": "disabled"},
+                "nzb": {"ready": False, "reason": "client_not_ready"},
+                "torrent": {"ready": False, "reason": "disabled"},
+            },
         },
     )
     search_for_issue = MagicMock()
@@ -40,6 +42,8 @@ def test_force_search_reports_blocked_when_no_viable_route(monkeypatch):
 
     assert result["success"] is False
     assert result["status"] == "blocked"
+    # The nearest-to-ready route names the gap, not the disabled majority.
+    assert result["error"] == "client_not_ready"
     search_for_issue.assert_not_called()
 
 
@@ -47,7 +51,6 @@ def test_force_search_accepts_when_route_is_ready(monkeypatch):
     monkeypatch.setattr(
         "comicarr.app.search.health.get_search_health",
         lambda *_args, **_kwargs: {
-            "blocked": False,
             "viable_route": True,
             "routes": {"ddl": {"ready": True}, "nzb": {"ready": False}, "torrent": {"ready": False}},
         },
@@ -78,7 +81,6 @@ def test_force_search_reports_no_match_with_a_terminal_empty_run(monkeypatch):
     monkeypatch.setattr(
         "comicarr.app.search.health.get_search_health",
         lambda *_args, **_kwargs: {
-            "blocked": False,
             "viable_route": True,
             "routes": {"ddl": {"ready": True}, "nzb": {}, "torrent": {}},
         },
@@ -110,7 +112,6 @@ def test_force_search_reports_partial_when_some_wanted_handoffs_fail(monkeypatch
     monkeypatch.setattr(
         "comicarr.app.search.health.get_search_health",
         lambda *_args, **_kwargs: {
-            "blocked": False,
             "viable_route": True,
             "routes": {"ddl": {"ready": True}, "nzb": {}, "torrent": {}},
         },
@@ -150,7 +151,6 @@ def test_force_search_closes_rejected_empty_runs(monkeypatch, search_result, exp
     monkeypatch.setattr(
         "comicarr.app.search.health.get_search_health",
         lambda *_args, **_kwargs: {
-            "blocked": False,
             "viable_route": True,
             "routes": {"ddl": {"ready": True}, "nzb": {}, "torrent": {}},
         },

--- a/tests/unit/test_search_health.py
+++ b/tests/unit/test_search_health.py
@@ -211,6 +211,23 @@ def test_maintenance_blocks_handoff_without_hiding_route_configuration(tmp_path)
     assert all(route["ready"] is False for route in routes.values())
     assert all(route["reason"] == "persistent_maintenance" for route in routes.values())
     assert health.has_viable_route(routes) is False
+    assert health.blocking_route_reason(routes) == "persistent_maintenance"
+
+
+def test_blocking_route_reason_names_the_smallest_remaining_gap(tmp_path):
+    routes = health.build_route_readiness(
+        _config(tmp_path, ENABLE_DDL=False, ENABLE_GETCOMICS=False, POST_PROCESSING=True, SAB_DIRECTORY=None)
+    )
+
+    assert health.has_viable_route(routes) is False
+    assert routes["ddl"]["reason"] == "disabled"
+    # DDL sorts first but is merely off; the NZB route is one directory away.
+    assert health.blocking_route_reason(routes) == "path_not_ready"
+
+
+def test_blocking_route_reason_falls_back_when_routes_report_nothing():
+    assert health.blocking_route_reason({}) == health.NO_VIABLE_ROUTE
+    assert health.blocking_route_reason({"ddl": {"ready": False}}) == health.NO_VIABLE_ROUTE
 
 
 def test_dispatch_success_and_acquisition_completion_are_separate_projections():

--- a/tests/unit/test_search_missing_bulk.py
+++ b/tests/unit/test_search_missing_bulk.py
@@ -85,7 +85,6 @@ def _ready_route(monkeypatch):
     monkeypatch.setattr(
         "comicarr.app.search.health.get_search_health",
         lambda *_args, **_kwargs: {
-            "blocked": False,
             "viable_route": True,
             "routes": {"ddl": {"ready": True}, "nzb": {}, "torrent": {}},
         },

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -347,11 +347,11 @@ def test_preview_search_all_missing_excludes_owned_future_and_skipped(monkeypatc
         search_health,
         "get_search_health",
         lambda *_args, **_kwargs: {
-            "blocked": False,
+            "viable_route": True,
             "routes": {
-                "ddl": {"viable": True},
-                "nzb": {"viable": False},
-                "torrent": {"viable": False},
+                "ddl": {"ready": True, "reason": "ready"},
+                "nzb": {"ready": False, "reason": "disabled"},
+                "torrent": {"ready": False, "reason": "disabled"},
             },
         },
     )


### PR DESCRIPTION
## Problem

The "Search missing issues" dialog always showed `no viable acquisition route` when a search was blocked, regardless of the actual cause — a missing download directory, an unconfigured client, a provider backoff, or a maintenance hold all rendered identically. That leaves no path to a fix.

`comicarr/app/series/service.py` and `comicarr/app/search/service.py` both did:

```python
"reason": health.get("reason") or "no_viable_acquisition_route"
```

But `get_search_health()` returns `providers`, `routes`, `viable_route`, `acquisition`, `workers`, `maintenance`, and `blocked_producer_count` — there is no top-level `reason`, so the `.get()` was always `None` and the fallback always won. `health.get("blocked")` in the same condition was dead for the same reason.

Meanwhile `build_route_readiness()` was already computing a precise blocker for every route (`disabled`, `client_not_ready`, `path_not_ready`, `unsupported_restart_correlation`, or a maintenance reason) — the information existed and was being thrown away.

## Fix

Add `blocking_route_reason()` next to `has_viable_route()` in `comicarr/app/search/health.py`. It ranks the per-route blockers nearest-to-ready first, so the operator sees the smallest remaining gap rather than whichever route happens to sort first. An unrecognized reason — a maintenance hold, which suppresses every route at once — outranks all of them, since it is the true cause.

Both call sites now use it, and the dead `health.get("blocked")` check is gone.

On the frontend, the blocked panel's description line now explains the code in plain language ("The configured download directory does not exist on the server. Check the path and any container mounts.") and the mono line keeps the raw token for support and log grepping.

## Why this wasn't caught

The `get_search_health` test fakes carried `reason` and `blocked` keys the real projection never emits, so the fallback path never ran under test. They now match the real shape, and `test_force_search_reports_blocked_when_no_viable_route` asserts on the specific reason.

## Testing

- `pytest tests/unit` — 1721 passed
- `npx vitest run tests/pages/SeriesDetailPage.test.tsx` — 3 passed
- `npm run lint` (all three lanes) and `npm --prefix frontend run typecheck` clean

Note: only the reason reported changes. The gate itself — search is blocked unless a route is handoff-ready — is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfyuWsvNCF1E5tgvV38Xse