### PR TITLE
refactor: Extract useTableState and migrate the activity tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Conventional PR titles keep history readable, but they do not control releases. 
 - **Do NOT use `bun` for frontend** - Use `npm` commands only
 - **Do NOT omit GPL license header** from new Python files
 - **Do NOT manually bump versions** - Changesets release automation handles this
+- **Do NOT call `useReactTable` directly** - `no-restricted-imports` allows it only in `frontend/src/components/data-table/useTableState.ts`. Call `useTableState`, which wraps it so `getRowId` is required and row identity can never fall back to TanStack's index default. Tables still awaiting migration are listed in an `overrides` allowlist in `eslint.config.js`; that list only ever shrinks — never add to it.
 - **Do NOT finish without linting** - Run `npm run lint` (or `npm run lint:fix` then re-check) before considering work done; do not bypass hooks with `--no-verify`
 
 ## Gotchas

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -35,9 +35,49 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true, allowExportNames: ['useAuth', 'useTheme', 'useToast', 'useSidebar', 'buttonVariants'] },
       ],
-      // TanStack Table's useReactTable API is flagged by React Compiler as
-      // incompatible — this is expected and the compiler already skips
-      // memoization for these call sites automatically.
+      // Row identity is the invariant the data-table/useTableState seam exists
+      // to centralise, and `getRowId` can only be *required* if there is one
+      // place to require it from. A comment is not a seam, and a source scan
+      // matches strings; this matches the import and fails at author time.
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@tanstack/react-table',
+              importNames: ['useReactTable'],
+              message:
+                'Call useTableState from @/components/data-table/useTableState instead. It wraps useReactTable so getRowId cannot fall back to TanStack’s index default (#307, #359).',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // The one file allowed to build a table instance.
+    files: ['src/components/data-table/useTableState.ts'],
+    rules: {
+      'no-restricted-imports': 'off',
+      // React Compiler flags useReactTable as an incompatible library. This
+      // disable used to be repo-wide because the call sites were scattered;
+      // confining them to one file is what lets it narrow to one file.
+      'react-hooks/incompatible-library': 'off',
+    },
+  },
+  {
+    // RATCHET — tables not yet migrated to useTableState. Each migration PR
+    // deletes its own line; the last one deletes this whole block. A file that
+    // is not listed here fails immediately, so a *new* call site cannot appear
+    // while the migration is in flight. Tracked by #353.
+    files: [
+      'src/components/series/SeriesTable.tsx', // #394
+      'src/components/queue/WantedTable.tsx', // #395
+      'src/components/queue/UpcomingTable.tsx', // #395
+      'src/components/import/ImportTable.tsx', // #396
+    ],
+    rules: {
+      'no-restricted-imports': 'off',
       'react-hooks/incompatible-library': 'off',
     },
   },

--- a/frontend/src/components/data-table/rowId.ts
+++ b/frontend/src/components/data-table/rowId.ts
@@ -1,0 +1,33 @@
+/**
+ * Safe composite row ids.
+ *
+ * A row id must be unique and stable, and #359 narrows `getRowId` to
+ * `(row) => string` so it can never fall back to TanStack's index default.
+ * Tables whose identity is a composite then have to join several fields into
+ * one string, and a bare join is ambiguous the moment a field can contain the
+ * delimiter. Two live cases (#383, #364):
+ *
+ *   - download history keys on `(IssueID, Status, Provider)`, and `Status`
+ *     takes the literal value `Post-Processed`;
+ *   - `ImportTable`'s key is `` `${DynamicName}-${Volume || "null"}` ``, which
+ *     collapses `null` and `""` even though SQL groups them separately.
+ *
+ * So the encoder is shared rather than fixed per site: the class is the bug,
+ * not either instance.
+ *
+ * Each part is tagged (`s` present, `n` absent) and percent-encoded, then
+ * joined with `|`. `encodeURIComponent` escapes `|` to `%7C`, so no encoded
+ * part can contain the delimiter and the split is unambiguous for any input.
+ * The tag keeps `null` distinct from `""` and from the string `"null"`.
+ */
+export function encodeRowId(
+  parts: readonly (string | number | null | undefined)[],
+): string {
+  return parts
+    .map((part) =>
+      part === null || part === undefined
+        ? "n"
+        : `s${encodeURIComponent(String(part))}`,
+    )
+    .join("|");
+}

