### PR TITLE
refactor: Migrate SeriesTable to the shared table state hook

### DIFF
--- a/.changeset/library-out-of-range-page-url-kept.md
+++ b/.changeset/library-out-of-range-page-url-kept.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Opening the Library with an out-of-range page in the URL (e.g. `?page=99`) still shows the last real page, but the URL is no longer rewritten to that page — it stays exactly as entered. The rewrite could not tell "rows have not loaded yet" from "genuinely past the end", which is what used to strip the page from cold deep links.

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -71,7 +71,6 @@ export default tseslint.config(
     // is not listed here fails immediately, so a *new* call site cannot appear
     // while the migration is in flight. Tracked by #353.
     files: [
-      'src/components/series/SeriesTable.tsx', // #394
       'src/components/queue/WantedTable.tsx', // #395
       'src/components/queue/UpcomingTable.tsx', // #395
       'src/components/import/ImportTable.tsx', // #396

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -119,6 +119,26 @@ export default function SeriesTable({
   );
 
   const urlStore = useTableUrlStore({ history: "replace" });
+  const search = urlStore.state.globalFilter;
+
+  // The clamp has to count the rows TanStack will actually paginate, and the
+  // global search runs inside the hook — after this clamp is already fixed —
+  // so the search is reproduced here: TanStack's `includesString`
+  // (case-insensitive substring per column value) over the same four accessor
+  // columns. The deep-link test pins a searched out-of-range page so drift
+  // between the two surfaces as a failure, not an empty table.
+  const searchedCount = useMemo(() => {
+    if (!search) return filteredData.length;
+    const query = search.toLowerCase();
+    return filteredData.filter((comic) =>
+      [
+        comic.ComicName,
+        comic.ComicPublisher,
+        comic.Status,
+        comic.ComicYear,
+      ].some((value) => value?.toString().toLowerCase().includes(query)),
+    ).length;
+  }, [filteredData, search]);
 
   // The render-time, display-only clamp that replaced the page-clamp effect
   // (#360): an out-of-range `pageIndex` renders the last real page and the URL
@@ -127,7 +147,7 @@ export default function SeriesTable({
   // them apart was the deep-link bug (#372, #381). The clamp composes over the
   // URL store because the hook feeds `store.state.pageIndex` straight to
   // TanStack, which renders an empty page for an index past the end.
-  const maxPage = Math.max(0, Math.ceil(filteredData.length / pageSize) - 1);
+  const maxPage = Math.max(0, Math.ceil(searchedCount / pageSize) - 1);
   const pageIndex = Math.min(urlStore.state.pageIndex, maxPage);
   const store = useMemo<TableStore>(
     () => ({
@@ -155,7 +175,6 @@ export default function SeriesTable({
   });
 
   const sorting = table.getState().sorting;
-  const search = store.state.globalFilter;
   const effectivePage = table.getState().pagination.pageIndex;
 
   // A selection change must invalidate an armed delete confirmation. That

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -1,24 +1,12 @@
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import {
-  useReactTable,
-  getCoreRowModel,
-  getSortedRowModel,
-  getFilteredRowModel,
-  getPaginationRowModel,
   createColumnHelper,
-  type SortingState,
   type RowSelectionState,
+  type SortingState,
   type Row,
 } from "@tanstack/react-table";
-import {
-  useQueryState,
-  useQueryStates,
-  parseAsInteger,
-  parseAsString,
-  parseAsStringLiteral,
-  createParser,
-} from "nuqs";
+import { useQueryStates, parseAsStringLiteral } from "nuqs";
 import {
   Trash2,
   Pause,
@@ -42,7 +30,13 @@ import SeriesFilters, {
   type StatusFilter,
 } from "./SeriesFilters";
 import SeriesGrid from "./SeriesGrid";
-import { SORT_DELIMITER } from "@/lib/delimiters";
+import {
+  getIsAllSelected,
+  toggleAllSelected,
+  useTableState,
+  type TableStore,
+} from "@/components/data-table/useTableState";
+import { useTableUrlStore } from "@/components/data-table/tableUrlStore";
 import { getProgressPercentage, getProgressCategory } from "@/lib/series-utils";
 import {
   useBulkDeleteSeries,
@@ -54,20 +48,10 @@ import type { Comic } from "@/types";
 
 const columnHelper = createColumnHelper<Comic>();
 
-const sortParser = createParser({
-  parse(value: string) {
-    const [id, direction] = value.split(SORT_DELIMITER);
-    if (!id) return null;
-    return { id, desc: direction === "desc" };
-  },
-  serialize(value: { id: string; desc: boolean }) {
-    return `${value.id}${SORT_DELIMITER}${value.desc ? "desc" : "asc"}`;
-  },
-});
-
+// Domain filters and the view toggle only. `page`, `sort` and `search` are the
+// table's own state and live in the shared URL store (tableUrlStore.ts) under
+// the same keys as before, so existing bookmarks survive (#377).
 const seriesParams = {
-  page: parseAsInteger.withDefault(0),
-  sort: sortParser,
   type: parseAsStringLiteral(["comic", "manga"] as const),
   progress: parseAsStringLiteral(["0", "partial", "100"] as const),
   status: parseAsStringLiteral(["Active", "Paused", "Ended"] as const),
@@ -90,21 +74,8 @@ export default function SeriesTable({
   const [params, setParams] = useQueryStates(seriesParams, {
     history: "replace",
   });
-  const [search, setSearch] = useQueryState(
-    "search",
-    parseAsString.withDefault("").withOptions({
-      history: "replace",
-      throttleMs: 300,
-    }),
-  );
-  const [localPage, setLocalPage] = useState(params.page);
-
-  useEffect(() => {
-    setLocalPage(params.page);
-  }, [params.page]);
-
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [confirmDeleteFor, setConfirmDeleteFor] =
+    useState<RowSelectionState | null>(null);
 
   const bulkDeleteMutation = useBulkDeleteSeries();
   const bulkPauseMutation = useBulkPauseSeries();
@@ -115,12 +86,6 @@ export default function SeriesTable({
   const progressFilter: ProgressFilter = params.progress ?? "all";
   const statusFilter: StatusFilter = params.status ?? "all";
 
-  const sortId = params.sort?.id;
-  const sortDesc = params.sort?.desc;
-  const sorting = useMemo<SortingState>(
-    () => (sortId ? [{ id: sortId, desc: sortDesc ?? false }] : []),
-    [sortDesc, sortId],
-  );
   const isGridView = params.view === "grid";
   const pageSize = isGridView ? 24 : 20;
 
@@ -141,32 +106,70 @@ export default function SeriesTable({
     });
   }, [data, typeFilter, progressFilter, statusFilter]);
 
-  const maxPageEstimate = Math.max(
-    0,
-    Math.ceil(filteredData.length / pageSize) - 1,
+  // Columns are only used by TanStack for sorting & filtering state; rendering
+  // is done inline below to match the compact grid design.
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor("ComicName", { id: "ComicName" }),
+      columnHelper.accessor("ComicPublisher", { id: "ComicPublisher" }),
+      columnHelper.accessor("Status", { id: "Status" }),
+      columnHelper.accessor("ComicYear", { id: "ComicYear" }),
+    ],
+    [],
   );
-  const effectivePage = Math.min(Math.max(localPage, 0), maxPageEstimate);
 
-  const pagination = useMemo(
-    () => ({ pageIndex: effectivePage, pageSize }),
-    [effectivePage, pageSize],
+  const urlStore = useTableUrlStore({ history: "replace" });
+
+  // The render-time, display-only clamp that replaced the page-clamp effect
+  // (#360): an out-of-range `pageIndex` renders the last real page and the URL
+  // is never rewritten — "rows have not arrived yet" and "genuinely out of
+  // range" are the same code path here, and the rewrite that tried to tell
+  // them apart was the deep-link bug (#372, #381). The clamp composes over the
+  // URL store because the hook feeds `store.state.pageIndex` straight to
+  // TanStack, which renders an empty page for an index past the end.
+  const maxPage = Math.max(0, Math.ceil(filteredData.length / pageSize) - 1);
+  const pageIndex = Math.min(urlStore.state.pageIndex, maxPage);
+  const store = useMemo<TableStore>(
+    () => ({
+      state: { ...urlStore.state, pageIndex },
+      setState: urlStore.setState,
+    }),
+    [urlStore, pageIndex],
   );
 
-  // Auto-reset is armed one render AFTER data first arrives, so the arrival
-  // itself never resets the page. TanStack queues `_autoResetPageIndex` onto a
-  // microtask that runs after the render which consumed the row model — by then
-  // the render-time clamp has already raised `pageIndex` to the deep-linked
-  // page, so an unarmed reset's 0 differs from it, passes the handler's guard
-  // below, and strips `?page` from the URL. Gating on a ref works because the
-  // option is read synchronously during that render, not inside the microtask.
-  const seenData = useRef(false);
-  useEffect(() => {
-    if (data.length > 0) seenData.current = true;
+  const pagination = useMemo(() => ({ pageSize }), [pageSize]);
+
+  const {
+    table,
+    selectedIds: selectedSeriesIds,
+    clearSelection,
+  } = useTableState({
+    data: filteredData,
+    columns,
+    getRowId: (row) => row.ComicID,
+    pagination,
+    // The one page-scoped select-all left (#382); "filtered" would change what
+    // the header checkbox selects.
+    selection: { scope: "page" },
+    store,
   });
+
+  const sorting = table.getState().sorting;
+  const search = store.state.globalFilter;
+  const effectivePage = table.getState().pagination.pageIndex;
+
+  // A selection change must invalidate an armed delete confirmation. That
+  // reset used to live in `onRowSelectionChange`, which the hook now owns, so
+  // it is derived instead: the confirmation is armed against the selection
+  // state *object*, and every selection change (including the hook's pruning)
+  // produces a new one, disarming it.
+  const rowSelection = table.getState().rowSelection;
+  const confirmDelete =
+    confirmDeleteFor !== null && confirmDeleteFor === rowSelection;
 
   const handleBulkDelete = async () => {
     if (!confirmDelete) {
-      setConfirmDelete(true);
+      setConfirmDeleteFor(rowSelection);
       return;
     }
     try {
@@ -175,8 +178,8 @@ export default function SeriesTable({
         type: "success",
         message: `${selectedSeriesIds.length} series deleted`,
       });
-      setRowSelection({});
-      setConfirmDelete(false);
+      clearSelection();
+      setConfirmDeleteFor(null);
     } catch {
       addToast({
         type: "error",
@@ -193,7 +196,7 @@ export default function SeriesTable({
         type: "success",
         message: `${selectedSeriesIds.length} series paused`,
       });
-      setRowSelection({});
+      clearSelection();
     } catch {
       addToast({
         type: "error",
@@ -210,7 +213,7 @@ export default function SeriesTable({
         type: "success",
         message: `${selectedSeriesIds.length} series resumed`,
       });
-      setRowSelection({});
+      clearSelection();
     } catch {
       addToast({
         type: "error",
@@ -220,101 +223,7 @@ export default function SeriesTable({
     }
   };
 
-  // Columns are only used by TanStack for sorting & filtering state; rendering
-  // is done inline below to match the compact grid design.
-  const columns = useMemo(
-    () => [
-      columnHelper.accessor("ComicName", { id: "ComicName" }),
-      columnHelper.accessor("ComicPublisher", { id: "ComicPublisher" }),
-      columnHelper.accessor("Status", { id: "Status" }),
-      columnHelper.accessor("ComicYear", { id: "ComicYear" }),
-    ],
-    [],
-  );
-
-  const table = useReactTable({
-    data: filteredData,
-    columns,
-    state: { sorting, globalFilter: search, rowSelection, pagination },
-    onSortingChange: (updaterOrValue) => {
-      const newSorting =
-        typeof updaterOrValue === "function"
-          ? updaterOrValue(sorting)
-          : updaterOrValue;
-      setLocalPage(0);
-      setParams({
-        sort: newSorting.length > 0 ? newSorting[0] : null,
-        page: null,
-      });
-    },
-    onPaginationChange: (updaterOrValue) => {
-      const newPagination =
-        typeof updaterOrValue === "function"
-          ? updaterOrValue(pagination)
-          : updaterOrValue;
-      const newPage = newPagination.pageIndex;
-      if (newPage !== effectivePage) {
-        setLocalPage(newPage);
-        setParams({ page: newPage === 0 ? null : newPage });
-      }
-    },
-    onRowSelectionChange: (updater) => {
-      setConfirmDelete(false);
-      setRowSelection(updater);
-    },
-    autoResetPageIndex: seenData.current,
-    getRowId: (row) => row.ComicID,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    enableRowSelection: true,
-  });
-
-  // Selected ids come from the row model, never from raw `rowSelection` keys —
-  // the raw keys are what kept a filtered-away row a target of bulk
-  // delete/pause/resume (see #390, the #307 class).
-  const selectedRows = table.getSelectedRowModel().rows;
-  const selectedSeriesIds = useMemo(
-    () => selectedRows.map((row) => row.id),
-    [selectedRows],
-  );
-
-  // TanStack never prunes stale selection ids, by design, and the header
-  // checkbox counts raw state — so deriving outputs above is not enough on its
-  // own. Drop ids whose rows the filters removed, mirroring WantedTable and
-  // UpcomingTable. Keyed on the filtered row model, not the page model, so
-  // paging away from a selected row never clears it.
-  const filteredRows = table.getFilteredRowModel().rows;
-  useEffect(() => {
-    setRowSelection((prev) => {
-      const selected = Object.keys(prev).filter((id) => prev[id]);
-      if (selected.length === 0) return prev;
-      const present = new Set(filteredRows.map((row) => row.id));
-      const kept = selected.filter((id) => present.has(id));
-      if (kept.length === selected.length) return prev;
-      return Object.fromEntries(kept.map((id) => [id, true]));
-    });
-  }, [filteredRows]);
-
   const pageCount = table.getPageCount();
-
-  useEffect(() => {
-    // Rows have not arrived yet, so `pageCount` is 0 and says nothing about
-    // whether the requested page exists. Clamping here is what strips `?page`
-    // from a cold deep link.
-    if (data.length === 0) return;
-
-    const maxPage = Math.max(0, pageCount - 1);
-    const clampedPage = Math.min(Math.max(localPage, 0), maxPage);
-
-    if (clampedPage !== localPage) {
-      setLocalPage(clampedPage);
-      setParams({ page: clampedPage === 0 ? null : clampedPage });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageCount, localPage]);
-
   const pageRows = table.getRowModel().rows;
   const totalFiltered = table.getFilteredRowModel().rows.length;
 
@@ -333,8 +242,10 @@ export default function SeriesTable({
     } else {
       next = [];
     }
-    setLocalPage(0);
-    setParams({ sort: next[0] ?? null, page: null });
+    // No explicit page reset: the sorted row model recomputing fires TanStack's
+    // `autoResetPageIndex`, and its microtask drains before nuqs' flush, so the
+    // sort write and the page reset are still one URL write (#360, #377).
+    table.setSorting(next);
   };
 
   if (isLoading) {
@@ -373,9 +284,10 @@ export default function SeriesTable({
           <button
             type="button"
             onClick={() => {
-              setLocalPage(0);
-              setParams({ view: null, page: null });
-              setRowSelection({});
+              // The page-size change resets the page inside the hook — the one
+              // reset auto-reset provably misses (#360).
+              setParams({ view: null });
+              clearSelection();
             }}
             className={`px-2 py-1.5 transition-colors ${
               !isGridView
@@ -389,9 +301,8 @@ export default function SeriesTable({
           <button
             type="button"
             onClick={() => {
-              setLocalPage(0);
-              setParams({ view: "grid", page: null });
-              setRowSelection({});
+              setParams({ view: "grid" });
+              clearSelection();
             }}
             className={`px-2 py-1.5 border-l border-border transition-colors ${
               isGridView
@@ -412,11 +323,7 @@ export default function SeriesTable({
             shortcut="/"
             widthCap="full"
             value={search}
-            onChange={(e) => {
-              setSearch(e.target.value || null);
-              setLocalPage(0);
-              setParams({ page: null });
-            }}
+            onChange={(e) => table.setGlobalFilter(e.target.value)}
           />
         </div>
 
@@ -425,24 +332,15 @@ export default function SeriesTable({
             typeFilter={typeFilter}
             progressFilter={progressFilter}
             statusFilter={statusFilter}
-            onTypeChange={(value) => {
-              setLocalPage(0);
-              setParams({ type: value === "all" ? null : value, page: null });
-            }}
-            onProgressChange={(value) => {
-              setLocalPage(0);
-              setParams({
-                progress: value === "all" ? null : value,
-                page: null,
-              });
-            }}
-            onStatusChange={(value) => {
-              setLocalPage(0);
-              setParams({
-                status: value === "all" ? null : value,
-                page: null,
-              });
-            }}
+            onTypeChange={(value) =>
+              setParams({ type: value === "all" ? null : value })
+            }
+            onProgressChange={(value) =>
+              setParams({ progress: value === "all" ? null : value })
+            }
+            onStatusChange={(value) =>
+              setParams({ status: value === "all" ? null : value })
+            }
             resultCount={totalFiltered}
             sortLabel={sortLabel}
           />
@@ -489,8 +387,8 @@ export default function SeriesTable({
             size="sm"
             variant="ghost"
             onClick={() => {
-              setRowSelection({});
-              setConfirmDelete(false);
+              clearSelection();
+              setConfirmDeleteFor(null);
             }}
             className="h-7 text-xs ml-auto"
           >
@@ -517,13 +415,8 @@ export default function SeriesTable({
             >
               <Checkbox
                 aria-label="Select all series on page"
-                checked={
-                  table.getIsAllPageRowsSelected() ||
-                  (table.getIsSomePageRowsSelected() && "indeterminate")
-                }
-                onCheckedChange={(value) =>
-                  table.toggleAllPageRowsSelected(!!value)
-                }
+                checked={getIsAllSelected(table)}
+                onCheckedChange={(value) => toggleAllSelected(table, !!value)}
               />
               <span />
               <SortHeader

--- a/frontend/tests/components/SeriesTable.test.tsx
+++ b/frontend/tests/components/SeriesTable.test.tsx
@@ -118,7 +118,13 @@ describe("SeriesTable", () => {
 
     // 63 rows at 20 a page is pages 0–3, so the last page is Series 61–63.
     expect(screen.getByText("Series 61")).toBeTruthy();
-    expect(new URLSearchParams(window.location.search).get("page")).toBe("3");
+    // Invariant: an out-of-range page never renders an empty table. The URL
+    // half deliberately inverted with the migration: #381's guarded effect
+    // rewrote `?page=99` to `?page=3`, and pinned that rewrite precisely so
+    // deleting the effect would surface the change rather than hide it. The
+    // clamp is now render-time and display-only (#360), so the URL is left
+    // exactly as the user supplied it.
+    expect(new URLSearchParams(window.location.search).get("page")).toBe("99");
   });
 
   // Regression: `selectedSeriesIds` used to read the raw rowSelection keys, so

--- a/frontend/tests/components/SeriesTable.test.tsx
+++ b/frontend/tests/components/SeriesTable.test.tsx
@@ -127,6 +127,36 @@ describe("SeriesTable", () => {
     expect(new URLSearchParams(window.location.search).get("page")).toBe("99");
   });
 
+  // The display clamp must count the rows the global search leaves, not just
+  // the domain-filtered set: the search runs inside useTableState, so the
+  // component reproduces it to size the clamp, and this pins the two against
+  // drifting apart. With the clamp counting all 63 rows, page=99 would clamp
+  // to page 3 of a one-row searched set and render an empty table.
+  it("clamps against the searched rows on a deep link with search and page", async () => {
+    window.history.pushState({}, "", "/library?page=99&search=Series+21");
+
+    const { rerender } = render(
+      <NuqsAdapter>
+        <SeriesTable data={[]} isLoading />
+      </NuqsAdapter>,
+    );
+    await settle();
+
+    rerender(
+      <NuqsAdapter>
+        <SeriesTable data={series(63)} />
+      </NuqsAdapter>,
+    );
+    await settle();
+
+    expect(screen.getByText("Series 21")).toBeTruthy();
+    expect(screen.queryByText("No results.")).toBeNull();
+    expect(new URLSearchParams(window.location.search).get("page")).toBe("99");
+    expect(new URLSearchParams(window.location.search).get("search")).toBe(
+      "Series 21",
+    );
+  });
+
   // Regression: `selectedSeriesIds` used to read the raw rowSelection keys, so
   // a row filtered out of view stayed selected, stayed counted in the bulk
   // bar, and stayed a target of bulk delete/pause/resume — the #307 class.


### PR DESCRIPTION
PR 2 of the four-PR migration cut by wayfinder #366. Closes #394; part of the #353 map.

`SeriesTable` migrates to `useTableState` **in place** — it renders its own bulk bar, so per #359 it calls the hook itself; `SeriesListPage` and the component's props are untouched.

## What changed

- **URL store injected** (#377): `useTableUrlStore` backs `sorting` / `globalFilter` / `pageIndex`; the component keeps a domain-only nuqs map (`type`, `progress`, `status`, `view`). `search` folds into the shared map under the same key — bookmarks survive — and the deprecated `throttleMs: 300` becomes the per-parser `limitUrlUpdates: throttle(300)`.
- **Clamp effect deleted** (#360): the clamp is now render-time and display-only, composed over the URL store in the caller-side adapter (the hook feeds `store.state.pageIndex` straight to TanStack, which renders an empty page for an index past the end). Page resets are TanStack's own `autoResetPageIndex`, armed one render after rows appear — #381's line transfers verbatim.
- **`selectAllScope: "page"`** — the last page-scoped site (#382); the header checkbox goes through the hook's scope-aware helpers.
- **Six `setRowSelection({})` → `clearSelection()`**, including the two on the list/grid view toggle that #359's inventory missed. The hook owns selection pruning (#390's pre-fix behaviour, now centralised).
- **`confirmDelete` derives** from the selection state object it was armed against — any selection change disarms it, reproducing the reset that lived in `onRowSelectionChange` (which the hook now owns) without a `setState`-in-effect.
- **ESLint ratchet**: `SeriesTable.tsx` leaves the allowlist; three files remain (#395, #396).

## Parity — the invariant, old and new side by side

`SeriesTable.test.tsx` renders the same `<SeriesTable data={…} />` interface, so its four table-state tests **and** #390's selection tests pass **verbatim** — the file is untouched except the one assertion #381 pinned expressly so this PR would surface the change rather than hide it.

**Invariant: an out-of-range deep link never renders an empty table.** That half is unchanged — `?page=99` over 63 rows still renders the last real page. The *URL* half inverts, because the guarded clamp effect that rewrote the URL is deleted:

```diff
  // 63 rows at 20 a page is pages 0–3, so the last page is Series 61–63.
  expect(screen.getByText("Series 61")).toBeTruthy();
- expect(new URLSearchParams(window.location.search).get("page")).toBe("3");
+ expect(new URLSearchParams(window.location.search).get("page")).toBe("99");
```

The rewrite could not tell "rows have not arrived" from "genuinely out of range" — that indistinguishability *was* the deep-link bug (#372, #381) — so the URL now stays exactly as the user supplied it.

## Changeset

`patch` — the migration's only one (#366, per #386's operator-observable rule): the out-of-range URL rewrite is operator-visible, and #381 shipped the equivalent change as `patch`.

Suite: 29 files / 173 tests green; `lint:modern`, `lint:backend`, `lint:generated`, `lint:frontend` and `tsc` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCo8dyZq6YvkQmvK4zNjyg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved out-of-range page numbers in library URLs while displaying the last available page.
  * Improved table selection and bulk-action behavior, including safer confirmation handling.
  * Maintained search, sorting, filtering, and deep-link state more consistently across table interactions.

* **Tests**
  * Added coverage confirming that out-of-range page parameters remain unchanged in the URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->