### PR TITLE
fix: Unblock library chat schema upgrade for pre-chat installs

### DIFF
--- a/.changeset/ai-chat-thread-list-upgrade.md
+++ b/.changeset/ai-chat-thread-list-upgrade.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix the AI chat thread list returning HTTP 500 on ordinary page loads after upgrading past pre-library-chat installs. Schema validation now requires the complete schema for the *stamped* Alembic revision rather than the migration head, so `0002` databases missing `ai_chat_*` tables can reach `0003_library_chat` and the recent-chats endpoint can return an empty or populated list.

--- a/comicarr/app/core/schema.py
+++ b/comicarr/app/core/schema.py
@@ -48,6 +48,19 @@ _REQUIRED_LEGACY_COLUMNS = {
     "annuals": {"IssueID", "Issue_Number"},
     "mylar_info": {"DatabaseVersion"},
 }
+# Tables first introduced by a post-baseline revision. When a database is
+# stamped at an earlier known revision these must not be treated as required
+# by that revision — otherwise upgrade to head is blocked before the revision
+# that creates them can run (see #409: pre-chat 0002 installs).
+_REVISION_INTRODUCED_TABLES = {
+    "0003_library_chat": frozenset(
+        {
+            "ai_chat_threads",
+            "ai_chat_messages",
+            "ai_chat_attachments",
+        }
+    ),
+}
 _READINGLIST_TO_STORYARCS_COLUMNS = (
     "StoryArcID",
     "ComicName",
@@ -80,11 +93,29 @@ def _application_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
+def _tables_introduced_after(revision: str, scripts: ScriptDirectory) -> frozenset[str]:
+    """Return tables first created by revisions strictly after ``revision``.
+
+    Head metadata includes every table that exists at the migration head. A
+    database stamped at an earlier known revision is expected to lack tables
+    that later revisions introduce; those absences must not fail closed or
+    upgrade can never create them.
+    """
+
+    introduced: set[str] = set()
+    for script in scripts.walk_revisions():
+        if script.revision == revision:
+            break
+        introduced.update(_REVISION_INTRODUCED_TABLES.get(script.revision, ()))
+    return frozenset(introduced)
+
+
 def _legacy_fingerprint_error(
     engine: Engine,
     *,
     require_control_row: bool = True,
     require_complete_schema: bool = False,
+    optional_tables: frozenset[str] | set[str] | None = None,
 ) -> str | None:
     inspector = inspect(engine)
     table_names = set(inspector.get_table_names()) - {_ALEMBIC_VERSION_TABLE}
@@ -97,8 +128,9 @@ def _legacy_fingerprint_error(
     if missing:
         return "is missing required Comicarr tables: %s" % ", ".join(missing)
 
+    deferred = frozenset(optional_tables or ())
     if require_complete_schema:
-        missing = sorted(set(metadata.tables) - table_names)
+        missing = sorted((set(metadata.tables) - deferred) - table_names)
         if missing:
             return "is missing tables required by its Comicarr revision: %s" % ", ".join(missing)
 
@@ -167,10 +199,13 @@ def _validate_versioned_database(engine: Engine) -> None:
     if resolved is None or resolved.revision != revision:
         raise MigrationStateError("Alembic version table contains an unknown Comicarr revision: %s" % revision)
 
+    # Require the complete schema for *this* revision, not the migration head.
+    # Tables introduced by later revisions are optional until those upgrades run.
     error = _legacy_fingerprint_error(
         engine,
         require_control_row=False,
         require_complete_schema=True,
+        optional_tables=_tables_introduced_after(revision, scripts),
     )
     if error:
         raise MigrationStateError("versioned database is not a recognized Comicarr database: %s" % error)

--- a/docs/operations/schema-migrations.md
+++ b/docs/operations/schema-migrations.md
@@ -11,9 +11,12 @@ Startup classifies the configured database before it changes anything:
 - An empty database upgrades from base to the current Alembic head.
 - A database with `alembic_version` upgrades only when the table contains one
   exact revision from Comicarr's reviewed, single-head migration graph and the
-  database contains the complete Comicarr schema required by that revision.
-  Empty, multiple, partial, unknown, or structurally spoofed revision states
-  fail before schema mutation.
+  database contains the complete Comicarr schema required by **that stamped
+  revision** (not the migration head). Tables first introduced by later
+  revisions are optional until those upgrades run, so a pre-library-chat
+  `0002` install is not blocked before `0003_library_chat` can create
+  `ai_chat_*`. Empty, multiple, partial, unknown, or structurally spoofed
+  revision states fail before schema mutation.
 - A pre-Alembic Comicarr database is adopted only after it matches the
   conservative table, column, and `mylar_info` control-row fingerprint.
 - Any other nonempty database is left untouched and worker startup is blocked.

--- a/tests/unit/test_ai_library_chat.py
+++ b/tests/unit/test_ai_library_chat.py
@@ -17,6 +17,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from PIL import Image
+from sqlalchemy import text
 from starlette.datastructures import UploadFile
 
 import comicarr
@@ -24,6 +25,7 @@ from comicarr import db
 from comicarr.app.ai import chat_images, chat_store
 from comicarr.app.ai.chat_service import stream_turn
 from comicarr.app.ai.router import router
+from comicarr.app.core.schema import upgrade_database
 from comicarr.app.core.security import require_session
 from comicarr.tables import ai_chat_messages, metadata
 
@@ -35,6 +37,31 @@ def chat_db(tmp_path, monkeypatch):
     monkeypatch.delenv("DATABASE_URL", raising=False)
     db.shutdown_engine()
     metadata.create_all(db.get_engine())
+    yield tmp_path
+    db.shutdown_engine()
+
+
+@pytest.fixture
+def production_chat_db(tmp_path, monkeypatch):
+    """Schema via the Alembic runner, starting from a pre-library-chat stamp.
+
+    Mirrors upgraded self-hosted installs that still lack ai_chat_* until 0003
+    applies — the path that previously left GET /chat/threads returning 500.
+    """
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", None, raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE ai_chat_attachments"))
+        conn.execute(text("DROP TABLE ai_chat_messages"))
+        conn.execute(text("DROP TABLE ai_chat_threads"))
+        conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+        conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0002_legacy_adoption')"))
+    assert upgrade_database(engine) == "0003_library_chat"
     yield tmp_path
     db.shutdown_engine()
 
