### PR TITLE
fix: Re-raise SystemExit after config transaction rollback

### DIFF
--- a/.changeset/apply-transaction-systemexit-reraise.md
+++ b/.changeset/apply-transaction-systemexit-reraise.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Re-raise SystemExit after config transaction rollback instead of swallowing it as a failed save

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -1200,6 +1200,10 @@ class Config(object):
                     # but already-completed external effects are not reversible here.
                     self.configure(update=True, startup=False)
                 return True
+            # BaseException is deliberate: rollback must run even for
+            # interpreter-exiting exceptions (a torn config.ini is worse than a
+            # cancelled save); the isinstance re-raise below preserves their
+            # propagation once state is restored.
             except BaseException as e:
                 comicarr.PROVIDER_START_ID = provider_start_id
                 durable_write_happened = self._durable_write_changed(config_path, file_existed, file_contents)
@@ -1226,7 +1230,7 @@ class Config(object):
                         % (runtime_ok, file_ok)
                     )
                 logger.error("[CONFIG] Transactional update failed: %s" % e)
-                if isinstance(e, (KeyboardInterrupt, GeneratorExit)):
+                if isinstance(e, (KeyboardInterrupt, SystemExit, GeneratorExit)):
                     raise
                 return False
 

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -2206,14 +2206,15 @@ class TestConfigTransactions:
         writer.assert_called_once_with()
 
     def test_transaction_restores_state_when_configure_raises_system_exit(self, tmp_path, monkeypatch):
-        """SystemExit from legacy configure cannot bypass transactional rollback."""
+        """SystemExit from legacy configure rolls back, then propagates."""
         cfg, config_path, config_module = _make_real_config(tmp_path, monkeypatch)
         cfg.process_kwargs({"COMIC_DIR": "/old/library"})
         assert cfg.writeconfig() is True
         original_file = config_path.read_bytes()
         cfg.configure = MagicMock(side_effect=SystemExit(1))
 
-        assert cfg.apply_transaction({"COMIC_DIR": "/new/library"}) is False
+        with pytest.raises(SystemExit):
+            cfg.apply_transaction({"COMIC_DIR": "/new/library"})
 
         assert cfg.COMIC_DIR == "/old/library"
         assert config_module.config.get("Import", "comic_dir") == "/old/library"


### PR DESCRIPTION
## Summary

Resolves wayfinder ticket #379 (map #354).

The ticket asked whether `apply_transaction`'s `except BaseException` should narrow to `except Exception`. The answer is **no** — the breadth is deliberate — but the investigation surfaced one real inconsistency, fixed here.

**Decision (kept as-is):**
- The #301 unknown-key `KeyError` mode is structurally dead: all five call sites pass hardcoded registry-defined keys, filter through `WRITABLE_CONFIG_KEYS`, or take the provider path that never calls `process_kwargs`.
- The broad catch earns its place on different grounds: rollback of a half-written `config.ini` must run even for interpreter-exiting exceptions (Ctrl-C mid-save), which then re-raise. Narrowing would reintroduce torn-file risk for zero lint gain (`E722` only flags bare `except:`).

**Changes:**
- `SystemExit` joins the post-rollback re-raise tuple — previously it was rolled back but swallowed into `return False`, silently cancelling an intentional shutdown. `KeyboardInterrupt` and `GeneratorExit` already propagated.
- A comment above the `except` states the breadth is deliberate and why, so this question doesn't get re-filed.
- Updated `test_transaction_restores_state_when_configure_raises_system_exit` to pin the new contract: rollback still completes, then `SystemExit` propagates.

## Test plan
- `uv run pytest tests/unit/test_system_domain.py` — 122 passed
- `npm run lint:modern`, `lint:backend`, `lint:generated` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xTgfvXeALAf2XoWK7N5Hw