### PR TITLE
fix: Stop Mylar3 config migration discarding every setting

### DIFF
--- a/.changeset/olive-cups-repeat.md
+++ b/.changeset/olive-cups-repeat.md
@@ -1,0 +1,9 @@
+---
+"comicarr": patch
+---
+
+Fix Mylar3 config migration discarding every setting when the source config used NZBsu or DOGnzb
+
+`_BAD_DEFINITIONS` carried seven remapping entries for NZBsu and DOGnzb — providers Mylar3 shipped built in and Comicarr no longer defines. `migrate_mylar3_config` reads that table independently of `_CONFIG_DEFINITIONS`, so a `config.ini` with an `[NZBsu]` or `[DOGnzb]` section produced keys nothing could define. `process_kwargs` then raised `KeyError` inside `writeconfig`, and the caller swallowed it as "config migration failed (data migration succeeded)" — so all 400+ settings were dropped and the install came up on defaults, with one log line as the only trace.
+
+The seven entries are removed, and the migration now skips any undefined key with a warning instead of losing the whole batch to it.

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -583,13 +583,11 @@ _BAD_DEFINITIONS = OrderedDict(
         "ENABLE_PUBLIC": ("Torrents", "ENABLE_TPSE"),
         "PUBLIC_VERIFY": ("Torrents", "TPSE_VERIFY"),
         "IGNORED_PUBLISHERS": ("CV", "BLACKLISTED_PUBLISHERS"),
-        "NZBSU": ("NZBsu", "nzbsu", bool, None),
-        "NZBSU_UID": ("NZBsu", "nzbsu_uid", str, None),
-        "NZBSU_APIKEY": ("NZBsu", "nzbsu_apikey", str, None),
-        "NZBSU_VERIFY": ("NZBsu", "nzbsu_verify", bool, None),
-        "DOGNZB": ("DOGnzb", "dognzb", bool, None),
-        "DOGNZB_APIKEY": ("DOGnzb", "dognzb_apikey", str, None),
-        "DOGNZB_VERIFY": ("DOGnzb", "dognzb_verify", bool, None),
+        # NZBsu and DOGnzb entries were removed here. They remapped onto keys
+        # Comicarr does not define, and migrate_mylar3_config reads this dict
+        # independently of _CONFIG_DEFINITIONS -- so migrating a Mylar3 config
+        # that used either provider handed writeconfig an undefined key,
+        # process_kwargs raised KeyError, and every setting was discarded.
         "SAB_DIRECT_UNPACK": ("SABnzbd", "SAB_TO_MYLAR"),
     }
 )
@@ -1243,11 +1241,7 @@ class Config(object):
     def _define(self, name):
         key = name.upper()
         ini_key = name.lower()
-        definition = _CONFIG_DEFINITIONS[key]
-        if len(definition) == 3:
-            definition_type, section, default = definition
-        elif len(definition) == 4:
-            definition_type, section, _, default = definition
+        definition_type, section, default = _CONFIG_DEFINITIONS[key]
         return key, definition_type, section, ini_key, default
 
     def _provider_max_id(self):

--- a/comicarr/migration.py
+++ b/comicarr/migration.py
@@ -485,6 +485,15 @@ def migrate_mylar3_config(source_path):
                     logger.warn("[MIGRATION] Failed to encrypt %s, skipping" % key)
                     del values[key]
 
+    # Drop anything config cannot define before handing the batch over.
+    # process_kwargs raises KeyError on an undefined key, and the caller treats
+    # that as "config migration failed" -- so one stray key silently costs the
+    # user every other setting in this dict. Skipping it costs only that key.
+    undefined = [key for key in values if key not in _CONFIG_DEFINITIONS]
+    for key in undefined:
+        logger.warn("[MIGRATION] Skipping %s — no config definition for it in this version" % key)
+        del values[key]
+
     # Write config atomically
     comicarr.CONFIG.writeconfig(values)
     logger.info("[MIGRATION] Config migration completed — %d settings imported" % len(values))