@@ -165,6 +192,28 @@ def test_threads_are_private_paginated_and_return_message_contract(chat_db):
     assert chat_store.get_thread("bob", first["id"]) is None
     assert chat_store.rename_thread("bob", first["id"], "stolen") is None
     assert chat_store.delete_thread("bob", first["id"]) is None
+
+
+def test_thread_list_route_returns_empty_and_populated_after_production_upgrade(production_chat_db):
+    """#409: upgraded installs must list threads without 500 on ordinary page loads."""
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_session] = lambda: "alice"
+
+    with TestClient(app) as client:
+        empty = client.get("/api/ai/chat/threads?limit=30")
+        assert empty.status_code == 200
+        assert empty.json() == {"threads": [], "next_cursor": None}
+
+        thread, _, _ = _create_turn("alice", "Saved chat")
+        populated = client.get("/api/ai/chat/threads?limit=30")
+        assert populated.status_code == 200
+        body = populated.json()
+        assert body["next_cursor"] is None
+        assert len(body["threads"]) == 1
+        assert body["threads"][0]["id"] == thread["id"]
+        assert body["threads"][0]["title"] == "Saved chat"
+        assert body["threads"][0]["message_count"] == 1
 
 
 def test_only_twenty_recent_messages_are_sent_to_provider(chat_db):

--- a/tests/unit/test_schema_migrations.py
+++ b/tests/unit/test_schema_migrations.py
@@ -200,6 +200,46 @@ def test_upgrade_database_accepts_a_known_prior_comicarr_revision(tmp_path):
     assert current_revision(engine) == "0003_library_chat"
 
 
