### PR TITLE
fix: Use one release version across UI surfaces

### DIFF
--- a/.changeset/fix-ui-version-mismatch.md
+++ b/.changeset/fix-ui-version-mismatch.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Show one release version across the sidebar, Settings, and About instead of mixing the package badge with a git SHA or stale install metadata.

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -213,6 +213,52 @@ def initial_setup(ctx, username, password, setup_token):
 # Sorted so the response key order is stable; get_safe_config reads it every call.
 _READABLE_KEYS = sorted(readable_keys())
 
+# Repo root: comicarr/app/system/service.py → ../../../..
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+
+def get_release_version():
+    """Return the Changesets-managed release version (semver), not a git SHA.
+
+    User-facing ``config.version`` must match the frontend package badge. The
+    runtime ``current_version`` field is often a commit hash or an unexpanded
+    export-subst placeholder; those stay on ``/api/system/version`` / build
+    identity, not on the app version string.
+
+    Preference order:
+    1. ``pyproject.toml`` project.version (release SSOT in source/Docker trees)
+    2. ``importlib.metadata`` for pure installs without a nearby pyproject
+    """
+    version = _read_pyproject_version()
+    if version:
+        return version
+    try:
+        from importlib.metadata import version as package_version
+
+        return package_version("comicarr")
+    except Exception:
+        return None
+
+
+def _read_pyproject_version():
+    """Read [project].version from the repo pyproject.toml when present."""
+    pyproject = _REPO_ROOT / "pyproject.toml"
+    if not pyproject.is_file():
+        return None
+    try:
+        try:
+            import tomllib
+        except ModuleNotFoundError:  # Python 3.10
+            import tomli as tomllib
+        with open(pyproject, "rb") as f:
+            data = tomllib.load(f)
+        version = data.get("project", {}).get("version")
+        if not version or "%" in str(version) or "$" in str(version):
+            return None
+        return str(version)
+    except Exception:
+        return None
+
 
 def get_safe_config(ctx):
     """Return configuration as a safe dict (no passwords/keys)."""
@@ -252,28 +298,8 @@ def get_safe_config(ctx):
 
     # Lowercase all keys for frontend convention
     result = {k.lower(): v for k, v in result.items()}
-    version = ctx.current_version
-    # Fall back to package metadata if version is missing or contains
-    # unexpanded git export-subst placeholders (e.g. "%H$")
-    if not version or "%" in version or "$" in version:
-        try:
-            from importlib.metadata import version as get_version
-
-            version = get_version("comicarr")
-        except Exception:
-            version = None
-    # Final fallback: read version directly from pyproject.toml
-    if not version:
-        try:
-            import tomllib
-
-            pyproject = Path(__file__).resolve().parent.parent.parent.parent / "pyproject.toml"
-            if pyproject.is_file():
-                with open(pyproject, "rb") as f:
-                    data = tomllib.load(f)
-                version = data.get("project", {}).get("version")
-        except Exception:
-            version = None
+    # Release semver only — never ctx.current_version (git SHA / install id).
+    version = get_release_version()
     if version:
         result["version"] = version
     return result

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useChatThreads } from "@/hooks/useLibraryChat";
 import { isEditableTarget } from "@/lib/keyboard";
