### PR TITLE
fix: Prune filtered-out rows from the Library selection

### DIFF
--- a/.changeset/prune-filtered-library-selection.md
+++ b/.changeset/prune-filtered-library-selection.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix the Library table keeping a filtered-out series selected. Selecting a series and then filtering it out of view left it selected: the bulk bar still read "1 selected" and Delete, Pause, and Resume would still act on a series you could no longer see. The selection now follows the view — a series the filters remove is dropped from the selection, and comes back deselected when the filter is cleared. Selections still survive paging, since a series on another page is only out of sight, not filtered out.

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -164,10 +164,6 @@ export default function SeriesTable({
     if (data.length > 0) seenData.current = true;
   });
 
-  const selectedSeriesIds = useMemo(() => {
-    return Object.keys(rowSelection).filter((id) => rowSelection[id]);
-  }, [rowSelection]);
-
   const handleBulkDelete = async () => {
     if (!confirmDelete) {
       setConfirmDelete(true);
@@ -274,6 +270,32 @@ export default function SeriesTable({
     getPaginationRowModel: getPaginationRowModel(),
     enableRowSelection: true,
   });
+
+  // Selected ids come from the row model, never from raw `rowSelection` keys —
+  // the raw keys are what kept a filtered-away row a target of bulk
+  // delete/pause/resume (see #390, the #307 class).
+  const selectedRows = table.getSelectedRowModel().rows;
+  const selectedSeriesIds = useMemo(
+    () => selectedRows.map((row) => row.id),
+    [selectedRows],
+  );
+
+  // TanStack never prunes stale selection ids, by design, and the header
+  // checkbox counts raw state — so deriving outputs above is not enough on its
+  // own. Drop ids whose rows the filters removed, mirroring WantedTable and
+  // UpcomingTable. Keyed on the filtered row model, not the page model, so
+  // paging away from a selected row never clears it.
+  const filteredRows = table.getFilteredRowModel().rows;
+  useEffect(() => {
+    setRowSelection((prev) => {
+      const selected = Object.keys(prev).filter((id) => prev[id]);
+      if (selected.length === 0) return prev;
+      const present = new Set(filteredRows.map((row) => row.id));
+      const kept = selected.filter((id) => present.has(id));
+      if (kept.length === selected.length) return prev;
+      return Object.fromEntries(kept.map((id) => [id, true]));
+    });
+  }, [filteredRows]);
 
   const pageCount = table.getPageCount();
 

--- a/frontend/tests/components/SeriesTable.test.tsx
+++ b/frontend/tests/components/SeriesTable.test.tsx
@@ -121,6 +121,79 @@ describe("SeriesTable", () => {
     expect(new URLSearchParams(window.location.search).get("page")).toBe("3");
   });
 
+  // Regression: `selectedSeriesIds` used to read the raw rowSelection keys, so
+  // a row filtered out of view stayed selected, stayed counted in the bulk
+  // bar, and stayed a target of bulk delete/pause/resume — the #307 class.
+  // See wayfinder #365 / #390.
+  it("drops a filtered-away row from the selection and the bulk bar", async () => {
+    const user = userEvent.setup();
+    window.history.pushState({}, "", "/library");
+
+    const data = [
+      { ComicID: "1", ComicName: "Akira", Status: "Active" },
+      { ComicID: "2", ComicName: "Berserk", Status: "Active" },
+    ] as Comic[];
+
+    render(
+      <NuqsAdapter>
+        <SeriesTable data={data} />
+      </NuqsAdapter>,
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "Select Akira" }));
+    expect(screen.queryAllByText("1 selected")).not.toHaveLength(0);
+
+    // Filter Akira out of view.
+    await user.type(screen.getByLabelText("Filter series"), "Berserk");
+    await settle();
+
+    expect(screen.queryByText("Akira")).toBeNull();
+    expect(screen.queryAllByText(/\d+ selected/)).toHaveLength(0);
+
+    // The selection was pruned, not hidden: clearing the filter brings Akira
+    // back deselected, so no bulk action can reach a row the user never saw
+    // re-selected.
+    await user.clear(screen.getByLabelText("Filter series"));
+    await settle();
+
+    expect(screen.getByText("Akira")).toBeTruthy();
+    expect(screen.queryAllByText(/\d+ selected/)).toHaveLength(0);
+    expect(
+      screen
+        .getByRole("checkbox", { name: "Select Akira" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
+  it("keeps a selection on rows the pager, not the filter, hid", async () => {
+    const user = userEvent.setup();
+    window.history.pushState({}, "", "/library");
+
+    render(
+      <NuqsAdapter>
+        <SeriesTable data={series(21)} />
+      </NuqsAdapter>,
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "Select Series 1" }));
+    await user.click(screen.getByRole("button", { name: "next" }));
+    await settle();
+
+    // Series 1 is on the previous page — out of sight but not out of the
+    // filtered row set, so it must stay selected and counted.
+    expect(screen.queryByText("Series 1")).toBeNull();
+    expect(screen.queryAllByText("1 selected")).not.toHaveLength(0);
+
+    await user.click(screen.getByRole("button", { name: "prev" }));
+    await settle();
+
+    expect(
+      screen
+        .getByRole("checkbox", { name: "Select Series 1" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
   it("still resets to the first page when the row set changes later", async () => {
     window.history.pushState({}, "", "/library?page=2");
 


### PR DESCRIPTION
Closes #390 (wayfinder map #353).

## The defect

`selectedSeriesIds` (`SeriesTable.tsx:155`) read the **raw** `rowSelection` keys rather than `getSelectedRowModel()`. A row filtered out of view stayed selected, stayed counted in the bulk bar, and stayed a target of bulk delete / pause / resume — select a series, filter it away, and the bar read *1 selected* over a series the user cannot see. Same class as #307; with `IssuesTable` deleted (#391), `SeriesTable` was the only live site.

## The fix — both halves required

1. **Derive `selectedSeriesIds` from `table.getSelectedRowModel()`**, never from raw keys. This is the durable half: #359's hook shape returns selection the same way, so it transfers into the migration.
2. **Prune `rowSelection` when rows leave the filtered row model**, mirroring the pruning effect `WantedTable`/`UpcomingTable` already carry — TanStack never prunes stale selection ids, by design (#355). Deriving alone is not enough: the header checkbox counts raw state. Pruning is keyed on the **filtered** row model, not the page model, so paging away from a selected row never clears it.

## Red-then-green

The regression test (`drops a filtered-away row from the selection and the bulk bar`) was written first and failed against the unfixed component exactly as the [reference probe](https://github.com/frankieramirez/comicarr/blob/research/seriestable-selection-leak/frontend/tests/probe-seriestable-selection.test.tsx) predicted — bulk bar still counting the hidden row. It also pins that the selection is *pruned, not hidden*: clearing the filter brings the row back deselected. A second test guards the boundary: rows hidden by the **pager** stay selected. This is the selection coverage `SeriesTable` was missing (#365), which is what lets it later migrate on "the tests stay green".

Deliberately untouched, per the ticket: the six hand-rolled `setRowSelection({})` calls (become `clearSelection()` at migration), `ActivityPage`'s row id, and anything `IssuesTable` (#382/#383 — latent, ship with the migration).

## Verification

- Full frontend suite: **27 files / 146 tests passing** (baseline 144 + the 2 new).
- All lint lanes pass (`lint:modern`, `lint:backend`, `lint:generated`, `lint:frontend`).
- Changeset: **patch** — bug fix, no interface change (matching #381/#384).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYM9bwjHLWtEEsPhhaLFTF