### PR TITLE
fix: Reset the page size before paint, not after

### DIFF
--- a/frontend/src/components/data-table/useTableState.ts
+++ b/frontend/src/components/data-table/useTableState.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   getCoreRowModel,
   getExpandedRowModel,
@@ -269,9 +276,14 @@ export function useTableState<TData>({
 
   // A page-size change alters no `data` identity, so TanStack's auto-reset
   // provably cannot see it — the one page reset the hook still owes (#360).
+  //
+  // Layout effect, not effect: the reset has to land before paint, or a
+  // pageSize change renders one frame of the *old* page index against the new
+  // size — on the Library grid/list toggle (20 <-> 24) that is a visible flash
+  // of rows the user did not ask for.
   const pageSize = pagination?.pageSize;
   const previousPageSize = useRef(pageSize);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (previousPageSize.current !== pageSize) {
       previousPageSize.current = pageSize;
       if (store) store.setState({ pageIndex: 0 });


### PR DESCRIPTION
Follow-up to #401, which merged while this commit was still in flight — everything else from the review round landed, this one missed the window.

The page-size reset in `useTableState` ran in a `useEffect`, so a `pageSize` change painted one frame of the **old** `pageIndex` against the new size. On the Library grid/list toggle (20 ⇄ 24) that is a visible flash of rows the user did not ask for. `useLayoutEffect` lands the reset before paint. No SSR in this app, so the usual caveat does not apply.

This is the one page reset the hook still owes: a page-size change alters no `data` identity, so TanStack's `autoResetPageIndex` provably cannot see it (#360).

Found by a CodeRabbit CLI review — the PR-level CodeRabbit check has returned `Review rate limited` on every PR in this series, so nothing automated is actually reading these.

**Verified:** `tsc` clean, lint clean, 29 files / 173 tests. Re-mutated — removing the reset still turns the suite red, so the pin survives the effect swap.

No changeset: nothing here is observable to an operator on `main` today, since the only site with a variable page size is `SeriesTable`, which migrates under #394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TGrvFNfYXfV5U1aMMZvHb