### PR TITLE
fix: Keep a deep-linked page on the Library table

### DIFF
--- a/.changeset/keep-deep-linked-library-page.md
+++ b/.changeset/keep-deep-linked-library-page.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix the Library page dropping a deep-linked page number. Opening or reloading `/library?page=2` rendered the first page and stripped `page` from the URL, so bookmarks and shared links always landed on page one. Two independent causes had to be addressed: the page-clamp effect ran while the series list was still empty, and TanStack Table's automatic page reset fired after the first render that had rows, undoing the page the URL asked for. A page number that is genuinely out of range still settles onto the last page, and changing the row set still returns you to the first page.

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   useReactTable,
@@ -152,6 +152,18 @@ export default function SeriesTable({
     [effectivePage, pageSize],
   );
 
+  // Auto-reset is armed one render AFTER data first arrives, so the arrival
+  // itself never resets the page. TanStack queues `_autoResetPageIndex` onto a
+  // microtask that runs after the render which consumed the row model — by then
+  // the render-time clamp has already raised `pageIndex` to the deep-linked
+  // page, so an unarmed reset's 0 differs from it, passes the handler's guard
+  // below, and strips `?page` from the URL. Gating on a ref works because the
+  // option is read synchronously during that render, not inside the microtask.
+  const seenData = useRef(false);
+  useEffect(() => {
+    if (data.length > 0) seenData.current = true;
+  });
+
   const selectedSeriesIds = useMemo(() => {
     return Object.keys(rowSelection).filter((id) => rowSelection[id]);
   }, [rowSelection]);
@@ -254,6 +266,7 @@ export default function SeriesTable({
       setConfirmDelete(false);
       setRowSelection(updater);
     },
+    autoResetPageIndex: seenData.current,
     getRowId: (row) => row.ComicID,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
@@ -265,6 +278,11 @@ export default function SeriesTable({
   const pageCount = table.getPageCount();
 
   useEffect(() => {
+    // Rows have not arrived yet, so `pageCount` is 0 and says nothing about
+    // whether the requested page exists. Clamping here is what strips `?page`
+    // from a cold deep link.
+    if (data.length === 0) return;
+
     const maxPage = Math.max(0, pageCount - 1);
     const clampedPage = Math.min(Math.max(localPage, 0), maxPage);
 

--- a/frontend/tests/components/SeriesTable.test.tsx
+++ b/frontend/tests/components/SeriesTable.test.tsx
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { NuqsAdapter } from "nuqs/adapters/react-router/v7";
-import { render, screen } from "../test-utils";
+import { act, render, screen } from "../test-utils";
 import SeriesTable from "@/components/series/SeriesTable";
 import type { Comic } from "@/types";
 
@@ -20,7 +20,34 @@ function series(count: number): Comic[] {
   });
 }
 
+/**
+ * Record every URL the app commits, so a page param that is stripped and never
+ * restored cannot hide behind the final assertion.
+ */
+function recordUrlWrites(): string[] {
+  const urls: string[] = [];
+  for (const method of ["pushState", "replaceState"] as const) {
+    const original = window.history[method].bind(window.history);
+    vi.spyOn(window.history, method).mockImplementation((...args) => {
+      original(...args);
+      urls.push(window.location.pathname + window.location.search);
+    });
+  }
+  return urls;
+}
+
+/** Let nuqs' setTimeout flush and TanStack's queued microtasks drain. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+  });
+}
+
 describe("SeriesTable", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("shows the next page when pagination advances", async () => {
     const user = userEvent.setup();
     window.history.pushState({}, "", "/library");
@@ -35,5 +62,85 @@ describe("SeriesTable", () => {
 
     expect(screen.getByText("Series 21")).toBeTruthy();
     expect(screen.queryByText("Series 1")).toBeNull();
+  });
+
+  // Regression: a cold load of /library?page=2 used to render page 0 and strip
+  // `page` from the URL. Two independent causes, one symptom — the page-clamp
+  // effect running while `data` was still empty, and TanStack's auto-reset
+  // firing on a microtask after the render-time clamp had already raised
+  // `pageIndex` to the requested page. See wayfinder #372 / #381.
+  it("keeps a deep-linked page when rows arrive after mount", async () => {
+    window.history.pushState({}, "", "/library?page=2");
+    const urls = recordUrlWrites();
+
+    const { rerender } = render(
+      <NuqsAdapter>
+        <SeriesTable data={[]} isLoading />
+      </NuqsAdapter>,
+    );
+    await settle();
+
+    rerender(
+      <NuqsAdapter>
+        <SeriesTable data={series(63)} />
+      </NuqsAdapter>,
+    );
+    await settle();
+
+    // Page 2 at 20 rows a page is Series 41–60.
+    expect(screen.getByText("Series 41")).toBeTruthy();
+    expect(screen.queryByText("Series 1")).toBeNull();
+
+    expect(new URLSearchParams(window.location.search).get("page")).toBe("2");
+    for (const url of urls) {
+      expect(new URLSearchParams(url.split("?")[1] ?? "").get("page")).toBe(
+        "2",
+      );
+    }
+  });
+
+  it("clamps a genuinely out-of-range deep link once rows are known", async () => {
+    window.history.pushState({}, "", "/library?page=99");
+
+    const { rerender } = render(
+      <NuqsAdapter>
+        <SeriesTable data={[]} isLoading />
+      </NuqsAdapter>,
+    );
+    await settle();
+
+    rerender(
+      <NuqsAdapter>
+        <SeriesTable data={series(63)} />
+      </NuqsAdapter>,
+    );
+    await settle();
+
+    // 63 rows at 20 a page is pages 0–3, so the last page is Series 61–63.
+    expect(screen.getByText("Series 61")).toBeTruthy();
+    expect(new URLSearchParams(window.location.search).get("page")).toBe("3");
+  });
+
+  it("still resets to the first page when the row set changes later", async () => {
+    window.history.pushState({}, "", "/library?page=2");
+
+    const { rerender } = render(
+      <NuqsAdapter>
+        <SeriesTable data={series(63)} />
+      </NuqsAdapter>,
+    );
+    await settle();
+    expect(screen.getByText("Series 41")).toBeTruthy();
+
+    // e.g. a bulk delete lands and the query refetches.
+    rerender(
+      <NuqsAdapter>
+        <SeriesTable data={series(61)} />
+      </NuqsAdapter>,
+    );
+    await settle();
+
+    expect(screen.getByText("Series 1")).toBeTruthy();
+    expect(new URLSearchParams(window.location.search).get("page")).toBeNull();
   });
 });


### PR DESCRIPTION
Resolves [Ship the deep-linked-page pre-fix on SeriesTable](https://github.com/frankieramirez/comicarr/issues/381) on map [Wayfinder: One useTableState hook for every table](https://github.com/frankieramirez/comicarr/issues/353). Mechanism was established on [#372](https://github.com/frankieramirez/comicarr/issues/372); this ships it ahead of the `useTableState` seam.

## The bug

A cold load of `/library?page=2` rendered page 0 and stripped `page` from the URL. Bookmarks and shared links to any page but the first silently lost the page.

## Two causes, both live, neither sufficient alone

**1. The clamp effect wrote on empty data** (`SeriesTable.tsx:280`). Before rows arrive, `pageCount` is 0, so `maxPage` is 0 and any requested page clamps to 0 — the effect then writes `page: null`. It now returns early while `data` is empty; once rows are known the clamp is meaningful again.

**2. Auto-reset lands one microtask too late.** `_autoResetPageIndex` queues onto a microtask that runs *after* the render which consumed the row model. By then the render-time clamp has already raised `pageIndex` to the requested page, so the reset's 0 differs from it, passes `onPaginationChange`'s guard, and writes `page: null`.

`autoResetPageIndex` is now armed one render after `data` first becomes non-empty:

```ts
const seenData = useRef(false);
useEffect(() => {
  if (data.length > 0) seenData.current = true;
});
// ...
autoResetPageIndex: seenData.current,
```

This preserves today's reset-on-data-change, which `autoResetPageIndex: false` would silently drop. Gating on a ref read during render is sound because `table.options.autoResetPageIndex` is read **synchronously** inside `_autoResetPageIndex` (`table-core/features/RowPagination.js:49`), not inside the queued microtask.

I verified independently that each half alone leaves the regression test failing — reverting either one reproduces the bug.

## Why pre-fix rather than fix during the migration

The `autoResetPageIndex` line transfers verbatim into `useTableState`; only the effect guard is throwaway (the effect is deleted outright at migration). And the regression test can only be written against working code, which makes it the concrete parity artifact [#365](https://github.com/frankieramirez/comicarr/issues/365) needs while still blocked.

## Behaviour note

An out-of-range `?page=99` renders the last page and the URL is rewritten to `?page=3`. #372's *no URL tidying* describes the post-migration state, where the effect is gone entirely; while the effect survives as the throwaway half, this stays as it is today. Captured as a test so the change is visible when the effect is deleted.

## Tests

Three cases in `frontend/tests/components/SeriesTable.test.tsx`:
- deep-linked `?page=2` with rows arriving after mount — page 2 renders and `page` is never stripped from any URL the app commits
- out-of-range `?page=99` settles onto the last page
- a later row-set change still resets to page 0

Full frontend suite: 143 passed / 27 files. `typecheck`, `lint:frontend`, `lint:modern` and `lint:backend` all clean.

## Scope

Deliberately excluded, per #372: `IssuesTable`'s stale-key decode and `ActivityPage.tsx:590`'s index-embedded row id. Those stay under the map's *Where the two identity fixes ship*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TGrvFNfYXfV5U1aMMZvHb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Library pagination for deep links, preserving URLs such as `/library?page=2` after reload.
  * Out-of-range page numbers now settle on the last available page.
  * When the underlying results change, pagination correctly returns to the first page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->