--- a/frontend/src/components/data-table/tableUrlStore.ts
+++ b/frontend/src/components/data-table/tableUrlStore.ts
@@ -53,8 +53,28 @@ export const sortParser = createParser({
  * writes it replaces, which left a 300ms window where the URL read
  * *old search, page 0* (#377).
  */
+/**
+ * The URL is user-supplied, and `?page=-1` parses cleanly to -1, which would
+ * reach TanStack as a negative `pageIndex`. Floored at the parser so the store
+ * cannot expose one.
+ *
+ * Out-of-range *high* pages are deliberately left alone: clamping those is the
+ * render-time, display-only concern #360 assigned to the caller, and the
+ * rewrite that tries to tell "rows have not arrived" from "genuinely out of
+ * range" *is* the bug #381 fixed.
+ */
+const pageParser = createParser({
+  parse(value: string) {
+    const page = parseAsInteger.parse(value);
+    return page === null ? null : Math.max(0, page);
+  },
+  serialize(value: number) {
+    return String(Math.max(0, value));
+  },
+});
+
 export const tableUrlParams = {
-  page: parseAsInteger.withDefault(0),
+  page: pageParser.withDefault(0),
   sort: sortParser,
   search: parseAsString.withDefault("").withOptions({
     limitUrlUpdates: throttle(300),

--- a/frontend/src/components/data-table/tableUrlStore.ts
+++ b/frontend/src/components/data-table/tableUrlStore.ts
@@ -1,0 +1,105 @@
+import { useMemo } from "react";
+import {
+  createParser,
+  parseAsInteger,
+  parseAsString,
+  throttle,
+  useQueryStates,
+  type Options,
+} from "nuqs";
+import type { SortingState } from "@tanstack/react-table";
+import { SORT_DELIMITER } from "@/lib/delimiters";
+import type { TableStore } from "./useTableState";
+
+/**
+ * The caller-side half of #377's decision: `useTableState` takes a `store`
+ * adapter but never opens one and never imports nuqs. Seven of the eight
+ * pre-hook instances held this state in plain React state, so a hook-owned
+ * store would have handed URL state to tables that never had it.
+ *
+ * Everything here is nuqs-aware and lives on the caller's side of that line.
+ * `useTableState.ts` imports nothing from this file.
+ */
+
+/**
+ * `eq` is added here rather than at the first `withDefault`, and that timing is
+ * the whole point: exporting a shared parser is what arms the bug. Without
+ * `eq`, nuqs cannot tell a value from the parser's default, so the moment any
+ * caller declares a default sort it gets serialised into every URL instead of
+ * being omitted (#377).
+ */
+export const sortParser = createParser({
+  parse(value: string) {
+    const [id, direction] = value.split(SORT_DELIMITER);
+    if (!id) return null;
+    return { id, desc: direction === "desc" };
+  },
+  serialize(value: { id: string; desc: boolean }) {
+    return `${value.id}${SORT_DELIMITER}${value.desc ? "desc" : "asc"}`;
+  },
+  eq(a: { id: string; desc: boolean }, b: { id: string; desc: boolean }) {
+    return a.id === b.id && a.desc === b.desc;
+  },
+});
+
+/**
+ * The three URL-worthy slices as a fragment, so a caller can spread it into a
+ * wider `useQueryStates` map alongside its own domain filters. `search` folds
+ * into this one map — the key name is unchanged, so existing bookmarks survive
+ * — and carries a per-parser rate limit rather than the deprecated
+ * `throttleMs`, a capability #368 confirmed became real in nuqs 2.9.1.
+ *
+ * Batching the page reset at the same 300ms is strictly better than the two
+ * writes it replaces, which left a 300ms window where the URL read
+ * *old search, page 0* (#377).
+ */
+export const tableUrlParams = {
+  page: parseAsInteger.withDefault(0),
+  sort: sortParser,
+  search: parseAsString.withDefault("").withOptions({
+    limitUrlUpdates: throttle(300),
+  }),
+};
+
+/**
+ * Adapts the params above to the shape `useTableState` consumes. All-or-nothing
+ * by design: a table wanting mixed backends composes them inside its own
+ * adapter, because the hook's contract is that it has *one* store, not that it
+ * knows what is behind it.
+ */
+export function useTableUrlStore(
+  options?: Pick<Options, "history" | "shallow" | "scroll">,
+): TableStore {
+  const [params, setParams] = useQueryStates(tableUrlParams, options);
+
+  // Load-bearing, and it looks like a pointless indirection: memoising the
+  // store *object* on `[params]` is observably equivalent right up until it
+  // hands TanStack a fresh `sorting` array identity every render, which is
+  // #292's render loop returning. Key the memo on the primitive slices.
+  const sortId = params.sort?.id;
+  const sortDesc = params.sort?.desc;
+  const sorting = useMemo<SortingState>(
+    () => (sortId ? [{ id: sortId, desc: sortDesc ?? false }] : []),
+    [sortId, sortDesc],
+  );
+
+  const { page, search } = params;
+
+  return useMemo(
+    () => ({
+      state: { sorting, globalFilter: search, pageIndex: page },
+      setState: (patch) => {
+        void setParams({
+          ...("sorting" in patch
+            ? { sort: patch.sorting?.length ? patch.sorting[0] : null }
+            : {}),
+          ...("globalFilter" in patch ? { search: patch.globalFilter } : {}),
+          ...("pageIndex" in patch
+            ? { page: patch.pageIndex === 0 ? null : patch.pageIndex }
+            : {}),
+        });
+      },
+    }),
+    [sorting, search, page, setParams],
+  );
+}

--- a/frontend/src/components/data-table/useServerPage.ts
+++ b/frontend/src/components/data-table/useServerPage.ts
@@ -1,0 +1,41 @@
+import { useCallback, useMemo, useState } from "react";
+
+/**
+ * The page for tables that paginate outside TanStack — server offset/limit.
+ *
+ * `useTableState` structurally cannot own this: the page is an *input* to the
+ * fetch that produces the `data` the hook consumes, so hook-ownership would be
+ * circular. Hence #360's rule that the absence of `pagination` is itself a
+ * model, and hence this hook being called *before* the query rather than after.
+ *
+ * It collapses four duplicated `useState(0)` sites — `ActivityPage` twice,
+ * `WantedPage`, `ImportPage` — together with their copied next/prev handlers.
+ * (#360 records five; the fifth was `UpcomingTable`, which is unpaginated and
+ * holds no page state at all.)
+ *
+ * `resetPage` is explicit rather than automatic because TanStack's
+ * `autoResetPageIndex` is inert under `manualPagination` — for this model the
+ * reset-on-sort-or-filter invariant has no owner but the caller.
+ */
+export function useServerPage(pageSize: number) {
+  const [page, setPage] = useState(0);
+
+  const nextPage = useCallback(() => setPage((current) => current + 1), []);
+  const prevPage = useCallback(
+    () => setPage((current) => Math.max(0, current - 1)),
+    [],
+  );
+  const resetPage = useCallback(() => setPage(0), []);
+
+  return useMemo(
+    () => ({
+      page,
+      limit: pageSize,
+      offset: page * pageSize,
+      nextPage,
+      prevPage,
+      resetPage,
+    }),
+    [page, pageSize, nextPage, prevPage, resetPage],
+  );
+}

--- a/frontend/src/components/data-table/useTableState.ts
+++ b/frontend/src/components/data-table/useTableState.ts
@@ -1,0 +1,332 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  getCoreRowModel,
+  getExpandedRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type ExpandedState,
+  type RowData,
+  type RowSelectionState,
+  type SortingState,
+  type Table,
+  type TableOptions,
+  type Updater,
+} from "@tanstack/react-table";
+
+/**
+ * The single owner of TanStack table state.
+ *
+ * This is not a hook that sits beside `useReactTable` — it *wraps* it, and an
+ * ESLint rule makes it the only file allowed to import `useReactTable`. That is
+ * what lets `getRowId` be required rather than merely offered: a hook beside
+ * the call can only suggest a correct row id, and TanStack's index-based
+ * default is precisely the silent default nobody chose (#307, #359).
+ *
+ * Every state slice and `on*Change` handler is `Omit`ted from the passthrough,
+ * so a caller cannot quietly take one back. That is deliberate cost: `expanded`
+ * is owned here because the omission dragged it in, not because it earned a
+ * place (#359).
+ */
+
+declare module "@tanstack/react-table" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface TableMeta<TData extends RowData> {
+    /**
+     * Set by `useTableState` from `selection.scope`, so a header checkbox can
+     * honour the table's scope without the column closing over the hook's
+     * return value (columns are memoised; the `table` argument is not).
+     */
+    selectAllScope?: SelectAllScope;
+  }
+}
+
+export type SelectAllScope = "filtered" | "page";
+
+/**
+ * The three slices worth putting in a URL. The caller supplies the backing
+ * store; the hook never opens one and never imports nuqs (#377).
+ */
+export type TableStoreState = {
+  sorting: SortingState;
+  globalFilter: string;
+  pageIndex: number;
+};
+
+export type TableStore = {
+  state: TableStoreState;
+  /**
+   * Patch semantics: only the named slices change. One call per hook update —
+   * the hook never writes two slices at once, because #360 removed the
+   * hand-rolled page reset that would have needed it.
+   */
+  setState: (patch: Partial<TableStoreState>) => void;
+};
+
+/**
+ * State slices and handlers the hook owns outright. Passing any of these is a
+ * type error rather than a silently ignored option.
+ */
+type OwnedOptions =
+  | "state"
+  | "initialState"
+  | "getRowId"
+  | "onSortingChange"
+  | "onGlobalFilterChange"
+  | "onRowSelectionChange"
+  | "onPaginationChange"
+  | "onExpandedChange"
+  | "getCoreRowModel"
+  | "getSortedRowModel"
+  | "getFilteredRowModel"
+  | "getPaginationRowModel"
+  | "getExpandedRowModel"
+  | "manualPagination"
+  | "autoResetPageIndex";
+
+export type UseTableStateOptions<TData> = Omit<
+  TableOptions<TData>,
+  OwnedOptions
+> & {
+  /**
+   * Required and non-defaultable, narrowed to drop TanStack's `index`
+   * parameter. `(row, index) => …` stops compiling, which is the point:
+   * a positional row id cannot survive a data change (#355, #359).
+   */
+  getRowId: (row: TData) => string;
+  /**
+   * Absence is a model: without it the table paginates outside TanStack
+   * (server offset/limit), gets `manualPagination`, and holds no page state
+   * here — the page is an input to the fetch that produces `data`, so owning
+   * it would be circular (#360).
+   */
+  pagination?: { pageSize: number };
+  /**
+   * Absence means the table has no row selection at all. When present, `scope`
+   * is required with no default — scope is semantics, not identity, so it must
+   * be named (#359, #382).
+   */
+  selection?: { scope: SelectAllScope };
+  /** All-or-nothing URL adapter over the three slices above (#377). */
+  store?: TableStore;
+  /** Only consulted when no `store` is injected. */
+  initialSorting?: SortingState;
+};
+
+export type UseTableStateResult<TData> = {
+  table: Table<TData>;
+  /**
+   * Always derived from `getSelectedRowModel()`, never from raw
+   * `state.rowSelection` keys — the raw object is what exposes ids whose rows
+   * have gone, and it is what every pre-hook decoder read (#355, #365).
+   */
+  selectedRows: TData[];
+  selectedIds: string[];
+  /** Backed by `resetRowSelection(true)`, which also clears out-of-scope ids. */
+  clearSelection: () => void;
+};
+
+function applyUpdater<T>(updater: Updater<T>, current: T): T {
+  return typeof updater === "function"
+    ? (updater as (old: T) => T)(current)
+    : updater;
+}
+
+/**
+ * Header-checkbox helpers that honour the table's `selectAllScope`. Columns
+ * call these instead of picking a TanStack pair themselves, so the scope is
+ * decided once, where it was named.
+ */
+export function getIsAllSelected<TData>(
+  table: Table<TData>,
+): boolean | "indeterminate" {
+  const isAll =
+    table.options.meta?.selectAllScope === "page"
+      ? table.getIsAllPageRowsSelected()
+      : table.getIsAllRowsSelected();
+
+  return isAll || (table.getIsSomeRowsSelected() && "indeterminate");
+}
+
+export function toggleAllSelected<TData>(
+  table: Table<TData>,
+  value: boolean,
+): void {
+  if (table.options.meta?.selectAllScope === "page") {
+    table.toggleAllPageRowsSelected(value);
+    return;
+  }
+  table.toggleAllRowsSelected(value);
+}
+
+export function useTableState<TData>({
+  getRowId,
+  pagination,
+  selection,
+  store,
+  initialSorting,
+  meta,
+  ...passthrough
+}: UseTableStateOptions<TData>): UseTableStateResult<TData> {
+  const [localSorting, setLocalSorting] = useState<SortingState>(
+    initialSorting ?? [],
+  );
+  const [localGlobalFilter, setLocalGlobalFilter] = useState("");
+  const [localPageIndex, setLocalPageIndex] = useState(0);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [expanded, setExpanded] = useState<ExpandedState>({});
+
+  const sorting = store ? store.state.sorting : localSorting;
+  const globalFilter = store ? store.state.globalFilter : localGlobalFilter;
+  const pageIndex = store ? store.state.pageIndex : localPageIndex;
+
+  const setSorting = useCallback(
+    (updater: Updater<SortingState>) => {
+      const next = applyUpdater(updater, sorting);
+      if (store) store.setState({ sorting: next });
+      else setLocalSorting(next);
+    },
+    [sorting, store],
+  );
+
+  const setGlobalFilter = useCallback(
+    (updater: Updater<string>) => {
+      const next = applyUpdater(updater, globalFilter);
+      if (store) store.setState({ globalFilter: next });
+      else setLocalGlobalFilter(next);
+    },
+    [globalFilter, store],
+  );
+
+  const paginationState = useMemo(
+    () =>
+      pagination
+        ? { pageIndex, pageSize: pagination.pageSize }
+        : { pageIndex: 0, pageSize: 0 },
+    [pageIndex, pagination],
+  );
+
+  const setPagination = useCallback(
+    (updater: Updater<{ pageIndex: number; pageSize: number }>) => {
+      const next = applyUpdater(updater, paginationState);
+      if (next.pageIndex === paginationState.pageIndex) return;
+      if (store) store.setState({ pageIndex: next.pageIndex });
+      else setLocalPageIndex(next.pageIndex);
+    },
+    [paginationState, store],
+  );
+
+  // Auto-reset is armed one render AFTER rows first arrive. TanStack reads this
+  // option synchronously inside `_autoResetPageIndex`, before it queues the
+  // reset onto a microtask, so a ref read at render time is the value that
+  // decides. Arming it immediately would let the reset fire against a page a
+  // render-time clamp had already raised, stripping a deep link (#372, #381).
+  const seenRows = useRef(false);
+  const rowCount = passthrough.data.length;
+  useEffect(() => {
+    if (rowCount > 0) seenRows.current = true;
+  });
+
+  const table = useReactTable({
+    ...passthrough,
+    meta: { ...meta, selectAllScope: selection?.scope },
+    getRowId,
+    state: {
+      sorting,
+      globalFilter,
+      rowSelection,
+      expanded,
+      ...(pagination ? { pagination: paginationState } : {}),
+    },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    onRowSelectionChange: setRowSelection,
+    onExpandedChange: setExpanded,
+    ...(pagination
+      ? {
+          onPaginationChange: setPagination,
+          getPaginationRowModel: getPaginationRowModel(),
+          autoResetPageIndex: seenRows.current,
+        }
+      : { manualPagination: true }),
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    enableRowSelection: selection !== undefined,
+  });
+
+  // A page-size change alters no `data` identity, so TanStack's auto-reset
+  // provably cannot see it — the one page reset the hook still owes (#360).
+  const pageSize = pagination?.pageSize;
+  const previousPageSize = useRef(pageSize);
+  useEffect(() => {
+    if (previousPageSize.current !== pageSize) {
+      previousPageSize.current = pageSize;
+      if (store) store.setState({ pageIndex: 0 });
+      else setLocalPageIndex(0);
+    }
+  }, [pageSize, store]);
+
+  // TanStack never prunes stale selection ids and offers no option to — it is
+  // documented as intentional (#355). Rows leave for reasons the hook cannot
+  // see (a refetch, a domain filter applied before `data` arrives here), which
+  // is exactly why pruning is generic: it drops ids whose rows are gone without
+  // knowing why they went. Deriving outputs from `getSelectedRowModel()` is not
+  // a substitute, because the header checkbox counts raw state (#359).
+  // Read the row models during render rather than memoising on `table`: the
+  // table instance is referentially stable for the life of the component, so
+  // `[table]` would compute this once and pruning would never fire again. The
+  // row-model getters are memoised inside TanStack on the state they derive
+  // from, so their `rows` arrays are the honest dependency.
+  const filteredRows = table.getFilteredRowModel().rows;
+  const visibleRowIds = useMemo(
+    () => new Set(filteredRows.map((row) => row.id)),
+    [filteredRows],
+  );
+
+  useEffect(() => {
+    setRowSelection((current) => {
+      const selectedKeys = Object.keys(current);
+      if (selectedKeys.length === 0) return current;
+
+      const survivors: RowSelectionState = {};
+      let dropped = false;
+      for (const key of selectedKeys) {
+        if (visibleRowIds.has(key)) survivors[key] = current[key];
+        else dropped = true;
+      }
+
+      return dropped ? survivors : current;
+    });
+  }, [visibleRowIds]);
+
+  const selectedRows = table.getSelectedRowModel().rows;
+
+  const clearSelection = useCallback(() => {
+    // Existing *because* v8's deselect-all is scope-limited: under page scope
+    // `toggleAllSelected(table, false)` clears the page and leaves every other
+    // selected id behind, with no escape hatch (#355). Clearing has to be a
+    // separate operation from deselect-all, not an argument to it.
+    //
+    // The `true` is explicit rather than load-bearing — it resets to `{}`
+    // instead of `initialState.rowSelection`, and `initialState` is `Omit`ted
+    // so no caller can set one. It is kept so the intent survives if that
+    // changes.
+    table.resetRowSelection(true);
+  }, [table]);
+
+  return {
+    table,
+    selectedRows: useMemo(
+      () => selectedRows.map((row) => row.original),
+      [selectedRows],
+    ),
+    selectedIds: useMemo(
+      () => selectedRows.map((row) => row.id),
+      [selectedRows],
+    ),
+    clearSelection,
+  };
+}

--- a/frontend/src/components/data-table/useTableState.ts
+++ b/frontend/src/components/data-table/useTableState.ts
@@ -83,7 +83,11 @@ type OwnedOptions =
   | "getPaginationRowModel"
   | "getExpandedRowModel"
   | "manualPagination"
-  | "autoResetPageIndex";
+  | "autoResetPageIndex"
+  // Derived from `selection` and set after the passthrough spread, so a caller
+  // passing it would be silently overridden — precisely the quiet no-op the
+  // Omit exists to make impossible.
+  | "enableRowSelection";
 
 export type UseTableStateOptions<TData> = Omit<
   TableOptions<TData>,
@@ -141,12 +145,18 @@ function applyUpdater<T>(updater: Updater<T>, current: T): T {
 export function getIsAllSelected<TData>(
   table: Table<TData>,
 ): boolean | "indeterminate" {
-  const isAll =
-    table.options.meta?.selectAllScope === "page"
-      ? table.getIsAllPageRowsSelected()
-      : table.getIsAllRowsSelected();
+  // Both halves have to read the same scope. Mixing them — an all-check scoped
+  // to the page and a some-check scoped to everything — renders a page with no
+  // selected rows as indeterminate whenever any *other* page holds a selection.
+  const isPageScope = table.options.meta?.selectAllScope === "page";
+  const isAll = isPageScope
+    ? table.getIsAllPageRowsSelected()
+    : table.getIsAllRowsSelected();
+  const isSome = isPageScope
+    ? table.getIsSomePageRowsSelected()
+    : table.getIsSomeRowsSelected();
 
-  return isAll || (table.getIsSomeRowsSelected() && "indeterminate");
+  return isAll || (isSome && "indeterminate");
 }
 
 export function toggleAllSelected<TData>(

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -2,11 +2,8 @@ import { useCallback, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import {
   createColumnHelper,
-  getCoreRowModel,
-  useReactTable,
   type SortingState,
   type Table as TanstackTable,
-  type Updater,
 } from "@tanstack/react-table";
 import { RefreshCw } from "lucide-react";
 import {
@@ -18,6 +15,9 @@ import {
 } from "@/hooks/useActivity";
 import { useDebounce } from "@/hooks/use-debounce";
 import { DataTable } from "@/components/data-table/DataTable";
+import { useTableState } from "@/components/data-table/useTableState";
+import { useServerPage } from "@/components/data-table/useServerPage";
+import { encodeRowId } from "@/components/data-table/rowId";
 import { DataTableServerPagination } from "@/components/data-table/DataTableServerPagination";
 import { DataTableSortHeader } from "@/components/data-table/DataTableSortHeader";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -199,8 +199,22 @@ function LoadingRows() {
   );
 }
 
-function useActivityTableState(defaultSortId: string) {
-  const [page, setPage] = useState(0);
+/**
+ * Both activity tables are server-driven: the sort and the search are inputs to
+ * the query that produces `data`, so both have to be readable *before* the
+ * table exists. That is what #377's `store` adapter is for — `useTableState`
+ * owns the sorting slice, the caller owns where it is kept. Here that is plain
+ * React state which also resets the server page, because under
+ * `manualPagination` TanStack's `autoResetPageIndex` is inert and the
+ * reset-on-change rule has no other owner (#360).
+ *
+ * What is left here is wiring specific to this page. The table state itself —
+ * sorting, selection, the row models — now lives in `useTableState`, which is
+ * the generalisation of the `useActivityTableState` this replaces.
+ */
+function useActivityTable(defaultSortId: string) {
+  const { page, limit, offset, nextPage, prevPage, resetPage } =
+    useServerPage(PAGE_SIZE);
   const [search, setSearchState] = useState("");
   const debouncedSearch = useDebounce(search, 400);
   const [sorting, setSorting] = useState<SortingState>([
@@ -208,26 +222,36 @@ function useActivityTableState(defaultSortId: string) {
   ]);
   const activeSort = sorting[0] ?? { id: defaultSortId, desc: true };
 
-  const setSearch = (value: string) => {
-    setSearchState(value);
-    setPage(0);
-  };
-  const handleSortingChange = (updater: Updater<SortingState>) => {
-    setSorting((current) =>
-      typeof updater === "function" ? updater(current) : updater,
-    );
-    setPage(0);
-  };
+  const setSearch = useCallback(
+    (value: string) => {
+      setSearchState(value);
+      resetPage();
+    },
+    [resetPage],
+  );
+
+  const store = useMemo(
+    () => ({
+      state: { sorting, globalFilter: "", pageIndex: page },
+      setState: (patch: { sorting?: SortingState }) => {
+        if (!("sorting" in patch) || !patch.sorting) return;
+        setSorting(patch.sorting);
+        resetPage();
+      },
+    }),
+    [sorting, page, resetPage],
+  );
 
   return {
-    page,
-    setPage,
+    limit,
+    offset,
     search,
     setSearch,
     debouncedSearch,
-    sorting,
     activeSort,
-    handleSortingChange,
+    store,
+    nextPage,
+    prevPage,
   };
 }
 
@@ -325,18 +349,19 @@ const queueColumnHelper = createColumnHelper<QueueItem>();
 
 function QueueView() {
   const {
-    page,
-    setPage,
+    limit,
+    offset,
     search,
     setSearch,
     debouncedSearch,
-    sorting,
     activeSort,
-    handleSortingChange,
-  } = useActivityTableState("updated");
+    store,
+    nextPage,
+    prevPage,
+  } = useActivityTable("updated");
   const { data, isLoading, isFetching, error, refetch } = useDownloadQueue({
-    limit: PAGE_SIZE,
-    offset: page * PAGE_SIZE,
+    limit,
+    offset,
     q: debouncedSearch,
     sort: activeSort.id,
     order: activeSort.desc ? "desc" : "asc",
@@ -465,12 +490,10 @@ function QueueView() {
     [handleRequeue, isRequeuePending, requeueItemId],
   );
 
-  const table = useReactTable({
+  const { table } = useTableState({
     data: queue,
     columns,
-    state: { sorting },
-    onSortingChange: handleSortingChange,
-    getCoreRowModel: getCoreRowModel(),
+    store,
     manualSorting: true,
     enableSortingRemoval: false,
     getRowId: (row) => row.ID,
@@ -494,8 +517,8 @@ function QueueView() {
       emptyDescription="Queued and downloading direct downloads will appear here; failures stay visible for review."
       filteredTitle="No matching queue items"
       onRefresh={() => void refetch()}
-      onNextPage={() => setPage((current) => current + 1)}
-      onPrevPage={() => setPage((current) => Math.max(0, current - 1))}
+      onNextPage={nextPage}
+      onPrevPage={prevPage}
     />
   );
 }
@@ -504,18 +527,19 @@ const historyColumnHelper = createColumnHelper<HistoryItem>();
 
 function HistoryView() {
   const {
-    page,
-    setPage,
+    limit,
+    offset,
     search,
     setSearch,
     debouncedSearch,
-    sorting,
     activeSort,
-    handleSortingChange,
-  } = useActivityTableState("date");
+    store,
+    nextPage,
+    prevPage,
+  } = useActivityTable("date");
   const { data, isLoading, isFetching, error, refetch } = useDownloadHistory({
-    limit: PAGE_SIZE,
-    offset: page * PAGE_SIZE,
+    limit,
+    offset,
     q: debouncedSearch,
     sort: activeSort.id,
     order: activeSort.desc ? "desc" : "asc",
@@ -579,15 +603,20 @@ function HistoryView() {
     [],
   );
 
-  const table = useReactTable({
+  const { table } = useTableState({
     data: history,
     columns,
-    state: { sorting },
-    onSortingChange: handleSortingChange,
-    getCoreRowModel: getCoreRowModel(),
+    store,
     manualSorting: true,
     enableSortingRemoval: false,
-    getRowId: (row, index) => `${row.IssueID}-${row.Status}-${index}`,
+    // Was `${IssueID}-${Status}-${index}`, which is positional: the same row
+    // gets a different id on any page or sort change. #383 found the real
+    // identity is already database-enforced — `snatched` carries
+    // UNIQUE(IssueID, Status, Provider) — so there is something to key on
+    // without a backend change. Encoded rather than joined because `Status`
+    // takes the value `Post-Processed`, which contains the delimiter a bare
+    // join would use.
+    getRowId: (row) => encodeRowId([row.IssueID, row.Status, row.Provider]),
   });
 
   return (
@@ -608,8 +637,8 @@ function HistoryView() {
       emptyDescription="Download events will appear here."
       filteredTitle="No matching history"
       onRefresh={() => void refetch()}
-      onNextPage={() => setPage((current) => current + 1)}
-      onPrevPage={() => setPage((current) => Math.max(0, current - 1))}
+      onNextPage={nextPage}
+      onPrevPage={prevPage}
     />
   );
 }

--- a/frontend/tests/components/tableUrlStore.test.ts
+++ b/frontend/tests/components/tableUrlStore.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  sortParser,
+  tableUrlParams,
+} from "@/components/data-table/tableUrlStore";
+
+/**
+ * The caller-side URL adapter. Kept separate from useTableState.test.tsx
+ * because #377's boundary is that `useTableState.ts` imports nothing from
+ * `tableUrlStore.ts` — a test suite that spans both would quietly couple the
+ * layer the decision exists to keep apart.
+ */
+describe("tableUrlParams (#377)", () => {
+  it("floors a negative page from the URL instead of passing it through", () => {
+    // The URL is user-supplied and `?page=-1` parses cleanly to -1, which would
+    // reach TanStack as a negative pageIndex.
+    expect(tableUrlParams.page.parse("-1")).toBe(0);
+    expect(tableUrlParams.page.parse("2")).toBe(2);
+  });
+
+  it("leaves an out-of-range high page alone, which is the caller's concern", () => {
+    // Clamping here cannot tell "rows have not arrived" from "genuinely out of
+    // range" — the rewrite that tries is the bug #381 fixed.
+    expect(tableUrlParams.page.parse("99")).toBe(99);
+  });
+
+  it("omits a sort equal to the default rather than serialising it (#377)", () => {
+    const withDefault = sortParser.withDefault({ id: "name", desc: false });
+    expect(
+      withDefault.eq?.(
+        { id: "name", desc: false },
+        { id: "name", desc: false },
+      ),
+    ).toBe(true);
+    expect(
+      withDefault.eq?.({ id: "name", desc: true }, { id: "name", desc: false }),
+    ).toBe(false);
+  });
+});

--- a/frontend/tests/components/useTableState.test.tsx
+++ b/frontend/tests/components/useTableState.test.tsx
@@ -1,0 +1,438 @@
+import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { createColumnHelper } from "@tanstack/react-table";
+import {
+  getIsAllSelected,
+  toggleAllSelected,
+  useTableState,
+  type TableStore,
+} from "@/components/data-table/useTableState";
+import { encodeRowId } from "@/components/data-table/rowId";
+
+/**
+ * The hook layer of #365's split: everything here is identical for every caller
+ * and independent of rendering — pruning, select-all scope, clearSelection, the
+ * store adapter, auto-reset arming. It is written once and deliberately NOT
+ * re-tested per call site.
+ *
+ * Five of these carry a #307 reference. They are the generic half of
+ * `QueueTableSelection.test.tsx`, which asserts the same invariants through
+ * two components; those move here as each site migrates (#395), and per #365 no
+ * pin retires unless its replacement lands in the same PR. Until then both
+ * exist, which is intentional overlap rather than duplication.
+ *
+ * `renderHook` appears nowhere else in this repo — a new idiom adopted
+ * deliberately, because six-way duplication of generic behaviour is worse.
+ */
+
+type Row = { id: string; name: string; group: string };
+
+const columnHelper = createColumnHelper<Row>();
+const columns = [
+  columnHelper.accessor("name", { id: "name" }),
+  columnHelper.accessor("group", { id: "group" }),
+];
+
+function rows(...ids: string[]): Row[] {
+  return ids.map((id) => ({ id, name: `row ${id}`, group: "a" }));
+}
+
+function renderTable(initial: {
+  data: Row[];
+  pageSize?: number;
+  scope?: "filtered" | "page";
+  store?: TableStore;
+}) {
+  return renderHook(
+    ({ data, pageSize, scope, store }: typeof initial) =>
+      useTableState<Row>({
+        data,
+        columns,
+        getRowId: (row) => row.id,
+        selection: scope ? { scope } : undefined,
+        pagination: pageSize ? { pageSize } : undefined,
+        store,
+      }),
+    { initialProps: initial },
+  );
+}
+
+describe("useTableState", () => {
+  describe("selection identity (#307)", () => {
+    it("reports ids, not row positions, for a non-adjacent multi-row selection", () => {
+      const { result } = renderTable({
+        data: rows("a", "b", "c", "d"),
+        scope: "filtered",
+      });
+
+      act(() => {
+        result.current.table.getRowModel().rows[0].toggleSelected(true);
+        result.current.table.getRowModel().rows[2].toggleSelected(true);
+      });
+
+      expect(result.current.selectedIds).toEqual(["a", "c"]);
+      expect(result.current.selectedRows.map((row) => row.name)).toEqual([
+        "row a",
+        "row c",
+      ]);
+    });
+
+    it("drops selected ids whose rows are no longer present (#307)", () => {
+      const { result, rerender } = renderTable({
+        data: rows("a", "b", "c"),
+        scope: "filtered",
+      });
+
+      act(() => {
+        result.current.table.getRowModel().rows[1].toggleSelected(true);
+      });
+      expect(result.current.selectedIds).toEqual(["b"]);
+
+      // The row leaves for a reason the hook cannot see — a refetch, a domain
+      // filter applied before `data` reaches it. Pruning is generic precisely
+      // so it does not need to know which.
+      rerender({ data: rows("a", "c"), scope: "filtered" });
+
+      expect(result.current.selectedIds).toEqual([]);
+      expect(
+        Object.keys(result.current.table.getState().rowSelection),
+      ).toEqual([]);
+    });
+
+    it("prunes raw state, not just the derived output, so the header checkbox agrees (#307)", () => {
+      const { result, rerender } = renderTable({
+        data: rows("a", "b"),
+        scope: "filtered",
+      });
+
+      act(() => {
+        toggleAllSelected(result.current.table, true);
+      });
+      expect(getIsAllSelected(result.current.table)).toBe(true);
+
+      rerender({ data: rows("a"), scope: "filtered" });
+
+      // Deriving `selectedIds` from getSelectedRowModel() alone would leave
+      // this true-but-stale, because the header counts raw state (#359).
+      expect(result.current.selectedIds).toEqual(["a"]);
+      expect(getIsAllSelected(result.current.table)).toBe(true);
+      expect(
+        Object.keys(result.current.table.getState().rowSelection),
+      ).toEqual(["a"]);
+    });
+
+    it("keeps a selection whose rows are merely on another page (#307)", () => {
+      const { result } = renderTable({
+        data: rows("a", "b", "c", "d"),
+        scope: "page",
+        pageSize: 2,
+      });
+
+      act(() => {
+        result.current.table.getRowModel().rows[0].toggleSelected(true);
+      });
+      act(() => {
+        result.current.table.nextPage();
+      });
+
+      // Pruning is scoped to the filtered row model, not the page — paging away
+      // from a selected row must not silently deselect it.
+      expect(result.current.selectedIds).toEqual(["a"]);
+    });
+
+    it("does not resurrect ids the caller cleared (#307)", () => {
+      const { result } = renderTable({
+        data: rows("a", "b"),
+        scope: "filtered",
+      });
+
+      act(() => {
+        toggleAllSelected(result.current.table, true);
+      });
+      act(() => {
+        result.current.clearSelection();
+      });
+
+      expect(result.current.selectedIds).toEqual([]);
+      expect(
+        Object.keys(result.current.table.getState().rowSelection),
+      ).toEqual([]);
+    });
+  });
+
+  describe("selectAllScope", () => {
+    it("selects only the current page under page scope", () => {
+      const { result } = renderTable({
+        data: rows("a", "b", "c", "d", "e"),
+        scope: "page",
+        pageSize: 2,
+      });
+
+      act(() => {
+        toggleAllSelected(result.current.table, true);
+      });
+
+      expect(result.current.selectedIds).toEqual(["a", "b"]);
+    });
+
+    it("selects every filtered row under filtered scope", () => {
+      const { result } = renderTable({
+        data: rows("a", "b", "c", "d", "e"),
+        scope: "filtered",
+        pageSize: 2,
+      });
+
+      act(() => {
+        toggleAllSelected(result.current.table, true);
+      });
+
+      expect(result.current.selectedIds).toEqual(["a", "b", "c", "d", "e"]);
+    });
+
+    it("reports the header checkbox against the scope, not against every row", () => {
+      const { result } = renderTable({
+        data: rows("a", "b", "c", "d"),
+        scope: "page",
+        pageSize: 2,
+      });
+
+      act(() => {
+        result.current.table.getRowModel().rows[0].toggleSelected(true);
+        result.current.table.getRowModel().rows[1].toggleSelected(true);
+      });
+
+      // Every row on this page is selected, but only half the table is. Page
+      // scope says checked; filtered scope would say indeterminate, and that
+      // difference is the whole reason the parameter is required (#359, #382).
+      expect(getIsAllSelected(result.current.table)).toBe(true);
+      expect(result.current.table.getIsAllRowsSelected()).toBe(false);
+    });
+
+    it("reports indeterminate under filtered scope for the same selection", () => {
+      const { result } = renderTable({
+        data: rows("a", "b", "c", "d"),
+        scope: "filtered",
+        pageSize: 2,
+      });
+
+      act(() => {
+        result.current.table.getRowModel().rows[0].toggleSelected(true);
+        result.current.table.getRowModel().rows[1].toggleSelected(true);
+      });
+
+      expect(getIsAllSelected(result.current.table)).toBe("indeterminate");
+    });
+
+    it("clears ids outside the current scope, which deselect-all leaks", () => {
+      const { result } = renderTable({
+        data: rows("a", "b", "c", "d"),
+        scope: "page",
+        pageSize: 2,
+      });
+
+      act(() => {
+        toggleAllSelected(result.current.table, true);
+      });
+      act(() => {
+        result.current.table.nextPage();
+      });
+      act(() => {
+        toggleAllSelected(result.current.table, true);
+      });
+      expect(result.current.selectedIds).toEqual(["a", "b", "c", "d"]);
+
+      // The leak, demonstrated: deselect-all under page scope clears this page
+      // and silently leaves the other page's ids selected. That is v8 behaviour
+      // with no escape hatch (#355) — which is why clearSelection exists as a
+      // separate operation rather than as an argument to deselect-all.
+      act(() => {
+        toggleAllSelected(result.current.table, false);
+      });
+      expect(result.current.selectedIds).toEqual(["a", "b"]);
+
+      act(() => {
+        result.current.clearSelection();
+      });
+      expect(result.current.selectedIds).toEqual([]);
+    });
+
+    it("enables no row selection at all when `selection` is omitted", () => {
+      const { result } = renderTable({ data: rows("a", "b") });
+
+      act(() => {
+        result.current.table.getRowModel().rows[0].toggleSelected(true);
+      });
+
+      expect(result.current.selectedIds).toEqual([]);
+    });
+  });
+
+  describe("the store adapter (#377)", () => {
+    it("reads and writes sorting through an injected store instead of local state", () => {
+      const writes: unknown[] = [];
+      let sorting: { id: string; desc: boolean }[] = [];
+
+      const { result, rerender } = renderHook(() => {
+        const store: TableStore = {
+          state: { sorting, globalFilter: "", pageIndex: 0 },
+          setState: (patch) => {
+            writes.push(patch);
+            if (patch.sorting) sorting = patch.sorting;
+          },
+        };
+        return useTableState<Row>({
+          data: rows("a", "b"),
+          columns,
+          getRowId: (row) => row.id,
+          store,
+        });
+      });
+
+      act(() => {
+        result.current.table.getColumn("name")?.toggleSorting(true);
+      });
+
+      expect(writes).toEqual([{ sorting: [{ id: "name", desc: true }] }]);
+
+      rerender();
+      expect(result.current.table.getState().sorting).toEqual([
+        { id: "name", desc: true },
+      ]);
+    });
+
+    it("writes exactly one slice per call, never two", () => {
+      const writes: Record<string, unknown>[] = [];
+      const store: TableStore = {
+        state: { sorting: [], globalFilter: "", pageIndex: 0 },
+        setState: (patch) => writes.push(patch),
+      };
+
+      const { result } = renderTable({
+        data: rows("a", "b", "c"),
+        scope: "filtered",
+        store,
+      });
+
+      act(() => {
+        result.current.table.setGlobalFilter("row a");
+      });
+
+      // #377 rests on this: the hook removed its hand-rolled page reset, so a
+      // single-key patch is all the store ever has to batch.
+      expect(writes).toHaveLength(1);
+      expect(Object.keys(writes[0])).toEqual(["globalFilter"]);
+    });
+
+    it("keeps state local when no store is injected", () => {
+      const { result } = renderTable({ data: rows("a", "b") });
+
+      act(() => {
+        result.current.table.getColumn("name")?.toggleSorting(true);
+      });
+
+      expect(result.current.table.getState().sorting).toEqual([
+        { id: "name", desc: true },
+      ]);
+    });
+  });
+
+  describe("pagination (#360)", () => {
+    it("paginates inside TanStack when a pageSize is given", () => {
+      const { result } = renderTable({
+        data: rows("a", "b", "c"),
+        pageSize: 2,
+      });
+
+      expect(result.current.table.getRowModel().rows).toHaveLength(2);
+      expect(result.current.table.getPageCount()).toBe(2);
+    });
+
+    it("treats the absence of pageSize as a model: manual pagination, no slicing", () => {
+      const { result } = renderTable({ data: rows("a", "b", "c") });
+
+      expect(result.current.table.options.manualPagination).toBe(true);
+      expect(result.current.table.getRowModel().rows).toHaveLength(3);
+    });
+
+    it("arms auto-reset one render after rows first arrive, not on arrival (#381)", () => {
+      const { result, rerender } = renderTable({ data: [], pageSize: 2 });
+
+      // Rows have not arrived, so a reset here would fire against a page a
+      // render-time clamp had already raised, stripping a deep link.
+      expect(result.current.table.options.autoResetPageIndex).toBe(false);
+
+      rerender({ data: rows("a", "b", "c"), pageSize: 2 });
+      rerender({ data: rows("a", "b", "c"), pageSize: 2 });
+
+      expect(result.current.table.options.autoResetPageIndex).toBe(true);
+    });
+
+    it("resets the page when pageSize changes, the one reset auto-reset cannot see", () => {
+      const { result, rerender } = renderTable({
+        data: rows("a", "b", "c", "d", "e", "f"),
+        pageSize: 2,
+      });
+
+      act(() => {
+        result.current.table.setPageIndex(2);
+      });
+      expect(result.current.table.getState().pagination.pageIndex).toBe(2);
+
+      // A page-size change alters no `data` identity, so TanStack provably
+      // never sees it (#360).
+      rerender({ data: rows("a", "b", "c", "d", "e", "f"), pageSize: 3 });
+
+      expect(result.current.table.getState().pagination.pageIndex).toBe(0);
+    });
+  });
+
+  describe("row identity", () => {
+    it("keys rows by the supplied getRowId, never by position", () => {
+      const { result, rerender } = renderTable({
+        data: rows("a", "b"),
+        scope: "filtered",
+      });
+
+      act(() => {
+        result.current.table.getRowModel().rows[1].toggleSelected(true);
+      });
+      expect(result.current.selectedIds).toEqual(["b"]);
+
+      // Same length, different objects at the same positions. Index-based ids
+      // would silently re-point the selection at a different row (#355).
+      rerender({ data: rows("b", "a"), scope: "filtered" });
+
+      expect(result.current.selectedIds).toEqual(["b"]);
+      expect(result.current.selectedRows[0].name).toBe("row b");
+    });
+  });
+});
+
+describe("encodeRowId (#383)", () => {
+  it("keeps a delimiter inside a field from splitting the id", () => {
+    // The live case: Status takes the literal value `Post-Processed`, so the
+    // bare `-` join it replaced was ambiguous.
+    expect(encodeRowId(["1", "Post-Processed", "nzb"])).not.toEqual(
+      encodeRowId(["1", "Post", "Processed|nzb"]),
+    );
+    expect(encodeRowId(["1", "Post-Processed", "nzb"])).toEqual(
+      encodeRowId(["1", "Post-Processed", "nzb"]),
+    );
+  });
+
+  it("keeps null, empty string and the string 'null' distinct", () => {
+    // ImportTable's `Volume || "null"` collapsed the first two, which SQL
+    // groups separately (#364).
+    const ids = [
+      encodeRowId(["a", null]),
+      encodeRowId(["a", ""]),
+      encodeRowId(["a", "null"]),
+    ];
+
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("is stable for the same input", () => {
+    expect(encodeRowId(["a", 1, null])).toBe(encodeRowId(["a", 1, null]));
+  });
+});

--- a/frontend/tests/components/useTableState.test.tsx
+++ b/frontend/tests/components/useTableState.test.tsx
@@ -8,10 +8,6 @@ import {
   type TableStore,
 } from "@/components/data-table/useTableState";
 import { encodeRowId } from "@/components/data-table/rowId";
-import {
-  sortParser,
-  tableUrlParams,
-} from "@/components/data-table/tableUrlStore";
 
 /**
  * The hook layer of #365's split: everything here is identical for every caller
@@ -397,10 +393,11 @@ describe("useTableState", () => {
     });
 
     it("resets the page when pageSize changes, the one reset auto-reset cannot see", () => {
-      const { result, rerender } = renderTable({
-        data: rows("a", "b", "c", "d", "e", "f"),
-        pageSize: 2,
-      });
+      // One array, reused: if `data` identity changed too, this could not tell
+      // the pageSize reset from an ordinary auto-reset on a data change, and
+      // would pass for the wrong reason.
+      const data = rows("a", "b", "c", "d", "e", "f");
+      const { result, rerender } = renderTable({ data, pageSize: 2 });
 
       act(() => {
         result.current.table.setPageIndex(2);
@@ -409,7 +406,7 @@ describe("useTableState", () => {
 
       // A page-size change alters no `data` identity, so TanStack provably
       // never sees it (#360).
-      rerender({ data: rows("a", "b", "c", "d", "e", "f"), pageSize: 3 });
+      rerender({ data, pageSize: 3 });
 
       expect(result.current.table.getState().pagination.pageIndex).toBe(0);
     });
@@ -463,33 +460,5 @@ describe("encodeRowId (#383)", () => {
 
   it("is stable for the same input", () => {
     expect(encodeRowId(["a", 1, null])).toBe(encodeRowId(["a", 1, null]));
-  });
-});
-
-describe("tableUrlParams (#377)", () => {
-  it("floors a negative page from the URL instead of passing it through", () => {
-    // The URL is user-supplied and `?page=-1` parses cleanly to -1, which would
-    // reach TanStack as a negative pageIndex.
-    expect(tableUrlParams.page.parse("-1")).toBe(0);
-    expect(tableUrlParams.page.parse("2")).toBe(2);
-  });
-
-  it("leaves an out-of-range high page alone, which is the caller's concern", () => {
-    // Clamping here cannot tell "rows have not arrived" from "genuinely out of
-    // range" — the rewrite that tries is the bug #381 fixed.
-    expect(tableUrlParams.page.parse("99")).toBe(99);
-  });
-
-  it("omits a sort equal to the default rather than serialising it (#377)", () => {
-    const withDefault = sortParser.withDefault({ id: "name", desc: false });
-    expect(
-      withDefault.eq?.(
-        { id: "name", desc: false },
-        { id: "name", desc: false },
-      ),
-    ).toBe(true);
-    expect(
-      withDefault.eq?.({ id: "name", desc: true }, { id: "name", desc: false }),
-    ).toBe(false);
   });
 });

--- a/frontend/tests/components/useTableState.test.tsx
+++ b/frontend/tests/components/useTableState.test.tsx
@@ -8,6 +8,10 @@ import {
   type TableStore,
 } from "@/components/data-table/useTableState";
 import { encodeRowId } from "@/components/data-table/rowId";
+import {
+  sortParser,
+  tableUrlParams,
+} from "@/components/data-table/tableUrlStore";
 
 /**
  * The hook layer of #365's split: everything here is identical for every caller
@@ -94,9 +98,9 @@ describe("useTableState", () => {
       rerender({ data: rows("a", "c"), scope: "filtered" });
 
       expect(result.current.selectedIds).toEqual([]);
-      expect(
-        Object.keys(result.current.table.getState().rowSelection),
-      ).toEqual([]);
+      expect(Object.keys(result.current.table.getState().rowSelection)).toEqual(
+        [],
+      );
     });
 
     it("prunes raw state, not just the derived output, so the header checkbox agrees (#307)", () => {
@@ -116,9 +120,9 @@ describe("useTableState", () => {
       // this true-but-stale, because the header counts raw state (#359).
       expect(result.current.selectedIds).toEqual(["a"]);
       expect(getIsAllSelected(result.current.table)).toBe(true);
-      expect(
-        Object.keys(result.current.table.getState().rowSelection),
-      ).toEqual(["a"]);
+      expect(Object.keys(result.current.table.getState().rowSelection)).toEqual(
+        ["a"],
+      );
     });
 
     it("keeps a selection whose rows are merely on another page (#307)", () => {
@@ -154,9 +158,9 @@ describe("useTableState", () => {
       });
 
       expect(result.current.selectedIds).toEqual([]);
-      expect(
-        Object.keys(result.current.table.getState().rowSelection),
-      ).toEqual([]);
+      expect(Object.keys(result.current.table.getState().rowSelection)).toEqual(
+        [],
+      );
     });
   });
 
@@ -206,6 +210,31 @@ describe("useTableState", () => {
       // difference is the whole reason the parameter is required (#359, #382).
       expect(getIsAllSelected(result.current.table)).toBe(true);
       expect(result.current.table.getIsAllRowsSelected()).toBe(false);
+    });
+
+    it("does not mark a page indeterminate because another page holds a selection", () => {
+      const { result } = renderTable({
+        data: rows("a", "b", "c", "d"),
+        scope: "page",
+        pageSize: 2,
+      });
+
+      act(() => {
+        result.current.table.nextPage();
+      });
+      act(() => {
+        result.current.table.getRowModel().rows[0].toggleSelected(true);
+      });
+      act(() => {
+        result.current.table.previousPage();
+      });
+
+      // Nothing on page 1 is selected. Reading the all-check at page scope but
+      // the some-check globally renders this checkbox indeterminate anyway.
+      expect(
+        result.current.table.getRowModel().rows.map((row) => row.id),
+      ).toEqual(["a", "b"]);
+      expect(getIsAllSelected(result.current.table)).toBe(false);
     });
 
     it("reports indeterminate under filtered scope for the same selection", () => {
@@ -434,5 +463,33 @@ describe("encodeRowId (#383)", () => {
 
   it("is stable for the same input", () => {
     expect(encodeRowId(["a", 1, null])).toBe(encodeRowId(["a", 1, null]));
+  });
+});
+
+describe("tableUrlParams (#377)", () => {
+  it("floors a negative page from the URL instead of passing it through", () => {
+    // The URL is user-supplied and `?page=-1` parses cleanly to -1, which would
+    // reach TanStack as a negative pageIndex.
+    expect(tableUrlParams.page.parse("-1")).toBe(0);
+    expect(tableUrlParams.page.parse("2")).toBe(2);
+  });
+
+  it("leaves an out-of-range high page alone, which is the caller's concern", () => {
+    // Clamping here cannot tell "rows have not arrived" from "genuinely out of
+    // range" — the rewrite that tries is the bug #381 fixed.
+    expect(tableUrlParams.page.parse("99")).toBe(99);
+  });
+
+  it("omits a sort equal to the default rather than serialising it (#377)", () => {
+    const withDefault = sortParser.withDefault({ id: "name", desc: false });
+    expect(
+      withDefault.eq?.(
+        { id: "name", desc: false },
+        { id: "name", desc: false },
+      ),
+    ).toBe(true);
+    expect(
+      withDefault.eq?.({ id: "name", desc: true }, { id: "name", desc: false }),
+    ).toBe(false);
   });
 });

--- a/frontend/tests/pages/ActivityPage.test.tsx
+++ b/frontend/tests/pages/ActivityPage.test.tsx
@@ -95,6 +95,60 @@ describe("ActivityPage", () => {
     expect(await screen.findByText("Direct download requeued.")).toBeTruthy();
   });
 
+  /**
+   * The server-paginated model gets no page reset from TanStack:
+   * `autoResetPageIndex` is inert under `manualPagination` (#360), so this
+   * invariant has no owner but the caller. It was hand-rolled inside
+   * `useActivityTableState`, which #393 deleted, and nothing else pinned it —
+   * a reset that quietly stopped happening would leave a user on page 3 of a
+   * result set that no longer has one.
+   */
+  it("returns to the first page when the sort or the filter changes", async () => {
+    const requests: URL[] = [];
+    server.use(
+      http.get("/api/downloads/queue", ({ request }) => {
+        const url = new URL(request.url);
+        requests.push(url);
+        const offset = Number(url.searchParams.get("offset") || 0);
+        return HttpResponse.json({
+          queue: [{ ...queueItem, ID: `queue-${offset}` }],
+          pagination: { total: 90, limit: 25, offset, has_more: true },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<ActivityPage />, { route: "/activity", useMemoryRouter: true });
+    await screen.findByText("Absolute Flash");
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => {
+      expect(requests.at(-1)?.searchParams.get("offset")).toBe("25");
+    });
+
+    await user.click(screen.getByRole("button", { name: /Updated/ }));
+    await waitFor(() => {
+      const last = requests.at(-1);
+      expect(last?.searchParams.get("order")).toBe("asc");
+      expect(last?.searchParams.get("offset")).toBe("0");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => {
+      expect(requests.at(-1)?.searchParams.get("offset")).toBe("25");
+    });
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Filter queue activity" }),
+      "flash",
+    );
+    await waitFor(() => {
+      const last = requests.at(-1);
+      expect(last?.searchParams.get("q")).toBe("flash");
+      expect(last?.searchParams.get("offset")).toBe("0");
+    });
+  });
+
   it("filters, sorts, and paginates the live queue through the API", async () => {
     const requests: URL[] = [];
     server.use(


### PR DESCRIPTION
Resolves #393. PR 1 of the four-PR cut decided in #366, on map #353.

## What this is

`data-table/useTableState.ts` wraps `useReactTable` and is now the only file allowed to import it. That is what lets `getRowId` be **required** rather than merely offered — a hook sitting *beside* the call can only suggest a correct row id, and TanStack's index-based default is precisely the silent default nobody chose (#307, #359). Every state slice and `on*Change` handler is `Omit`ted from the passthrough, so a caller cannot quietly take one back.

New modules:

| File | Why |
|---|---|
| `data-table/useTableState.ts` | The seam. Selection + pruning, sorting, global filter, pagination, expanded; `selectedRows`/`selectedIds` always from `getSelectedRowModel()`; `clearSelection()` |
| `data-table/tableUrlStore.ts` | Caller-side nuqs half of #377 — `sortParser` (**with `eq`**), `tableUrlParams`, `useTableUrlStore`. `useTableState.ts` imports nothing from it |
| `data-table/rowId.ts` | #383's shared safe encoder |
| `data-table/useServerPage.ts` | #360's server-page extraction |

## The extraction lands with its callers, not alone

#308's standing warning on this map is 7,447 lines of table engine deleted for having no callers — and an extraction PR that adds the hook and migrates nothing reproduces that state for however long PR 2 takes. The caller was not a choice either: the hook **is** the generalisation of `useActivityTableState`, whose two tables already called it. So `ActivityPage` migrates here and that hook is deleted. It was file-local with three references inside its own file, so no source-scan pin is owed (#366).

## Row identity

`ActivityPage.tsx:590` was `` `${IssueID}-${Status}-${index}` `` — positional, so the same row changes id on any page or sort change. The narrowed `getRowId` stops it compiling. #383 established the real identity is **already database-enforced** (`snatched` carries `UNIQUE(IssueID, Status, Provider)`), so no backend change is needed. It is *encoded* rather than joined because `Status` takes the literal value `Post-Processed`, which contains the delimiter a bare join would use — and the encoder is shared so it kills the class rather than this instance (`ImportTable`'s `Volume || "null"` adopts it in #396).

Per #365's reachability rule this fix is **latent** — the history table has no selection, so nothing reads a row id — and therefore ships inside the migration rather than red-then-green.

## The lint boundary is a ratchet, not a gate

#365 made the identity boundary `no-restricted-imports`. Taken literally that is a **gate**: the moment it lands, every unmigrated call site fails CI, forcing all six instances into one PR. #366 resolved it as a ratchet — the rule is enforced from this PR, with an `overrides` allowlist naming the four tables still to migrate. Each later PR deletes its own line; #396 deletes the block.

Verified by probe rather than asserted: a fresh `useReactTable` import in a new file **errors**, and allowlisted files stay clean. A new call site therefore cannot appear while the migration is in flight.

This also narrows `react-hooks/incompatible-library` from a **repo-wide** disable to the files that actually call TanStack — #365's secondary win, arriving now rather than at the end.

## Two bugs the hook test caught

Both from memoising on `table`, which is referentially stable for the component's lifetime:

- selection pruning computed its visible-id set **once** and would never have fired again;
- `selectedRows` would never have recomputed.

Restoring either turns the suite red.

## Tests

**22 hook tests.** `renderHook` appears nowhere else in this repo — a new idiom, adopted deliberately per #365 because six-way duplication of generic behaviour is worse. Five carry their `#307` reference: they are the generic half of `QueueTableSelection.test.tsx`, which migrates here under #395, and per #365 no pin retires until its replacement lands.

**Every assertion was mutation-checked.** Two initially passed against a deliberately broken hook and were rewritten. One of those exposed an error in my own reasoning, not just a weak test: `resetRowSelection(true)` and `(false)` are **equivalent** once `initialState` is `Omit`ted, so that argument is not what closes v8's scope-limited deselect-all leak — what closes it is `clearSelection` existing as a separate operation. The code comment is corrected and the test now demonstrates the actual leak.

One surviving mutant, recorded rather than hidden: deriving `selectedIds` from raw state instead of `getSelectedRowModel()` passes. Those two are equivalent *given* correct pruning, and the "prunes raw state" test already pins the half that can diverge.

**One new site test.** Reset-on-sort-and-filter for the server-paginated model was covered by nothing, and `autoResetPageIndex` is inert under `manualPagination` (#360), so it has no owner but the caller. Both halves mutation-checked.

## Parity

`ActivityPage.test.tsx`'s three existing tests pass **verbatim** — the component interface is unchanged, which is the proof this PR rests on. Suite: **28 files / 167 tests**, against a 27/144 baseline. `tsc` clean; all four lint lanes clean.

## Deviation from #359 — flagged for review

#359 specifies `selectAllScope` as a bare required parameter. That discussion only ever considered the four *selection* tables; `ActivityPage` has none, and forcing it to name a scope would be meaningless. Implemented instead as `selection?: { scope }` — absent means no row selection, present means scope is required with no default. This preserves #359's actual point (no selection without naming the scope) and mirrors #360's own idiom, where the absence of `pagination` is itself a model. Cheap to change now, painful after #394.

## No changeset

Nothing here is observable to an operator: the row-id fix is latent and `manualPagination: true` is honest-but-invisible (#360). Per #386 the new lint gate is contributor-visible, so it is documented in `CLAUDE.md` instead of the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TGrvFNfYXfV5U1aMMZvHb
