### PR TITLE
fix: Make METRON_PASSWORD writable so the Metron Password field saves

### DIFF
--- a/.changeset/metron-password-saves.md
+++ b/.changeset/metron-password-saves.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+The Metron Password field in Settings → API now actually saves. `METRON_PASSWORD` was never registered as writable, so every save silently dropped it — the "Password saved" indicator could only ever reflect a value set outside the UI. The password is stored encrypted like the other secrets, and an empty field leaves a previously saved password unchanged.

--- a/comicarr/app/config/registry.py
+++ b/comicarr/app/config/registry.py
@@ -254,7 +254,7 @@ _KEYS: tuple[ConfigKey, ...] = (
     ConfigKey("CV_MAX_PARALLEL_REQUESTS", int, "CV", 3),
     ConfigKey("IMPRINT_MAPPING_TYPE", str, "CV", "CV"),
     ConfigKey("METRON_USERNAME", str, "Metron", None, readable=True, writable=True),
-    ConfigKey("METRON_PASSWORD", str, "Metron", None),
+    ConfigKey("METRON_PASSWORD", str, "Metron", None, writable=True),
     ConfigKey("USE_METRON_SEARCH", bool, "Metron", False, readable=True, writable=True),
     ConfigKey("MANGADEX_ENABLED", bool, "MangaDex", True, readable=True, writable=True),
     ConfigKey("MANGADEX_LANGUAGES", str, "MangaDex", "en", readable=True, writable=True),

--- a/frontend/src/components/settings/ApiTab.tsx
+++ b/frontend/src/components/settings/ApiTab.tsx
@@ -36,15 +36,6 @@ export function ApiTab({
   const comicvineApiIsSet = config.comicvine_api_set || false;
   const metronPasswordIsSet = config.metron_password_set || false;
 
-  // METRON_PASSWORD is default-deny in the registry, so it has no
-  // SettingsFormData/WritableConfig key and update_config silently drops it —
-  // this field has never saved. #398 tracks making it writable; these two
-  // escapes keep the field behaving exactly as before until then.
-  const metronPassword = (formData as { metron_password?: string })
-    .metron_password;
-  const metronPasswordKey =
-    "metron_password" as unknown as keyof WritableConfig;
-
   const handleCopyApiKey = async () => {
     if (!displayedApiKey) {
       addToast({
@@ -206,16 +197,16 @@ export function ApiTab({
           />
           <SettingField
             label="Metron Password"
-            value={metronPassword}
+            value={formData.metron_password}
             type="password"
-            onChange={(value) => onChange(metronPasswordKey, value as string)}
+            onChange={(value) => onChange("metron_password", value as string)}
             placeholder={
               metronPasswordIsSet
                 ? "Password saved (enter new value to change)"
                 : "Your Metron password"
             }
             helpText={
-              metronPasswordIsSet && !metronPassword
+              metronPasswordIsSet && !formData.metron_password
                 ? "Metron password is configured. Enter a new value to change it."
                 : "Register at https://metron.cloud"
             }

--- a/frontend/src/lib/configSave.ts
+++ b/frontend/src/lib/configSave.ts
@@ -15,6 +15,7 @@ const REDACTED_SECRET_FIELDS: ReadonlyArray<{
   { field: "ai_api_key", indicator: "ai_api_key_set" },
   { field: "comicvine_api", indicator: "comicvine_api_set" },
   { field: "mal_client_id", indicator: "mal_client_id_set" },
+  { field: "metron_password", indicator: "metron_password_set" },
   { field: "prowl_keys", indicator: "prowl_keys_set" },
   { field: "slack_webhook_url", indicator: "slack_webhook_url_set" },
   { field: "mattermost_webhook_url", indicator: "mattermost_webhook_url_set" },

--- a/frontend/src/types/config.generated.ts
+++ b/frontend/src/types/config.generated.ts
@@ -159,6 +159,7 @@ export interface WritableConfig {
   cv_verify?: boolean;
   cv_only?: boolean;
   metron_username?: string;
+  metron_password?: string;
   use_metron_search?: boolean;
   mangadex_enabled?: boolean;
   mangadex_languages?: string;


### PR DESCRIPTION
Closes #398.

## What

The Metron Password field in Settings → API has never persisted: `METRON_PASSWORD` was default-deny in `comicarr/app/config/registry.py` (and missing from the old hand-maintained `WRITABLE_CONFIG_KEYS` before the registry existed), so `update_config` silently filtered it out of every save while the UI showed success.

## How

- Register `METRON_PASSWORD` as a write-only secret (`writable=True`, not readable) like the other 15 redacted keys; the existing `metron_password_set` indicator and the encrypted-items map in `comicarr/config.py` already handle the rest, so the value is Fernet-encrypted at rest.
- Regenerate `frontend/src/types/config.generated.ts` (+1 writable key).
- Add `metron_password` → `metron_password_set` to `REDACTED_SECRET_FIELDS` in `frontend/src/lib/configSave.ts`, so an empty field with a saved password means "unchanged" rather than clearing it.
- Drop the typed escape hatch `ApiTab.tsx` carried for the unwritable key since #400; the field now uses the generated types directly.

Operator-observable (the field starts working), so it carries a patch changeset.

## Verification

- `npm run lint` passes (modern + backend + generated freshness + frontend)
- `tsc --noEmit` clean
- `pytest tests/unit`: 1825 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wxer8NPNJ3TJCk2X37aCMB