### PR TITLE
fix: Point default GIT_USER at the Comicarr project owner

### DIFF
--- a/.changeset/fix-git-user-default.md
+++ b/.changeset/fix-git-user-default.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Default `GIT_USER` now points at the Comicarr project owner so update checks hit the real repository instead of an unrelated third-party one.

--- a/comicarr/app/config/registry.py
+++ b/comicarr/app/config/registry.py
@@ -266,7 +266,7 @@ _KEYS: tuple[ConfigKey, ...] = (
     ConfigKey("MAX_LOGFILES", int, "Logs", 5),
     ConfigKey("LOG_LEVEL", int, "Logs", 1, readable=True, writable=True),
     ConfigKey("GIT_PATH", str, "Git", None),
-    ConfigKey("GIT_USER", str, "Git", "comicarr"),
+    ConfigKey("GIT_USER", str, "Git", "frankieramirez"),
     ConfigKey("GIT_TOKEN", str, "Git", None),
     ConfigKey("GIT_BRANCH", str, "Git", None),
     ConfigKey("CHECK_GITHUB", bool, "Git", False),

--- a/tests/unit/test_version_state.py
+++ b/tests/unit/test_version_state.py
@@ -20,8 +20,18 @@ import pytest
 
 import comicarr
 from comicarr import versioncheck
+from comicarr.app.config.registry import REGISTRY
 from comicarr.app.core.context import AppContext
 from comicarr.app.system import service as system_service
+
+
+def test_git_user_default_is_project_owner():
+    """Out-of-box update checks must hit frankieramirez/comicarr, not comicarr/comicarr.
+
+    The latter resolves to an unrelated third-party repo, so a 404 looks like
+    "no releases" rather than a misconfigured owner. Regression for #456.
+    """
+    assert REGISTRY["GIT_USER"].default == "frankieramirez"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Out-of-the-box update checks built URLs as `github.com/{GIT_USER}/comicarr`. The default `comicarr` resolved to an unrelated third-party repo, so failures looked like missing releases instead of a misconfigured owner.

- Set registry default `GIT_USER` to `frankieramirez`
- Add a regression test locking the default to the project owner
- Leave `GIT_BRANCH` auto-detect (`None`) unchanged

Closes #456

## Test plan

- [x] `uv run pytest tests/unit/test_version_state.py -v`
- [x] `uv run pytest tests/unit/test_carepackage_security.py -v`
- [x] `uv run ruff check` / `ruff format --check` on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Git user configuration to target the Comicarr project owner.

* **Tests**
  * Added regression coverage to verify the updated default configuration.

* **Documentation**
  * Documented the configuration change in the release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->