### PR TITLE
fix: Bound GitHub update-check request timeouts

### DIFF
--- a/comicarr/versioncheck.py
+++ b/comicarr/versioncheck.py
@@ -53,6 +53,10 @@ _VERSION_FIELDS = {
     "update_value": "UPDATE_VALUE",
 }
 
+# GitHub update-check calls must not hang indefinitely on a dropped SYN
+# (air-gapped / firewalled installs). Bound from issue #446: 10s connect, 10s read.
+_GITHUB_REQUEST_TIMEOUT = (10, 10)
+
 
 def _set_version_state(**fields):
     """Write version state once and project it to legacy callers.
@@ -200,7 +204,7 @@ def getVersion(ptv):
             if cur_commit_hash.startswith("v") and ptv["check_github_on_startup"] is True:
                 url2 = "https://api.github.com/repos/%s/comicarr/tags" % (ptv["git_user"])
                 try:
-                    response = requests.get(url2, verify=True, auth=ptv["git_token"])
+                    response = requests.get(url2, verify=True, auth=ptv["git_token"], timeout=_GITHUB_REQUEST_TIMEOUT)
                     git = response.json()
                 except Exception as e:
                     logger.warn("[ERROR] %s" % e)
@@ -219,7 +223,9 @@ def getVersion(ptv):
                         )
                         # logger.fdebug('url3: %s' % url3)
                         try:
-                            repochk = requests.get(url3, verify=True, auth=ptv["git_token"])
+                            repochk = requests.get(
+                                url3, verify=True, auth=ptv["git_token"], timeout=_GITHUB_REQUEST_TIMEOUT
+                            )
                             repo_resp = repochk.json()
                             # logger.fdebug('repo_resp: %s' % repo_resp)
                             current_release_name = repo_resp["name"]
@@ -344,7 +350,9 @@ def getVersion(ptv):
             # and comicarr.CONFIG.CHECK_GITHUB_ON_STARTUP is True:
             url2 = "https://api.github.com/repos/%s/comicarr/releases/tags/%s" % (ptv["git_user"], current_version_name)
             try:
-                response = requests.get(url2, verify=True, auth=comicarr.CONFIG.GIT_TOKEN)
+                response = requests.get(
+                    url2, verify=True, auth=comicarr.CONFIG.GIT_TOKEN, timeout=_GITHUB_REQUEST_TIMEOUT
+                )
                 git = response.json()
                 current_release_name = git["name"]
             except Exception:
@@ -425,7 +433,7 @@ def checkGithub(current_version=None):
     # Get the latest commit available from github
     url = "https://api.github.com/repos/%s/comicarr/commits/%s" % (comicarr.CONFIG.GIT_USER, comicarr.CONFIG.GIT_BRANCH)
     try:
-        response = requests.get(url, verify=True, auth=comicarr.CONFIG.GIT_TOKEN)
+        response = requests.get(url, verify=True, auth=comicarr.CONFIG.GIT_TOKEN, timeout=_GITHUB_REQUEST_TIMEOUT)
         git = response.json()
         _set_version_state(latest_version=git["sha"])
     except Exception as e:
@@ -461,7 +469,9 @@ def checkGithub(current_version=None):
             )
 
             try:
-                response = requests.get(url, verify=True, auth=comicarr.CONFIG.GIT_TOKEN)
+                response = requests.get(
+                    url, verify=True, auth=comicarr.CONFIG.GIT_TOKEN, timeout=_GITHUB_REQUEST_TIMEOUT
+                )
                 git = response.json()
                 _set_version_state(commits_behind=git["total_commits"])
             except Exception as e:

--- a/tests/unit/test_version_state.py
+++ b/tests/unit/test_version_state.py
@@ -134,6 +134,50 @@ class TestATransientOutageDoesNotClearAKnownUpdate:
         assert system_service.get_version_info(ctx)["commits_behind"] == 0
 
 
+class TestGithubRequestTimeout:
+    """Update checks must bound connect/read so a dropped SYN cannot hang forever.
+
+    Issue #455 / #446: failed checks keep retrying on the 360-minute schedule.
+    That policy is only safe when each attempt has a hard timeout (10s, 10s).
+    """
+
+    def test_check_github_passes_timeout_on_every_request(self, ctx):
+        responses = [
+            _github_response({"sha": "bbbbbbb"}),
+            _github_response({"total_commits": 1}),
+        ]
+        with patch.object(versioncheck.requests, "get", side_effect=responses) as mock_get:
+            versioncheck.checkGithub(current_version="aaaaaaa")
+
+        assert mock_get.call_count == 2
+        for call in mock_get.call_args_list:
+            assert call.kwargs.get("timeout") == versioncheck._GITHUB_REQUEST_TIMEOUT
+        assert versioncheck._GITHUB_REQUEST_TIMEOUT == (10, 10)
+
+    def test_check_github_preserves_auth_with_timeout(self, ctx):
+        token = ("ghp_test", "x-oauth-basic")
+        comicarr.CONFIG.GIT_TOKEN = token
+        responses = [
+            _github_response({"sha": "bbbbbbb"}),
+            _github_response({"total_commits": 0}),
+        ]
+        with patch.object(versioncheck.requests, "get", side_effect=responses) as mock_get:
+            versioncheck.checkGithub(current_version="aaaaaaa")
+
+        for call in mock_get.call_args_list:
+            assert call.kwargs.get("auth") is token
+            assert call.kwargs.get("timeout") == (10, 10)
+
+    def test_timeout_error_is_treated_as_a_failed_check(self, ctx):
+        with patch.object(
+            versioncheck.requests, "get", side_effect=versioncheck.requests.exceptions.Timeout("connect timed out")
+        ):
+            result = versioncheck.checkGithub(current_version="aaaaaaa")
+
+        assert result["status"] == "failure"
+        assert system_service.get_version_info(ctx)["commits_behind"] == 0
+
+
 class TestVersionStateHelper:
     def test_writes_context_and_legacy_together(self, ctx):
         versioncheck._set_version_state(current_branch="python3-dev")


### PR DESCRIPTION
## Summary

Add a hard 10s connect / 10s read timeout to every GitHub API call used by the update check so a dropped SYN cannot hang the calling thread on air-gapped or firewalled installs.

- Prerequisite for #446's "keep retrying forever" policy (failed checks must be cheap)
- Leaves `GIT_TOKEN` auth unchanged (already normalized to a Basic-auth tuple)
- Leaves the streaming tarball download path alone

Fixes #455

## Test plan

- [x] `uv run pytest tests/unit/test_version_state.py -v` (13 passed)
- [x] New tests assert `timeout=(10, 10)` and auth still passed on `checkGithub`
- [x] Timeout errors surface as failed checks, not hangs