### PR TITLE
docs: Record when a refactor earns a changeset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ Default HTTP port is **8090**. Vite dev proxy targets `http://localhost:8090` (o
 
 Releases are automated via Changesets. See the `releases` skill (`.claude/skills/releases/SKILL.md`) for the full workflow.
 
+**When a refactor earns a changeset:** when it changes something an *operator* could observe. Pure internal restructuring with verified-identical behaviour does not get one, and neither does tooling/CI-only work — `changeset-status.yml` treats a missing changeset as an allowed warning for exactly that. A change only a *contributor* can observe (a new lint gate, a type that now rejects a bad key) is documented here, not in the changelog.
+
 ## Branch & PR Conventions
 
 **Branch names** must use a conventional prefix with `/` separator:


### PR DESCRIPTION
Closes #378. Part of the [Settings key registry](https://github.com/frankieramirez/comicarr/issues/354) map.

Two wayfinder maps of the same shape got opposite changeset treatment, and nothing in `CLAUDE.md` distinguished them:

| Map | Refactor PRs | Changesets |
|---|---|---|
| [One placement seam for every file operation](https://github.com/frankieramirez/comicarr/issues/328) | #348, #351, #352 | one patch each |
| [Settings key registry](https://github.com/frankieramirez/comicarr/issues/354) | #371, #376 | none |

Resolving #378 settled that the registry refactor gets **no** retroactive changeset — the map's one user-visible change (the Mylar3 data-loss fix) already shipped logged in 0.20.5, and a changeset added now would land in 0.20.7 claiming work that shipped in 0.20.5/0.20.6. This records the rule behind that call so the next map doesn't re-litigate it.

**The test is observable behaviour, which is what actually separated the two cases.** The placement refactors changed whether the file operation setting was honoured — an operator using a link mode stopped losing source files on every manual import. The registry migration was verified in #362 to preserve keys, values *and* `OrderedDict` order before anything was deleted, so nothing an operator could see moved.

The rule also records two things confirmed empirically while resolving #378:

- Tooling/CI-only work needs no changeset — #380 merged with none and `Changeset Status` passed. Reading `changeset-status.yml`, that is by design: a `no unreleased changesets` exit becomes a `> [!WARNING]` step-summary block and `exit 0`.
- Contributor-facing changes (a new lint gate, a generated type that now rejects a bad key) belong in `CLAUDE.md` rather than a user-facing changelog — which is where #380 already put the codegen freshness check.

Docs only, so no changeset — which is the rule applying to itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qn2sB6iMLTpiXiuwzpBWz9