+def test_upgrade_database_accepts_pre_chat_revision_without_library_chat_tables(tmp_path):
+    """Pre-#296 installs stamped at 0002 lack ai_chat_* tables until 0003 runs.
+
+    Validation must require the schema for the *stamped* revision, not the head
+    metadata, or upgrade is blocked and GET /api/ai/chat/threads 500s forever.
+    """
+    engine = create_engine("sqlite:///%s" % (tmp_path / "pre-chat-version.db"))
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE ai_chat_attachments"))
+        conn.execute(text("DROP TABLE ai_chat_messages"))
+        conn.execute(text("DROP TABLE ai_chat_threads"))
+        conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+        conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0002_legacy_adoption')"))
+
+    assert "ai_chat_threads" not in set(inspect(engine).get_table_names())
+    assert classify_database(engine) is DatabaseState.VERSIONED
+    assert upgrade_database(engine) == "0003_library_chat"
+    assert current_revision(engine) == "0003_library_chat"
+    assert {"ai_chat_threads", "ai_chat_messages", "ai_chat_attachments"}.issubset(
+        set(inspect(engine).get_table_names())
+    )
+
+
+def test_head_revision_still_requires_library_chat_tables(tmp_path):
+    engine = create_engine("sqlite:///%s" % (tmp_path / "head-missing-chat.db"))
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE ai_chat_attachments"))
+        conn.execute(text("DROP TABLE ai_chat_messages"))
+        conn.execute(text("DROP TABLE ai_chat_threads"))
+        conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+        conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0003_library_chat')"))
+
+    with pytest.raises(MigrationStateError, match="missing tables required by its Comicarr revision"):
+        upgrade_database(engine)
+
+
 def test_classifier_refuses_to_adopt_an_unknown_nonempty_database(tmp_path):
     engine = create_engine("sqlite:///%s" % (tmp_path / "unknown.db"))
     with engine.begin() as conn:


### PR DESCRIPTION
## Summary

Unblocks Alembic upgrades for pre-library-chat installs so `GET /api/ai/chat/threads` stops returning 500 on ordinary authenticated page loads.

Closes #409.

### Root cause

Databases stamped at `0002_legacy_adoption` (before library chat) correctly lack `ai_chat_*` tables. Versioned-schema validation compared the live DB against **head** metadata, so those missing tables failed closed *before* `0003_library_chat` could run. Startup kept the web process available for diagnostics, the tables never appeared, and every sidebar/dashboard recent-chats request hit `OperationalError` → plain `500 Internal Server Error`.

### Fix

- Require the complete schema for the **stamped** Alembic revision only.
- Treat tables first introduced by later revisions (currently `ai_chat_*` via `0003_library_chat`) as optional until those upgrades run.
- Head revision still requires the full schema (spoofed / incomplete head DBs remain fail-closed).

## Test plan

- [x] `uv run pytest tests/unit/test_schema_migrations.py tests/unit/test_ai_library_chat.py -v` — **46 passed**
- [x] `ruff check` / `ruff format --check` on touched files — pass
- [x] `lint:modern` — pass
- [x] E2E harness: pre-chat `0002` DB (no `ai_chat_*`) → `upgrade_database()` → `0003_library_chat` → `GET /api/ai/chat/threads?limit=30` returns **200** empty, then **200** with a persisted thread

### Coverage added

- Pre-chat `0002` without `ai_chat_*` classifies and upgrades to head
- Head stamped as `0003` but missing chat tables still rejected
- Thread-list route empty + populated after production-compatible upgrade path

## Post-merge operator check (do not skip on the live instance)

After deploy, **restart the Comicarr process once** so `dbcheck()` / `upgrade_database()` can apply `0003_library_chat`. Do not manually stamp.

```bash
uv run alembic current
# expect: 0003_library_chat
```

Then confirm while signed in:

- `GET /api/ai/chat/threads?limit=30` → **200** with `{"threads":[...],"next_cursor":null}` (empty list is valid)
- Normal navigation (Dashboard, Library, Wanted, …) no longer logs thread-list 500s

This PR does **not** deploy or touch the live NAS instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recent-chat list failures on databases upgraded from earlier versions.
  * Upgrades now correctly create missing chat tables before serving chat requests.
  * Preserved validation for invalid or incomplete migration states.

* **Documentation**
  * Clarified how schema validation and migration upgrades work across database revisions.

* **Tests**
  * Added coverage for upgraded databases, chat thread lists, pagination, metadata, and message counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->