### PR TITLE
refactor: Migrate ImportTable to the shared table state hook

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -66,19 +66,6 @@ export default tseslint.config(
     },
   },
   {
-    // RATCHET — tables not yet migrated to useTableState. Each migration PR
-    // deletes its own line; the last one deletes this whole block. A file that
-    // is not listed here fails immediately, so a *new* call site cannot appear
-    // while the migration is in flight. Tracked by #353.
-    files: [
-      'src/components/import/ImportTable.tsx', // #396
-    ],
-    rules: {
-      'no-restricted-imports': 'off',
-      'react-hooks/incompatible-library': 'off',
-    },
-  },
-  {
     files: ['playwright.config.ts', 'tests/**/*.{ts,tsx}'],
     languageOptions: {
       globals: {

--- a/frontend/src/components/data-table/rowId.ts
+++ b/frontend/src/components/data-table/rowId.ts
@@ -9,8 +9,9 @@
  *
  *   - download history keys on `(IssueID, Status, Provider)`, and `Status`
  *     takes the literal value `Post-Processed`;
- *   - `ImportTable`'s key is `` `${DynamicName}-${Volume || "null"}` ``, which
- *     collapses `null` and `""` even though SQL groups them separately.
+ *   - the import table's key was `` `${DynamicName}-${Volume || "null"}` ``,
+ *     which collapsed `null` and `""` even though SQL groups them separately
+ *     (fixed by #396's `getImportGroupRowId`).
  *
  * So the encoder is shared rather than fixed per site: the class is the bug,
  * not either instance.

--- a/frontend/src/components/import/ImportTable.tsx
+++ b/frontend/src/components/import/ImportTable.tsx
@@ -1,90 +1,31 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  useReactTable,
-  getCoreRowModel,
-  getExpandedRowModel,
-  createColumnHelper,
-  type RowSelectionState,
-  type ExpandedState,
-  type Updater,
-} from "@tanstack/react-table";
-import {
-  ChevronRight,
-  ChevronDown,
-  FileText,
-  Link2,
-  Eye,
-  EyeOff,
-  Trash2,
-} from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
+import { useRef, useState } from "react";
+import type { Table as TanstackTable } from "@tanstack/react-table";
+import { FileText } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import StatusBadge from "@/components/StatusBadge";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import EmptyState from "@/components/ui/EmptyState";
 import ConfidenceBadge from "./ConfidenceBadge";
 import { DataTable } from "@/components/data-table/DataTable";
 import { DataTableServerPagination } from "@/components/data-table/DataTableServerPagination";
 import { TableCell, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
-import {
-  getImportGroupTypeLabel,
-  getImportIssueLabel,
-} from "@/lib/importUtils";
+import { getImportIssueLabel } from "@/lib/importUtils";
 import type { ImportGroup, ImportFile, PaginationMeta } from "@/types";
 
-const columnHelper = createColumnHelper<ImportGroup>();
-
-function getImportGroupRowId(row: ImportGroup): string {
-  return `${row.DynamicName}-${row.Volume || "null"}`;
-}
-
-function getSelectedImportIds(
-  imports: ImportGroup[],
-  selection: RowSelectionState,
-): { selectedIds: string[]; selectedGroupIds: string[] } {
-  const selectedIds: string[] = [];
-  const selectedGroupIds: string[] = [];
-
-  Object.keys(selection).forEach((rowId) => {
-    if (!selection[rowId]) {
-      return;
-    }
-    const group = imports.find(
-      (importGroup) => getImportGroupRowId(importGroup) === rowId,
-    );
-    if (group?.files) {
-      selectedGroupIds.push(rowId);
-      group.files.forEach((file) => selectedIds.push(file.impID));
-    }
-  });
-
-  return { selectedIds, selectedGroupIds };
-}
-
 interface ImportTableProps {
-  imports?: ImportGroup[];
+  /**
+   * Built by `ImportPage` with `useTableState` (#396). The page owns the table
+   * instance because it owns selection — `ImportBulkActions` is its sibling —
+   * and this component only renders it.
+   */
+  table: TanstackTable<ImportGroup>;
   pagination?: PaginationMeta;
   onNextPage?: () => void;
   onPrevPage?: () => void;
-  onSelectionChange?: (
-    selectedIds: string[],
-    selectedGroupIds: string[],
-  ) => void;
-  onMatchClick?: (group: ImportGroup) => void;
-  onIgnoreClick?: (group: ImportGroup, ignore: boolean) => void;
-  onDeleteClick?: (group: ImportGroup) => void;
   onIssueNumberChange?: (
     file: ImportFile,
     issueNumber: string,
   ) => Promise<void>;
-  isActionLoading?: boolean;
   isMetadataSaving?: boolean;
 }
 
@@ -242,280 +183,14 @@ function FileRow({
 }
 
 export default function ImportTable({
-  imports = [],
+  table,
   pagination,
   onNextPage,
   onPrevPage,
-  onSelectionChange,
-  onMatchClick,
-  onIgnoreClick,
-  onDeleteClick,
   onIssueNumberChange,
-  isActionLoading = false,
   isMetadataSaving = false,
 }: ImportTableProps) {
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-  const [expanded, setExpanded] = useState<ExpandedState>({});
-  const lastSelectionKeyRef = useRef(JSON.stringify([[], []]));
-
-  const emitSelectionChange = useCallback(
-    (selection: RowSelectionState) => {
-      if (!onSelectionChange) {
-        return;
-      }
-      const { selectedIds, selectedGroupIds } = getSelectedImportIds(
-        imports,
-        selection,
-      );
-      const selectionKey = JSON.stringify([selectedIds, selectedGroupIds]);
-      if (lastSelectionKeyRef.current === selectionKey) {
-        return;
-      }
-      lastSelectionKeyRef.current = selectionKey;
-      onSelectionChange(selectedIds, selectedGroupIds);
-    },
-    [imports, onSelectionChange],
-  );
-
-  useEffect(() => {
-    emitSelectionChange(rowSelection);
-  }, [emitSelectionChange, rowSelection]);
-
-  const columns = useMemo(
-    () => [
-      columnHelper.display({
-        id: "select",
-        header: ({ table }) => (
-          <Checkbox
-            checked={
-              table.getIsAllRowsSelected() ||
-              (table.getIsSomeRowsSelected() && "indeterminate")
-            }
-            onCheckedChange={(value) => table.toggleAllRowsSelected(!!value)}
-          />
-        ),
-        cell: ({ row }) => (
-          <Checkbox
-            checked={row.getIsSelected()}
-            onCheckedChange={(value) => row.toggleSelected(!!value)}
-            onClick={(e) => e.stopPropagation()}
-          />
-        ),
-        size: 40,
-      }),
-      columnHelper.display({
-        id: "expander",
-        header: "",
-        cell: ({ row }) => {
-          const canExpand = row.original.files && row.original.files.length > 0;
-          return canExpand ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  aria-label={
-                    row.getIsExpanded()
-                      ? "Collapse import files"
-                      : "Expand import files"
-                  }
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    row.toggleExpanded();
-                  }}
-                  className="p-1 hover:bg-muted rounded"
-                >
-                  {row.getIsExpanded() ? (
-                    <ChevronDown className="w-4 h-4" />
-                  ) : (
-                    <ChevronRight className="w-4 h-4" />
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {row.getIsExpanded() ? "Collapse files" : "Review files"}
-              </TooltipContent>
-            </Tooltip>
-          ) : null;
-        },
-        size: 40,
-      }),
-      columnHelper.accessor("ComicName", {
-        header: "Series",
-        cell: ({ row }) => (
-          <div>
-            <div className="font-medium">{row.original.ComicName}</div>
-            <div className="mt-1">
-              <span className="inline-flex items-center rounded border border-border/70 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-                {getImportGroupTypeLabel(row.original)}
-              </span>
-            </div>
-            {row.original.Volume && (
-              <div className="text-sm text-muted-foreground">
-                Volume {row.original.Volume}
-              </div>
-            )}
-            {row.original.ComicYear && (
-              <div className="text-xs text-muted-foreground">
-                ({row.original.ComicYear})
-              </div>
-            )}
-          </div>
-        ),
-        enableSorting: false,
-      }),
-      columnHelper.accessor("FileCount", {
-        header: "Files",
-        cell: ({ getValue }) => (
-          <span className="font-mono text-sm">{getValue()}</span>
-        ),
-        enableSorting: false,
-      }),
-      columnHelper.accessor("MatchConfidence", {
-        header: "Confidence",
-        cell: ({ row, getValue }) => {
-          if (
-            !row.original.SuggestedComicID &&
-            !row.original.SuggestedComicName
-          ) {
-            return (
-              <span className="text-xs text-muted-foreground/70">
-                No suggestion
-              </span>
-            );
-          }
-
-          return <ConfidenceBadge confidence={getValue() ?? null} />;
-        },
-        enableSorting: false,
-      }),
-      columnHelper.accessor("SuggestedComicName", {
-        header: "Suggested Match",
-        cell: ({ row }) => {
-          const suggestedName = row.original.SuggestedComicName;
-          const suggestedId = row.original.SuggestedComicID;
-
-          if (!suggestedName) {
-            return (
-              <span className="text-muted-foreground/70">No match found</span>
-            );
-          }
-
-          return (
-            <div className="flex items-center gap-2">
-              <Link2 className="w-4 h-4 text-muted-foreground" />
-              <span className="text-sm">{suggestedName}</span>
-              {suggestedId && (
-                <span className="text-xs text-muted-foreground">
-                  (ID: {suggestedId})
-                </span>
-              )}
-            </div>
-          );
-        },
-        enableSorting: false,
-      }),
-      columnHelper.accessor("Status", {
-        header: "Status",
-        cell: ({ getValue }) => <StatusBadge status={getValue()} />,
-        enableSorting: false,
-      }),
-      columnHelper.display({
-        id: "actions",
-        header: "Actions",
-        cell: ({ row }) => {
-          const allIgnored =
-            row.original.files?.every((file) => file.IgnoreFile === 1) ?? false;
-          const ignoreLabel = allIgnored ? "Unignore import" : "Ignore import";
-
-          return (
-            <div className="flex items-center gap-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    aria-label="Match import"
-                    disabled={isActionLoading}
-                    className="h-8 px-2"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onMatchClick?.(row.original);
-                    }}
-                  >
-                    <Link2 className="w-4 h-4" />
-                    Match
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Match this review group</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="icon"
-                    variant="outline"
-                    aria-label={ignoreLabel}
-                    disabled={isActionLoading}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onIgnoreClick?.(row.original, !allIgnored);
-                    }}
-                  >
-                    {allIgnored ? (
-                      <Eye className="w-4 h-4" />
-                    ) : (
-                      <EyeOff className="w-4 h-4" />
-                    )}
-                    <span className="sr-only">{ignoreLabel}</span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>{ignoreLabel}</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    aria-label="Delete import record"
-                    disabled={isActionLoading}
-                    className="text-destructive hover:text-destructive"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onDeleteClick?.(row.original);
-                    }}
-                  >
-                    <Trash2 className="w-4 h-4" />
-                    <span className="sr-only">Delete</span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Delete import record</TooltipContent>
-              </Tooltip>
-            </div>
-          );
-        },
-      }),
-    ],
-    [isActionLoading, onDeleteClick, onIgnoreClick, onMatchClick],
-  );
-
-  const table = useReactTable({
-    data: imports,
-    columns,
-    state: { rowSelection, expanded },
-    onRowSelectionChange: (updater: Updater<RowSelectionState>) => {
-      const newSelection =
-        typeof updater === "function" ? updater(rowSelection) : updater;
-      setRowSelection(newSelection);
-      emitSelectionChange(newSelection);
-    },
-    onExpandedChange: setExpanded,
-    getCoreRowModel: getCoreRowModel(),
-    getExpandedRowModel: getExpandedRowModel(),
-    getRowId: getImportGroupRowId,
-    enableRowSelection: true,
-    getRowCanExpand: (row) =>
-      !!(row.original.files && row.original.files.length > 0),
-  });
-
-  if (imports.length === 0) {
+  if (table.getCoreRowModel().rows.length === 0) {
     return (
       <EmptyState
         variant="search"

--- a/frontend/src/components/import/importColumns.tsx
+++ b/frontend/src/components/import/importColumns.tsx
@@ -1,0 +1,283 @@
+import { useMemo } from "react";
+import { createColumnHelper } from "@tanstack/react-table";
+import {
+  ChevronRight,
+  ChevronDown,
+  Link2,
+  Eye,
+  EyeOff,
+  Trash2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import StatusBadge from "@/components/StatusBadge";
+import ConfidenceBadge from "./ConfidenceBadge";
+import { encodeRowId } from "@/components/data-table/rowId";
+import {
+  getIsAllSelected,
+  toggleAllSelected,
+} from "@/components/data-table/useTableState";
+import { getImportGroupTypeLabel } from "@/lib/importUtils";
+import type { ImportGroup } from "@/types";
+
+const columnHelper = createColumnHelper<ImportGroup>();
+
+/**
+ * `queries.py` returns the SQL group-by key as `DynamicName`, so distinct rows
+ * are guaranteed distinct `(DynamicName, Volume)` pairs — the encoding is the
+ * only part that could collapse them. The previous bare join mapped both
+ * `null` and `""` to `"null"`, which SQL groups separately (#383, #396).
+ */
+export function getImportGroupRowId(row: ImportGroup): string {
+  return encodeRowId([row.DynamicName, row.Volume]);
+}
+
+/**
+ * The bulk-action fan-out: selected *groups* map to their constituent file
+ * `impID`s, which row ids alone cannot express — that is why `useTableState`
+ * returns `selectedRows` as well as `selectedIds` (#359). Built from the
+ * selected row objects, never from raw `rowSelection` keys, so a data refresh
+ * recomputes the file ids from the fresh groups.
+ */
+export function getSelectedImportFileIds(
+  selectedGroups: ImportGroup[],
+): string[] {
+  return selectedGroups.flatMap((group) =>
+    group.files.map((file) => file.impID),
+  );
+}
+
+/**
+ * Columns for the pending-imports table. The table instance itself lives in
+ * `ImportPage`, which owns selection because it renders `ImportBulkActions` as
+ * a sibling; the columns live here so the page and the selection tests drive
+ * the same select column (#396, same shape as #395).
+ */
+export function useImportColumns({
+  onMatchClick,
+  onIgnoreClick,
+  onDeleteClick,
+  isActionLoading = false,
+}: {
+  onMatchClick?: (group: ImportGroup) => void;
+  onIgnoreClick?: (group: ImportGroup, ignore: boolean) => void;
+  onDeleteClick?: (group: ImportGroup) => void;
+  isActionLoading?: boolean;
+}) {
+  return useMemo(
+    () => [
+      columnHelper.display({
+        id: "select",
+        header: ({ table }) => (
+          <Checkbox
+            checked={getIsAllSelected(table)}
+            onCheckedChange={(value) => toggleAllSelected(table, !!value)}
+          />
+        ),
+        cell: ({ row }) => (
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => row.toggleSelected(!!value)}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ),
+        size: 40,
+      }),
+      columnHelper.display({
+        id: "expander",
+        header: "",
+        cell: ({ row }) => {
+          const canExpand = row.original.files && row.original.files.length > 0;
+          return canExpand ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  aria-label={
+                    row.getIsExpanded()
+                      ? "Collapse import files"
+                      : "Expand import files"
+                  }
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    row.toggleExpanded();
+                  }}
+                  className="p-1 hover:bg-muted rounded"
+                >
+                  {row.getIsExpanded() ? (
+                    <ChevronDown className="w-4 h-4" />
+                  ) : (
+                    <ChevronRight className="w-4 h-4" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {row.getIsExpanded() ? "Collapse files" : "Review files"}
+              </TooltipContent>
+            </Tooltip>
+          ) : null;
+        },
+        size: 40,
+      }),
+      columnHelper.accessor("ComicName", {
+        header: "Series",
+        cell: ({ row }) => (
+          <div>
+            <div className="font-medium">{row.original.ComicName}</div>
+            <div className="mt-1">
+              <span className="inline-flex items-center rounded border border-border/70 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                {getImportGroupTypeLabel(row.original)}
+              </span>
+            </div>
+            {row.original.Volume && (
+              <div className="text-sm text-muted-foreground">
+                Volume {row.original.Volume}
+              </div>
+            )}
+            {row.original.ComicYear && (
+              <div className="text-xs text-muted-foreground">
+                ({row.original.ComicYear})
+              </div>
+            )}
+          </div>
+        ),
+        enableSorting: false,
+      }),
+      columnHelper.accessor("FileCount", {
+        header: "Files",
+        cell: ({ getValue }) => (
+          <span className="font-mono text-sm">{getValue()}</span>
+        ),
+        enableSorting: false,
+      }),
+      columnHelper.accessor("MatchConfidence", {
+        header: "Confidence",
+        cell: ({ row, getValue }) => {
+          if (
+            !row.original.SuggestedComicID &&
+            !row.original.SuggestedComicName
+          ) {
+            return (
+              <span className="text-xs text-muted-foreground/70">
+                No suggestion
+              </span>
+            );
+          }
+
+          return <ConfidenceBadge confidence={getValue() ?? null} />;
+        },
+        enableSorting: false,
+      }),
+      columnHelper.accessor("SuggestedComicName", {
+        header: "Suggested Match",
+        cell: ({ row }) => {
+          const suggestedName = row.original.SuggestedComicName;
+          const suggestedId = row.original.SuggestedComicID;
+
+          if (!suggestedName) {
+            return (
+              <span className="text-muted-foreground/70">No match found</span>
+            );
+          }
+
+          return (
+            <div className="flex items-center gap-2">
+              <Link2 className="w-4 h-4 text-muted-foreground" />
+              <span className="text-sm">{suggestedName}</span>
+              {suggestedId && (
+                <span className="text-xs text-muted-foreground">
+                  (ID: {suggestedId})
+                </span>
+              )}
+            </div>
+          );
+        },
+        enableSorting: false,
+      }),
+      columnHelper.accessor("Status", {
+        header: "Status",
+        cell: ({ getValue }) => <StatusBadge status={getValue()} />,
+        enableSorting: false,
+      }),
+      columnHelper.display({
+        id: "actions",
+        header: "Actions",
+        cell: ({ row }) => {
+          const allIgnored =
+            row.original.files?.every((file) => file.IgnoreFile === 1) ?? false;
+          const ignoreLabel = allIgnored ? "Unignore import" : "Ignore import";
+
+          return (
+            <div className="flex items-center gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    aria-label="Match import"
+                    disabled={isActionLoading}
+                    className="h-8 px-2"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onMatchClick?.(row.original);
+                    }}
+                  >
+                    <Link2 className="w-4 h-4" />
+                    Match
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Match this review group</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="outline"
+                    aria-label={ignoreLabel}
+                    disabled={isActionLoading}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onIgnoreClick?.(row.original, !allIgnored);
+                    }}
+                  >
+                    {allIgnored ? (
+                      <Eye className="w-4 h-4" />
+                    ) : (
+                      <EyeOff className="w-4 h-4" />
+                    )}
+                    <span className="sr-only">{ignoreLabel}</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{ignoreLabel}</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    aria-label="Delete import record"
+                    disabled={isActionLoading}
+                    className="text-destructive hover:text-destructive"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDeleteClick?.(row.original);
+                    }}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                    <span className="sr-only">Delete</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Delete import record</TooltipContent>
+              </Tooltip>
+            </div>
+          );
+        },
+      }),
+    ],
+    [isActionLoading, onDeleteClick, onIgnoreClick, onMatchClick],
+  );
+}

