### PR TITLE
fix: Upgrade nuqs to 2.9.2 before the shared table hook lands

### DIFF
--- a/.changeset/upgrade-nuqs-to-2-9-2.md
+++ b/.changeset/upgrade-nuqs-to-2-9-2.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Upgrade `nuqs` to 2.9.2, which fixes an upstream bug where URL-backed state could permanently desync from the URL after React discarded a render (nuqs#1501). The library's React Router adapter on React 19 was affected, and the Library page's sorting, filtering and pagination are the state this repo keeps in the URL.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,7 +27,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "lucide-react": "^1.8.0",
-        "nuqs": "^2.9.0",
+        "nuqs": "^2.9.2",
         "react": "^19.2.0",
         "react-day-picker": "^10.0.1",
         "react-dom": "^19.2.5",
@@ -117,12 +117,6 @@
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
-    },
-    "node_modules/@ai-sdk/provider-utils/node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -2085,9 +2079,9 @@
       }
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -3415,13 +3409,6 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/@vitest/expect/node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/mocker": {
       "version": "4.1.10",
@@ -5327,12 +5314,12 @@
       }
     },
     "node_modules/nuqs": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-2.9.0.tgz",
-      "integrity": "sha512-1ckQBhVHaQYjLZ3kWhhH40A32lPJ7TNTQMa2T+SUvl5azyVt7swCQfUXt9xOXJV3YidWq8VHIHcMzVAJ0knRsw==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-2.9.2.tgz",
+      "integrity": "sha512-SUrBU5PfLckv2SAquHkYs76s603vbjl2OLEc+jlL3sITwvJDbE/fg3vN7l9Rdp4WIUs6E0QD+m3DfH9QUQfLkg==",
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "1.0.0"
+        "@standard-schema/spec": "1.1.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/franky47"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
     "lucide-react": "^1.8.0",
-    "nuqs": "^2.9.0",
+    "nuqs": "^2.9.2",
     "react": "^19.2.0",
     "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.5",


### PR DESCRIPTION
Resolves #368, unblocking #360 on the [useTableState map](https://github.com/frankieramirez/comicarr/issues/353).

## Why

`nuqs` 2.9.0 and 2.9.1 carry an upstream bug ([nuqs#1501](https://github.com/47ng/nuqs/issues/1501)) where `useQueryState(s)` **permanently** desyncs from the URL after React discards a render. It is fixed in 2.9.2.

This repo was on the affected configuration, not just an affected version: `src/App.tsx:10` imports `NuqsAdapter` from `nuqs/adapters/react-router/v7` on React 19, and `SeriesTable.tsx` is the only nuqs consumer — so the blast radius was the Library page's sort, filter and pagination state.

The fix is three lines in nuqs' own `useQueryStates.ts` ([nuqs#1502](https://github.com/47ng/nuqs/pull/1502)): a render-phase recovery when the mirrored `internalState` drifts from the authoritative `stateRef.current`.

## What changed

`frontend/package.json` `^2.9.0` → `^2.9.2`, and the lockfile follows.

Raising the declared floor rather than only moving the lock is deliberate — it stops a fresh `npm install` resolving back onto 2.9.0/2.9.1. The only other lockfile movement is nuqs' own dependency `@standard-schema/spec` 1.0.0 → 1.1.0, which dedupes against the copy vitest already pulled in. No source changes.

## Verification

`npm run lint` clean; `npm --prefix frontend test` 141/141 across 27 files; production build succeeds.

Beyond that, a manual pass against a **production build in Chrome**, since the existing tests do not cover the back/forward path. The real database holds one series, so pagination was not exercisable against it; the production build was served behind a throwaway proxy forwarding to the live backend for real auth, overriding only `GET /api/series` with 63 synthetic rows. Data synthetic; router, adapter, build and browser real.

| Step | Result |
|---|---|
| page next ×2, prev | rows 20–39 / 40–59 / 20–39, URL in step |
| sort change while on `page=1` | `?sort=ComicName.asc`, `page` dropped in the same write |
| status filter while on `page=1` | `page` dropped, sort preserved, only paused rows |
| search (300ms) while on `page=1` | `?search=Marvel`, `page` dropped — the mixed 300ms/50ms batch collapses correctly |
| back/forward across a route change | state restored exactly, round-trip stable |

`history.length` never grew, confirming `history: "replace"` is not being escalated by a batched key.

## Notes for the map

- The research in #356 was pinned to 2.9.0. I re-checked its load-bearing findings against the installed 2.9.2 `dist/` rather than the changelog: the three batching rules are byte-identical and the synchronous `emitter.emit` is unchanged, so the shared hook's `setParams({ sort, page: null })` plan is unaffected. Two findings get *stronger* — 2.9.1 [#1480](https://github.com/47ng/nuqs/pull/1480) makes `limitUrlUpdates` precedence true in code and not merely in the docs, and [#1469](https://github.com/47ng/nuqs/pull/1469) reinforces the single-emitter premise. This also discharges #356's owed production-build caveat.
- The pass surfaced a **pre-existing** defect: a cold load of `/library?page=2` renders page 0 and strips `page`, because the clamp at `SeriesTable.tsx:267-276` runs while `data` is still empty. A/B'd against `nuqs@2.9.0` on the same build with the same data — identical wrong result, so it is neither caused nor fixed by this bump. Left untouched here so a regression has one obvious suspect; filed as #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Et1eFmQyJUBncfpsWWvSJC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of URL-backed sorting, filtering, and pagination on the Library page.
  * Prevented state from becoming out of sync with the URL after certain React rendering updates.
* **Chores**
  * Updated the underlying URL state handling package to improve React Router compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->