### PR TITLE
fix: Submit Story Arcs search and render provider results

### DIFF
--- a/.changeset/fix-story-arcs-search-submit.md
+++ b/.changeset/fix-story-arcs-search-submit.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix Story Arcs search so Enter, the Search button, and the empty-state action submit the query and render provider results or clear empty/error states

--- a/frontend/src/components/storyarcs/ArcSearch.tsx
+++ b/frontend/src/components/storyarcs/ArcSearch.tsx
@@ -1,18 +1,30 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useFindStoryArc } from "@/hooks/useArcSearch";
+import { useContentSources } from "@/hooks/useContentSources";
 import FilterField from "@/components/ui/FilterField";
+import EmptyState from "@/components/ui/EmptyState";
 import ArcSearchResultCard from "./ArcSearchResultCard";
+import { Settings } from "lucide-react";
 
 interface ArcSearchProps {
   searchInputRef?: React.RefObject<HTMLInputElement | null>;
+  formRef?: React.RefObject<HTMLFormElement | null>;
 }
 
-export default function ArcSearch({ searchInputRef }: ArcSearchProps) {
+export default function ArcSearch({ searchInputRef, formRef }: ArcSearchProps) {
   const [query, setQuery] = useState("");
-  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [activeQuery, setActiveQuery] = useState("");
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const localFormRef = useRef<HTMLFormElement>(null);
+  const resolvedFormRef = formRef ?? localFormRef;
+  const { comicsConfigured, isLoaded } = useContentSources();
 
-  const { data: results, isLoading } = useFindStoryArc(debouncedQuery);
+  const {
+    data: results,
+    isLoading,
+    isFetching,
+    error,
+  } = useFindStoryArc(activeQuery);
 
   useEffect(() => {
     return () => {
@@ -22,31 +34,99 @@ export default function ArcSearch({ searchInputRef }: ArcSearchProps) {
     };
   }, []);
 
-  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setQuery(value);
-
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
+  const commitSearch = useCallback((value: string) => {
+    const trimmed = value.trim();
+    if (trimmed.length > 2) {
+      setActiveQuery(trimmed);
     }
-    debounceRef.current = setTimeout(() => {
-      setDebouncedQuery(value);
-    }, 400);
   }, []);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      setQuery(value);
+
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+      debounceRef.current = setTimeout(() => {
+        commitSearch(value);
+      }, 400);
+    },
+    [commitSearch],
+  );
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      commitSearch(query);
+    },
+    [commitSearch, query],
+  );
+
+  const searching = (isLoading || isFetching) && activeQuery.length > 2;
+  const showResults = !!results && results.length > 0;
+  const showEmpty =
+    activeQuery.length > 2 && !searching && !error && results?.length === 0;
+  const providerUnavailable = isLoaded && !comicsConfigured;
 
   return (
     <div className="space-y-4">
-      <FilterField
-        ref={searchInputRef}
-        placeholder="Search story arcs on ComicVine…"
-        aria-label="Search story arcs"
-        value={query}
-        onChange={handleChange}
-        shortcut="/"
-        loading={isLoading && debouncedQuery.length > 2}
-      />
+      <form
+        ref={resolvedFormRef}
+        onSubmit={handleSubmit}
+        className="flex items-center gap-2 flex-1 min-w-[260px] max-w-[560px]"
+      >
+        <FilterField
+          ref={searchInputRef}
+          placeholder="Search story arcs on ComicVine…"
+          aria-label="Search story arcs"
+          value={query}
+          onChange={handleChange}
+          shortcut="↵"
+          loading={searching}
+          widthCap="full"
+        />
+        <button
+          type="submit"
+          disabled={query.trim().length < 3}
+          className="inline-flex items-center gap-1 px-3 h-8 rounded-[5px] text-[12px] font-semibold disabled:opacity-60"
+          style={{
+            background: "var(--primary)",
+            color: "var(--primary-foreground)",
+          }}
+        >
+          Search
+        </button>
+      </form>
 
-      {results && results.length > 0 && (
+      {error && activeQuery.length > 2 && (
+        <div>
+          {providerUnavailable ? (
+            <EmptyState
+              variant="custom"
+              icon={Settings}
+              eyebrow="PROVIDER · NOT CONFIGURED"
+              title="Comic Vine API key required"
+              description="Add a Comic Vine API key in Settings → API to search story arcs."
+              action={{ label: "Open settings", to: "/settings" }}
+            />
+          ) : (
+            <EmptyState
+              variant="custom"
+              eyebrow="SEARCH · ERROR"
+              title="Story arc search failed"
+              description={error.message}
+            />
+          )}
+        </div>
+      )}
+
+      {showResults && (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {results.map((result) => (
             <ArcSearchResultCard key={result.cvarcid} result={result} />
@@ -54,9 +134,9 @@ export default function ArcSearch({ searchInputRef }: ArcSearchProps) {
         </div>
       )}
 
-      {debouncedQuery.length > 2 && !isLoading && results?.length === 0 && (
+      {showEmpty && (
         <p className="text-[12px] text-muted-foreground text-center py-6">
-          No story arcs found for &ldquo;{debouncedQuery}&rdquo;
+          No story arcs found for &ldquo;{activeQuery}&rdquo;
         </p>
       )}
     </div>

--- a/frontend/src/hooks/useArcSearch.ts
+++ b/frontend/src/hooks/useArcSearch.ts
@@ -5,8 +5,49 @@ import {
   type UseQueryResult,
   type UseMutationResult,
 } from "@tanstack/react-query";
-import { apiRequest } from "@/lib/api";
+import { apiRequest, ApiError } from "@/lib/api";
 import type { ArcSearchResult } from "@/types";
+
+interface RawArcSearchResult {
+  comicid?: string;
+  cvarcid?: string;
+  name?: string;
+  publisher?: string | null;
+  issues?: string | number | null;
+  description?: string | null;
+  comicimage?: string | null;
+  comicthumb?: string | null;
+  image?: string | null;
+  arclist?: string | null;
+  haveit?: string | null;
+  [key: string]: unknown;
+}
+
+type RawArcSearchResponse =
+  | RawArcSearchResult[]
+  | {
+      results?: RawArcSearchResult[];
+    };
+
+function normalizeArcSearchResults(
+  data: RawArcSearchResponse,
+): ArcSearchResult[] {
+  const rows = Array.isArray(data) ? data : (data.results ?? []);
+  return rows.map((row) => {
+    const cvarcid = String(row.cvarcid ?? row.comicid ?? "");
+    return {
+      id: cvarcid,
+      name: row.name ?? "",
+      publisher: row.publisher ?? null,
+      issues: String(row.issues ?? "?"),
+      description: row.description ?? null,
+      image: row.image || row.comicimage || row.comicthumb || null,
+      cvarcid,
+      arclist: row.arclist ?? null,
+      haveit: row.haveit ?? null,
+    };
+  });
+}
 
 /**
  * Search for story arcs by name (ComicVine)
@@ -16,12 +57,30 @@ export function useFindStoryArc(
 ): UseQueryResult<ArcSearchResult[]> {
   return useQuery({
     queryKey: ["arcSearch", query],
-    queryFn: () =>
-      apiRequest<ArcSearchResult[]>("POST", "/api/search/comics", {
-        name: query,
-        type: "story_arc",
-      }),
-    enabled: !!query && query.length > 2,
+    queryFn: async () => {
+      try {
+        const data = await apiRequest<RawArcSearchResponse>(
+          "POST",
+          "/api/search/comics",
+          {
+            name: query,
+            type: "story_arc",
+          },
+        );
+        return normalizeArcSearchResults(data);
+      } catch (error) {
+        // Backend returns 400 with this detail when the provider finds no matches.
+        // Surface that as an empty list so the page can show a distinct empty state.
+        if (
+          error instanceof ApiError &&
+          /no results/i.test(error.userMessage)
+        ) {
+          return [];
+        }
+        throw error;
+      }
+    },
+    enabled: !!query && query.trim().length > 2,
     staleTime: 10 * 60 * 1000,
   });
 }

--- a/frontend/src/pages/StoryArcsPage.tsx
+++ b/frontend/src/pages/StoryArcsPage.tsx
@@ -12,9 +12,11 @@ export default function StoryArcsPage() {
   const { data: arcs, isLoading, error } = useStoryArcs();
   const { data: aiStatus } = useAiStatus();
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchFormRef = useRef<HTMLFormElement>(null);
 
-  const handleSearchFocus = () => {
+  const handleSearchAction = () => {
     searchInputRef.current?.focus();
+    searchFormRef.current?.requestSubmit();
   };
 
   const count = arcs?.length ?? 0;
@@ -33,7 +35,7 @@ export default function StoryArcsPage() {
       <div className="px-5 py-4 space-y-6">
         {aiStatus?.configured && <ArcGenerator />}
 
-        <ArcSearch searchInputRef={searchInputRef} />
+        <ArcSearch searchInputRef={searchInputRef} formRef={searchFormRef} />
 
         {isLoading ? (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
@@ -70,7 +72,7 @@ export default function StoryArcsPage() {
             ))}
           </div>
         ) : (
-          <StoryArcEmptyState onSearchFocus={handleSearchFocus} />
+          <StoryArcEmptyState onSearchFocus={handleSearchAction} />
         )}
       </div>
     </div>

--- a/frontend/tests/components/ArcSearch.test.tsx
+++ b/frontend/tests/components/ArcSearch.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Regression tests for Story Arc search submission (issue #411).
+ *
+ * Enter and the Search button must POST /api/search/comics with type=story_arc
+ * and render results from the backend { results: [...] } envelope.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/server";
+import { render, screen } from "../test-utils";
+import ArcSearch from "@/components/storyarcs/ArcSearch";
+import StoryArcsPage from "@/pages/StoryArcsPage";
+
+const ARC_RESULT = {
+  name: "Dark Phoenix Saga",
+  comicid: "4045-12345",
+  cvarcid: "4045-12345",
+  publisher: "Marvel",
+  issues: "?",
+  comicimage: "https://example.com/dark-phoenix.jpg",
+  description: "Story Arc - Click to load details",
+  arclist: null,
+  haveit: "No",
+};
+
+describe("ArcSearch", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("submits via Enter and renders results from the {results} envelope", async () => {
+    const user = userEvent.setup();
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post("/api/search/comics", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ results: [ARC_RESULT] });
+      }),
+    );
+
+    render(<ArcSearch />);
+
+    const input = screen.getByRole("textbox", { name: /search story arcs/i });
+    await user.type(input, "Dark Phoenix");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(capturedBody).toEqual({
+        name: "Dark Phoenix",
+        type: "story_arc",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Dark Phoenix Saga")).toBeTruthy();
+    });
+    expect(screen.getByText("Marvel")).toBeTruthy();
+  });
+
+  it("submits via the Search button for the same non-empty query", async () => {
+    const user = userEvent.setup();
+    let requestCount = 0;
+
+    server.use(
+      http.post("/api/search/comics", async ({ request }) => {
+        requestCount += 1;
+        const body = (await request.json()) as { name?: string; type?: string };
+        expect(body.name).toBe("House of M");
+        expect(body.type).toBe("story_arc");
+        return HttpResponse.json({
+          results: [{ ...ARC_RESULT, name: "House of M" }],
+        });
+      }),
+    );
+
+    render(<ArcSearch />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: /search story arcs/i }),
+      "House of M",
+    );
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    await waitFor(() => {
+      expect(requestCount).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("House of M")).toBeTruthy();
+    });
+  });
+
+  it("shows an empty-result state when the provider returns no matches", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.post("/api/search/comics", () => {
+        return HttpResponse.json(
+          { detail: "Search returned no results" },
+          { status: 400 },
+        );
+      }),
+    );
+
+    render(<ArcSearch />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: /search story arcs/i }),
+      "zzzznotanarc",
+    );
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No story arcs found for .*zzzznotanarc/i),
+      ).toBeTruthy();
+    });
+  });
+
+  it("shows a request-failure state when search errors", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get("/api/config", () => {
+        return HttpResponse.json({
+          comicvine_enabled: true,
+          comicvine_api_set: true,
+        });
+      }),
+      http.post("/api/search/comics", () => {
+        return HttpResponse.json(
+          { detail: "ComicVine is temporarily unavailable" },
+          { status: 502 },
+        );
+      }),
+    );
+
+    render(<ArcSearch />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: /search story arcs/i }),
+      "Dark Phoenix",
+    );
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByText("Story arc search failed")).toBeTruthy();
+      expect(
+        screen.getByText(
+          /ComicVine is temporarily unavailable|Unable to reach/i,
+        ),
+      ).toBeTruthy();
+    });
+  });
+});
+
+describe("StoryArcsPage empty-state search action", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("submits the typed query when the empty-state Search Story Arcs action is clicked", async () => {
+    const user = userEvent.setup();
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get("/api/storyarcs", () => {
+        return HttpResponse.json([]);
+      }),
+      http.get("/api/ai/status", () => {
+        return HttpResponse.json({ configured: false, available: false });
+      }),
+      http.post("/api/search/comics", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ results: [ARC_RESULT] });
+      }),
+    );
+
+    render(<StoryArcsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No story arcs tracked")).toBeTruthy();
+    });
+
+    const input = screen.getByRole("textbox", { name: /search story arcs/i });
+    await user.type(input, "Dark Phoenix");
+    await user.click(
+      screen.getByRole("button", { name: /search story arcs/i }),
+    );
+
+    await waitFor(() => {
+      expect(capturedBody).toEqual({
+        name: "Dark Phoenix",
+        type: "story_arc",
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Dark Phoenix Saga")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes Story Arcs search so Enter, the Search button, and the empty-state action submit a non-empty query to Comic Vine and render matching arcs (or a clear empty/error/unconfigured state). Closes #411.

### Root cause
1. `useFindStoryArc` expected a bare array, but `/api/search/comics` returns `{ results: [...] }`, so successful responses never rendered.
2. `ArcSearch` had no form submit path — only debounce — so Enter and the empty-state **Search Story Arcs** button never issued a request.

### Changes
- Form submit via Enter and Search button; empty-state CTA focuses + `requestSubmit()`
- Normalize the search response envelope and map ComicVine fields (`comicimage` → `image`, etc.)
- Distinct empty, error, and unconfigured-provider UI states
- Regression tests for submit paths, empty results, and request failures
- Patch changeset

## Follow-up (not in this PR)

**Add Arc endpoint is missing.** After search works, the result card still calls `POST /api/storyarcs` via `useAddStoryArc`, but `comicarr/app/storyarcs/router.py` has no create/add handler (only generate, list, detail, delete, want-all, refresh). Users may still be unable to add an arc from search results until that endpoint is wired to `_add_story_arc` (or equivalent). Out of scope for #411 per Agent Brief.

## Test plan
- [x] `cd frontend && npm run test:run -- tests/components/ArcSearch.test.tsx` (5 passed)
- [x] Frontend typecheck, eslint, prettier
- [ ] Manual: open `/story-arcs`, type a query, press Enter — network POST `/api/search/comics` with `type: "story_arc"` and results (or empty/error) appear
- [ ] Manual: empty library → type query → click **Search Story Arcs** empty-state button — same request
- [ ] Manual: Search button next to the field submits the same query
- [ ] Do **not** deploy to live NAS as part of this PR