--- a/frontend/src/components/import/importColumns.tsx
+++ b/frontend/src/components/import/importColumns.tsx
@@ -207,8 +207,10 @@ export function useImportColumns({
         id: "actions",
         header: "Actions",
         cell: ({ row }) => {
+          // [].every() is true; require files so empty groups stay "Ignore".
+          const files = row.original.files ?? [];
           const allIgnored =
-            row.original.files?.every((file) => file.IgnoreFile === 1) ?? false;
+            files.length > 0 && files.every((file) => file.IgnoreFile === 1);
           const ignoreLabel = allIgnored ? "Unignore import" : "Ignore import";
 
           return (

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { EyeOff, Eye, Inbox, RefreshCw } from "lucide-react";
 import {
   useImportPending,
@@ -13,12 +13,19 @@ import { useToast } from "@/components/ui/toast";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import ImportTable from "@/components/import/ImportTable";
+import {
+  getImportGroupRowId,
+  getSelectedImportFileIds,
+  useImportColumns,
+} from "@/components/import/importColumns";
 import ImportBulkActions from "@/components/import/ImportBulkActions";
 import MatchModal from "@/components/import/MatchModal";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 import LibraryScanSection from "@/components/import/LibraryScanSection";
 import ImportInboxSection from "@/components/import/ImportInboxSection";
 import PageHeader from "@/components/layout/PageHeader";
+import { useServerPage } from "@/components/data-table/useServerPage";
+import { useTableState } from "@/components/data-table/useTableState";
 import type { ImportGroup } from "@/types";
 
 function pluralize(count: number, singular: string, plural = `${singular}s`) {
@@ -48,14 +55,10 @@ function SectionHeader({
 }
 
 export default function ImportPage() {
-  const [page, setPage] = useState(0);
+  const { limit, offset, nextPage, prevPage, resetPage } = useServerPage(50);
   const [showIgnored, setShowIgnored] = useState(false);
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
   const [matchModalOpen, setMatchModalOpen] = useState(false);
   const [matchingGroup, setMatchingGroup] = useState<ImportGroup | null>(null);
-  const limit = 50;
-  const offset = page * limit;
 
   const { data, isLoading, error, refetch } = useImportPending(
     limit,
@@ -88,10 +91,40 @@ export default function ImportPage() {
   const { data: appConfig } = useConfig();
   const { addToast } = useToast();
 
-  const handleMatchClick = (group: ImportGroup) => {
+  // The row handlers are hoisted function declarations: the columns need them
+  // here, but their bodies close over `clearSelection`, which the hook below
+  // returns — they only run on click, after both exist.
+  const columns = useImportColumns({
+    onMatchClick: handleMatchClick,
+    onIgnoreClick: handleGroupIgnore,
+    onDeleteClick: handleGroupDelete,
+    isActionLoading:
+      matchImportMutation.isPending ||
+      ignoreImportMutation.isPending ||
+      deleteImportMutation.isPending,
+  });
+
+  // The server page is an input to the fetch that produced `imports`, so the
+  // hook holds no page state (#360); `pagination` is omitted deliberately.
+  const { table, selectedRows, clearSelection } = useTableState({
+    data: imports,
+    columns,
+    getRowId: getImportGroupRowId,
+    selection: { scope: "filtered" },
+    getRowCanExpand: (row) =>
+      !!(row.original.files && row.original.files.length > 0),
+  });
+
+  const selectedFileIds = useMemo(
+    () => getSelectedImportFileIds(selectedRows),
+    [selectedRows],
+  );
+  const selectedGroupCount = selectedRows.length;
+
+  function handleMatchClick(group: ImportGroup) {
     setMatchingGroup(group);
     setMatchModalOpen(true);
-  };
+  }
 
   const handleMatch = async (comicId: string, comicName: string) => {
     if (!matchingGroup) return;
@@ -130,17 +163,7 @@ export default function ImportPage() {
     }
   };
 
-  const clearSelection = () => {
-    setSelectedIds([]);
-    setSelectedGroupIds([]);
-  };
-
-  const handleSelectionChange = (fileIds: string[], groupIds: string[]) => {
-    setSelectedIds(fileIds);
-    setSelectedGroupIds(groupIds);
-  };
-
-  const handleGroupIgnore = async (group: ImportGroup, ignore: boolean) => {
+  async function handleGroupIgnore(group: ImportGroup, ignore: boolean) {
     const impIds = group.files.map((f) => f.impID);
     try {
       await ignoreImportMutation.mutateAsync({ impIds, ignore });
@@ -155,9 +178,9 @@ export default function ImportPage() {
         message: `Failed to ${ignore ? "ignore" : "unignore"} files: ${err instanceof Error ? err.message : "Unknown error"}`,
       });
     }
-  };
+  }
 
-  const handleGroupDelete = async (group: ImportGroup) => {
+  async function handleGroupDelete(group: ImportGroup) {
     const impIds = group.files.map((f) => f.impID);
     if (
       !window.confirm(
@@ -179,17 +202,17 @@ export default function ImportPage() {
         message: `Failed to delete records: ${err instanceof Error ? err.message : "Unknown error"}`,
       });
     }
-  };
+  }
 
   const handleBulkIgnore = async () => {
     try {
       await ignoreImportMutation.mutateAsync({
-        impIds: selectedIds,
+        impIds: selectedFileIds,
         ignore: true,
       });
       addToast({
         type: "success",
-        message: `${selectedIds.length} file${selectedIds.length !== 1 ? "s" : ""} ignored`,
+        message: `${selectedFileIds.length} file${selectedFileIds.length !== 1 ? "s" : ""} ignored`,
       });
       clearSelection();
     } catch (err) {
@@ -203,12 +226,12 @@ export default function ImportPage() {
   const handleBulkUnignore = async () => {
     try {
       await ignoreImportMutation.mutateAsync({
-        impIds: selectedIds,
+        impIds: selectedFileIds,
         ignore: false,
       });
       addToast({
         type: "success",
-        message: `${selectedIds.length} file${selectedIds.length !== 1 ? "s" : ""} unignored`,
+        message: `${selectedFileIds.length} file${selectedFileIds.length !== 1 ? "s" : ""} unignored`,
       });
       clearSelection();
     } catch (err) {
@@ -222,16 +245,16 @@ export default function ImportPage() {
   const handleBulkDelete = async () => {
     if (
       !window.confirm(
-        `Delete ${selectedIds.length} import record${selectedIds.length !== 1 ? "s" : ""}? (Files on disk are untouched.)`,
+        `Delete ${selectedFileIds.length} import record${selectedFileIds.length !== 1 ? "s" : ""}? (Files on disk are untouched.)`,
       )
     ) {
       return;
     }
     try {
-      await deleteImportMutation.mutateAsync(selectedIds);
+      await deleteImportMutation.mutateAsync(selectedFileIds);
       addToast({
         type: "success",
-        message: `${selectedIds.length} import record${selectedIds.length !== 1 ? "s" : ""} deleted`,
+        message: `${selectedFileIds.length} import record${selectedFileIds.length !== 1 ? "s" : ""} deleted`,
       });
       clearSelection();
     } catch (err) {
@@ -281,7 +304,7 @@ export default function ImportPage() {
               aria-pressed={showIgnored}
               onClick={() => {
                 setShowIgnored((prev) => !prev);
-                setPage(0);
+                resetPage();
                 clearSelection();
               }}
               className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border font-mono text-[11px]"
@@ -329,26 +352,17 @@ export default function ImportPage() {
             !error &&
             (imports.length > 0 ? (
               <ImportTable
-                imports={imports}
+                table={table}
                 pagination={pagination}
                 onNextPage={() => {
-                  setPage((p) => p + 1);
+                  nextPage();
                   clearSelection();
                 }}
                 onPrevPage={() => {
-                  setPage((p) => Math.max(0, p - 1));
+                  prevPage();
                   clearSelection();
                 }}
-                onSelectionChange={handleSelectionChange}
-                onMatchClick={handleMatchClick}
-                onIgnoreClick={handleGroupIgnore}
-                onDeleteClick={handleGroupDelete}
                 onIssueNumberChange={handleIssueNumberChange}
-                isActionLoading={
-                  matchImportMutation.isPending ||
-                  ignoreImportMutation.isPending ||
-                  deleteImportMutation.isPending
-                }
                 isMetadataSaving={updateImportMetadataMutation.isPending}
               />
             ) : (
@@ -394,8 +408,8 @@ export default function ImportPage() {
             ))}
 
           <ImportBulkActions
-            selectedGroupCount={selectedGroupIds.length}
-            selectedFileCount={selectedIds.length}
+            selectedGroupCount={selectedGroupCount}
+            selectedFileCount={selectedFileIds.length}
             onIgnore={handleBulkIgnore}
             onUnignore={handleBulkUnignore}
             onDelete={handleBulkDelete}

--- a/frontend/tests/components/ImportTable.test.tsx
+++ b/frontend/tests/components/ImportTable.test.tsx
@@ -203,6 +203,49 @@ describe("ImportTable", () => {
     expect(screen.queryByText("0%")).toBeNull();
   });
 
+  it("labels empty-file groups as Ignore, not Unignore", () => {
+    renderMinimal(
+      <Harness
+        imports={[
+          makeGroup({
+            DynamicName: "folder:empty",
+            ComicName: "Empty Group",
+            FileCount: 0,
+            files: [],
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Ignore import" })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Unignore import" }),
+    ).toBeNull();
+  });
+
+  it("labels fully ignored groups as Unignore", () => {
+    renderMinimal(
+      <Harness
+        imports={[
+          makeGroup({
+            files: [
+              makeFile({ impID: "1", IgnoreFile: 1 }),
+              makeFile({
+                impID: "2",
+                IgnoreFile: 1,
+                ComicFilename: "chapter 2.cbz",
+              }),
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Unignore import" }),
+    ).toBeTruthy();
+  });
+
   it("saves edited chapter values from expanded file rows", async () => {
     const file = makeFile();
     const onIssueNumberChange = vi.fn().mockResolvedValue(undefined);

--- a/frontend/tests/components/ImportTable.test.tsx
+++ b/frontend/tests/components/ImportTable.test.tsx
@@ -1,11 +1,63 @@
+import { useEffect, useMemo } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { screen, renderMinimal } from "../test-utils";
 import ImportTable from "@/components/import/ImportTable";
-import type { ImportGroup } from "@/types";
+import {
+  getImportGroupRowId,
+  getSelectedImportFileIds,
+  useImportColumns,
+} from "@/components/import/importColumns";
+import { useTableState } from "@/components/data-table/useTableState";
+import type { ImportGroup, ImportFile } from "@/types";
 
-type ImportFile = ImportGroup["files"][number];
+/**
+ * The harness stands in for `ImportPage` as it now is (#396): calling
+ * `useTableState` with the shared columns, passing `table` down, and deriving
+ * the bulk-action file ids from `selectedRows` via `getSelectedImportFileIds`
+ * — the same fan-out the page runs, not a re-implementation.
+ *
+ * The two selection pins guard this site's only unique invariant, the
+ * group→file fan-out; nothing else in the repo covers it. #396 deleted the
+ * `onSelectionChange` prop they asserted on, so each names its invariant with
+ * the old assertion alongside the new one.
+ */
+function Harness({
+  imports,
+  onSelectionChange,
+  onIssueNumberChange,
+}: {
+  imports: ImportGroup[];
+  onSelectionChange?: (fileIds: string[], groupCount: number) => void;
+  onIssueNumberChange?: (
+    file: ImportFile,
+    issueNumber: string,
+  ) => Promise<void>;
+}) {
+  const columns = useImportColumns({});
+  const { table, selectedRows } = useTableState({
+    data: imports,
+    columns,
+    getRowId: getImportGroupRowId,
+    selection: { scope: "filtered" },
+    getRowCanExpand: (row) =>
+      !!(row.original.files && row.original.files.length > 0),
+  });
+
+  const fileIds = useMemo(
+    () => getSelectedImportFileIds(selectedRows),
+    [selectedRows],
+  );
+  const groupCount = selectedRows.length;
+  useEffect(() => {
+    if (fileIds.length > 0) onSelectionChange?.(fileIds, groupCount);
+  }, [fileIds, groupCount, onSelectionChange]);
+
+  return (
+    <ImportTable table={table} onIssueNumberChange={onIssueNumberChange} />
+  );
+}
 
 function makeFile(overrides: Partial<ImportFile> = {}): ImportFile {
   return {
@@ -79,9 +131,7 @@ describe("ImportTable", () => {
       }),
     ];
 
-    renderMinimal(
-      <ImportTable imports={groups} onIssueNumberChange={vi.fn()} />,
-    );
+    renderMinimal(<Harness imports={groups} onIssueNumberChange={vi.fn()} />);
 
     expect(screen.getByText("Manga A")).toBeTruthy();
     expect(screen.getByText("Manga B")).toBeTruthy();
@@ -101,7 +151,7 @@ describe("ImportTable", () => {
 
   it("renders root files as one review group per file", () => {
     renderMinimal(
-      <ImportTable
+      <Harness
         imports={[
           makeGroup({
             DynamicName: "file:root-a",
@@ -138,7 +188,7 @@ describe("ImportTable", () => {
 
   it("shows no suggestion instead of a misleading zero confidence", () => {
     renderMinimal(
-      <ImportTable
+      <Harness
         imports={[
           makeGroup({
             MatchConfidence: 0,
@@ -158,7 +208,7 @@ describe("ImportTable", () => {
     const onIssueNumberChange = vi.fn().mockResolvedValue(undefined);
 
     renderMinimal(
-      <ImportTable
+      <Harness
         imports={[makeGroup({ files: [file] })]}
         onIssueNumberChange={onIssueNumberChange}
       />,
@@ -185,7 +235,7 @@ describe("ImportTable", () => {
     const onIssueNumberChange = vi.fn().mockResolvedValue(undefined);
 
     renderMinimal(
-      <ImportTable
+      <Harness
         imports={[makeGroup({ files: [file] })]}
         onIssueNumberChange={onIssueNumberChange}
       />,
@@ -229,7 +279,7 @@ describe("ImportTable", () => {
     );
 
     renderMinimal(
-      <ImportTable
+      <Harness
         imports={[makeGroup()]}
         onIssueNumberChange={onIssueNumberChange}
       />,
@@ -259,7 +309,7 @@ describe("ImportTable", () => {
       .mockRejectedValue(new Error("Unable to save"));
 
     renderMinimal(
-      <ImportTable
+      <Harness
         imports={[makeGroup()]}
         onIssueNumberChange={onIssueNumberChange}
       />,
@@ -284,7 +334,7 @@ describe("ImportTable", () => {
     const onIssueNumberChange = vi.fn().mockResolvedValue(undefined);
 
     renderMinimal(
-      <ImportTable
+      <Harness
         imports={[makeGroup()]}
         onIssueNumberChange={onIssueNumberChange}
       />,
@@ -304,11 +354,21 @@ describe("ImportTable", () => {
     expect(onIssueNumberChange).not.toHaveBeenCalled();
   });
 
+  // INVARIANT (pin 1 of 2): selecting a *group* row fans out to its
+  // constituent file impIDs — row ids alone cannot express this.
+  //
+  //   old: expect(onSelectionChange).toHaveBeenCalledWith(
+  //          ["1", "2"], ["folder:manga-a-null"]);   // ImportTable prop, deleted
+  //   new: expect(onSelectionChange).toHaveBeenCalledWith(["1", "2"], 1);
+  //
+  // The group id argument became a count: the page consumes group *identity*
+  // only through `selectedRows`, and the row id is now the #383 encoding, an
+  // implementation detail no caller reads.
   it("keeps bulk row selection mapped to import file IDs", async () => {
     const onSelectionChange = vi.fn();
 
     renderMinimal(
-      <ImportTable
+      <Harness
         imports={[
           makeGroup({
             files: [
@@ -323,16 +383,25 @@ describe("ImportTable", () => {
 
     await userEvent.click(screen.getAllByRole("checkbox")[1]);
 
-    expect(onSelectionChange).toHaveBeenCalledWith(
-      ["1", "2"],
-      ["folder:manga-a-null"],
-    );
+    expect(onSelectionChange).toHaveBeenCalledWith(["1", "2"], 1);
   });
 
+  // INVARIANT (pin 2 of 2): a data refresh recomputes the selected file ids
+  // from the *fresh* groups — the selection keys on group identity, so new
+  // impIDs under the same group must flow through without reselection.
+  //
+  //   old: rerender(<ImportTable imports={refreshed} …/>);
+  //        expect(onSelectionChange).toHaveBeenCalledWith(
+  //          ["3", "4"], ["folder:manga-a-null"]);   // emit-upward effect, deleted
+  //   new: rerender(<Harness imports={refreshed} …/>);
+  //        expect(onSelectionChange).toHaveBeenCalledWith(["3", "4"], 1);
+  //
+  // Deriving from `selectedRows` is what makes this hold: the stale-copy
+  // plumbing (`lastSelectionKeyRef`, the emit effect) is deleted, not ported.
   it("recomputes selected import file IDs when imports refresh", async () => {
     const onSelectionChange = vi.fn();
     const { rerender } = renderMinimal(
-      <ImportTable
+      <Harness
         imports={[
           makeGroup({
             files: [
@@ -346,14 +415,11 @@ describe("ImportTable", () => {
     );
 
     await userEvent.click(screen.getAllByRole("checkbox")[1]);
-    expect(onSelectionChange).toHaveBeenCalledWith(
-      ["1", "2"],
-      ["folder:manga-a-null"],
-    );
+    expect(onSelectionChange).toHaveBeenCalledWith(["1", "2"], 1);
 
     onSelectionChange.mockClear();
     rerender(
-      <ImportTable
+      <Harness
         imports={[
           makeGroup({
             files: [
@@ -367,10 +433,42 @@ describe("ImportTable", () => {
     );
 
     await waitFor(() => {
-      expect(onSelectionChange).toHaveBeenCalledWith(
-        ["3", "4"],
-        ["folder:manga-a-null"],
-      );
+      expect(onSelectionChange).toHaveBeenCalledWith(["3", "4"], 1);
     });
+  });
+
+  // Pins the #383 encoder adoption. SQL groups `Volume` null and `""`
+  // separately, but the old `${DynamicName}-${Volume || "null"}` id collapsed
+  // both to "folder:manga-a-null" — duplicate row ids, so selecting either row
+  // reported the *first* group's files. Latent until now (#364, #365).
+  it("keeps groups whose Volume is null and empty string separately selectable", async () => {
+    const onSelectionChange = vi.fn();
+
+    renderMinimal(
+      <Harness
+        imports={[
+          makeGroup({
+            Volume: null,
+            files: [makeFile({ impID: "1" })],
+          }),
+          makeGroup({
+            Volume: "",
+            files: [
+              makeFile({
+                impID: "2",
+                ComicFilename: "chapter 2.cbz",
+                ComicLocation: "/imports/Manga A/chapter 2.cbz",
+              }),
+            ],
+          }),
+        ]}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    // checkboxes[0] is the header select-all; [2] is the second group's row.
+    await userEvent.click(screen.getAllByRole("checkbox")[2]);
+
+    expect(onSelectionChange).toHaveBeenCalledWith(["2"], 1);
   });
 });


### PR DESCRIPTION
Closes #396. Part of #353 — PR 4 of 4; the ratchet closes here.

## What

- **`ImportPage` owns the table** via `useTableState` (`selection: { scope: "filtered" }`, `getRowId` required) and adopts `useServerPage(50)`; `ImportTable` becomes a dumb renderer taking `table`, keeping only the chapter-editing UI (#359).
- **`lastSelectionKeyRef`, the `JSON.stringify` guard, and the emit-upward effect are deleted, not ported** — the two-copies bug is unrepresentable now that the page is the only caller.
- **Fan-out rebuilt off `selectedRows`**: new `getSelectedImportFileIds` maps selected groups to their constituent file `impID`s; no raw `rowSelection` key reads remain.
- **#383's shared safe encoder adopted**: `getImportGroupRowId` is now `encodeRowId([DynamicName, Volume])`. The old `` `${DynamicName}-${Volume || "null"}` `` join collapsed `Volume` `null` and `""` (which SQL groups separately) and was delimiter-ambiguous. Latent per #364/#365, shipped inside the migration.
- **Ratchet closed**: the `ImportTable.tsx` allowlist line and the now-empty overrides block are deleted from `eslint.config.js`. `useReactTable` and `react-hooks/incompatible-library: 'off'` are now confined to `data-table/useTableState.ts` alone. Destination met: six instances, one owner, `getRowId` required.

## Parity (#366 guard)

The two table-state pins asserted on `onSelectionChange`, the prop this PR deletes; both are rewired to a harness that mirrors the page's wiring, old and new assertions side by side in the test file. The other eight chapter-editing/rendering assertions pass verbatim (only the render entry point changed, forced by the prop deletion).

**Pin 1 — group→file fan-out** (this site's only unique invariant):
```
old: expect(onSelectionChange).toHaveBeenCalledWith(["1", "2"], ["folder:manga-a-null"]);
new: expect(onSelectionChange).toHaveBeenCalledWith(["1", "2"], 1);
```
The group-id array became a count: the page only ever consumed `selectedGroupIds.length`, and group identity now flows through `selectedRows`.

**Pin 2 — refresh recomputes file ids from fresh groups**:
```
old: rerender(<ImportTable imports={refreshed} …/>);
     expect(onSelectionChange).toHaveBeenCalledWith(["3", "4"], ["folder:manga-a-null"]);
new: rerender(<Harness imports={refreshed} …/>);
     expect(onSelectionChange).toHaveBeenCalledWith(["3", "4"], 1);
```

Plus one new pin for the encoder adoption: groups whose `Volume` is `null` vs `""` stay separately selectable (under the old id both collapsed to `folder:manga-a-null`, so selecting either reported the first group's files).

## Changeset

None — relocation plus a latent encoding fix; nothing an operator can observe (#364, #386, `CLAUDE.md`).

## Verification

- `tsc --noEmit` clean
- 172/172 frontend tests pass (29 files)
- `npm run lint` (CI parity) passes — confirms no `useReactTable` import outside `useTableState.ts` with the ratchet block gone
- Two-axis review (standards + spec vs #396): no missing requirements; one naming flag applied (`selectedIds` → `selectedFileIds` in `ImportPage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yiumyHavS6ZkjjgESGuoT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the pending imports table with expandable groups, richer row actions, and improved empty-state behavior.
  * Switched to server-driven pagination for the import browsing experience.
* **Bug Fixes**
  * Fixed bulk selection so it reliably targets the underlying imported files for selected groups.
  * Prevented selection from becoming stale after refreshed imports.
  * Ensured groups with `Volume` of `null` vs `""` remain independently selectable.
* **Tests**
  * Updated and expanded ImportTable coverage for the new selection and empty-state behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->