--- a/tests/unit/test_mylar3_config_migration.py
+++ b/tests/unit/test_mylar3_config_migration.py
@@ -1,0 +1,154 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Migrating a Mylar3 config must not lose every setting to one unknown key.
+
+`_BAD_DEFINITIONS` carried seven entries for NZBsu and DOGnzb -- providers
+Mylar3 shipped built in and Comicarr removed. `migrate_mylar3_config` iterates
+that dict independently of `_CONFIG_DEFINITIONS`, so a source config with an
+`[NZBsu]` or `[DOGnzb]` section produced `values["NZBSU"]`, which has no
+definition. `process_kwargs` then raised `KeyError` inside `writeconfig`, and
+the caller at `migration.py:369` swallows it as "config migration failed (data
+migration succeeded)" -- discarding all 400+ settings and leaving the user on
+defaults with a single log line as the only trace.
+"""
+
+import configparser
+
+import pytest
+
+from comicarr.config import _BAD_DEFINITIONS, _CONFIG_DEFINITIONS
+
+MYLAR3_CONFIG = """
+[General]
+annuals_on = True
+search_delay = 4
+
+[Import]
+comic_dir = /comics
+
+[NZBsu]
+nzbsu = True
+nzbsu_uid = someuid
+nzbsu_apikey = deadbeef
+
+[DOGnzb]
+dognzb = True
+dognzb_apikey = cafebabe
+
+[Torrents]
+enable_tpse = True
+"""
+
+
+def _remapped_values(source_text):
+    """The `_BAD_DEFINITIONS` remapping loop from `migrate_mylar3_config`."""
+    source = configparser.RawConfigParser()
+    source.read_string(source_text)
+
+    values = {}
+    for new_key, bad_def in _BAD_DEFINITIONS.items():
+        if len(bad_def) < 2:
+            continue
+        old_section, old_key = bad_def[0], bad_def[1]
+        if old_key is None:
+            continue
+        try:
+            raw = source.get(old_section, old_key.lower())
+        except (configparser.NoOptionError, configparser.NoSectionError):
+            continue
+        if raw is not None and new_key not in values:
+            values[new_key] = raw.strip()
+    return values
+
+
+class TestBadDefinitionsStayDefinable:
+    """Every remapping target must be a key `process_kwargs` can actually define."""
+
+    def test_no_bad_definition_targets_an_undefined_key(self):
+        undefined = sorted(key for key in _BAD_DEFINITIONS if key not in _CONFIG_DEFINITIONS)
+
+        assert undefined == [], (
+            "_BAD_DEFINITIONS remaps onto keys config cannot define: %s. "
+            "migrate_mylar3_config will hand these to writeconfig, process_kwargs "
+            "will raise KeyError, and the entire config migration is discarded." % undefined
+        )
+
+    def test_mylar3_config_with_removed_providers_yields_only_definable_keys(self):
+        values = _remapped_values(MYLAR3_CONFIG)
+
+        undefined = sorted(key for key in values if key not in _CONFIG_DEFINITIONS)
+
+        assert undefined == [], "migrating a Mylar3 config produced undefined keys: %s" % undefined
+
+    def test_the_legacy_rename_still_migrates(self):
+        """The guard must not cost us the remappings that do work."""
+        values = _remapped_values(MYLAR3_CONFIG)
+
+        assert values.get("ENABLE_PUBLIC") == "True", "enable_tpse -> ENABLE_PUBLIC remapping was lost"
+
+    @pytest.mark.parametrize("definition", _BAD_DEFINITIONS.values())
+    def test_every_bad_definition_is_a_2_tuple(self, definition):
+        """The 4-tuple form was only ever used by the seven orphaned entries.
+
+        `migration.py` reads `bad_def[0]` and `bad_def[1]` and ignores the rest,
+        so a 4-tuple's declared type and default were never consulted anywhere.
+        """
+        assert len(definition) == 2, "unexpected _BAD_DEFINITIONS arity: %r" % (definition,)
+
+
+class TestUndefinedKeysAreSkippedNotFatal:
+    """Defence in depth: one unknown key must cost only that key."""
+
+    def test_a_stray_key_costs_only_itself(self, tmp_path, monkeypatch):
+        """Drives the real `migrate_mylar3_config` with a key nothing defines."""
+        import comicarr
+        from comicarr import migration
+
+        (tmp_path / "config.ini").write_text(MYLAR3_CONFIG + "\n[Bogus]\nnot_a_real_key = 1\n")
+
+        captured = {}
+
+        class FakeConfig:
+            SECURE_DIR = str(tmp_path / ".secure")
+
+            def writeconfig(self, values):
+                # Stand in for process_kwargs, which raises on an undefined key.
+                for key in values:
+                    _CONFIG_DEFINITIONS[key]
+                captured.update(values)
+                return True
+
+        monkeypatch.setattr(comicarr, "CONFIG", FakeConfig(), raising=False)
+        monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path), raising=False)
+        monkeypatch.setattr(migration.encrypted, "_get_fernet", lambda: object())
+
+        migration.migrate_mylar3_config(str(tmp_path))
+
+        assert captured, "config migration produced nothing — the write was discarded"
+        assert captured["COMIC_DIR"] == "/comics"
+        assert captured["ANNUALS_ON"] == "True"
+        assert captured["ENABLE_PUBLIC"] == "True", "the enable_tpse remapping must survive"
+        assert all(key in _CONFIG_DEFINITIONS for key in captured)
+
+
+class TestDefineHandlesOnly3Tuples:
+    """`_CONFIG_DEFINITIONS` is uniformly 3-tuples, so `_define` need not branch."""
+
+    def test_every_definition_is_a_3_tuple(self):
+        wrong = {key: value for key, value in _CONFIG_DEFINITIONS.items() if len(value) != 3}
+
+        assert wrong == {}, "_CONFIG_DEFINITIONS is no longer uniformly 3-tuples: %s" % wrong
+
+    def test_define_unpacks_a_real_key(self):
+        from comicarr.config import Config
+
+        key, definition_type, section, ini_key, default = Config._define(object.__new__(Config), "annuals_on")
+
+        assert (key, definition_type, section, ini_key, default) == ("ANNUALS_ON", bool, "General", "annuals_on", False)


### PR DESCRIPTION
## Summary

Started as [#367](https://github.com/frankieramirez/comicarr/issues/367), a dead-code cleanup. It is not dead code — it is a **live data-loss bug** on the Mylar3 upgrade path, and the "unreachable" finding only held for `check_setting`.

Migrating a Mylar3 `config.ini` that used **NZBsu or DOGnzb** — both Mylar3 built-in providers — silently discarded **every** config setting. The install came up on defaults with one log line as the only trace.

## The failure

`_BAD_DEFINITIONS` carried seven entries remapping old NZBsu/DOGnzb option names onto keys Comicarr no longer defines. `check_setting` never reaches them (it iterates `_CONFIG_DEFINITIONS` and looks *up* into `_BAD_DEFINITIONS`) — which is why #367 called them dead. But `migrate_mylar3_config` iterates `_BAD_DEFINITIONS` **directly** (`migration.py:441`), so:

1. Source config has `[NZBsu] nzbsu = True` → `values["NZBSU"] = "True"`
2. `writeconfig(values)` → `process_kwargs` → `_define("NZBSU")` → `_CONFIG_DEFINITIONS["NZBSU"]` → **`KeyError`**
3. `migration.py:369` catches it: `"Config migration failed (data migration succeeded)"`
4. All 400+ settings gone. Database migrated fine, so the failure looks like a successful upgrade.

Reproduced against a representative Mylar3 config — five of six remapped keys were undefined, any one of which is fatal to the batch.

## Changes

- **Remove the seven orphaned `_BAD_DEFINITIONS` entries.** These providers no longer exist in Comicarr; there is nowhere to migrate their settings to, so dropping them is the correct behaviour, not merely the safe one.
- **Skip undefined keys with a warning before `writeconfig`** (`migration.py`). Defence in depth: this failure mode costs the user *everything* for one bad key, and the guard reduces it to costing that key. Without it the same total loss can recur from any future remapping typo.
- **Collapse `_define`'s `len(definition)` branch.** All 411 `_CONFIG_DEFINITIONS` values are 3-tuples, so the 4-arity arm was genuinely unreachable — and its unpack order (`type, section, _, default`) never matched the `_BAD_DEFINITIONS` 4-tuple order (`section, oldkey, type, default`) anyway, so it could not have handled them correctly even if reached.

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset`
- [ ] No app release impact; no changeset needed

`patch` — data-loss fix on the Mylar3 upgrade path.

## Testing

- [x] Tests pass locally (`pytest tests/unit -v`) — **1825 passed** (1814 + 11 new)
- [x] Backend lint/format (`ruff check comicarr/` and `ruff format --check comicarr/`)
- [x] `npm run lint:modern`
- [ ] Frontend — n/a, no frontend files touched
- [x] **Regression-verified**: reverted the two source files with the new tests in place and confirmed they go red (`test_a_stray_key_costs_only_itself` fails with the exact `KeyError`), then restored and confirmed green. The tests fail without the fix.

New `tests/unit/test_mylar3_config_migration.py` covers: no `_BAD_DEFINITIONS` target is undefined; a realistic Mylar3 config yields only definable keys; the `enable_tpse → ENABLE_PUBLIC` remapping still works (the guard must not cost us the remappings that do); `_BAD_DEFINITIONS` is uniformly 2-tuples; `_CONFIG_DEFINITIONS` is uniformly 3-tuples.

## Additional Notes

Found while working [#367](https://github.com/frankieramirez/comicarr/issues/367) under the settings-registry map ([#354](https://github.com/frankieramirez/comicarr/issues/354)). The registry work did not cause this — it surfaced it, because pinning the entry shape forced an audit of every definition arity.

Resolves #367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qn2sB6iMLTpiXiuwzpBWz9
