### PR TITLE
fix: Apply Wanted filter to the full queue, not the current page

### DIFF
--- a/.changeset/wanted-filter-full-queue.md
+++ b/.changeset/wanted-filter-full-queue.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Wanted filtering now searches the full queue, not only the currently loaded page. Typing a filter term sends it to `/api/wanted` so match count, pagination total, and Next/Previous all describe the same filtered result set — matches that used to sit on page 2 are no longer invisible from page 1.

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -227,8 +227,13 @@ def unqueue_issue(issue_id, audit_identity):
 # ---------------------------------------------------------------------------
 
 
-def get_wanted_issues(limit=None, offset=None):
-    """Get all wanted issues joined with comic info."""
+def get_wanted_issues(limit=None, offset=None, search=None):
+    """Get all wanted issues joined with comic info.
+
+    When ``search`` is set, ComicName and Issue_Number are matched with a
+    case-insensitive substring filter *before* pagination so the page total,
+    has_more flag, and returned rows all describe the same filtered set.
+    """
     stmt = (
         select(
             t_comics.c.ComicName,
@@ -250,6 +255,14 @@ def get_wanted_issues(limit=None, offset=None):
         .select_from(t_comics.join(t_issues, t_comics.c.ComicID == t_issues.c.ComicID))
         .where(t_issues.c.Status == "Wanted")
     )
+    if search and str(search).strip():
+        pattern = "%%%s%%" % str(search).strip().lower()
+        stmt = stmt.where(
+            or_(
+                t_comics.c.ComicName.ilike(pattern),
+                t_issues.c.Issue_Number.ilike(pattern),
+            )
+        )
     if limit is not None:
         return paginated_query(stmt, limit=limit, offset=offset)
     return db.select_all(stmt)

--- a/comicarr/app/series/router.py
+++ b/comicarr/app/series/router.py
@@ -299,11 +299,22 @@ async def search_one_wanted_issue(
 def get_wanted(
     limit: int = Query(None),
     offset: int = Query(0),
+    q: str = Query(None, max_length=200),
     story_arcs: bool = Query(False, alias="story_arcs"),
     ctx: AppContext = Depends(get_context),
 ):
-    """Get all wanted issues with optional story arcs and annuals."""
-    return series_service.get_wanted(ctx, limit=limit, offset=offset, include_story_arcs=story_arcs)
+    """Get all wanted issues with optional story arcs and annuals.
+
+    ``q`` is a case-insensitive substring match on series name or issue
+    number and is applied before pagination.
+    """
+    return series_service.get_wanted(
+        ctx,
+        limit=limit,
+        offset=offset,
+        include_story_arcs=story_arcs,
+        search=q,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -833,11 +833,15 @@ def search_all_missing(
     }
 
 
-def get_wanted(ctx, limit=None, offset=None, include_story_arcs=False):
-    """Get all wanted issues, optionally with story arcs and annuals."""
+def get_wanted(ctx, limit=None, offset=None, include_story_arcs=False, search=None):
+    """Get all wanted issues, optionally with story arcs and annuals.
+
+    ``search`` filters ComicName / Issue_Number before pagination so the
+    returned rows and pagination metadata describe the same result set.
+    """
     # Issues
     if limit is not None:
-        paginated = series_queries.get_wanted_issues(limit=limit, offset=offset)
+        paginated = series_queries.get_wanted_issues(limit=limit, offset=offset, search=search)
         result = {
             "issues": paginated["results"],
             "pagination": {
@@ -848,7 +852,7 @@ def get_wanted(ctx, limit=None, offset=None, include_story_arcs=False):
             },
         }
     else:
-        result = {"issues": series_queries.get_wanted_issues()}
+        result = {"issues": series_queries.get_wanted_issues(search=search)}
 
     # Story arcs
     if include_story_arcs:

--- a/frontend/src/hooks/useQueue.ts
+++ b/frontend/src/hooks/useQueue.ts
@@ -101,14 +101,18 @@ export function useUpcoming(
 export function useWanted(
   limit = 50,
   offset = 0,
+  q = "",
 ): UseQueryResult<WantedResponse> {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+  });
+  const search = q.trim();
+  if (search) params.set("q", search);
   return useQuery({
-    queryKey: ["wanted", limit, offset],
+    queryKey: ["wanted", limit, offset, search],
     queryFn: () =>
-      apiRequest<WantedResponse>(
-        "GET",
-        `/api/wanted?limit=${limit}&offset=${offset}`,
-      ),
+      apiRequest<WantedResponse>("GET", `/api/wanted?${params.toString()}`),
     staleTime: 2 * 60 * 1000,
   });
 }

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -559,7 +559,14 @@ export function mockApiResponse(
     return SERIES;
   }
   if (m === "GET" && url === "/api/wanted") {
-    const all = wantedIssues();
+    const q = (parsed.searchParams.get("q") ?? "").trim().toLowerCase();
+    const all = wantedIssues().filter((issue) => {
+      if (!q) return true;
+      return (
+        issue.ComicName?.toLowerCase().includes(q) ||
+        issue.Issue_Number?.toLowerCase().includes(q)
+      );
+    });
     const limit = Number(parsed.searchParams.get("limit") ?? 50);
     const offset = Number(parsed.searchParams.get("offset") ?? 0);
     const issues = all.slice(offset, offset + limit);

--- a/frontend/src/pages/WantedPage.tsx
+++ b/frontend/src/pages/WantedPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Search, RefreshCw } from "lucide-react";
 import {
   useWanted,
@@ -17,12 +17,29 @@ import PageHeader from "@/components/layout/PageHeader";
 import FilterField from "@/components/ui/FilterField";
 import { useServerPage } from "@/components/data-table/useServerPage";
 import { useTableState } from "@/components/data-table/useTableState";
+import { useDebounce } from "@/hooks/use-debounce";
 
 export default function WantedPage() {
-  const { limit, offset, nextPage, prevPage } = useServerPage(50);
-  const [searchQuery, setSearchQuery] = useState("");
+  // Search is an input to the server fetch (same model as Activity #377):
+  // page-local filtering would only see the current offset window and would
+  // leave pagination totals describing the unfiltered queue (#408).
+  const { limit, offset, nextPage, prevPage, resetPage } = useServerPage(50);
+  const [searchQuery, setSearchQueryState] = useState("");
+  const debouncedSearch = useDebounce(searchQuery, 400);
 
-  const { data, isLoading, error, refetch } = useWanted(limit, offset);
+  const setSearchQuery = useCallback(
+    (value: string) => {
+      setSearchQueryState(value);
+      resetPage();
+    },
+    [resetPage],
+  );
+
+  const { data, isLoading, error, refetch } = useWanted(
+    limit,
+    offset,
+    debouncedSearch,
+  );
   const issues = data?.issues || [];
   const pagination = data?.pagination;
 
@@ -31,19 +48,11 @@ export default function WantedPage() {
   const bulkUnqueue = useBulkUnqueueIssues();
   const { addToast } = useToast();
 
-  const filteredIssues = searchQuery
-    ? issues.filter(
-        (i) =>
-          i.ComicName?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          i.Issue_Number?.toLowerCase().includes(searchQuery.toLowerCase()),
-      )
-    : issues;
-
   const columns = useWantedColumns();
   // The server page is an input to the fetch that produced `issues`, so the
   // hook holds no page state (#360); `pagination` is omitted deliberately.
   const { table, selectedIds, clearSelection } = useTableState({
-    data: filteredIssues,
+    data: issues,
     columns,
     getRowId: (row) => row.IssueID,
     selection: { scope: "filtered" },
@@ -156,6 +165,8 @@ export default function WantedPage() {
   };
 
   const total = pagination?.total ?? issues.length;
+  const isFiltering = Boolean(debouncedSearch.trim());
+  const matchCount = isFiltering ? total : null;
 
   return (
     <div className="page-transition">
@@ -207,10 +218,10 @@ export default function WantedPage() {
             shortcut="/"
           />
         </div>
-        {searchQuery && (
+        {matchCount !== null && (
           <div className="font-mono text-[11px] text-muted-foreground">
-            {filteredIssues.length} match
-            {filteredIssues.length === 1 ? "" : "es"}
+            {matchCount} match
+            {matchCount === 1 ? "" : "es"}
           </div>
         )}
       </div>

--- a/frontend/tests/pages/WantedPage.test.tsx
+++ b/frontend/tests/pages/WantedPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
+import { waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "../mocks/server";
 import { render, screen } from "../test-utils";
@@ -20,6 +21,18 @@ function renderWantedWithForceResult(result: Record<string, unknown>) {
     vi.fn(() => true),
   );
   return render(<WantedPage />);
+}
+
+function sagaIssue(id: string, number: string) {
+  return {
+    IssueID: id,
+    ComicID: "comic-saga",
+    ComicName: "Saga",
+    Issue_Number: number,
+    IssueDate: "2020-01-01",
+    Status: "Wanted",
+    DateAdded: "2026-01-01",
+  };
 }
 
 describe("WantedPage", () => {
@@ -135,5 +148,121 @@ describe("WantedPage", () => {
         "Search accepted — 3 wanted issues queued. Run run-123.",
       ),
     ).toBeNull();
+  });
+
+  /**
+   * #408: filtering was applied only to the currently loaded page while the
+   * footer still described the unfiltered queue. The filter term must ride
+   * the server query, and match count / pagination total must agree on the
+   * filtered set — including matches that would have lived past offset 50.
+   */
+  it("filters the full Wanted queue through the API and reports matching totals", async () => {
+    const requests: URL[] = [];
+    server.use(
+      http.get("/api/wanted", ({ request }) => {
+        const url = new URL(request.url);
+        requests.push(url);
+        const q = (url.searchParams.get("q") || "").toLowerCase();
+        const offset = Number(url.searchParams.get("offset") || 0);
+        if (q === "saga") {
+          return HttpResponse.json({
+            issues: [
+              sagaIssue("saga-1", "1"),
+              sagaIssue("saga-2", "2"),
+              sagaIssue("saga-10", "10"),
+              sagaIssue("saga-11", "11"),
+              sagaIssue("saga-12", "12"),
+            ],
+            pagination: {
+              total: 12,
+              limit: 50,
+              offset: 0,
+              has_more: false,
+            },
+          });
+        }
+        return HttpResponse.json({
+          issues:
+            offset === 0
+              ? [sagaIssue("saga-page1", "1")]
+              : [sagaIssue("saga-page2", "10")],
+          pagination: {
+            total: 53,
+            limit: 50,
+            offset,
+            has_more: offset === 0,
+          },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<WantedPage />);
+
+    expect(await screen.findByText("53 issues in queue")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => {
+      expect(requests.at(-1)?.searchParams.get("offset")).toBe("50");
+    });
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Filter wanted issues" }),
+      "saga",
+    );
+
+    await waitFor(() => {
+      const last = requests.at(-1);
+      expect(last?.searchParams.get("q")).toBe("saga");
+      expect(last?.searchParams.get("offset")).toBe("0");
+    });
+
+    expect(await screen.findByText("12 matches")).toBeTruthy();
+    expect(screen.getByText("12 issues in queue")).toBeTruthy();
+    expect(await screen.findByText("Showing 1 to 12 of 12")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Next" }).hasAttribute("disabled"),
+    ).toBe(true);
+    // Matches that lived past the first unfiltered page are still listed.
+    expect(screen.getByText("10")).toBeTruthy();
+    expect(screen.getByText("12")).toBeTruthy();
+  });
+
+  it("returns to the first page when the filter changes", async () => {
+    const requests: URL[] = [];
+    server.use(
+      http.get("/api/wanted", ({ request }) => {
+        const url = new URL(request.url);
+        requests.push(url);
+        const offset = Number(url.searchParams.get("offset") || 0);
+        return HttpResponse.json({
+          issues: [sagaIssue(`row-${offset}`, "1")],
+          pagination: {
+            total: 90,
+            limit: 50,
+            offset,
+            has_more: true,
+          },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<WantedPage />);
+    await screen.findByText("90 issues in queue");
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => {
+      expect(requests.at(-1)?.searchParams.get("offset")).toBe("50");
+    });
+
+    await user.type(
+      screen.getByRole("textbox", { name: "Filter wanted issues" }),
+      "flash",
+    );
+    await waitFor(() => {
+      const last = requests.at(-1);
+      expect(last?.searchParams.get("q")).toBe("flash");
+      expect(last?.searchParams.get("offset")).toBe("0");
+    });
   });
 });

--- a/tests/unit/test_wanted_filter_pagination.py
+++ b/tests/unit/test_wanted_filter_pagination.py
@@ -1,0 +1,194 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Wanted queue search must filter before pagination (#408).
+
+A client-side filter over the current page only reports page-local match
+counts while the footer still describes the unfiltered queue. These pins
+force the server query to apply ``search`` before limit/offset so totals,
+has_more, and returned rows all describe the same filtered set.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import insert
+
+import comicarr
+from comicarr import db
+from comicarr.app.series import queries as series_queries
+from comicarr.app.series import router as series_router
+from comicarr.app.series import service as series_service
+from comicarr.tables import comics, issues, metadata
+
+
+@pytest.fixture
+def wanted_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+def _seed_multi_page_wanted(engine):
+    """53 Wanted rows: 12 match 'Saga' — 9 on the first page of 50, 3 beyond."""
+    with engine.begin() as conn:
+        conn.execute(
+            insert(comics),
+            [
+                {
+                    "ComicID": "comic-filler",
+                    "ComicName": "Alpha Filler",
+                    "ComicSortName": "Alpha Filler",
+                    "ComicPublisher": "Image",
+                    "Status": "Active",
+                    "Have": 0,
+                    "Total": 41,
+                    "ContentType": "comic",
+                },
+                {
+                    "ComicID": "comic-saga",
+                    "ComicName": "Saga",
+                    "ComicSortName": "Saga",
+                    "ComicPublisher": "Image",
+                    "Status": "Active",
+                    "Have": 0,
+                    "Total": 12,
+                    "ContentType": "comic",
+                },
+            ],
+        )
+        issue_rows = []
+        # First 41 of page 1 are non-matches.
+        for i in range(1, 42):
+            issue_rows.append(
+                {
+                    "IssueID": f"filler-{i}",
+                    "ComicID": "comic-filler",
+                    "Issue_Number": str(i),
+                    "Status": "Wanted",
+                    "DateAdded": f"2026-01-{i:02d}",
+                }
+            )
+        # Next 9 of page 1 match "Saga".
+        for i in range(1, 10):
+            issue_rows.append(
+                {
+                    "IssueID": f"saga-{i}",
+                    "ComicID": "comic-saga",
+                    "Issue_Number": str(i),
+                    "Status": "Wanted",
+                    "DateAdded": f"2026-02-{i:02d}",
+                }
+            )
+        # Page 2 has 3 more Saga matches (issues 10–12).
+        for i in range(10, 13):
+            issue_rows.append(
+                {
+                    "IssueID": f"saga-{i}",
+                    "ComicID": "comic-saga",
+                    "Issue_Number": str(i),
+                    "Status": "Wanted",
+                    "DateAdded": f"2026-03-{i:02d}",
+                }
+            )
+        conn.execute(insert(issues), issue_rows)
+
+
+def test_wanted_search_filters_before_pagination_across_pages(wanted_db):
+    _seed_multi_page_wanted(wanted_db)
+
+    unfiltered = series_queries.get_wanted_issues(limit=50, offset=0)
+    assert unfiltered["total"] == 53
+    assert unfiltered["has_more"] is True
+    assert len(unfiltered["results"]) == 50
+
+    # Without search the first page only has 9 Saga rows — the page-local
+    # filter that caused #408 would report 9 matches and keep Next enabled
+    # against an unfiltered total of 53.
+    page_local_matches = [
+        row
+        for row in unfiltered["results"]
+        if "saga" in (row.get("ComicName") or "").lower() or "saga" in (row.get("Issue_Number") or "").lower()
+    ]
+    assert len(page_local_matches) == 9
+
+    page1 = series_queries.get_wanted_issues(limit=50, offset=0, search="Saga")
+    assert page1["total"] == 12
+    assert page1["has_more"] is False
+    assert len(page1["results"]) == 12
+    assert all(row["ComicName"] == "Saga" for row in page1["results"])
+    assert {row["IssueID"] for row in page1["results"]} == {f"saga-{i}" for i in range(1, 13)}
+
+    # Filtered set is smaller than one page, so a second page is empty and
+    # does not invent more of the unfiltered queue.
+    page2 = series_queries.get_wanted_issues(limit=50, offset=50, search="Saga")
+    assert page2["total"] == 12
+    assert page2["has_more"] is False
+    assert page2["results"] == []
+
+    # Clearing search restores the unfiltered multi-page queue.
+    restored = series_queries.get_wanted_issues(limit=50, offset=0, search="")
+    assert restored["total"] == 53
+    assert restored["has_more"] is True
+
+
+def test_wanted_search_matches_issue_number_and_is_case_insensitive(wanted_db):
+    _seed_multi_page_wanted(wanted_db)
+
+    by_number = series_queries.get_wanted_issues(limit=10, offset=0, search="12")
+    assert by_number["total"] == 2  # filler-12 and saga-12
+    assert {row["IssueID"] for row in by_number["results"]} == {
+        "filler-12",
+        "saga-12",
+    }
+
+    lower = series_queries.get_wanted_issues(limit=50, offset=0, search="saga")
+    assert lower["total"] == 12
+
+
+def test_get_wanted_service_forwards_search(monkeypatch):
+    captured = {}
+
+    def fake_get_wanted_issues(**kwargs):
+        captured.update(kwargs)
+        return {
+            "results": [{"IssueID": "1", "ComicName": "Saga"}],
+            "total": 1,
+            "limit": 50,
+            "offset": 0,
+            "has_more": False,
+        }
+
+    monkeypatch.setattr(series_service.series_queries, "get_wanted_issues", fake_get_wanted_issues)
+    result = series_service.get_wanted(SimpleNamespace(config=None), limit=50, offset=0, search="Saga")
+    assert captured == {"limit": 50, "offset": 0, "search": "Saga"}
+    assert result["pagination"]["total"] == 1
+    assert result["issues"][0]["IssueID"] == "1"
+
+
+def test_wanted_route_forwards_q_as_search(monkeypatch):
+    spy = MagicMock(return_value={"issues": [], "pagination": {}})
+    monkeypatch.setattr(series_router.series_service, "get_wanted", spy)
+    ctx = SimpleNamespace()
+
+    series_router.get_wanted(limit=50, offset=0, q="flash", story_arcs=False, ctx=ctx)
+
+    spy.assert_called_once_with(
+        ctx,
+        limit=50,
+        offset=0,
+        include_story_arcs=False,
+        search="flash",
+    )


### PR DESCRIPTION
## Summary

Closes #408.

Wanted filtering only ran over the currently loaded server page, so a multi-page queue could show a page-local match count while the footer still described the unfiltered total and kept paging enabled.

### Root cause

`WantedPage` fetched `/api/wanted?limit&offset` and then applied a client-side `ComicName` / `Issue_Number` filter to that page only. Match count used `filteredIssues.length`; pagination still used the unfiltered server `pagination` metadata.

### Fix

- **Backend:** `/api/wanted` accepts `q` (max 200). `get_wanted_issues` applies a case-insensitive substring match on `ComicName` and `Issue_Number` *before* pagination so `total`, `has_more`, and rows describe the same filtered set.
- **Frontend:** `useWanted` forwards `q`; `WantedPage` debounces the filter (400ms, same model as Activity), resets the server page on change, and shows match count / footer from the filtered pagination payload.
- **Mock data:** `/api/wanted` mock honors `q` for local dev consistency.

### Out of scope (unchanged)

- Acquisition / force-search behavior
- New filter fields beyond the existing text filter
- Stable SQL `ORDER BY` for Wanted (pre-existing; client still sorts the current page by `DateAdded`)

## Verification

- `uv run pytest tests/unit/test_wanted_filter_pagination.py -v`
  - Seeds 53 Wanted rows with 12 “Saga” matches spanning page boundaries; asserts filtered `total=12`, all matches returned on page 1, `has_more=false`, cleared search restores 53.
- `cd frontend && npm run test:run -- tests/pages/WantedPage.test.tsx`
  - Asserts filter sends `q` with `offset=0`, match count and “Showing 1 to 12 of 12” agree, Next disabled, and cross-page issue numbers appear.
  - Asserts filter change resets to first page.
- `uv run ruff check` / `ruff format` on touched backend files
- Frontend ESLint + Prettier on touched files; `npm run typecheck`
- `uv run python scripts/run_ruff.py modern`

## Follow-up risks

- **Debounce latency:** match count updates after 400ms (and the network round-trip), not keystroke-by-keystroke.
- **No sort in SQL:** Wanted still has no server `ORDER BY`; with search the filtered set is usually small, but unfiltered multi-page order remains insertion/engine-dependent.
- **Header meta while filtering:** “N issues in queue” uses the filtered total when a query is active (same source as match count / footer), not a separate unfiltered queue size.

## Test plan

- [ ] Open `/wanted` with >50 wanted issues
- [ ] Filter with a term that matches rows on page 1 and page 2 of the unfiltered queue
- [ ] Confirm match count, “Showing X to Y of Z”, and Next/Previous all describe the filtered set
- [ ] Confirm matches that previously only appeared on page 2 show up without paging
- [ ] Clear the filter and confirm the unfiltered multi-page queue returns
- [ ] Force search / bulk skip still work on filtered selection