-import { APP_VERSION } from "@/lib/version";
+import { formatAppVersion } from "@/lib/version";
 import {
   Sidebar,
   SidebarContent,
@@ -192,7 +192,7 @@ export default function AppSidebar() {
             <Logo className="h-3 w-auto text-foreground" />
           </Link>
           <span className="group-data-[collapsible=icon]:hidden font-mono text-[10px] text-muted-foreground px-1.5 py-0.5 border border-sidebar-border rounded-sm">
-            {APP_VERSION}
+            {formatAppVersion(false)}
           </span>
         </div>
       </SidebarHeader>

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -1,17 +1,23 @@
 import { version } from "../../package.json";
 
 /**
- * Authoritative app release version for every user-facing UI surface
- * (sidebar, login, onboarding, Settings header, About).
+ * Authoritative app release version for every user-facing UI surface.
+ *
+ * Consumers (must import only from this module):
+ * - AppSidebar badge
+ * - LoginPage badge
+ * - OnboardingDialog welcome label
+ * - SettingsPage header + About row
  *
  * Sourced from frontend/package.json. Changesets + scripts/release/sync-version
- * keep this in lockstep with root package.json and pyproject.toml. Do not
- * substitute backend current_version / config.version here — those can be a
- * git SHA or stale install metadata and caused conflicting badges (#412).
+ * keep this in lockstep with root package.json and pyproject.toml (backend
+ * get_release_version / config.version). Do not substitute backend
+ * current_version or config.version in UI chrome — those can be a git SHA or
+ * stale install metadata and caused conflicting badges (#412).
  */
 export const APP_VERSION: string = version;
 
-/** Format for badges, e.g. `v0.18.5`. */
+/** Format for badges. Prefer this helper over raw APP_VERSION in UI. */
 export function formatAppVersion(withPrefix = true): string {
   return withPrefix ? `v${APP_VERSION}` : APP_VERSION;
 }

--- a/frontend/src/lib/version.ts
+++ b/frontend/src/lib/version.ts
@@ -1,10 +1,13 @@
 import { version } from "../../package.json";
 
 /**
- * App release version for UI chrome (sidebar, login, onboarding).
+ * Authoritative app release version for every user-facing UI surface
+ * (sidebar, login, onboarding, Settings header, About).
  *
- * Sourced from frontend/package.json. Changesets keeps this in sync with the
- * root package and pyproject versions on release.
+ * Sourced from frontend/package.json. Changesets + scripts/release/sync-version
+ * keep this in lockstep with root package.json and pyproject.toml. Do not
+ * substitute backend current_version / config.version here — those can be a
+ * git SHA or stale install metadata and caused conflicting badges (#412).
  */
 export const APP_VERSION: string = version;
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -14,7 +14,7 @@ import { AcquisitionHealthTab } from "@/components/settings/AcquisitionHealthTab
 import { SaveButton } from "@/components/settings/SaveButton";
 import PageHeader from "@/components/layout/PageHeader";
 import { prepareConfigSaveData } from "@/lib/configSave";
-import { APP_VERSION, formatAppVersion } from "@/lib/version";
+import { formatAppVersion } from "@/lib/version";
 import type { Config } from "@/types";
 import type {
   ReadableConfig,
@@ -272,7 +272,7 @@ export default function SettingsPage() {
 
 function AboutSection({ config }: { config: Config }) {
   const rows: Array<[string, string]> = [
-    ["version", APP_VERSION],
+    ["version", formatAppVersion(false)],
     ["config path", config.config_path || "/config/config.ini"],
     ["data directory", config.data_dir || "—"],
     ["python", config.python_version || "—"],

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -14,6 +14,7 @@ import { AcquisitionHealthTab } from "@/components/settings/AcquisitionHealthTab
 import { SaveButton } from "@/components/settings/SaveButton";
 import PageHeader from "@/components/layout/PageHeader";
 import { prepareConfigSaveData } from "@/lib/configSave";
+import { APP_VERSION, formatAppVersion } from "@/lib/version";
 import type { Config } from "@/types";
 import type {
   ReadableConfig,
@@ -168,7 +169,9 @@ export default function SettingsPage() {
   }
 
   const configPath = config?.config_path || "/config/config.ini";
-  const version = config?.version ? `comicarr v${config.version}` : "comicarr";
+  // Same release SSOT as sidebar/login/onboarding (frontend/package.json), not
+  // config.version which used to surface git SHAs or stale install metadata.
+  const version = `comicarr ${formatAppVersion()}`;
 
   const configData: ReadableConfig = config ?? {};
   const tabProps = { config: configData, formData, onChange: handleChange };
@@ -269,7 +272,7 @@ export default function SettingsPage() {
 
 function AboutSection({ config }: { config: Config }) {
   const rows: Array<[string, string]> = [
-    ["version", config.version || "—"],
+    ["version", APP_VERSION],
     ["config path", config.config_path || "/config/config.ini"],
     ["data directory", config.data_dir || "—"],
     ["python", config.python_version || "—"],

--- a/frontend/tests/pages/LoginPage.test.tsx
+++ b/frontend/tests/pages/LoginPage.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { server } from "../mocks/server";
 import { http, HttpResponse } from "msw";
 import { render, screen } from "../test-utils";
+import { formatAppVersion } from "@/lib/version";
 import LoginPage from "@/pages/LoginPage";
 
 describe("LoginPage", () => {
@@ -28,6 +29,7 @@ describe("LoginPage", () => {
     expect(
       screen.getByPlaceholderText("from server logs if required"),
     ).toBeTruthy();
+    expect(screen.getByText(formatAppVersion())).toBeTruthy();
   });
 
   it("submits setup token with credentials", async () => {

--- a/frontend/tests/pages/SettingsPage.test.ts
+++ b/frontend/tests/pages/SettingsPage.test.ts
@@ -5,7 +5,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../mocks/server";
 import { render, screen } from "../test-utils";
 import { prepareConfigSaveData } from "@/lib/configSave";
-import { APP_VERSION, formatAppVersion } from "@/lib/version";
+import { formatAppVersion } from "@/lib/version";
 import SettingsPage from "@/pages/SettingsPage";
 
 describe("prepareConfigSaveData", () => {
@@ -55,6 +55,9 @@ describe("prepareConfigSaveData", () => {
     });
   });
 
+});
+
+describe("SettingsPage", () => {
   it("opens the acquisition operator surface from Settings", async () => {
     server.use(
       http.get("/api/search/health", () =>
@@ -82,7 +85,6 @@ describe("prepareConfigSaveData", () => {
     expect(await screen.findByText("Acquisition health")).toBeTruthy();
     expect(screen.getByText("Evidence-driven repair")).toBeTruthy();
   });
-
   it("shows the package release version even when the API reports a different one", async () => {
     // Regression for #412: Settings/About must not echo backend config.version
     // when that field is a git SHA or stale install metadata.
@@ -101,12 +103,14 @@ describe("prepareConfigSaveData", () => {
     render(createElement(SettingsPage));
 
     expect(
-      await screen.findByText(`comicarr ${formatAppVersion()}`, { exact: false }),
+      await screen.findByText(`comicarr ${formatAppVersion()}`, {
+        exact: false,
+      }),
     ).toBeTruthy();
     expect(screen.queryByText(/0\.19\.13/)).toBeNull();
 
     await user.click(screen.getAllByRole("button", { name: "About" })[0]);
-    expect(await screen.findByText(APP_VERSION)).toBeTruthy();
+    expect(await screen.findByText(formatAppVersion(false))).toBeTruthy();
     expect(screen.queryByText("0.19.13")).toBeNull();
   });
 });

--- a/frontend/tests/pages/SettingsPage.test.ts
+++ b/frontend/tests/pages/SettingsPage.test.ts
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../mocks/server";
 import { render, screen } from "../test-utils";
 import { prepareConfigSaveData } from "@/lib/configSave";
+import { APP_VERSION, formatAppVersion } from "@/lib/version";
 import SettingsPage from "@/pages/SettingsPage";
 
 describe("prepareConfigSaveData", () => {
@@ -80,5 +81,32 @@ describe("prepareConfigSaveData", () => {
 
     expect(await screen.findByText("Acquisition health")).toBeTruthy();
     expect(screen.getByText("Evidence-driven repair")).toBeTruthy();
+  });
+
+  it("shows the package release version even when the API reports a different one", async () => {
+    // Regression for #412: Settings/About must not echo backend config.version
+    // when that field is a git SHA or stale install metadata.
+    server.use(
+      http.get("/api/config", () =>
+        HttpResponse.json({
+          version: "0.19.13",
+          config_path: "/config/config.ini",
+          data_dir: "/data",
+          python_version: "3.12.0",
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+
+    render(createElement(SettingsPage));
+
+    expect(
+      await screen.findByText(`comicarr ${formatAppVersion()}`, { exact: false }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/0\.19\.13/)).toBeNull();
+
+    await user.click(screen.getAllByRole("button", { name: "About" })[0]);
+    expect(await screen.findByText(APP_VERSION)).toBeTruthy();
+    expect(screen.queryByText("0.19.13")).toBeNull();
   });
 });

--- a/frontend/tests/unit/lib/version.displays.test.tsx
+++ b/frontend/tests/unit/lib/version.displays.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Render-level coverage for every user-facing version display consumer (#412).
+ * Each surface must show the shared formatAppVersion() helper output.
+ */
+import { createElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import userEvent from "@testing-library/user-event";
+import { waitFor } from "@testing-library/react";
+import { server } from "../../mocks/server";
+import { render, screen } from "../../test-utils";
+import { formatAppVersion } from "@/lib/version";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import AppSidebar from "@/components/layout/AppSidebar";
+import OnboardingDialog from "@/components/onboarding/OnboardingDialog";
+import LoginPage from "@/pages/LoginPage";
+import SettingsPage from "@/pages/SettingsPage";
+
+describe("version display consumers", () => {
+  it("LoginPage badge uses formatAppVersion()", async () => {
+    server.use(
+      http.get("/api/auth/check-setup", () =>
+        HttpResponse.json({ success: true, needs_setup: false }),
+      ),
+    );
+    render(createElement(LoginPage));
+    expect(await screen.findByText(formatAppVersion())).toBeTruthy();
+  });
+
+  it("OnboardingDialog welcome label uses formatAppVersion()", async () => {
+    render(
+      createElement(OnboardingDialog, {
+        open: true,
+        onFinish: vi.fn(),
+      }),
+    );
+    expect(
+      await screen.findByText(`Welcome · ${formatAppVersion()}`),
+    ).toBeTruthy();
+  });
+
+  it("AppSidebar badge uses formatAppVersion(false)", async () => {
+    server.use(
+      http.get("/api/ai/chat/threads", () =>
+        HttpResponse.json({ threads: [], next_cursor: null }),
+      ),
+    );
+    render(
+      createElement(SidebarProvider, null, createElement(AppSidebar)),
+    );
+    expect(await screen.findByText(formatAppVersion(false))).toBeTruthy();
+  });
+
+  it("Settings header and About use formatAppVersion()", async () => {
+    server.use(
+      http.get("/api/config", () =>
+        HttpResponse.json({
+          version: "0.19.13",
+          config_path: "/config/config.ini",
+          data_dir: "/data",
+          python_version: "3.12.0",
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    render(createElement(SettingsPage));
+
+    expect(
+      await screen.findByText(`comicarr ${formatAppVersion()}`, {
+        exact: false,
+      }),
+    ).toBeTruthy();
+    expect(screen.queryByText(/0\.19\.13/)).toBeNull();
+
+    await user.click(screen.getAllByRole("button", { name: "About" })[0]);
+    await waitFor(() => {
+      expect(screen.getByText(formatAppVersion(false))).toBeTruthy();
+    });
+    expect(screen.queryByText("0.19.13")).toBeNull();
+  });
+});

--- a/frontend/tests/unit/lib/version.test.ts
+++ b/frontend/tests/unit/lib/version.test.ts
@@ -1,7 +1,49 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
 import packageJson from "../../../package.json";
 import rootPackageJson from "../../../../package.json";
 import { APP_VERSION, formatAppVersion } from "@/lib/version";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const frontendRoot = resolve(here, "../../..");
+const repoRoot = resolve(frontendRoot, "..");
+
+/** Every user-facing surface that shows the app release version. */
+const VERSION_DISPLAY_CONSUMERS = [
+  "src/components/layout/AppSidebar.tsx",
+  "src/pages/LoginPage.tsx",
+  "src/components/onboarding/OnboardingDialog.tsx",
+  "src/pages/SettingsPage.tsx",
+] as const;
+
+function readPyprojectVersion(): string {
+  const text = readFileSync(resolve(repoRoot, "pyproject.toml"), "utf8");
+  let inProject = false;
+  for (const line of text.split("\n")) {
+    if (/^\[.+\]\s*$/.test(line)) {
+      inProject = line.trim() === "[project]";
+      continue;
+    }
+    if (inProject) {
+      const match = line.match(/^version\s*=\s*"([^"]+)"/);
+      if (match) return match[1];
+    }
+  }
+  throw new Error("Could not find [project] version in pyproject.toml");
+}
+
+function* walkTsSources(dir: string): Generator<string> {
+  for (const name of readdirSync(dir)) {
+    const full = resolve(dir, name);
+    if (statSync(full).isDirectory()) {
+      yield* walkTsSources(full);
+    } else if (/\.(tsx?)$/.test(name) && !name.endsWith(".d.ts")) {
+      yield full;
+    }
+  }
+}
 
 describe("version", () => {
   it("matches frontend package.json", () => {
@@ -9,15 +51,51 @@ describe("version", () => {
     expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+/);
   });
 
-  it("stays in lockstep with the root package release version", () => {
-    // Changesets + scripts/release/sync-version.mjs keep these aligned.
-    // Divergence here is the same class of bug as #412.
+  it("stays in lockstep with root package.json and pyproject.toml", () => {
+    // Single build-version contract (#412). Changesets + sync-version.mjs
+    // keep these three surfaces aligned; any drift reopens conflicting badges.
+    const pyprojectVersion = readPyprojectVersion();
     expect(APP_VERSION).toBe(rootPackageJson.version);
+    expect(APP_VERSION).toBe(pyprojectVersion);
+    expect(packageJson.version).toBe(pyprojectVersion);
   });
 
   it("formats with and without v prefix", () => {
     expect(formatAppVersion()).toBe(`v${packageJson.version}`);
     expect(formatAppVersion(true)).toBe(`v${packageJson.version}`);
     expect(formatAppVersion(false)).toBe(packageJson.version);
+  });
+
+  describe("display consumers", () => {
+    for (const rel of VERSION_DISPLAY_CONSUMERS) {
+      it(`${rel} routes through @/lib/version`, () => {
+        const source = readFileSync(resolve(frontendRoot, rel), "utf8");
+        expect(source).toMatch(/from ["']@\/lib\/version["']/);
+        expect(source).toMatch(/\bformatAppVersion\b/);
+        // Must not paint config.version (git SHA / stale install metadata).
+        expect(source).not.toMatch(
+          /config\?\.version\s*\?|config\.version\s*\|\||\[\s*["']version["']\s*,\s*config\.version/,
+        );
+      });
+    }
+
+    it("lists every file that imports the version helper as a known consumer", () => {
+      // Fail if a new surface imports @/lib/version without joining the list
+      // above (or if a listed consumer stops importing it).
+      const importers = [...walkTsSources(resolve(frontendRoot, "src"))]
+        .filter((path) => {
+          if (path.replaceAll("\\", "/").endsWith("/lib/version.ts")) {
+            return false;
+          }
+          const text = readFileSync(path, "utf8");
+          return /from ["']@\/lib\/version["']/.test(text);
+        })
+        .map((path) =>
+          path.slice(frontendRoot.length + 1).replaceAll("\\", "/"),
+        )
+        .sort();
+
+      expect(importers).toEqual([...VERSION_DISPLAY_CONSUMERS].sort());
+    });
   });
 });

--- a/frontend/tests/unit/lib/version.test.ts
+++ b/frontend/tests/unit/lib/version.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect } from "vitest";
 import packageJson from "../../../package.json";
+import rootPackageJson from "../../../../package.json";
 import { APP_VERSION, formatAppVersion } from "@/lib/version";
 
 describe("version", () => {
   it("matches frontend package.json", () => {
     expect(APP_VERSION).toBe(packageJson.version);
     expect(APP_VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("stays in lockstep with the root package release version", () => {
+    // Changesets + scripts/release/sync-version.mjs keep these aligned.
+    // Divergence here is the same class of bug as #412.
+    expect(APP_VERSION).toBe(rootPackageJson.version);
   });
 
   it("formats with and without v prefix", () => {

--- a/tests/unit/test_release_version_contract.py
+++ b/tests/unit/test_release_version_contract.py
@@ -1,0 +1,121 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Single build-version contract across release manifests and the API.
+
+Regression for #412: UI chrome and Settings/About must never disagree because
+frontend package.json, root package.json, and pyproject.toml drifted, or
+because config.version fell back to a git SHA / stale install metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from comicarr.app.core.context import AppContext
+from comicarr.app.system import service as system_service
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parents[2]
+SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+def _read_json_version(path: Path) -> str:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    version = data.get("version")
+    assert isinstance(version, str) and version, f"missing version in {path}"
+    return version
+
+
+def _read_pyproject_version() -> str:
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    version = data.get("project", {}).get("version")
+    assert isinstance(version, str) and version, "missing [project].version in pyproject.toml"
+    return version
+
+
+def _manifest_versions() -> dict[str, str]:
+    return {
+        "root package.json": _read_json_version(ROOT / "package.json"),
+        "frontend/package.json": _read_json_version(ROOT / "frontend" / "package.json"),
+        "pyproject.toml": _read_pyproject_version(),
+    }
+
+
+@pytest.fixture
+def release_version() -> str:
+    versions = _manifest_versions()
+    unique = set(versions.values())
+    assert len(unique) == 1, f"release version drift between manifests: {versions}"
+    version = next(iter(unique))
+    assert SEMVER.fullmatch(version), f"invalid release version {version!r}"
+    return version
+
+
+class TestReleaseVersionContract:
+    def test_all_release_manifests_share_one_version(self, release_version):
+        """Changesets + sync-version must keep every release surface aligned."""
+        versions = _manifest_versions()
+        assert versions == {
+            "root package.json": release_version,
+            "frontend/package.json": release_version,
+            "pyproject.toml": release_version,
+        }
+
+    def test_get_release_version_matches_manifests(self, release_version):
+        """Backend display/API version must resolve to the same release SSOT."""
+        assert system_service.get_release_version() == release_version
+
+    def test_get_safe_config_version_matches_manifests_not_git_sha(self, release_version):
+        """config.version must not surface install/git identity."""
+        config = MagicMock()
+        # Minimal attrs so get_safe_config can run without real Config.
+        for key in (
+            "API_KEY",
+            "COMICVINE_API",
+            "AI_API_KEY",
+            "METRON_PASSWORD",
+            "MAL_CLIENT_ID",
+            "PROWL_KEYS",
+            "SLACK_WEBHOOK_URL",
+            "MATTERMOST_WEBHOOK_URL",
+            "DISCORD_WEBHOOK_URL",
+            "NZB_DOWNLOADER",
+            "TORRENT_DOWNLOADER",
+        ):
+            setattr(config, key, None)
+        ctx = AppContext(
+            prog_dir="/tmp/comicarr_test",
+            data_dir="/tmp/comicarr_test/data",
+            db_file=":memory:",
+            config=config,
+            scheduler=MagicMock(),
+            current_version="a1b2c3d4e5f6789012345678",
+            current_version_name="v0.19.13",
+        )
+        result = system_service.get_safe_config(ctx)
+        assert result["version"] == release_version
+        assert result["version"] != ctx.current_version
+        assert result["version"] != "0.19.13"
+        assert result["version"] != "v0.19.13"
+
+    def test_get_release_version_ignores_stale_importlib_when_pyproject_present(self, release_version):
+        """pyproject wins so a stale egg-info cannot reintroduce the mismatch."""
+        with patch("importlib.metadata.version", return_value="0.19.13") as mock_meta:
+            assert system_service.get_release_version() == release_version
+            mock_meta.assert_not_called()

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -8,6 +8,7 @@ import configparser
 import datetime
 import json
 import os
+import re
 import stat
 import threading
 from unittest.mock import MagicMock, patch
@@ -605,27 +606,52 @@ class TestConfigService:
         result = system_service.get_safe_config(ctx)
         assert result["nzb_downloader_label"] == "None"
 
-    def test_get_safe_config_includes_version_from_context(self):
-        """get_safe_config includes version when ctx.current_version is set."""
-        ctx = _make_test_ctx(current_version="1.2.3")
-        result = system_service.get_safe_config(ctx)
-        assert result["version"] == "1.2.3"
+    def test_get_safe_config_uses_release_version_not_git_sha(self):
+        """config.version is the release semver, never ctx.current_version (git SHA)."""
+        ctx = _make_test_ctx(current_version="a1b2c3d4e5f6789")
+        with patch.object(system_service, "get_release_version", return_value="0.20.10"):
+            result = system_service.get_safe_config(ctx)
+        assert result["version"] == "0.20.10"
+        assert result["version"] != ctx.current_version
 
+    def test_get_safe_config_ignores_stale_current_version_name(self):
+        """Install tags on the runtime context must not leak into config.version."""
+        ctx = _make_test_ctx(current_version="deadbeef", current_version_name="v0.19.13")
+        with patch.object(system_service, "get_release_version", return_value="0.20.10"):
+            result = system_service.get_safe_config(ctx)
+        assert result["version"] == "0.20.10"
+
+    @patch.object(system_service, "_read_pyproject_version", return_value=None)
     @patch("importlib.metadata.version", return_value="0.8.0")
-    def test_get_safe_config_falls_back_to_importlib_metadata(self, mock_version):
-        """get_safe_config falls back to importlib.metadata when ctx.current_version is None."""
-        ctx = _make_test_ctx(current_version=None)
+    def test_get_safe_config_falls_back_to_importlib_metadata(self, mock_version, mock_pyproject):
+        """get_safe_config uses importlib when pyproject is unavailable."""
+        ctx = _make_test_ctx(current_version="abc1234")
         result = system_service.get_safe_config(ctx)
         assert result["version"] == "0.8.0"
         mock_version.assert_called_once_with("comicarr")
 
+    @patch.object(system_service, "_read_pyproject_version", return_value=None)
     @patch("importlib.metadata.version", side_effect=Exception("not found"))
-    @patch("pathlib.Path.is_file", return_value=False)
-    def test_get_safe_config_omits_version_when_unavailable(self, mock_isfile, mock_version):
-        """get_safe_config omits version key when all sources fail."""
-        ctx = _make_test_ctx(current_version=None)
+    def test_get_safe_config_omits_version_when_unavailable(self, mock_version, mock_pyproject):
+        """get_safe_config omits version key when all release sources fail."""
+        ctx = _make_test_ctx(current_version="abc1234")
         result = system_service.get_safe_config(ctx)
         assert "version" not in result
+
+    def test_get_release_version_prefers_pyproject_over_importlib(self):
+        """pyproject.toml is the release SSOT when both sources are present."""
+        with (
+            patch.object(system_service, "_read_pyproject_version", return_value="0.20.10"),
+            patch("importlib.metadata.version", return_value="0.19.13") as mock_meta,
+        ):
+            assert system_service.get_release_version() == "0.20.10"
+            mock_meta.assert_not_called()
+
+    def test_get_release_version_reads_live_pyproject(self):
+        """Repo pyproject.toml is readable and looks like a release version."""
+        version = system_service.get_release_version()
+        assert version is not None
+        assert re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", version)
 
     def test_update_config_accepts_lowercase_keys(self):
         """update_config normalizes lowercase keys to uppercase."""


### PR DESCRIPTION
## Summary

Fixes #412 — the UI no longer reports conflicting Comicarr versions.

**Root cause:** Two independent version sources fed the UI:
1. **Sidebar / login / onboarding** used `APP_VERSION` from `frontend/package.json` (e.g. `0.20.10`).
2. **Settings header / About** used `config.version` from `get_safe_config()`, which preferred `ctx.current_version` (often a git SHA or unusable export-subst placeholder) and otherwise fell back to `importlib.metadata` / committed `comicarr.egg-info` (e.g. stale `0.19.13`).

**Fix (single-source-of-truth):**
- Backend: `config.version` is only the Changesets release semver via `get_release_version()` (`pyproject.toml` first, then package metadata). Git SHAs stay on `/api/system/version` / build identity.
- Frontend: every user-facing badge routes through `formatAppVersion()` from `@/lib/version` (sidebar, login, onboarding, Settings header, About).
- Contract tests pin root `package.json` ↔ `frontend/package.json` ↔ `pyproject.toml` ↔ `get_release_version()` so drift cannot reappear silently.
- Render + source coverage for every version display consumer.

## Verification

- `uv run pytest tests/unit/test_release_version_contract.py tests/unit/test_system_domain.py -k "release_version or safe_config_uses or safe_config_falls or safe_config_omits or safe_config_ignores or get_safe_config or ReleaseVersion" -q` — 20 passed
- `cd frontend && npm run test:run -- tests/unit/lib/version.test.ts tests/unit/lib/version.displays.test.tsx tests/pages/SettingsPage.test.ts tests/pages/LoginPage.test.tsx` — 18 passed
- `uv run ruff check` / `ruff format --check` on changed Python files
- `cd frontend && npm run lint` and `npm run typecheck`

## Follow-up risks

- **Stale install metadata:** `comicarr.egg-info` can still lag `pyproject.toml`. Display no longer depends on it when `pyproject.toml` is present; pure wheel installs still use `importlib.metadata`.
- **Split frontend/backend deploys:** UI chrome always reflects the built frontend package version. `GET /api/config` `version` reflects the running backend’s release metadata. Same-image Docker builds stay aligned via Changesets + `sync-version.mjs` (enforced by contract tests).
- **Not in scope:** Release numbering policy, production deploy, rewriting `/api/system/version` git identity fields.

## Test plan

- [x] Unit tests: release version ignores git SHA; prefers pyproject over importlib
- [x] Contract: package.json / frontend package / pyproject / get_release_version agree
- [x] Frontend: every display consumer uses formatAppVersion; Settings/About ignore mismatched API version
- [ ] Manual: open Settings → header and About match sidebar badge on a single-build deploy