### PR TITLE
fix: Open series issue links instead of Dashboard

### DIFF
--- a/.changeset/fix-series-issue-links.md
+++ b/.changeset/fix-series-issue-links.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix series issue title links so they open the issue detail page instead of redirecting to the Dashboard

--- a/comicarr/app/metadata/service.py
+++ b/comicarr/app/metadata/service.py
@@ -95,16 +95,26 @@ def get_comic_info(ctx, comic_id):
 
 
 def get_issue_info(ctx, issue_id):
-    """Get issue metadata from database."""
+    """Get issue metadata from database (regular issues, then active annuals)."""
     from sqlalchemy import select
 
     from comicarr import db
+    from comicarr.tables import annuals as t_annuals
     from comicarr.tables import issues as t_issues
 
     stmt = select(t_issues).where(t_issues.c.IssueID == issue_id)
     results = db.select_all(stmt)
     if results and len(results) == 1:
         return results[0]
+
+    # Series detail links annual rows with the same /library/.../issue/... path.
+    annual_stmt = select(t_annuals).where(
+        t_annuals.c.IssueID == issue_id,
+        t_annuals.c.Deleted != 1,
+    )
+    annual_results = db.select_all(annual_stmt)
+    if annual_results and len(annual_results) == 1:
+        return annual_results[0]
     return None
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,9 @@ const SeriesListPage = () => (
 const SeriesDetailPage = () => (
   <RouteLoader load={() => import("@/pages/SeriesDetailPage")} />
 );
+const IssueDetailPage = () => (
+  <RouteLoader load={() => import("@/pages/IssueDetailPage")} />
+);
 const SearchPage = () => (
   <RouteLoader load={() => import("@/pages/SearchPage")} />
 );
@@ -137,6 +140,10 @@ function AppContent() {
                   <Routes>
                     <Route path="/" element={<DashboardPage />} />
                     <Route path="/library" element={<SeriesListPage />} />
+                    <Route
+                      path="/library/:comicId/issue/:issueId"
+                      element={<IssueDetailPage />}
+                    />
                     <Route
                       path="/library/:comicId"
                       element={<SeriesDetailPage />}

--- a/frontend/src/hooks/useIssueDetail.ts
+++ b/frontend/src/hooks/useIssueDetail.ts
@@ -1,0 +1,55 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/api";
+import type { Comic, Issue } from "@/types";
+
+/** Raw issue row from the authenticated metadata API. */
+export type IssueMetadata = Issue & {
+  AcquisitionIntent?: string | null;
+  ArtworkURL?: string | null;
+  ComicSize?: string | null;
+  DigitalDate?: string | null;
+  Type?: string | null;
+  Deleted?: number | null;
+};
+
+export interface IssueDetailData {
+  issue: IssueMetadata;
+  series: Comic | null;
+}
+
+/**
+ * Load a single issue via the authenticated metadata API, optionally with its
+ * parent series for breadcrumb context. Rejects when the issue does not belong
+ * to the series id in the route.
+ */
+export function useIssueDetail(
+  comicId: string | undefined,
+  issueId: string | undefined,
+): UseQueryResult<IssueDetailData> {
+  return useQuery({
+    queryKey: ["issue-detail", comicId, issueId],
+    enabled: Boolean(comicId && issueId),
+    queryFn: async () => {
+      const issue = await apiRequest<IssueMetadata>(
+        "GET",
+        `/api/metadata/issue/${issueId}`,
+      );
+
+      const issueComicId = String(issue.ComicID ?? issue.comicId ?? "");
+      if (!issueComicId || issueComicId !== String(comicId)) {
+        throw new Error("Issue not found for this series");
+      }
+
+      try {
+        const detail = await apiRequest<{ comic: Comic }>(
+          "GET",
+          `/api/series/${comicId}`,
+        );
+        return { issue, series: detail.comic ?? null };
+      } catch {
+        // Series name is optional context; issue payload is still usable.
+        return { issue, series: null };
+      }
+    },
+  });
+}

--- a/frontend/src/pages/IssueDetailPage.tsx
+++ b/frontend/src/pages/IssueDetailPage.tsx
@@ -1,0 +1,218 @@
+import { Link, useParams } from "react-router-dom";
+import { ChevronRight, Library } from "lucide-react";
+import StatusBadge from "@/components/StatusBadge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useIssueDetail } from "@/hooks/useIssueDetail";
+import type { IssueMetadata } from "@/hooks/useIssueDetail";
+
+function issueNumber(issue: IssueMetadata): string {
+  return String(issue.Issue_Number ?? issue.number ?? "").trim();
+}
+
+function issueTitle(issue: IssueMetadata): string {
+  const name = issue.IssueName ?? issue.name;
+  if (name && String(name).trim()) return String(name);
+  const number = issueNumber(issue);
+  return number ? `Issue ${number}` : "Issue";
+}
+
+function issueStatus(issue: IssueMetadata): string {
+  return issue.displayState ?? issue.status ?? issue.Status ?? "Unknown";
+}
+
+function field(value: string | number | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "—";
+  return String(value);
+}
+
+export default function IssueDetailPage() {
+  const { comicId, issueId } = useParams<{
+    comicId: string;
+    issueId: string;
+  }>();
+  const { data, isLoading, error, isError } = useIssueDetail(comicId, issueId);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6 p-5 page-transition">
+        <Skeleton className="h-5 w-64" />
+        <Skeleton className="h-10 w-1/2" />
+        <Skeleton className="h-40 w-full rounded-lg" />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    const message = error instanceof Error ? error.message : "Issue not found";
+    return (
+      <div className="p-5 page-transition">
+        <div className="mx-auto max-w-lg py-16 text-center">
+          <h1 className="text-lg font-semibold">Issue not found</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{message}</p>
+          <div className="mt-6 flex flex-wrap items-center justify-center gap-3 text-sm">
+            {comicId ? (
+              <Link
+                to={`/library/${comicId}`}
+                className="text-primary hover:underline"
+              >
+                Back to series
+              </Link>
+            ) : null}
+            <Link to="/library" className="text-primary hover:underline">
+              Back to library
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const { issue, series } = data;
+  const seriesName = series?.ComicName ?? issue.ComicName ?? "Series";
+  const number = issueNumber(issue);
+  const title = issueTitle(issue);
+  const status = issueStatus(issue);
+  const releaseDate =
+    issue.ReleaseDate ??
+    issue.releaseDate ??
+    issue.IssueDate ??
+    issue.issueDate;
+  const location = issue.Location ?? issue.location;
+  const imageUrl = issue.ImageURL ?? issue.imageURL ?? issue.ArtworkURL;
+
+  return (
+    <div className="flex h-full flex-col page-transition">
+      <nav
+        className="flex items-center gap-1.5 border-b px-5 py-3.5 font-mono text-[11px]"
+        style={{
+          borderColor: "var(--border)",
+          color: "var(--muted-foreground)",
+        }}
+        aria-label="Breadcrumb"
+      >
+        <Link
+          to="/library"
+          className="inline-flex items-center gap-1 transition-colors hover:text-foreground"
+        >
+          <Library className="h-3.5 w-3.5" />
+          library
+        </Link>
+        <ChevronRight
+          className="h-3.5 w-3.5"
+          style={{ color: "var(--text-muted)" }}
+        />
+        <Link
+          to={`/library/${comicId}`}
+          className="truncate transition-colors hover:text-foreground"
+        >
+          {seriesName}
+        </Link>
+        <ChevronRight
+          className="h-3.5 w-3.5"
+          style={{ color: "var(--text-muted)" }}
+        />
+        <span className="truncate" style={{ color: "var(--foreground)" }}>
+          {number ? `#${number}` : title}
+        </span>
+      </nav>
+
+      <div className="grid gap-7 border-b px-5 py-6 md:grid-cols-[140px_minmax(0,1fr)]">
+        <div
+          className="aspect-[2/3] w-[112px] overflow-hidden rounded-[5px] border md:w-[140px]"
+          style={{
+            borderColor: "var(--border)",
+            background:
+              "color-mix(in oklab, var(--muted-foreground) 8%, transparent)",
+          }}
+        >
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt={title}
+              className="h-full w-full object-cover"
+              onError={(event) => {
+                event.currentTarget.style.display = "none";
+              }}
+            />
+          ) : null}
+        </div>
+
+        <div className="min-w-0 space-y-3">
+          <div className="flex flex-wrap items-center gap-2 font-mono text-[10px] uppercase tracking-[0.08em]">
+            {number ? (
+              <span style={{ color: "var(--muted-foreground)" }}>
+                Issue {number}
+              </span>
+            ) : null}
+            <StatusBadge status={status} />
+          </div>
+
+          <h1
+            className="text-[28px] font-bold leading-tight tracking-[-0.02em]"
+            data-testid="issue-detail-title"
+          >
+            {title}
+          </h1>
+
+          <p
+            className="font-mono text-[11px]"
+            style={{ color: "var(--muted-foreground)" }}
+            data-testid="issue-detail-ids"
+          >
+            series:{comicId} · issue:{issueId}
+          </p>
+        </div>
+      </div>
+
+      <div className="px-5 py-6">
+        <dl className="grid max-w-2xl gap-4 sm:grid-cols-2">
+          <div>
+            <dt
+              className="font-mono text-[10px] uppercase tracking-[0.08em]"
+              style={{ color: "var(--muted-foreground)" }}
+            >
+              Series
+            </dt>
+            <dd className="mt-1 text-sm">
+              <Link
+                to={`/library/${comicId}`}
+                className="text-primary hover:underline"
+              >
+                {seriesName}
+              </Link>
+            </dd>
+          </div>
+          <div>
+            <dt
+              className="font-mono text-[10px] uppercase tracking-[0.08em]"
+              style={{ color: "var(--muted-foreground)" }}
+            >
+              Status
+            </dt>
+            <dd className="mt-1 text-sm">{field(status)}</dd>
+          </div>
+          <div>
+            <dt
+              className="font-mono text-[10px] uppercase tracking-[0.08em]"
+              style={{ color: "var(--muted-foreground)" }}
+            >
+              Release date
+            </dt>
+            <dd className="mt-1 font-mono text-sm">{field(releaseDate)}</dd>
+          </div>
+          <div>
+            <dt
+              className="font-mono text-[10px] uppercase tracking-[0.08em]"
+              style={{ color: "var(--muted-foreground)" }}
+            >
+              Location
+            </dt>
+            <dd className="mt-1 break-all font-mono text-sm">
+              {field(location)}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/frontend/tests/pages/IssueDetailPage.test.tsx
+++ b/frontend/tests/pages/IssueDetailPage.test.tsx
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { Route, Routes, Navigate, useLocation } from "react-router-dom";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/server";
+import { render, screen, waitFor } from "../test-utils";
+import IssueDetailPage from "@/pages/IssueDetailPage";
+import SeriesDetailPage from "@/pages/SeriesDetailPage";
+
+const issuePayload = {
+  IssueID: "issue-23",
+  ComicID: "series-9",
+  ComicName: "Absolute Batman",
+  Issue_Number: "23",
+  IssueName: "Issue 23",
+  IssueDate: "2025-11-01",
+  ReleaseDate: "2025-11-05",
+  Status: "Wanted",
+  Location: "/library/comics/absolute-batman/023.cbz",
+};
+
+function LocationProbe() {
+  return <div data-testid="location">{useLocation().pathname}</div>;
+}
+
+/** Minimal protected-shell route tree matching App.tsx path ranking. */
+function LibraryRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<div>Dashboard</div>} />
+      <Route path="/library" element={<div>Library list</div>} />
+      <Route
+        path="/library/:comicId/issue/:issueId"
+        element={<IssueDetailPage />}
+      />
+      <Route path="/library/:comicId" element={<SeriesDetailPage />} />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+}
+
+describe("IssueDetailPage", () => {
+  beforeEach(() => {
+    server.use(
+      http.get("/api/metadata/issue/:issueId", ({ params }) => {
+        if (params.issueId === "issue-23") {
+          return HttpResponse.json(issuePayload);
+        }
+        if (params.issueId === "other-series-issue") {
+          return HttpResponse.json({
+            ...issuePayload,
+            IssueID: "other-series-issue",
+            ComicID: "other-series",
+          });
+        }
+        return HttpResponse.json(
+          { detail: "No issue found with ID: missing" },
+          { status: 404 },
+        );
+      }),
+      http.get("/api/series/series-9", () =>
+        HttpResponse.json({
+          comic: {
+            ComicID: "series-9",
+            ComicName: "Absolute Batman",
+            ComicYear: "2024",
+            Status: "Active",
+          },
+          issues: [issuePayload],
+          annuals: [],
+        }),
+      ),
+    );
+  });
+
+  it("loads issue detail from the route series and issue identifiers", async () => {
+    render(
+      <Routes>
+        <Route
+          path="/library/:comicId/issue/:issueId"
+          element={<IssueDetailPage />}
+        />
+      </Routes>,
+      {
+        route: "/library/series-9/issue/issue-23",
+        useMemoryRouter: true,
+      },
+    );
+
+    expect((await screen.findByTestId("issue-detail-title")).textContent).toBe(
+      "Issue 23",
+    );
+    expect(screen.getByTestId("issue-detail-ids").textContent).toBe(
+      "series:series-9 · issue:issue-23",
+    );
+    expect(screen.getAllByText("Wanted").length).toBeGreaterThan(0);
+    expect(screen.getByText("2025-11-05")).toBeTruthy();
+    expect(
+      screen.getByText("/library/comics/absolute-batman/023.cbz"),
+    ).toBeTruthy();
+    const seriesLinks = screen.getAllByRole("link", {
+      name: "Absolute Batman",
+    });
+    expect(seriesLinks.length).toBeGreaterThan(0);
+    expect(
+      seriesLinks.every(
+        (link) => link.getAttribute("href") === "/library/series-9",
+      ),
+    ).toBe(true);
+  });
+
+  it("shows a clear not-found state for unknown issue ids", async () => {
+    render(
+      <Routes>
+        <Route
+          path="/library/:comicId/issue/:issueId"
+          element={<IssueDetailPage />}
+        />
+      </Routes>,
+      {
+        route: "/library/series-9/issue/missing",
+        useMemoryRouter: true,
+      },
+    );
+
+    expect(await screen.findByText("Issue not found")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Back to series" }).getAttribute("href"),
+    ).toBe("/library/series-9");
+  });
+
+  it("rejects issues that do not belong to the series in the URL", async () => {
+    render(
+      <Routes>
+        <Route
+          path="/library/:comicId/issue/:issueId"
+          element={<IssueDetailPage />}
+        />
+      </Routes>,
+      {
+        route: "/library/series-9/issue/other-series-issue",
+        useMemoryRouter: true,
+      },
+    );
+
+    expect(await screen.findByText("Issue not found")).toBeTruthy();
+    expect(
+      await screen.findByText("Issue not found for this series"),
+    ).toBeTruthy();
+  });
+});
+
+describe("series issue link routing", () => {
+  beforeEach(() => {
+    server.use(
+      http.get("/api/metadata/issue/:issueId", ({ params }) => {
+        if (params.issueId === "issue-23") {
+          return HttpResponse.json(issuePayload);
+        }
+        return HttpResponse.json({ detail: "not found" }, { status: 404 });
+      }),
+      http.get("/api/series/series-9", () =>
+        HttpResponse.json({
+          comic: {
+            ComicID: "series-9",
+            ComicName: "Absolute Batman",
+            ComicYear: "2024",
+            ComicPublisher: "DC Comics",
+            Status: "Active",
+            Have: 1,
+            Total: 2,
+          },
+          issues: [
+            {
+              ...issuePayload,
+              displayState: "Wanted",
+              missing: true,
+              monitored: true,
+            },
+          ],
+          annuals: [],
+          summary: {
+            total: 1,
+            issues: 1,
+            annuals: 0,
+            owned: 0,
+            missing: 1,
+            monitored: 1,
+            completionPercent: 0,
+          },
+        }),
+      ),
+    );
+  });
+
+  it("propagates series row identifiers into the issue detail path", async () => {
+    render(
+      <>
+        <LocationProbe />
+        <LibraryRoutes />
+      </>,
+      {
+        route: "/library/series-9",
+        useMemoryRouter: true,
+      },
+    );
+
+    const issueLink = await screen.findByRole("link", { name: "Issue 23" });
+    expect(issueLink.getAttribute("href")).toBe(
+      "/library/series-9/issue/issue-23",
+    );
+  });
+
+  it("opens issue detail instead of redirecting to the Dashboard", async () => {
+    render(
+      <>
+        <LocationProbe />
+        <LibraryRoutes />
+      </>,
+      {
+        route: "/library/series-9/issue/issue-23",
+        useMemoryRouter: true,
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toBe(
+        "/library/series-9/issue/issue-23",
+      );
+    });
+    expect(screen.queryByText("Dashboard")).toBeNull();
+    expect((await screen.findByTestId("issue-detail-title")).textContent).toBe(
+      "Issue 23",
+    );
+  });
+});

--- a/tests/unit/test_metadata_domain.py
+++ b/tests/unit/test_metadata_domain.py
@@ -177,6 +177,31 @@ class TestGetIssueInfo:
 
         result = metadata_service.get_issue_info(ctx, "456")
         assert result["Issue_Number"] == "1"
+        mock_db.select_all.assert_called_once()
+
+    @patch("comicarr.db")
+    def test_falls_back_to_active_annuals(self, mock_db):
+        """Annual rows linked from series detail resolve through the same API."""
+        ctx = _make_test_ctx()
+        mock_db.select_all.side_effect = [
+            [],
+            [{"IssueID": "annual-1", "Issue_Number": "Annual 1", "ComicID": "9"}],
+        ]
+
+        result = metadata_service.get_issue_info(ctx, "annual-1")
+        assert result["IssueID"] == "annual-1"
+        assert result["Issue_Number"] == "Annual 1"
+        assert mock_db.select_all.call_count == 2
+
+    @patch("comicarr.db")
+    def test_returns_none_when_missing_from_issues_and_annuals(self, mock_db):
+        """Unknown identifiers return None after both table lookups."""
+        ctx = _make_test_ctx()
+        mock_db.select_all.side_effect = [[], []]
+
+        result = metadata_service.get_issue_info(ctx, "missing")
+        assert result is None
+        assert mock_db.select_all.call_count == 2
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes #410. Series issue title links pointed at `/library/{series_id}/issue/{issue_id}`, but that client route did not exist, so the catch-all sent users to the Dashboard.

- Register `/library/:comicId/issue/:issueId` and render a focused issue detail page
- Load issue data from the authenticated metadata API (including active annuals) and reject series/issue mismatches
- Add regression coverage for route matching, identifier propagation from series rows, and not-found states

## Root cause

`SeriesDetailPage` rendered issue titles as links to `/library/:comicId/issue/:issueId`. App routing only defined `/library` and `/library/:comicId`, and the protected-shell catch-all (`path="*"` → `Navigate to "/"`) treated issue deep links as unknown routes. Direct navigation produced the same Dashboard redirect.

## Test plan

- [x] `cd frontend && npm run test:run -- tests/pages/IssueDetailPage.test.tsx`
- [x] `.venv/bin/pytest tests/unit/test_metadata_domain.py::TestGetIssueInfo -v`
- [x] Frontend lint, Prettier check, and typecheck
- [x] `PATH=".venv/bin:$PATH" npm run lint`
- [ ] Manual: open a series with issues, click an issue title, land on issue detail (not Dashboard)
- [ ] Manual: paste the same `/library/{series}/issue/{issue}` URL and confirm it loads
- [ ] Manual: unknown issue id shows not-found with back links

## Notes

No deployment and no live NAS / production configuration changes in this PR.