### PR TITLE
refactor: Extract the file placement stage

### DIFF
--- a/.changeset/one-seam-places-every-file.md
+++ b/.changeset/one-seam-places-every-file.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Add a single file placement stage that reads the file operation setting at call time. Callers pass intent — what the file is for, and what to do if the destination is occupied — instead of a resolved mode, so no caller can bind a stale setting and place a file the wrong way. Nothing routes through it yet.

--- a/comicarr/app/common/placement.py
+++ b/comicarr/app/common/placement.py
@@ -1,0 +1,567 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""The one place a file is put somewhere.
+
+Callers pass **intent** -- a `Purpose` and an `OnExisting` policy -- never a
+resolved file-operation mode. The mode is read from config *inside* `place()`,
+at call time, so a caller cannot bind a stale value: there is no public callable
+that accepts one. That is the whole point of the module. Reading `FILE_OPTS`
+early and passing it down is what let manga post-processing destroy the
+operator's download while the setting said `hardlink`.
+
+Config is injected as a *source* (`config`), defaulting to `comicarr.CONFIG`, so
+tests swap the object rather than the values.
+
+Failures always raise `PlacementError`. It subclasses `OSError` so callers that
+already catch `OSError` keep working unchanged.
+"""
+
+import errno
+import logging
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from enum import Enum, auto
+
+log = logging.getLogger("comicarr")
+
+DISPLACED_SUFFIX = ".comicarr-displaced"
+
+
+class Purpose(Enum):
+    """Why a file is being placed. Selects the config key and the mechanics."""
+
+    SERIES = auto()  # FILE_OPTS,   plain mechanics
+    IMPORT = auto()  # FILE_OPTS,   plain mechanics
+    ONE_OFF = auto()  # ARC_FILEOPS, plain mechanics
+    ARC = auto()  # ARC_FILEOPS, preserve source + reverse link direction
+
+
+class OnExisting(Enum):
+    """What to do when the destination is already occupied."""
+
+    UNGUARDED = auto()  # no check; the mode's native behaviour decides
+    DISPLACE = auto()  # rename aside, place, then delete-or-restore
+    SKIP = auto()  # any file at the destination means no placement at all
+    REFUSE = auto()  # atomic no-clobber: the publish itself refuses
+
+
+class Outcome(Enum):
+    PLACED = auto()
+    ALREADY_PLACED = auto()
+
+
+class PlacementError(OSError):
+    """A placement did not happen.
+
+    Subclasses OSError deliberately: `storyarcs/service.py` catches the narrow
+    `(OSError, IOError)`, so migration stays mechanical rather than
+    behaviour-changing.
+    """
+
+    def __init__(self, message, *, purpose=None, mode=None, source=None, destination=None):
+        super().__init__(message)
+        self.purpose = purpose
+        self.mode = mode
+        self.source = source
+        self.destination = destination
+
+
+@dataclass(frozen=True)
+class PlacementResult:
+    """What actually happened. Describes success only -- failures raise.
+
+    `source_survived` and `source_is_symlink` are recorded by the mechanic that
+    ran rather than re-derived from the mode, because the same mode does
+    different things to the source depending on purpose and policy: non-arc
+    `softlink` moves the file and leaves a symlink behind at the source path,
+    arc `softlink` does not touch the source at all, and the REFUSE publish uses
+    a third shape again. Deriving that from `(purpose, effective_mode)` was the
+    original plan and it is not derivable.
+    """
+
+    outcome: Outcome
+    effective_mode: str
+    destination: str
+    purpose: Purpose
+    on_existing: OnExisting
+    source_survived: bool
+    source_is_symlink: bool
+
+
+def place(source, destination, purpose, *, on_existing, multiple=False, config=None) -> PlacementResult:
+    """Place `source` at `destination` according to intent.
+
+    `on_existing` is required and has no default. UNGUARDED covers five of the
+    eight call sites and would be the obvious default, which is exactly why it
+    is not one -- it is the policy nobody chose, and a default would let new
+    callers inherit it silently.
+    """
+    if config is None:
+        import comicarr
+
+        config = comicarr.CONFIG
+
+    mode = _resolve_mode(config, purpose, multiple)
+    arc = purpose is Purpose.ARC
+    softlink_type = _resolve_softlink_type(config, purpose)
+
+    if on_existing is OnExisting.SKIP:
+        # isfile, not lexists -- matches storyarcs' guard exactly, so a dangling
+        # symlink at the destination is still replaced.
+        if os.path.isfile(destination):
+            return _already_placed(destination, purpose, on_existing, mode)
+
+    elif on_existing is OnExisting.DISPLACE:
+        return _place_displacing(
+            source, destination, purpose, on_existing, mode=mode, arc=arc, softlink_type=softlink_type
+        )
+
+    elif on_existing is OnExisting.REFUSE:
+        return _place_refusing(source, destination, purpose, on_existing, mode=mode)
+
+    effective, survived, is_symlink = _apply(
+        source, destination, purpose=purpose, mode=mode, arc=arc, softlink_type=softlink_type
+    )
+    return PlacementResult(
+        outcome=Outcome.PLACED,
+        effective_mode=effective,
+        destination=destination,
+        purpose=purpose,
+        on_existing=on_existing,
+        source_survived=survived,
+        source_is_symlink=is_symlink,
+    )
+
+
+def _already_placed(destination, purpose, on_existing, mode) -> PlacementResult:
+    return PlacementResult(
+        outcome=Outcome.ALREADY_PLACED,
+        effective_mode=mode,
+        destination=destination,
+        purpose=purpose,
+        on_existing=on_existing,
+        source_survived=True,
+        source_is_symlink=False,
+    )
+
+
+def _resolve_mode(config, purpose, multiple):
+    """Read the operative mode from config. Called once per `place()`, never cached."""
+    if purpose in (Purpose.ONE_OFF, Purpose.ARC):
+        # `multiple` is a genuine bool at the one call site that passes it
+        # (postprocessor assigns literal True/False), so the identity check the
+        # legacy helper used is sound and is preserved.
+        if multiple is True:
+            return "copy"
+        return config.ARC_FILEOPS
+    return config.FILE_OPTS
+
+
+def _resolve_softlink_type(config, purpose):
+    if purpose in (Purpose.ONE_OFF, Purpose.ARC):
+        if config.ARC_FILEOPS_SOFTLINK_RELATIVE is True:
+            return "relative"
+    return "absolute"
+
+
+def _fail(message, *, purpose, mode, source, destination, cause=None):
+    error = PlacementError(message, purpose=purpose, mode=mode, source=source, destination=destination)
+    if cause is not None:
+        raise error from cause
+    raise error
+
+
+# ---------------------------------------------------------------------------
+# Mechanics
+#
+# Two families. `_apply` reproduces the legacy `file_ops` behaviour exactly,
+# including its fallbacks, and serves UNGUARDED / DISPLACE / SKIP. `_publish`
+# is the atomic no-clobber family and serves REFUSE alone.
+# ---------------------------------------------------------------------------
+
+
+def _apply(path, dst, *, purpose, mode, arc, softlink_type):
+    """The legacy mechanics, preserved. Returns (effective_mode, source_survived, source_is_symlink)."""
+    if mode == "copy" or (arc and mode in ("copy", "move")):
+        # An arc must keep the series file, so `move` degrades to a copy.
+        try:
+            shutil.copy(path, dst)
+        except Exception as e:
+            log.error("[%s] error : %s" % (mode, e))
+            _fail("copy failed: %s" % e, purpose=purpose, mode=mode, source=path, destination=dst, cause=e)
+        return "copy", True, False
+
+    if mode == "move":
+        try:
+            shutil.move(path, dst)
+        except Exception as e:
+            log.error("[MOVE] error : %s" % e)
+            _fail("move failed: %s" % e, purpose=purpose, mode=mode, source=path, destination=dst, cause=e)
+        return "move", False, False
+
+    if mode == "hardlink":
+        return _apply_hardlink(path, dst, purpose=purpose, mode=mode)
+
+    if mode == "softlink":
+        return _apply_softlink(path, dst, purpose=purpose, mode=mode, arc=arc, softlink_type=softlink_type)
+
+    _fail("unsupported file operation: %r" % (mode,), purpose=purpose, mode=mode, source=path, destination=dst)
+
+
+def _apply_hardlink(path, dst, *, purpose, mode):
+    try:
+        os.link(path, dst)
+    except OSError as e:
+        if e.errno == errno.EXDEV:
+            log.warning(
+                "[%s] Hardlinking failure. Could not create hardlink - dropping down to copy mode so that this "
+                "operation can complete. Intervention is required if you wish to continue using hardlinks." % e
+            )
+            try:
+                shutil.copy(path, dst)
+            except Exception as copy_error:
+                log.error("[COPY] error : %s" % copy_error)
+                _fail(
+                    "hardlink fell back to copy and the copy failed: %s" % copy_error,
+                    purpose=purpose,
+                    mode=mode,
+                    source=path,
+                    destination=dst,
+                    cause=copy_error,
+                )
+            log.debug("Successfully copied file to : " + dst)
+            return "copy", True, False
+
+        log.warning(
+            "[%s] Hardlinking failure. Could not create hardlink - Intervention is required if you wish to "
+            "continue using hardlinks." % e
+        )
+        _fail("hardlink failed: %s" % e, purpose=purpose, mode=mode, source=path, destination=dst, cause=e)
+
+    hardlinks = os.lstat(dst).st_nlink
+    if hardlinks > 1:
+        log.info("Created hard link [" + str(hardlinks) + "] successfully!! (" + dst + ")")
+    else:
+        log.warning("Hardlink cannot be verified. You should probably verify that it is created properly.")
+    return "hardlink", True, False
+
+
+def _apply_softlink(path, dst, *, purpose, mode, arc, softlink_type):
+    try:
+        if not arc:
+            # Non-arc: the file itself moves to the destination and the source
+            # path is replaced by a symlink pointing at it. The source path
+            # survives, but as a link -- which is why `source_is_symlink` is not
+            # derivable from the mode alone.
+            shutil.move(path, dst)
+            if os.path.lexists(path):
+                os.remove(path)
+            if softlink_type == "absolute":
+                os.symlink(dst, path)
+                log.debug("Successfully created softlink [" + dst + " --> " + path + "]")
+            else:
+                os.symlink(os.path.relpath(dst, os.path.dirname(path)), path)
+                log.debug(
+                    "Successfully created (relative) softlink [%s --> %s]"
+                    % (os.path.relpath(dst, os.path.dirname(path)), path)
+                )
+        else:
+            # Arc: the series file stays put and the arc directory gets the link.
+            if softlink_type == "absolute":
+                os.symlink(path, dst)
+                log.debug("Successfully created softlink [" + path + " --> " + dst + "]")
+            else:
+                os.symlink(os.path.relpath(path, os.path.dirname(dst)), dst)
+                log.debug(
+                    "Successfully created (relative) softlink [%s --> %s]"
+                    % (os.path.relpath(path, os.path.dirname(dst)), dst)
+                )
+    except OSError as e:
+        log.warning(
+            "[%s] Unable to create symlink. Dropping down to copy mode so that this operation can continue." % e
+        )
+        try:
+            if arc:
+                shutil.copy(path, dst)
+                log.debug("Successfully copied file [" + path + " --> " + dst + "]")
+            else:
+                # The move already happened, so the copy restores the source.
+                shutil.copy(dst, path)
+                log.debug("Successfully copied file [" + dst + " --> " + path + "]")
+        except Exception as copy_error:
+            log.error("[COPY] error : %s" % copy_error)
+            _fail(
+                "softlink fell back to copy and the copy failed: %s" % copy_error,
+                purpose=purpose,
+                mode=mode,
+                source=path,
+                destination=dst,
+                cause=copy_error,
+            )
+        return "copy", True, False
+
+    # The source path exists either way; only its nature differs. Arc leaves the
+    # real file untouched, non-arc leaves a symlink standing where it used to be.
+    return "softlink", True, not arc
+
+
+# ---------------------------------------------------------------------------
+# Policies
+# ---------------------------------------------------------------------------
+
+
+def _place_displacing(source, destination, purpose, on_existing, *, mode, arc, softlink_type):
+    """Rename what is there aside, place, then delete it or put it back.
+
+    Deliberately not a delete-first: copy and move truncate the destination as
+    they write, so an up-front delete would leave the library with nothing while
+    the database still reports the issue as Downloaded. A rename frees the
+    destination for every mode and keeps the old file restorable.
+    """
+    displaced = None
+    if os.path.lexists(destination):
+        try:
+            # Same inode (hardlinked) or same target (softlinked) means an
+            # earlier pass already placed this file; re-linking it would only
+            # fail, and the source must survive either way.
+            if os.path.samefile(source, destination):
+                return _already_placed(destination, purpose, on_existing, mode)
+        except OSError:
+            pass
+
+        displaced = destination + DISPLACED_SUFFIX
+        if os.path.lexists(displaced):
+            # An orphan from a crash between displace and restore. Clobbering it
+            # loses a stale backup; refusing would strand this file permanently
+            # after a single crash, which is the worse failure.
+            log.warning("Replacing an orphaned displaced file: %s" % displaced)
+        try:
+            os.replace(destination, displaced)
+        except OSError as e:
+            _fail(
+                "could not displace the existing file: %s" % e,
+                purpose=purpose,
+                mode=mode,
+                source=source,
+                destination=destination,
+                cause=e,
+            )
+
+    try:
+        effective, survived, is_symlink = _apply(
+            source, destination, purpose=purpose, mode=mode, arc=arc, softlink_type=softlink_type
+        )
+    except PlacementError:
+        if displaced is not None:
+            try:
+                os.replace(displaced, destination)
+                log.info("Restored the previous %s after a failed placement" % destination)
+            except OSError as restore_error:
+                # The original is still on disk under its marker name, which is
+                # strictly better than gone.
+                log.error("Failed to restore the previous %s: %s" % (destination, restore_error))
+        raise
+
+    if displaced is not None:
+        try:
+            os.remove(displaced)
+        except OSError as e:
+            log.warning("Failed to clean up %s: %s" % (displaced, e))
+
+    return PlacementResult(
+        outcome=Outcome.PLACED,
+        effective_mode=effective,
+        destination=destination,
+        purpose=purpose,
+        on_existing=on_existing,
+        source_survived=survived,
+        source_is_symlink=is_symlink,
+    )
+
+
+def _place_refusing(source, destination, purpose, on_existing, *, mode):
+    """Never replace an existing destination, and prove it atomically.
+
+    The guarantee is atomicity, not refusal. `os.link` and `os.symlink` fail with
+    EEXIST as part of creating the destination, so there is no window between
+    checking and writing. A caller-side `os.path.exists` check is not an
+    acceptable substitute and must not replace this.
+    """
+    if mode == "move":
+        effective = _publish_move(source, destination, purpose=purpose, mode=mode)
+        return PlacementResult(
+            outcome=Outcome.PLACED,
+            effective_mode=effective,
+            destination=destination,
+            purpose=purpose,
+            on_existing=on_existing,
+            source_survived=False,
+            source_is_symlink=False,
+        )
+
+    if mode == "copy":
+        _publish_copy(source, destination, purpose=purpose, mode=mode)
+        effective = "copy"
+
+    elif mode == "hardlink":
+        try:
+            os.link(source, destination)
+            effective = "hardlink"
+        except OSError as e:
+            if e.errno != errno.EXDEV:
+                _fail(
+                    "hardlink failed: %s" % e,
+                    purpose=purpose,
+                    mode=mode,
+                    source=source,
+                    destination=destination,
+                    cause=e,
+                )
+            # EXDEV is the dominant topology, not the exception -- two Docker
+            # volumes off one NAS volume are always cross-device. Degrade to the
+            # atomic copy publish, which preserves the source exactly as a
+            # hardlink would, so rollback is unaffected.
+            log.warning("[%s] Cannot hardlink across filesystems - dropping down to copy mode." % e)
+            _publish_copy(source, destination, purpose=purpose, mode=mode)
+            effective = "copy"
+
+    elif mode == "softlink":
+        # Deliberately not the non-arc move-then-link-back shape: an import must
+        # not consume the operator's inbox file and leave a link in its place.
+        # os.symlink is already atomically no-clobber.
+        try:
+            os.symlink(source, destination)
+            effective = "softlink"
+        except OSError as e:
+            _fail(
+                "softlink failed: %s" % e,
+                purpose=purpose,
+                mode=mode,
+                source=source,
+                destination=destination,
+                cause=e,
+            )
+
+    else:
+        _fail(
+            "unsupported file operation: %r" % (mode,),
+            purpose=purpose,
+            mode=mode,
+            source=source,
+            destination=destination,
+        )
+
+    return PlacementResult(
+        outcome=Outcome.PLACED,
+        effective_mode=effective,
+        destination=destination,
+        purpose=purpose,
+        on_existing=on_existing,
+        source_survived=True,
+        source_is_symlink=False,
+    )
+
+
+def _publish_copy(source, destination, *, purpose, mode):
+    """Copy to a private file on the target filesystem, then publish atomically."""
+    temporary_path = None
+    try:
+        descriptor, temporary_path = tempfile.mkstemp(
+            prefix=".comicarr-import-",
+            dir=os.path.dirname(destination),
+        )
+        os.close(descriptor)
+        shutil.copy2(source, temporary_path)
+        os.link(temporary_path, destination)
+    except OSError as e:
+        _fail(
+            "could not publish %s: %s" % (destination, e),
+            purpose=purpose,
+            mode=mode,
+            source=source,
+            destination=destination,
+            cause=e,
+        )
+    finally:
+        if temporary_path:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:
+                pass
+
+
+def _publish_move(source, destination, *, purpose, mode):
+    """Move without ever replacing an existing destination.
+
+    Hard-link publication gives same-filesystem moves an atomic no-clobber
+    boundary. Cross-filesystem moves first copy to a private file on the target
+    filesystem, then publish that complete file through the same boundary.
+    """
+    temporary_path = None
+    published_reference = source
+    try:
+        try:
+            os.link(source, destination)
+        except OSError as e:
+            if e.errno != errno.EXDEV:
+                _fail(
+                    "could not publish %s: %s" % (destination, e),
+                    purpose=purpose,
+                    mode=mode,
+                    source=source,
+                    destination=destination,
+                    cause=e,
+                )
+
+            descriptor, temporary_path = tempfile.mkstemp(
+                prefix=".comicarr-import-",
+                dir=os.path.dirname(destination),
+            )
+            os.close(descriptor)
+            shutil.copy2(source, temporary_path)
+            published_reference = temporary_path
+            os.link(temporary_path, destination)
+
+        try:
+            os.unlink(source)
+        except OSError as e:
+            remove_transfer_destination(destination, published_reference)
+            _fail(
+                "published %s but could not consume the source: %s" % (destination, e),
+                purpose=purpose,
+                mode=mode,
+                source=source,
+                destination=destination,
+                cause=e,
+            )
+    finally:
+        if temporary_path:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:
+                pass
+
+    return "move"
+
+
+def remove_transfer_destination(destination_path: str, reference_path: str) -> None:
+    """Remove a destination only while it still names this transfer's file.
+
+    Reachable only from the move publish, where a successful publish is followed
+    by a failed source unlink. The source-preserving modes never unlink the
+    source, so they never undo a publish this way.
+    """
+    try:
+        if os.path.samestat(os.stat(destination_path), os.stat(reference_path)):
+            os.unlink(destination_path)
+    except FileNotFoundError:
+        pass

--- a/tests/unit/test_placement.py
+++ b/tests/unit/test_placement.py
@@ -1,0 +1,639 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Unit tests for the placement stage.
+
+Covers the four modes against the four on-existing policies, arc and non-arc
+mechanics, and the fallback paths that `file_ops` never had coverage for: the
+EXDEV hardlink drop to copy and the softlink OSError drop to copy.
+"""
+
+import errno
+import os
+from unittest.mock import patch
+
+import pytest
+
+from comicarr.app.common.placement import (
+    OnExisting,
+    Outcome,
+    PlacementError,
+    Purpose,
+    place,
+)
+
+MODES = ("copy", "move", "hardlink", "softlink")
+
+
+class FakeConfig:
+    def __init__(self, file_opts="move", arc_fileops="copy", relative=False):
+        self.FILE_OPTS = file_opts
+        self.ARC_FILEOPS = arc_fileops
+        self.ARC_FILEOPS_SOFTLINK_RELATIVE = relative
+
+
+@pytest.fixture
+def paths(tmp_path):
+    source = tmp_path / "src" / "Saga 001.cbz"
+    source.parent.mkdir()
+    source.write_bytes(b"payload")
+    destination = tmp_path / "dst" / "Saga 001.cbz"
+    destination.parent.mkdir()
+    return str(source), str(destination)
+
+
+# ---------------------------------------------------------------------------
+# Mode resolution: the reason this module exists
+# ---------------------------------------------------------------------------
+
+
+class TestModeIsReadAtCallTime:
+    def test_series_and_import_read_file_opts(self, paths):
+        source, destination = paths
+        config = FakeConfig(file_opts="copy", arc_fileops="hardlink")
+
+        result = place(source, destination, Purpose.SERIES, on_existing=OnExisting.UNGUARDED, config=config)
+
+        assert result.effective_mode == "copy"
+
+    def test_one_off_and_arc_read_arc_fileops(self, paths):
+        source, destination = paths
+        config = FakeConfig(file_opts="move", arc_fileops="copy")
+
+        result = place(source, destination, Purpose.ONE_OFF, on_existing=OnExisting.UNGUARDED, config=config)
+
+        assert result.effective_mode == "copy"
+        assert os.path.exists(source), "one-off copy must not consume the source"
+
+    def test_multiple_forces_copy_for_one_off(self, paths):
+        source, destination = paths
+        config = FakeConfig(arc_fileops="move")
+
+        result = place(
+            source,
+            destination,
+            Purpose.ONE_OFF,
+            on_existing=OnExisting.UNGUARDED,
+            multiple=True,
+            config=config,
+        )
+
+        assert result.effective_mode == "copy"
+        assert os.path.exists(source)
+
+    def test_a_config_mutated_after_import_is_still_honoured(self, paths):
+        """The #303 invariant. Nothing may capture the mode before the call."""
+        source, destination = paths
+        config = FakeConfig(file_opts="move")
+        config.FILE_OPTS = "hardlink"
+
+        result = place(source, destination, Purpose.SERIES, on_existing=OnExisting.UNGUARDED, config=config)
+
+        assert result.effective_mode == "hardlink"
+        assert os.path.exists(source)
+
+    def test_place_has_no_parameter_that_accepts_a_mode(self):
+        import inspect
+
+        from comicarr.app.common import placement
+
+        parameters = set(inspect.signature(placement.place).parameters)
+
+        assert "mode" not in parameters
+        assert "file_opts" not in parameters
+        assert "os_detect" not in parameters, "dropped as dead in #334"
+
+    def test_unsupported_mode_raises(self, paths):
+        source, destination = paths
+
+        with pytest.raises(PlacementError):
+            place(
+                source,
+                destination,
+                Purpose.SERIES,
+                on_existing=OnExisting.UNGUARDED,
+                config=FakeConfig(file_opts="teleport"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Source survival, per mode and purpose
+# ---------------------------------------------------------------------------
+
+
+class TestSourceSurvival:
+    @pytest.mark.parametrize("mode", ("copy", "hardlink", "softlink"))
+    def test_non_move_modes_leave_the_source_in_place(self, paths, mode):
+        source, destination = paths
+
+        result = place(
+            source, destination, Purpose.SERIES, on_existing=OnExisting.UNGUARDED, config=FakeConfig(file_opts=mode)
+        )
+
+        assert os.path.lexists(source)
+        assert result.source_survived is True
+        assert os.path.exists(destination)
+
+    def test_move_consumes_the_source(self, paths):
+        source, destination = paths
+
+        result = place(
+            source, destination, Purpose.SERIES, on_existing=OnExisting.UNGUARDED, config=FakeConfig(file_opts="move")
+        )
+
+        assert not os.path.exists(source)
+        assert result.source_survived is False
+        assert result.effective_mode == "move"
+
+    def test_non_arc_softlink_leaves_a_symlink_at_the_source(self, paths):
+        """The sharp edge: the source path survives, but as a link into the library."""
+        source, destination = paths
+
+        result = place(
+            source,
+            destination,
+            Purpose.SERIES,
+            on_existing=OnExisting.UNGUARDED,
+            config=FakeConfig(file_opts="softlink"),
+        )
+
+        assert result.source_survived is True
+        assert result.source_is_symlink is True
+        assert os.path.islink(source)
+        assert os.path.realpath(source) == os.path.realpath(destination)
+
+    def test_arc_softlink_leaves_the_source_untouched(self, paths):
+        source, destination = paths
+
+        result = place(
+            source,
+            destination,
+            Purpose.ARC,
+            on_existing=OnExisting.UNGUARDED,
+            config=FakeConfig(arc_fileops="softlink"),
+        )
+
+        assert result.source_is_symlink is False
+        assert not os.path.islink(source)
+        assert os.path.islink(destination)
+
+    def test_arc_move_degrades_to_copy_to_keep_the_series_file(self, paths):
+        source, destination = paths
+
+        result = place(
+            source, destination, Purpose.ARC, on_existing=OnExisting.UNGUARDED, config=FakeConfig(arc_fileops="move")
+        )
+
+        assert result.effective_mode == "copy"
+        assert os.path.exists(source)
+
+    def test_arc_relative_softlink_is_relative(self, paths):
+        source, destination = paths
+
+        place(
+            source,
+            destination,
+            Purpose.ARC,
+            on_existing=OnExisting.UNGUARDED,
+            config=FakeConfig(arc_fileops="softlink", relative=True),
+        )
+
+        assert not os.path.isabs(os.readlink(destination))
+        assert os.path.exists(destination)
+
+
+# ---------------------------------------------------------------------------
+# Fallbacks -- the paths file_ops never had coverage for
+# ---------------------------------------------------------------------------
+
+
+class TestFallbacks:
+    def test_hardlink_drops_to_copy_on_exdev(self, paths):
+        source, destination = paths
+
+        with patch("comicarr.app.common.placement.os.link", side_effect=OSError(errno.EXDEV, "cross-device")):
+            result = place(
+                source,
+                destination,
+                Purpose.SERIES,
+                on_existing=OnExisting.UNGUARDED,
+                config=FakeConfig(file_opts="hardlink"),
+            )
+
+        assert result.effective_mode == "copy", "the caller must be able to see the link never happened"
+        assert os.path.exists(destination)
+        assert os.path.exists(source)
+
+    def test_hardlink_failure_that_is_not_exdev_raises(self, paths):
+        source, destination = paths
+
+        with patch("comicarr.app.common.placement.os.link", side_effect=OSError(errno.EPERM, "no hardlinks here")):
+            with pytest.raises(PlacementError):
+                place(
+                    source,
+                    destination,
+                    Purpose.SERIES,
+                    on_existing=OnExisting.UNGUARDED,
+                    config=FakeConfig(file_opts="hardlink"),
+                )
+
+    def test_arc_softlink_drops_to_copy_when_symlink_fails(self, paths):
+        source, destination = paths
+
+        with patch("comicarr.app.common.placement.os.symlink", side_effect=OSError("nope")):
+            result = place(
+                source,
+                destination,
+                Purpose.ARC,
+                on_existing=OnExisting.UNGUARDED,
+                config=FakeConfig(arc_fileops="softlink"),
+            )
+
+        assert result.effective_mode == "copy"
+        assert os.path.exists(destination)
+        assert not os.path.islink(destination)
+
+    def test_a_failed_fallback_still_raises(self, paths):
+        source, destination = paths
+
+        with (
+            patch("comicarr.app.common.placement.os.link", side_effect=OSError(errno.EXDEV, "cross-device")),
+            patch("comicarr.app.common.placement.shutil.copy", side_effect=OSError("disk full")),
+        ):
+            with pytest.raises(PlacementError):
+                place(
+                    source,
+                    destination,
+                    Purpose.SERIES,
+                    on_existing=OnExisting.UNGUARDED,
+                    config=FakeConfig(file_opts="hardlink"),
+                )
+
+
+# ---------------------------------------------------------------------------
+# Policies
+# ---------------------------------------------------------------------------
+
+
+class TestUnguarded:
+    @pytest.mark.parametrize("mode", ("copy", "move", "softlink"))
+    def test_three_of_four_modes_replace_the_destination(self, paths, mode):
+        """Measured behaviour, preserved deliberately. Only hardlink refuses."""
+        source, destination = paths
+        with open(destination, "wb") as handle:
+            handle.write(b"stale")
+
+        place(source, destination, Purpose.SERIES, on_existing=OnExisting.UNGUARDED, config=FakeConfig(file_opts=mode))
+
+        assert open(destination, "rb").read() == b"payload"
+
+    def test_hardlink_alone_refuses_an_existing_destination(self, paths):
+        source, destination = paths
+        with open(destination, "wb") as handle:
+            handle.write(b"stale")
+
+        with pytest.raises(PlacementError):
+            place(
+                source,
+                destination,
+                Purpose.SERIES,
+                on_existing=OnExisting.UNGUARDED,
+                config=FakeConfig(file_opts="hardlink"),
+            )
+
+        assert open(destination, "rb").read() == b"stale"
+
+    def test_never_reports_already_placed(self, paths):
+        source, destination = paths
+        os.link(source, destination)
+
+        result = place(
+            source, destination, Purpose.SERIES, on_existing=OnExisting.UNGUARDED, config=FakeConfig(file_opts="move")
+        )
+
+        assert result.outcome is Outcome.PLACED
+
+
+class TestSkip:
+    def test_an_existing_file_means_no_placement_and_no_error(self, paths):
+        source, destination = paths
+        with open(destination, "wb") as handle:
+            handle.write(b"already here")
+
+        result = place(
+            source, destination, Purpose.ARC, on_existing=OnExisting.SKIP, config=FakeConfig(arc_fileops="copy")
+        )
+
+        assert result.outcome is Outcome.ALREADY_PLACED
+        assert result.source_survived is True
+        assert open(destination, "rb").read() == b"already here"
+
+    def test_a_dangling_symlink_is_not_a_file_so_placement_proceeds(self, paths):
+        """isfile, not lexists -- matches the storyarcs guard exactly."""
+        source, destination = paths
+        target = os.path.join(os.path.dirname(destination), "gone.cbz")
+        os.symlink(target, destination)
+
+        result = place(
+            source, destination, Purpose.ARC, on_existing=OnExisting.SKIP, config=FakeConfig(arc_fileops="copy")
+        )
+
+        assert result.outcome is Outcome.PLACED, "SKIP must not short-circuit on a dangling symlink"
+        assert open(target, "rb").read() == b"payload"
+
+    def test_an_empty_destination_places_normally(self, paths):
+        source, destination = paths
+
+        result = place(
+            source, destination, Purpose.ARC, on_existing=OnExisting.SKIP, config=FakeConfig(arc_fileops="copy")
+        )
+
+        assert result.outcome is Outcome.PLACED
+        assert os.path.exists(destination)
+
+
+class TestDisplace:
+    def test_an_already_placed_file_short_circuits(self, paths):
+        source, destination = paths
+        os.link(source, destination)
+
+        result = place(
+            source,
+            destination,
+            Purpose.SERIES,
+            on_existing=OnExisting.DISPLACE,
+            config=FakeConfig(file_opts="hardlink"),
+        )
+
+        assert result.outcome is Outcome.ALREADY_PLACED
+        assert os.path.exists(source)
+
+    @pytest.mark.parametrize("mode", MODES)
+    def test_a_different_file_is_replaced_under_every_mode(self, paths, mode):
+        source, destination = paths
+        with open(destination, "wb") as handle:
+            handle.write(b"stale")
+
+        result = place(
+            source, destination, Purpose.SERIES, on_existing=OnExisting.DISPLACE, config=FakeConfig(file_opts=mode)
+        )
+
+        assert result.outcome is Outcome.PLACED
+        assert open(destination, "rb").read() == b"payload"
+
+    def test_the_displaced_marker_is_cleaned_up_on_success(self, paths):
+        source, destination = paths
+        with open(destination, "wb") as handle:
+            handle.write(b"stale")
+
+        place(source, destination, Purpose.SERIES, on_existing=OnExisting.DISPLACE, config=FakeConfig(file_opts="copy"))
+
+        assert not os.path.exists(destination + ".comicarr-displaced")
+
+    def test_a_failed_placement_restores_the_previous_file(self, paths):
+        source, destination = paths
+        with open(destination, "wb") as handle:
+            handle.write(b"the copy the operator already had")
+
+        with patch("comicarr.app.common.placement.shutil.copy", side_effect=OSError("disk full")):
+            with pytest.raises(PlacementError):
+                place(
+                    source,
+                    destination,
+                    Purpose.SERIES,
+                    on_existing=OnExisting.DISPLACE,
+                    config=FakeConfig(file_opts="copy"),
+                )
+
+        assert open(destination, "rb").read() == b"the copy the operator already had"
+        assert not os.path.exists(destination + ".comicarr-displaced")
+
+    def test_an_orphaned_marker_is_clobbered_rather_than_stranding_the_file(self, paths):
+        source, destination = paths
+        with open(destination, "wb") as handle:
+            handle.write(b"stale")
+        with open(destination + ".comicarr-displaced", "wb") as handle:
+            handle.write(b"orphan from an earlier crash")
+
+        result = place(
+            source, destination, Purpose.SERIES, on_existing=OnExisting.DISPLACE, config=FakeConfig(file_opts="copy")
+        )
+
+        assert result.outcome is Outcome.PLACED
+        assert open(destination, "rb").read() == b"payload"
+
+    def test_a_failed_displace_raises_before_placing(self, paths):
+        source, destination = paths
+        with open(destination, "wb") as handle:
+            handle.write(b"stale")
+
+        with patch("comicarr.app.common.placement.os.replace", side_effect=OSError("read-only")):
+            with pytest.raises(PlacementError):
+                place(
+                    source,
+                    destination,
+                    Purpose.SERIES,
+                    on_existing=OnExisting.DISPLACE,
+                    config=FakeConfig(file_opts="copy"),
+                )
+
+        assert open(destination, "rb").read() == b"stale"
+
+
+class TestRefuse:
+    @pytest.mark.parametrize("mode", MODES)
+    def test_an_existing_destination_is_never_replaced(self, paths, mode):
+        source, destination = paths
+        with open(destination, "wb") as handle:
+            handle.write(b"the operator's file")
+
+        with pytest.raises(PlacementError):
+            place(source, destination, Purpose.IMPORT, on_existing=OnExisting.REFUSE, config=FakeConfig(file_opts=mode))
+
+        assert open(destination, "rb").read() == b"the operator's file"
+        assert os.path.exists(source), "a refused placement must not consume the source"
+
+    @pytest.mark.parametrize("mode", ("copy", "hardlink", "softlink"))
+    def test_source_preserving_modes_keep_the_source_as_a_real_file(self, paths, mode):
+        source, destination = paths
+
+        result = place(
+            source, destination, Purpose.IMPORT, on_existing=OnExisting.REFUSE, config=FakeConfig(file_opts=mode)
+        )
+
+        assert result.source_survived is True
+        assert result.source_is_symlink is False, "an import must not replace the inbox file with a link"
+        assert not os.path.islink(source)
+        assert os.path.exists(destination)
+
+    def test_move_consumes_the_source(self, paths):
+        source, destination = paths
+
+        result = place(
+            source, destination, Purpose.IMPORT, on_existing=OnExisting.REFUSE, config=FakeConfig(file_opts="move")
+        )
+
+        assert result.source_survived is False
+        assert not os.path.exists(source)
+        assert open(destination, "rb").read() == b"payload"
+
+    def test_move_publishes_through_a_temporary_file_across_filesystems(self, paths):
+        source, destination = paths
+        real_link = os.link
+        calls = []
+
+        def link_once_exdev(src, dst, *args, **kwargs):
+            calls.append((src, dst))
+            if len(calls) == 1:
+                raise OSError(errno.EXDEV, "cross-device")
+            return real_link(src, dst, *args, **kwargs)
+
+        with patch("comicarr.app.common.placement.os.link", side_effect=link_once_exdev):
+            result = place(
+                source, destination, Purpose.IMPORT, on_existing=OnExisting.REFUSE, config=FakeConfig(file_opts="move")
+            )
+
+        assert result.effective_mode == "move", "a cross-filesystem move is still a move"
+        assert not os.path.exists(source)
+        assert open(destination, "rb").read() == b"payload"
+        assert not [
+            name for name in os.listdir(os.path.dirname(destination)) if name.startswith(".comicarr-import-")
+        ], "the temporary file must not be left behind"
+
+    def test_hardlink_degrades_to_an_atomic_copy_across_filesystems(self, paths):
+        source, destination = paths
+        real_link = os.link
+        calls = []
+
+        def link_first_exdev(src, dst, *args, **kwargs):
+            calls.append((src, dst))
+            if len(calls) == 1:
+                raise OSError(errno.EXDEV, "cross-device")
+            return real_link(src, dst, *args, **kwargs)
+
+        with patch("comicarr.app.common.placement.os.link", side_effect=link_first_exdev):
+            result = place(
+                source,
+                destination,
+                Purpose.IMPORT,
+                on_existing=OnExisting.REFUSE,
+                config=FakeConfig(file_opts="hardlink"),
+            )
+
+        assert result.effective_mode == "copy"
+        assert result.source_survived is True
+        assert os.path.exists(source)
+        assert open(destination, "rb").read() == b"payload"
+
+    def test_a_failed_source_unlink_undoes_the_publish(self, paths):
+        source, destination = paths
+
+        real_unlink = os.unlink
+
+        def refuse_to_unlink_the_source(path, *args, **kwargs):
+            if path == source:
+                raise OSError("busy")
+            return real_unlink(path, *args, **kwargs)
+
+        with patch("comicarr.app.common.placement.os.unlink", side_effect=refuse_to_unlink_the_source):
+            with pytest.raises(PlacementError):
+                place(
+                    source,
+                    destination,
+                    Purpose.IMPORT,
+                    on_existing=OnExisting.REFUSE,
+                    config=FakeConfig(file_opts="move"),
+                )
+
+        assert os.path.exists(source), "the source must survive a failed move"
+        assert not os.path.exists(destination), "source and destination must never both exist"
+
+    def test_never_reports_already_placed_even_for_the_same_file(self, paths):
+        """REFUSE refuses a same-file destination; it is a conflict, not a success."""
+        source, destination = paths
+        os.link(source, destination)
+
+        with pytest.raises(PlacementError):
+            place(
+                source,
+                destination,
+                Purpose.IMPORT,
+                on_existing=OnExisting.REFUSE,
+                config=FakeConfig(file_opts="hardlink"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# The failure contract
+# ---------------------------------------------------------------------------
+
+
+class TestFailuresAlwaysRaise:
+    def test_placement_error_is_an_oserror(self):
+        assert issubclass(PlacementError, OSError)
+
+    def test_a_narrow_oserror_handler_still_catches_it(self, paths):
+        """storyarcs catches (OSError, IOError); migration must stay mechanical."""
+        source, destination = paths
+
+        caught = False
+        try:
+            place(
+                source,
+                destination,
+                Purpose.SERIES,
+                on_existing=OnExisting.UNGUARDED,
+                config=FakeConfig(file_opts="move"),
+            )
+            place(
+                source,
+                destination,
+                Purpose.SERIES,
+                on_existing=OnExisting.UNGUARDED,
+                config=FakeConfig(file_opts="move"),
+            )
+        except (OSError, IOError):
+            caught = True
+
+        assert caught
+
+    def test_the_error_carries_the_context_a_log_line_needs(self, paths):
+        source, destination = paths
+
+        with pytest.raises(PlacementError) as excinfo:
+            place(
+                source,
+                destination,
+                Purpose.IMPORT,
+                on_existing=OnExisting.UNGUARDED,
+                config=FakeConfig(file_opts="teleport"),
+            )
+
+        assert excinfo.value.purpose is Purpose.IMPORT
+        assert excinfo.value.mode == "teleport"
+        assert excinfo.value.source == source
+        assert excinfo.value.destination == destination
+
+    def test_no_placement_returns_a_falsy_value(self, paths):
+        """The swallow-and-return-False shape is what let #303 stay invisible."""
+        source, destination = paths
+
+        result = place(
+            source, destination, Purpose.SERIES, on_existing=OnExisting.UNGUARDED, config=FakeConfig(file_opts="copy")
+        )
+
+        assert result
+
+
+class TestOnExistingIsRequired:
+    def test_place_refuses_to_run_without_a_policy(self, paths):
+        source, destination = paths
+
+        with pytest.raises(TypeError):
+            place(source, destination, Purpose.SERIES, config=FakeConfig())

--- a/tests/unit/test_placement_bracket_boundary.py
+++ b/tests/unit/test_placement_bracket_boundary.py
@@ -1,0 +1,109 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Architecture boundary tests for the placement stage.
+
+`place()` is journal-blind: it holds no journal import and writes no markers.
+The *caller* owns the `post_processing` / `moved` bracket, as a release-phase
+contract. That is a convention no type can enforce, so it is enforced here
+instead -- by scanning source, in the `test_fastapi_db_boundary.py` idiom, so a
+reintroduction fails even if nothing calls it.
+"""
+
+import re
+from pathlib import Path
+
+COMICARR_ROOT = Path(__file__).parents[2] / "comicarr"
+PLACEMENT = COMICARR_ROOT / "app" / "common" / "placement.py"
+
+# Every module permitted to call place(). Adding a module here is a deliberate
+# act: it means someone has decided who writes that call's journal bracket.
+PLACE_CALLERS = {
+    "comicarr/postprocessor.py",
+    "comicarr/app/storyarcs/service.py",
+    "comicarr/app/imports/finalization.py",
+}
+
+# Callers that legitimately place files outside the post-processing journal.
+# Story arcs run from a location-update pass, not a release; manual import
+# finalization has its own transactional rollback and never enters the journal.
+BRACKETLESS_CALLERS = {
+    "comicarr/app/storyarcs/service.py",
+    "comicarr/app/imports/finalization.py",
+}
+
+
+def _sources():
+    for path in COMICARR_ROOT.rglob("*.py"):
+        if "_vendor" in path.parts:
+            continue
+        yield path
+
+
+def _relative(path):
+    return str(path.relative_to(COMICARR_ROOT.parent))
+
+
+CALL = re.compile(r"(?<![\w.])place\s*\(|placement\.place\s*\(")
+
+
+def test_only_registered_modules_call_the_placement_stage():
+    callers = {_relative(path) for path in _sources() if path != PLACEMENT and CALL.search(path.read_text())}
+
+    assert callers <= PLACE_CALLERS, (
+        "unregistered module calls place(); decide who owns its journal bracket "
+        "and add it to PLACE_CALLERS: %s" % sorted(callers - PLACE_CALLERS)
+    )
+
+
+def test_post_processor_callers_also_write_the_pre_move_marker():
+    """A destructive placement in postprocessor.py must sit inside a bracket.
+
+    The marker is written per release phase rather than per call, so this checks
+    co-presence in the module rather than adjacency to any one call.
+    """
+    postprocessor = COMICARR_ROOT / "postprocessor.py"
+    source = postprocessor.read_text()
+
+    if "placement.place(" not in source and "= place(" not in source:
+        return
+
+    assert '_journal_pp("post_processing"' in source, (
+        "postprocessor.py places files but never writes the pre-move marker"
+    )
+    assert '_journal_pp("moved"' in source, "postprocessor.py places files but never writes the post-move marker"
+
+
+def test_the_placement_stage_is_journal_blind():
+    source = PLACEMENT.read_text()
+
+    assert "_journal_pp" not in source, "placement.py must not write journal markers"
+    assert "pipeline_journal" not in source
+    for marker in ('"post_processing"', '"moved"', '"post_processed"'):
+        assert marker not in source, "placement.py must not know the marker %s exists" % marker
+
+
+def test_the_placement_stage_does_not_depend_on_the_downloads_package():
+    """Imports and story arcs need placement; neither may pull in downloads to get it."""
+    source = PLACEMENT.read_text()
+
+    assert "app.downloads" not in source
+    assert "app/downloads" not in source
+
+
+def test_the_placement_stage_reads_config_lazily():
+    """A module-level `import comicarr` would let the config object be captured early."""
+    source = PLACEMENT.read_text()
+    module_level_imports = [
+        line for line in source.splitlines() if line.startswith("import ") or line.startswith("from ")
+    ]
+
+    assert not any("comicarr" in line for line in module_level_imports), (
+        "placement.py must import comicarr inside place(), so CONFIG is resolved at call time"
+    )


### PR DESCRIPTION
Closes #340. Part of #328.

First of five PRs. Adds `comicarr/app/common/placement.py` and its tests. **No call sites migrate** — nothing routes through it yet.

## What lands

`place(source, destination, purpose, *, on_existing, multiple=False, config=None) -> PlacementResult`

Callers pass **intent**, never a resolved mode. There is no public callable that accepts one, so the #303 class of bug — reading `FILE_OPTS` early and passing it down — has no parameter to travel through. Config is injected as a *source*, so the read happens inside `place()` at call time.

- `Purpose.SERIES | IMPORT | ONE_OFF | ARC` — selects the config key and the mechanics (#329)
- `OnExisting.UNGUARDED | DISPLACE | SKIP | REFUSE` — **required, no default** (#332). `UNGUARDED` covers five of eight call sites and would be the obvious default, which is exactly why it is not one: it is the policy nobody chose.
- Failures **always raise** `PlacementError(OSError)`. Subclassing `OSError` keeps storyarcs' narrow `except (OSError, IOError)` working, so migration stays mechanical.
- `PlacementResult` reports `effective_mode` *after* the EXDEV and symlink fallbacks — which today's logs misreport.

## One deviation from #329, and why

`source_survived` / `source_is_symlink` are **recorded by the mechanic that ran**, not derived from `(purpose, effective_mode)`. They aren't derivable: non-arc `softlink` moves the file and leaves a symlink standing at the source path, arc `softlink` doesn't touch the source at all, and `REFUSE`'s publish is a third shape again. Deriving would have re-introduced the guessing #335's rollback logic depends on not doing.

## Tests

`tests/unit/test_placement.py` — 52 tests: four modes × four policies, arc and non-arc, and the fallback paths `file_ops` never had coverage for (#331 measured `filesystem.py:121-132`, `:145`, `:175-197` as uncovered): the EXDEV hardlink drop to copy, the softlink `OSError` drop to copy, and the atomic no-clobber publish including its cross-filesystem temp path.

`tests/unit/test_placement_bracket_boundary.py` — the architecture test from #333, in the `test_fastapi_db_boundary.py` source-scan idiom: `place()` is journal-blind, `placement.py` doesn't import `app/downloads/`, `comicarr` is imported lazily so `CONFIG` can't be captured early, and the caller list is frozen so a new placement call has to declare who brackets it. The `file_ops`-appears-nowhere assertion from #334 lands in PR 5 — it cannot pass until the last caller is gone.

## Verification

- `tests/unit`: **1776 passed** (was 1719 — +57 new, zero changed)
- `npm run lint:modern` and `lint:backend`: clean, `ruff format` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5xobNiC6LwrYsSy5w8cZR