### PR TITLE
fix: Render unknown series issue dates as a placeholder

### DIFF
--- a/.changeset/fix-unknown-issue-dates.md
+++ b/.changeset/fix-unknown-issue-dates.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Render unknown series issue dates as a placeholder instead of the `0000-00-00` storage sentinel.

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -26,6 +26,51 @@ export function formatDate(value: Date | string) {
   return format(new Date(`${value}`), "LLL dd, y HH:mm");
 }
 
+/** Storage / API sentinel for unknown comic issue dates (MySQL zero-date style). */
+const UNKNOWN_DATE_SENTINELS = new Set(["0000-00-00"]);
+
+/** User-facing placeholder when an issue date is absent or a sentinel. */
+export const UNKNOWN_DATE_DISPLAY = "—";
+
+/**
+ * True when a value is not a displayable calendar date for issue tables.
+ * Treats null, empty/whitespace, and the 0000-00-00 storage sentinel as unknown.
+ */
+export function isUnknownComicDate(value: unknown): boolean {
+  if (value == null) return true;
+  const trimmed = String(value).trim();
+  if (trimmed === "") return true;
+  return UNKNOWN_DATE_SENTINELS.has(trimmed);
+}
+
+/**
+ * First usable date among candidates (release date preferred over cover/issue date).
+ * Skips null, empty, and sentinel values so a known cover date is not hidden by
+ * a zero release date.
+ */
+export function pickComicDate(
+  ...candidates: Array<string | null | undefined>
+): string | null {
+  for (const candidate of candidates) {
+    if (!isUnknownComicDate(candidate)) {
+      return String(candidate).trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Presentation-boundary formatting for series issue dates.
+ * Valid ISO-like strings pass through unchanged; unknown/sentinel → placeholder.
+ */
+export function displayComicDate(
+  value: unknown,
+  placeholder: string = UNKNOWN_DATE_DISPLAY,
+): string {
+  if (isUnknownComicDate(value)) return placeholder;
+  return String(value).trim();
+}
+
 export function formatCompactNumber(value: number) {
   if (value >= 100 && value < 1000) {
     return value.toString(); // Keep the number as is if it's in the hundreds

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -37,6 +37,7 @@ import type {
   SearchMissingPreview,
   SearchMissingResult,
 } from "@/types";
+import { displayComicDate, pickComicDate } from "@/lib/format";
 
 type IssueFilter = "all" | "have" | "missing" | "monitored";
 
@@ -647,11 +648,12 @@ export default function SeriesDetailPage() {
               const issueId = issue.id ?? issue.IssueID;
               const issueNumber = issue.number ?? issue.Issue_Number;
               const issueName = issue.name ?? issue.IssueName;
-              const issueDate =
-                issue.releaseDate ??
-                issue.ReleaseDate ??
-                issue.issueDate ??
-                issue.IssueDate;
+              const issueDate = pickComicDate(
+                issue.releaseDate,
+                issue.ReleaseDate,
+                issue.issueDate,
+                issue.IssueDate,
+              );
               const status = getIssueStatus(issue);
               const separateIntent = getSeparateIntent(issue);
               return (
@@ -699,7 +701,7 @@ export default function SeriesDetailPage() {
                     className="font-mono text-[10px]"
                     style={{ color: "var(--muted-foreground)" }}
                   >
-                    {issueDate || "—"}
+                    {displayComicDate(issueDate)}
                   </div>
                   <div className="flex min-w-0 flex-wrap items-center gap-1.5">
                     <StatusBadge status={status} />

--- a/frontend/tests/pages/SeriesDetailPage.test.tsx
+++ b/frontend/tests/pages/SeriesDetailPage.test.tsx
@@ -236,6 +236,102 @@ describe("SeriesDetailPage", () => {
     expect(screen.queryByText("Reserved handoff")).toBeNull();
   });
 
+  it("renders sentinel/null/empty issue dates as — and keeps valid ISO dates", async () => {
+    server.use(
+      http.get("/api/series/1", () =>
+        HttpResponse.json({
+          comic: {
+            ComicID: "1",
+            ComicName: "Date Edge Cases",
+            ComicYear: "2024",
+            ComicPublisher: "DC Comics",
+            Status: "Active",
+            Have: 0,
+            Total: 4,
+          },
+          issues: [
+            {
+              IssueID: "sentinel",
+              ComicID: "1",
+              Issue_Number: "1",
+              IssueName: "Sentinel release",
+              releaseDate: "0000-00-00",
+              issueDate: "0000-00-00",
+              Status: "Wanted",
+              displayState: "Wanted",
+              missing: true,
+              monitored: true,
+            },
+            {
+              IssueID: "null-date",
+              ComicID: "1",
+              Issue_Number: "2",
+              IssueName: "Null dates",
+              releaseDate: null,
+              issueDate: null,
+              Status: "Wanted",
+              displayState: "Wanted",
+              missing: true,
+              monitored: true,
+            },
+            {
+              IssueID: "empty-date",
+              ComicID: "1",
+              Issue_Number: "3",
+              IssueName: "Empty dates",
+              releaseDate: "",
+              issueDate: "",
+              Status: "Wanted",
+              displayState: "Wanted",
+              missing: true,
+              monitored: true,
+            },
+            {
+              IssueID: "valid-fallback",
+              ComicID: "1",
+              Issue_Number: "4",
+              IssueName: "Valid cover date",
+              releaseDate: "0000-00-00",
+              issueDate: "2025-08-15",
+              Status: "Wanted",
+              displayState: "Wanted",
+              missing: true,
+              monitored: true,
+            },
+          ],
+          annuals: [],
+          summary: {
+            total: 4,
+            issues: 4,
+            annuals: 0,
+            owned: 0,
+            archived: 0,
+            inFlight: 0,
+            missing: 4,
+            monitored: 4,
+            wanted: 4,
+            skipped: 0,
+            ignored: 0,
+            failed: 0,
+            unknown: 0,
+            eligible: 4,
+            completionPercent: 0,
+          },
+        }),
+      ),
+    );
+
+    renderDetail();
+
+    await screen.findByText("Date Edge Cases");
+    expect(screen.getByText("Sentinel release")).toBeTruthy();
+    expect(screen.getByText("Valid cover date")).toBeTruthy();
+    expect(screen.getByText("2025-08-15")).toBeTruthy();
+    expect(screen.queryByText("0000-00-00")).toBeNull();
+    // Three unknown rows share the em dash placeholder used elsewhere on the page.
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(3);
+  });
+
   it("previews once, requires confirmation, and follows the accepted durable run", async () => {
     let confirmationPayload: unknown;
     server.use(

--- a/frontend/tests/unit/lib/format.test.ts
+++ b/frontend/tests/unit/lib/format.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  displayComicDate,
+  isUnknownComicDate,
+  pickComicDate,
+  UNKNOWN_DATE_DISPLAY,
+} from "@/lib/format";
+
+describe("isUnknownComicDate", () => {
+  it("treats null, undefined, empty, and sentinel as unknown", () => {
+    expect(isUnknownComicDate(null)).toBe(true);
+    expect(isUnknownComicDate(undefined)).toBe(true);
+    expect(isUnknownComicDate("")).toBe(true);
+    expect(isUnknownComicDate("   ")).toBe(true);
+    expect(isUnknownComicDate("0000-00-00")).toBe(true);
+  });
+
+  it("treats valid ISO dates as known", () => {
+    expect(isUnknownComicDate("2025-08-01")).toBe(false);
+    expect(isUnknownComicDate("1999-01-15")).toBe(false);
+  });
+});
+
+describe("pickComicDate", () => {
+  it("skips sentinel and empty candidates in favor of a valid date", () => {
+    expect(pickComicDate("0000-00-00", null, "", "2024-03-12")).toBe(
+      "2024-03-12",
+    );
+  });
+
+  it("prefers the first valid candidate (release before issue)", () => {
+    expect(pickComicDate("2024-01-10", "2024-02-20")).toBe("2024-01-10");
+  });
+
+  it("returns null when every candidate is unknown", () => {
+    expect(pickComicDate("0000-00-00", null, "", undefined)).toBeNull();
+  });
+});
+
+describe("displayComicDate", () => {
+  it("renders sentinel, null, and empty as the placeholder", () => {
+    expect(displayComicDate("0000-00-00")).toBe(UNKNOWN_DATE_DISPLAY);
+    expect(displayComicDate(null)).toBe(UNKNOWN_DATE_DISPLAY);
+    expect(displayComicDate("")).toBe(UNKNOWN_DATE_DISPLAY);
+    expect(displayComicDate(undefined)).toBe(UNKNOWN_DATE_DISPLAY);
+  });
+
+  it("passes valid ISO dates through unchanged", () => {
+    expect(displayComicDate("2025-08-01")).toBe("2025-08-01");
+  });
+
+  it("allows a custom placeholder", () => {
+    expect(displayComicDate("0000-00-00", "Unknown")).toBe("Unknown");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #413 — series issue list showed the storage sentinel `0000-00-00` for unknown publication dates.

**Root cause:** `SeriesDetailPage` selected the first non-null date field with `??` and rendered it with `issueDate || "—"`. The sentinel string is truthy, so every unknown-date row displayed as a fake calendar date. Preferring `releaseDate` also hid a valid cover/`issueDate` when release was `0000-00-00`.

**Fix (presentation boundary only):**
- Add `isUnknownComicDate` / `pickComicDate` / `displayComicDate` in `frontend/src/lib/format.ts`
- Series detail picks the first usable date and renders `—` for null, empty, and `0000-00-00`
- Valid ISO dates pass through unchanged
- Storage/API semantics unchanged (no DB backfill)

## Test plan

- [x] `cd frontend && npm run test:run -- tests/unit/lib/format.test.ts tests/pages/SeriesDetailPage.test.tsx`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run typecheck`
- [ ] Manual: open a series whose issues have unknown dates and confirm the date column shows `—`, not `0000-00-00`; confirm a known ISO date still displays as-is

## Follow-up / risks

- Other tables (wanted/upcoming queue, story-arc issues) still use their own date cells and may still show sentinels; out of scope for this series-list fix but can reuse the shared helpers.
- Backend continues to store/emit `0000-00-00` for unknown dates; display normalization is frontend-only by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown comic issue dates now display as an em dash instead of `0000-00-00`, blank values, or other invalid date placeholders.
  * Valid issue dates remain visible, including when selected from fallback date values.

* **Tests**
  * Added coverage for unknown, valid, fallback, and custom placeholder date scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->