### PR TITLE
feat: Add indexes for ledger retention deletes

### DIFF
--- a/alembic/versions/0004_ledger_retention_indexes.py
+++ b/alembic/versions/0004_ledger_retention_indexes.py
@@ -1,0 +1,65 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Add ledger retention eligibility indexes.
+
+Revision ID: 0004_ledger_retention_indexes
+Revises: 0003_library_chat
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0004_ledger_retention_indexes"
+down_revision = "0003_library_chat"
+branch_labels = None
+depends_on = None
+
+_RETENTION_INDEXES = (
+    (
+        "acquisition_run_items_state_completed",
+        "acquisition_run_items",
+        ["state", "completed_at"],
+    ),
+    (
+        "acquisition_runs_state_completed",
+        "acquisition_runs",
+        ["completion_state", "completed_at"],
+    ),
+    (
+        "pipeline_journal_stage_updated",
+        "pipeline_journal",
+        ["stage", "updated_date"],
+    ),
+    (
+        "acquisition_maintenance_events_created",
+        "acquisition_maintenance_events",
+        ["created_at"],
+    ),
+)
+
+
+def upgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    for index_name, table_name, columns in _RETENTION_INDEXES:
+        if table_name not in existing_tables:
+            continue
+        indexes = {index["name"] for index in inspector.get_indexes(table_name)}
+        if index_name in indexes:
+            continue
+        op.create_index(index_name, table_name, columns)
+
+
+def downgrade():
+    for index_name, table_name, _columns in reversed(_RETENTION_INDEXES):
+        op.drop_index(index_name, table_name=table_name)

--- a/comicarr/tables.py
+++ b/comicarr/tables.py
@@ -738,7 +738,7 @@ pipeline_journal = Table(
     Column("stage_rank", Integer, nullable=False),  # derived from stage; drives the monotonic guard
     Column("payload_json", Text),  # reconstruct the SNATCHED_QUEUE/PP_QUEUE item
     Column("fail_reason", Text),  # nullable
-    Column("updated_date", Text, nullable=False),
+    Column("updated_date", MYSQL_KEY_TEXT, nullable=False),
     # Reserved-nullable (R9) — unpopulated now:
     Column("status", Text),
     Column("retry_count", Integer),
@@ -1065,10 +1065,21 @@ Index("failed_issueid", failed.c.IssueID)
 Index("upcoming_issuedate", upcoming.c.IssueDate)
 Index("upcoming_issueid", upcoming.c.IssueID)
 Index("pipeline_journal_stage", pipeline_journal.c.stage)
+Index("pipeline_journal_stage_updated", pipeline_journal.c.stage, pipeline_journal.c.updated_date)
 Index("issues_acquisition_intent", issues.c.AcquisitionIntent)
 Index("annuals_acquisition_intent", annuals.c.AcquisitionIntent)
 Index("acquisition_runs_state", acquisition_runs.c.completion_state)
+Index(
+    "acquisition_runs_state_completed",
+    acquisition_runs.c.completion_state,
+    acquisition_runs.c.completed_at,
+)
 Index("acquisition_run_items_run_state", acquisition_run_items.c.run_id, acquisition_run_items.c.state)
+Index(
+    "acquisition_run_items_state_completed",
+    acquisition_run_items.c.state,
+    acquisition_run_items.c.completed_at,
+)
 Index(
     "acquisition_run_items_entity",
     acquisition_run_items.c.command_kind,
@@ -1086,6 +1097,7 @@ Index(
     acquisition_maintenance_leases.c.epoch,
 )
 Index("acquisition_maintenance_events_epoch", acquisition_maintenance_events.c.epoch)
+Index("acquisition_maintenance_events_created", acquisition_maintenance_events.c.created_at)
 Index("acq_repair_runs_state", acquisition_repair_runs.c.state)
 Index("acq_repair_manifest_run", acquisition_repair_manifests.c.run_id)
 Index(

--- a/tests/integration/test_schema_migration_dialects.py
+++ b/tests/integration/test_schema_migration_dialects.py
@@ -92,9 +92,9 @@ def test_fresh_database_uses_application_runner_and_is_idempotent():
     try:
         _reset_database(engine)
 
-        assert upgrade_database(engine) == "0003_library_chat"
-        assert upgrade_database(engine) == "0003_library_chat"
-        assert current_revision(engine) == "0003_library_chat"
+        assert upgrade_database(engine) == "0004_ledger_retention_indexes"
+        assert upgrade_database(engine) == "0004_ledger_retention_indexes"
+        assert current_revision(engine) == "0004_ledger_retention_indexes"
         assert set(metadata.tables).issubset(set(inspect(engine).get_table_names()))
     finally:
         engine.dispose()
@@ -177,9 +177,9 @@ def test_legacy_adoption_preserves_data_and_is_idempotent_across_dialects():
         _reset_database(engine)
         _build_legacy_fixture(engine)
 
-        assert upgrade_database(engine) == "0003_library_chat"
-        assert upgrade_database(engine) == "0003_library_chat"
-        assert current_revision(engine) == "0003_library_chat"
+        assert upgrade_database(engine) == "0004_ledger_retention_indexes"
+        assert upgrade_database(engine) == "0004_ledger_retention_indexes"
+        assert current_revision(engine) == "0004_ledger_retention_indexes"
 
         table_names = set(inspect(engine).get_table_names())
         assert "readinglist" not in table_names

--- a/tests/unit/test_ai_library_chat.py
+++ b/tests/unit/test_ai_library_chat.py
@@ -61,7 +61,7 @@ def production_chat_db(tmp_path, monkeypatch):
         conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
         conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
         conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0002_legacy_adoption')"))
-    assert upgrade_database(engine) == "0003_library_chat"
+    assert upgrade_database(engine) == "0004_ledger_retention_indexes"
     yield tmp_path
     db.shutdown_engine()
 

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -79,7 +79,7 @@ def test_migrate_deduplicates_unique_keys_across_batches(tmp_path, capsys):
     target_engine = create_engine(_sqlite_url(target_path))
     with target_engine.connect() as conn:
         rows = conn.execute(text("SELECT ComicID, ComicName FROM comics ORDER BY rowid")).mappings().all()
-    assert current_revision(target_engine) == "0003_library_chat"
+    assert current_revision(target_engine) == "0004_ledger_retention_indexes"
     target_engine.dispose()
 
     assert rows == [
@@ -120,7 +120,7 @@ def test_migrate_deduplicates_composite_keys_with_empty_components(tmp_path, cap
             .mappings()
             .all()
         )
-    assert current_revision(target_engine) == "0003_library_chat"
+    assert current_revision(target_engine) == "0004_ledger_retention_indexes"
     target_engine.dispose()
 
     assert rows == [

--- a/tests/unit/test_schema_migrations.py
+++ b/tests/unit/test_schema_migrations.py
@@ -196,8 +196,8 @@ def test_upgrade_database_accepts_a_known_prior_comicarr_revision(tmp_path):
         conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
         conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0001_baseline')"))
 
-    assert upgrade_database(engine) == "0003_library_chat"
-    assert current_revision(engine) == "0003_library_chat"
+    assert upgrade_database(engine) == "0004_ledger_retention_indexes"
+    assert current_revision(engine) == "0004_ledger_retention_indexes"
 
 
 def test_upgrade_database_accepts_pre_chat_revision_without_library_chat_tables(tmp_path):
@@ -218,8 +218,8 @@ def test_upgrade_database_accepts_pre_chat_revision_without_library_chat_tables(
 
     assert "ai_chat_threads" not in set(inspect(engine).get_table_names())
     assert classify_database(engine) is DatabaseState.VERSIONED
-    assert upgrade_database(engine) == "0003_library_chat"
-    assert current_revision(engine) == "0003_library_chat"
+    assert upgrade_database(engine) == "0004_ledger_retention_indexes"
+    assert current_revision(engine) == "0004_ledger_retention_indexes"
     assert {"ai_chat_threads", "ai_chat_messages", "ai_chat_attachments"}.issubset(
         set(inspect(engine).get_table_names())
     )
@@ -254,7 +254,7 @@ def test_upgrade_database_builds_a_fresh_database_to_the_single_head(tmp_path):
 
     revision = upgrade_database(engine)
 
-    assert revision == "0003_library_chat"
+    assert revision == "0004_ledger_retention_indexes"
     assert set(metadata.tables).issubset(set(inspect(engine).get_table_names()))
 
 
@@ -264,8 +264,8 @@ def test_upgrade_database_stamps_only_a_verified_legacy_database(tmp_path):
     with engine.begin() as conn:
         conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
 
-    assert upgrade_database(engine) == "0003_library_chat"
-    assert current_revision(engine) == "0003_library_chat"
+    assert upgrade_database(engine) == "0004_ledger_retention_indexes"
+    assert current_revision(engine) == "0004_ledger_retention_indexes"
 
 
 def test_upgrade_database_never_stamps_an_unknown_database(tmp_path):


### PR DESCRIPTION
## Summary

Adds the four schema indexes needed for settled ledger-retention eligibility and age predicates (#478). No delete logic, config, scheduler, or operator-visible surface in this slice.

- Declare indexes on `acquisition_run_items (state, completed_at)`, `acquisition_runs (completion_state, completed_at)`, `pipeline_journal (stage, updated_date)`, and `acquisition_maintenance_events (created_at)` in `tables.py`
- Ship Alembic revision `0004_ledger_retention_indexes` for existing databases; retain `pipeline_journal_stage`
- Bound `pipeline_journal.updated_date` with `MYSQL_KEY_TEXT` so the new composite index stays portable

## Test plan

- [x] `uv run pytest tests/unit/test_schema_migrations.py tests/unit/test_acquisition_maintenance.py tests/unit/test_db_migrate.py tests/unit/test_pipeline_journal.py tests/unit/test_ai_library_chat.py -v` (100 passed)
- [x] `npm run lint` (passed)
- [ ] CI green on the PR

Closes #478