### PR TITLE
feat: Wanted page live-sticky acquisition annotations

### DIFF
--- a/.changeset/wanted-live-sticky-annotations.md
+++ b/.changeset/wanted-live-sticky-annotations.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Wanted rows now show a live-sticky search annotation (searching…, no match · N tries, never searched) from the latest acquisition run item, without changing when an issue leaves Wanted.

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -17,6 +17,7 @@ from sqlalchemy import delete, func, literal, or_, select
 
 from comicarr import db
 from comicarr.app.core.database import paginated_query  # noqa: F401 — re-exported
+from comicarr.tables import acquisition_run_items as t_acquisition_run_items
 from comicarr.tables import annuals as t_annuals
 from comicarr.tables import comics as t_comics
 from comicarr.tables import importresults as t_importresults
@@ -315,6 +316,71 @@ def get_wanted_annuals():
         .where(t_annuals.c.Deleted != 1)
         .where(t_annuals.c.Status == "Wanted")
     )
+
+
+def get_latest_search_items_by_entity_ids(entity_ids):
+    """Return the latest search run item per entity id (live-and-sticky annotation).
+
+    "Latest" is the most recently updated ``acquisition_run_items`` row for
+    ``command_kind='search'`` on entity types ``issue`` / ``annual``. A closed
+    run keeps annotating until a newer run supersedes that entity. Membership
+    of Wanted is not decided here — callers only attach fields.
+    """
+    ids = []
+    seen = set()
+    for raw in entity_ids or []:
+        entity_id = str(raw).strip() if raw is not None else ""
+        if not entity_id or entity_id in seen:
+            continue
+        seen.add(entity_id)
+        ids.append(entity_id)
+    if not ids:
+        return {}
+
+    row_number = func.row_number().over(
+        partition_by=(
+            t_acquisition_run_items.c.entity_type,
+            t_acquisition_run_items.c.entity_id,
+        ),
+        order_by=(
+            t_acquisition_run_items.c.updated_at.desc(),
+            t_acquisition_run_items.c.item_id.desc(),
+        ),
+    )
+    ranked = (
+        select(
+            t_acquisition_run_items.c.item_id,
+            t_acquisition_run_items.c.run_id,
+            t_acquisition_run_items.c.entity_type,
+            t_acquisition_run_items.c.entity_id,
+            t_acquisition_run_items.c.state,
+            t_acquisition_run_items.c.attempt_count,
+            t_acquisition_run_items.c.reason,
+            t_acquisition_run_items.c.updated_at,
+            t_acquisition_run_items.c.completed_at,
+            row_number.label("rn"),
+        )
+        .where(t_acquisition_run_items.c.command_kind == "search")
+        .where(t_acquisition_run_items.c.entity_type.in_(("issue", "annual")))
+        .where(t_acquisition_run_items.c.entity_id.in_(ids))
+        .subquery()
+    )
+    rows = db.select_all(select(ranked).where(ranked.c.rn == 1))
+    # One annotation key per IssueID. If both an issue and annual row somehow
+    # share an id (should not), the later row in the result set wins — callers
+    # always key by the Wanted row's IssueID alone.
+    latest = {}
+    for row in rows:
+        latest[str(row["entity_id"])] = {
+            "state": row["state"],
+            "attempt_count": int(row["attempt_count"] or 0),
+            "reason": row["reason"],
+            "run_id": row["run_id"],
+            "entity_type": row["entity_type"],
+            "updated_at": row["updated_at"],
+            "completed_at": row["completed_at"],
+        }
+    return latest
 
 
 # ---------------------------------------------------------------------------

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -833,17 +833,50 @@ def search_all_missing(
     }
 
 
+def _attach_wanted_acquisition_annotations(rows):
+    """Stamp each Wanted row with its latest search run-item annotation.
+
+    Membership is unchanged (``Status == 'Wanted'``). Annotation is derived
+    solely from the latest ``acquisition_run_items`` search row for that
+    IssueID so closed runs stay sticky until a newer run supersedes them.
+    """
+    if not rows:
+        return rows
+    entity_ids = [row.get("IssueID") for row in rows if row.get("IssueID")]
+    latest = series_queries.get_latest_search_items_by_entity_ids(entity_ids)
+    for row in rows:
+        issue_id = row.get("IssueID")
+        item = latest.get(str(issue_id)) if issue_id is not None else None
+        if item is None:
+            row["acquisition"] = None
+            continue
+        row["acquisition"] = {
+            "state": item["state"],
+            "attempt_count": item["attempt_count"],
+            "reason": item["reason"],
+            "run_id": item["run_id"],
+            "entity_type": item["entity_type"],
+            "updated_at": item["updated_at"],
+            "completed_at": item["completed_at"],
+        }
+    return rows
+
+
 def get_wanted(ctx, limit=None, offset=None, include_story_arcs=False, search=None):
     """Get all wanted issues, optionally with story arcs and annuals.
 
     ``search`` filters ComicName / Issue_Number before pagination so the
     returned rows and pagination metadata describe the same result set.
+
+    Each returned row also carries a live-and-sticky ``acquisition`` annotation
+    from the latest search run item for that IssueID (or ``null`` when never
+    searched). Membership filtering is unchanged.
     """
     # Issues
     if limit is not None:
         paginated = series_queries.get_wanted_issues(limit=limit, offset=offset, search=search)
         result = {
-            "issues": paginated["results"],
+            "issues": _attach_wanted_acquisition_annotations(paginated["results"]),
             "pagination": {
                 "total": paginated["total"],
                 "limit": paginated["limit"],
@@ -852,18 +885,20 @@ def get_wanted(ctx, limit=None, offset=None, include_story_arcs=False, search=No
             },
         }
     else:
-        result = {"issues": series_queries.get_wanted_issues(search=search)}
+        result = {
+            "issues": _attach_wanted_acquisition_annotations(series_queries.get_wanted_issues(search=search)),
+        }
 
     # Story arcs
     if include_story_arcs:
         upcoming_storyarcs = getattr(ctx.config, "UPCOMING_STORYARCS", False) if ctx.config else False
         if upcoming_storyarcs:
-            result["story_arcs"] = series_queries.get_wanted_storyarc_issues()
+            result["story_arcs"] = _attach_wanted_acquisition_annotations(series_queries.get_wanted_storyarc_issues())
 
     # Annuals
     annuals_on = getattr(ctx.config, "ANNUALS_ON", False) if ctx.config else False
     if annuals_on:
-        result["annuals"] = series_queries.get_wanted_annuals()
+        result["annuals"] = _attach_wanted_acquisition_annotations(series_queries.get_wanted_annuals())
 
     return result
 

--- a/frontend/src/components/queue/wantedColumns.tsx
+++ b/frontend/src/components/queue/wantedColumns.tsx
@@ -3,7 +3,6 @@ import { createColumnHelper } from "@tanstack/react-table";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import StatusBadge from "@/components/StatusBadge";
 import { DataTableSortHeader } from "@/components/data-table/DataTableSortHeader";
 import { CoverCell } from "@/components/data-table/cells/CoverCell";
 import {
@@ -11,6 +10,7 @@ import {
   toggleAllSelected,
 } from "@/components/data-table/useTableState";
 import { useUnqueueIssue } from "@/hooks/useSeries";
+import { formatWantedAcquisitionAnnotation } from "@/lib/wantedAnnotation";
 import type { WantedIssue } from "@/types";
 
 const columnHelper = createColumnHelper<WantedIssue>();
@@ -106,9 +106,37 @@ export function useWantedColumns() {
           return <span className="text-sm">{date}</span>;
         },
       }),
-      columnHelper.accessor("Status", {
+      columnHelper.display({
+        id: "acquisition",
         header: "Status",
-        cell: ({ getValue }) => <StatusBadge status={getValue()} />,
+        // Membership is always Wanted on this page; Status shows the live-
+        // sticky acquisition annotation from the latest search run item (#490).
+        cell: ({ row }) => {
+          const label = formatWantedAcquisitionAnnotation(
+            row.original.acquisition,
+          );
+          const state = row.original.acquisition?.state?.toLowerCase() ?? null;
+          const isLive = state === "accepted" || state === "running";
+          const isTrouble =
+            state === "no_match" ||
+            state === "failed" ||
+            state === "blocked" ||
+            state === "quarantined";
+          return (
+            <span
+              className={
+                isLive
+                  ? "text-sm text-foreground"
+                  : isTrouble
+                    ? "text-sm text-muted-foreground"
+                    : "text-sm text-muted-foreground/70"
+              }
+              data-acquisition-state={state ?? "never"}
+            >
+              {label}
+            </span>
+          );
+        },
         enableSorting: false,
       }),
       columnHelper.display({

--- a/frontend/src/lib/wantedAnnotation.ts
+++ b/frontend/src/lib/wantedAnnotation.ts
@@ -1,0 +1,82 @@
+/**
+ * Operator-language labels for Wanted row live-sticky acquisition annotations.
+ *
+ * Source of truth for *which* item annotates a row is the latest search
+ * `acquisition_run_items` row (backend). This module only maps that derived
+ * state into the approved Wanted vocabulary — no progress %, no fabricated
+ * `next_attempt_at` countdowns (#429 / #432 / #490).
+ */
+
+export type WantedAcquisitionState =
+  | "accepted"
+  | "running"
+  | "succeeded"
+  | "no_match"
+  | "blocked"
+  | "failed"
+  | "quarantined"
+  | "cancelled"
+  | string;
+
+export interface WantedAcquisitionAnnotation {
+  state: WantedAcquisitionState | null;
+  attempt_count: number;
+  reason?: string | null;
+  run_id?: string | null;
+  entity_type?: string | null;
+  updated_at?: string | null;
+  completed_at?: string | null;
+}
+
+/** Approved operator phrases for the common Wanted sticky states. */
+export const WANTED_ANNOTATION_NEVER_SEARCHED = "never searched";
+export const WANTED_ANNOTATION_SEARCHING = "searching…";
+
+function triesClause(attemptCount: number): string {
+  const n = Number.isFinite(attemptCount)
+    ? Math.max(0, Math.trunc(attemptCount))
+    : 0;
+  return `${n} ${n === 1 ? "try" : "tries"}`;
+}
+
+/**
+ * Render the sticky Status cell for one Wanted row.
+ *
+ * - no annotation / null state → `never searched`
+ * - accepted | running → `searching…`
+ * - no_match → `no match · N tries`
+ * - other terminal ledger states stay honest and countdown-free
+ */
+export function formatWantedAcquisitionAnnotation(
+  acquisition: WantedAcquisitionAnnotation | null | undefined,
+): string {
+  if (!acquisition || acquisition.state == null || acquisition.state === "") {
+    return WANTED_ANNOTATION_NEVER_SEARCHED;
+  }
+
+  const state = String(acquisition.state).toLowerCase();
+  const attempts = Number(acquisition.attempt_count) || 0;
+
+  if (state === "accepted" || state === "running") {
+    return WANTED_ANNOTATION_SEARCHING;
+  }
+  if (state === "no_match") {
+    return `no match · ${triesClause(attempts)}`;
+  }
+  if (state === "failed" || state === "quarantined") {
+    return `failed · ${triesClause(attempts)}`;
+  }
+  if (state === "blocked") {
+    return "blocked";
+  }
+  if (state === "cancelled") {
+    return "cancelled";
+  }
+  if (state === "succeeded") {
+    // Snatch should remove membership shortly; while still Wanted, stay neutral.
+    return WANTED_ANNOTATION_SEARCHING;
+  }
+
+  // Unknown ledger value: never invent progress; surface the token as-is.
+  return state.replace(/_/g, " ");
+}

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -312,10 +312,27 @@ export interface SearchResult {
   content_rating?: string | null;
 }
 
+/**
+ * Live-sticky acquisition annotation on a Wanted row (#490).
+ * Latest search `acquisition_run_items` row for this IssueID, or null when
+ * the issue has never been accepted into a search run.
+ */
+export interface WantedAcquisitionAnnotation {
+  state: string | null;
+  attempt_count: number;
+  reason?: string | null;
+  run_id?: string | null;
+  entity_type?: string | null;
+  updated_at?: string | null;
+  completed_at?: string | null;
+}
+
 /** Wanted issue (issue with extra fields from wanted queue) */
 export interface WantedIssue extends Issue {
   QueueType?: string;
   Provider?: string;
+  /** Latest search run-item annotation; null when never searched. */
+  acquisition?: WantedAcquisitionAnnotation | null;
 }
 
 /** Upcoming issue */

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -37,6 +37,7 @@ export type {
   SearchRunRetryResult,
   ForceSearchResult,
   SearchResult,
+  WantedAcquisitionAnnotation,
   WantedIssue,
   UpcomingIssue,
   SeriesDetail,

--- a/frontend/tests/pages/WantedPage.test.tsx
+++ b/frontend/tests/pages/WantedPage.test.tsx
@@ -23,7 +23,16 @@ function renderWantedWithForceResult(result: Record<string, unknown>) {
   return render(<WantedPage />);
 }
 
-function sagaIssue(id: string, number: string) {
+function sagaIssue(
+  id: string,
+  number: string,
+  acquisition?: {
+    state: string | null;
+    attempt_count: number;
+    reason?: string | null;
+    run_id?: string | null;
+  } | null,
+) {
   return {
     IssueID: id,
     ComicID: "comic-saga",
@@ -32,6 +41,7 @@ function sagaIssue(id: string, number: string) {
     IssueDate: "2020-01-01",
     Status: "Wanted",
     DateAdded: "2026-01-01",
+    acquisition: acquisition === undefined ? null : acquisition,
   };
 }
 
@@ -148,6 +158,48 @@ describe("WantedPage", () => {
         "Search accepted — 3 wanted issues queued. Run run-123.",
       ),
     ).toBeNull();
+  });
+
+  /**
+   * #490: Wanted rows show live-sticky acquisition copy from the latest run
+   * item — never searched / searching… / no match · N tries — without a
+   * countdown or progress percent.
+   */
+  it("renders live-sticky acquisition annotations from the API payload", async () => {
+    server.use(
+      http.get("/api/wanted", () =>
+        HttpResponse.json({
+          issues: [
+            sagaIssue("saga-never", "1", null),
+            sagaIssue("saga-live", "2", {
+              state: "running",
+              attempt_count: 1,
+              run_id: "run-live",
+            }),
+            sagaIssue("saga-sticky", "3", {
+              state: "no_match",
+              attempt_count: 3,
+              run_id: "run-old",
+              reason: "providers empty",
+            }),
+          ],
+          pagination: {
+            total: 3,
+            limit: 50,
+            offset: 0,
+            has_more: false,
+          },
+        }),
+      ),
+    );
+
+    render(<WantedPage />);
+
+    expect(await screen.findByText("never searched")).toBeTruthy();
+    expect(screen.getByText("searching…")).toBeTruthy();
+    expect(screen.getByText("no match · 3 tries")).toBeTruthy();
+    expect(screen.queryByText(/retry/i)).toBeNull();
+    expect(screen.queryByText(/%/)).toBeNull();
   });
 
   /**

--- a/frontend/tests/unit/lib/wantedAnnotation.test.ts
+++ b/frontend/tests/unit/lib/wantedAnnotation.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatWantedAcquisitionAnnotation,
+  WANTED_ANNOTATION_NEVER_SEARCHED,
+  WANTED_ANNOTATION_SEARCHING,
+} from "@/lib/wantedAnnotation";
+
+describe("formatWantedAcquisitionAnnotation", () => {
+  it("labels missing annotations as never searched", () => {
+    expect(formatWantedAcquisitionAnnotation(null)).toBe(
+      WANTED_ANNOTATION_NEVER_SEARCHED,
+    );
+    expect(formatWantedAcquisitionAnnotation(undefined)).toBe(
+      WANTED_ANNOTATION_NEVER_SEARCHED,
+    );
+    expect(
+      formatWantedAcquisitionAnnotation({ state: null, attempt_count: 0 }),
+    ).toBe(WANTED_ANNOTATION_NEVER_SEARCHED);
+  });
+
+  it("labels accepted and running as searching… without inventing progress", () => {
+    expect(
+      formatWantedAcquisitionAnnotation({
+        state: "accepted",
+        attempt_count: 0,
+      }),
+    ).toBe(WANTED_ANNOTATION_SEARCHING);
+    expect(
+      formatWantedAcquisitionAnnotation({
+        state: "running",
+        attempt_count: 2,
+      }),
+    ).toBe(WANTED_ANNOTATION_SEARCHING);
+    // attempt_count > 0 with accepted is retry-pending (#432) — still searching…
+    expect(
+      formatWantedAcquisitionAnnotation({
+        state: "accepted",
+        attempt_count: 3,
+      }),
+    ).toBe(WANTED_ANNOTATION_SEARCHING);
+  });
+
+  it("labels no_match with sticky try counts and no countdown", () => {
+    expect(
+      formatWantedAcquisitionAnnotation({
+        state: "no_match",
+        attempt_count: 3,
+      }),
+    ).toBe("no match · 3 tries");
+    expect(
+      formatWantedAcquisitionAnnotation({
+        state: "no_match",
+        attempt_count: 1,
+      }),
+    ).toBe("no match · 1 try");
+  });
+
+  it("does not fabricate next_attempt_at countdowns for any state", () => {
+    const labels = [
+      formatWantedAcquisitionAnnotation({
+        state: "accepted",
+        attempt_count: 4,
+      }),
+      formatWantedAcquisitionAnnotation({
+        state: "no_match",
+        attempt_count: 4,
+      }),
+      formatWantedAcquisitionAnnotation({
+        state: "failed",
+        attempt_count: 4,
+      }),
+    ];
+    for (const label of labels) {
+      expect(label).not.toMatch(/retry/i);
+      expect(label).not.toMatch(/%/);
+      expect(label).not.toMatch(/\d+h|\d+m|\d+s/);
+    }
+  });
+
+  it("keeps other terminal states countdown-free and operator-readable", () => {
+    expect(
+      formatWantedAcquisitionAnnotation({
+        state: "failed",
+        attempt_count: 2,
+      }),
+    ).toBe("failed · 2 tries");
+    expect(
+      formatWantedAcquisitionAnnotation({
+        state: "blocked",
+        attempt_count: 0,
+      }),
+    ).toBe("blocked");
+    expect(
+      formatWantedAcquisitionAnnotation({
+        state: "cancelled",
+        attempt_count: 1,
+      }),
+    ).toBe("cancelled");
+  });
+});

--- a/tests/unit/test_wanted_annotations.py
+++ b/tests/unit/test_wanted_annotations.py
@@ -1,0 +1,208 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Wanted page live-sticky acquisition annotations (#490).
+
+Pins:
+- annotation comes from the latest search ``acquisition_run_items`` row only
+- sticky after the run closes until a newer run supersedes it
+- membership filter stays ``Status == 'Wanted'`` (Snatched never annotates in)
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import insert, update
+
+import comicarr
+from comicarr import db
+from comicarr.app.acquisition.models import ItemOutcome
+from comicarr.app.acquisition.runs import RunLedger
+from comicarr.app.series import queries as series_queries
+from comicarr.app.series import service as series_service
+from comicarr.tables import comics, issues, metadata
+
+
+@pytest.fixture
+def wanted_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+def _seed_wanted_issues(engine, issue_ids):
+    with engine.begin() as conn:
+        conn.execute(
+            insert(comics),
+            {
+                "ComicID": "comic-1",
+                "ComicName": "Batman",
+                "ComicSortName": "Batman",
+                "ComicPublisher": "DC",
+                "Status": "Active",
+                "Have": 0,
+                "Total": len(issue_ids),
+                "ContentType": "comic",
+            },
+        )
+        conn.execute(
+            insert(issues),
+            [
+                {
+                    "IssueID": issue_id,
+                    "ComicID": "comic-1",
+                    "Issue_Number": str(index + 1),
+                    "Status": "Wanted",
+                    "DateAdded": f"2026-01-{index + 1:02d}",
+                }
+                for index, issue_id in enumerate(issue_ids)
+            ],
+        )
+
+
+def test_never_searched_rows_carry_null_acquisition(wanted_db):
+    _seed_wanted_issues(wanted_db, ["issue-a", "issue-b"])
+
+    result = series_service.get_wanted(SimpleNamespace(config=None), limit=50, offset=0)
+
+    assert result["pagination"]["total"] == 2
+    assert all(row["Status"] == "Wanted" for row in result["issues"])
+    assert all(row["acquisition"] is None for row in result["issues"])
+
+
+def test_latest_search_item_annotates_wanted_row(wanted_db):
+    _seed_wanted_issues(wanted_db, ["issue-12", "issue-13"])
+    ledger = RunLedger(wanted_db)
+    ledger.create_run("run-1", command_kind="search", trigger="manual")
+    ledger.accept_item("run-1", entity_type="issue", entity_id="issue-12")
+    assert ledger.claim_item("run-1", "issue", "issue-12") is True
+    ledger.record_outcome("run-1", "issue", "issue-12", ItemOutcome.NO_MATCH, reason="providers empty")
+
+    result = series_service.get_wanted(SimpleNamespace(config=None), limit=50, offset=0)
+    by_id = {row["IssueID"]: row for row in result["issues"]}
+
+    annotation = by_id["issue-12"]["acquisition"]
+    assert annotation is not None
+    assert annotation["state"] == ItemOutcome.NO_MATCH.value
+    assert annotation["attempt_count"] == 1
+    assert annotation["reason"] == "providers empty"
+    assert annotation["run_id"] == "run-1"
+    assert annotation["entity_type"] == "issue"
+    assert annotation["completed_at"] is not None
+
+    assert by_id["issue-13"]["acquisition"] is None
+
+
+def test_annotation_is_sticky_after_run_closes_until_newer_run_supersedes(wanted_db):
+    _seed_wanted_issues(wanted_db, ["issue-sticky"])
+    ledger = RunLedger(wanted_db)
+
+    ledger.create_run("run-old", command_kind="search", trigger="scheduler")
+    ledger.accept_item("run-old", entity_type="issue", entity_id="issue-sticky")
+    assert ledger.claim_item("run-old", "issue", "issue-sticky") is True
+    ledger.record_outcome("run-old", "issue", "issue-sticky", ItemOutcome.NO_MATCH)
+    old_run = ledger.get_run("run-old")
+    # Terminal no_match closes the run; annotation must still stick on Wanted.
+    assert old_run["completion_state"] == "completed"
+    assert old_run["completed_at"] is not None
+
+    after_close = series_service.get_wanted(SimpleNamespace(config=None), limit=10, offset=0)
+    sticky = after_close["issues"][0]["acquisition"]
+    assert sticky["run_id"] == "run-old"
+    assert sticky["state"] == ItemOutcome.NO_MATCH.value
+    assert sticky["attempt_count"] == 1
+
+    ledger.create_run("run-new", command_kind="search", trigger="manual")
+    ledger.accept_item("run-new", entity_type="issue", entity_id="issue-sticky")
+    # Live searching annotation from the newer run must supersede the sticky no_match.
+    live = series_service.get_wanted(SimpleNamespace(config=None), limit=10, offset=0)
+    annotation = live["issues"][0]["acquisition"]
+    assert annotation["run_id"] == "run-new"
+    assert annotation["state"] == ItemOutcome.ACCEPTED.value
+    assert annotation["attempt_count"] == 0
+
+    assert ledger.claim_item("run-new", "issue", "issue-sticky") is True
+    ledger.record_outcome("run-new", "issue", "issue-sticky", ItemOutcome.NO_MATCH)
+    after_new_close = series_service.get_wanted(SimpleNamespace(config=None), limit=10, offset=0)
+    superseded = after_new_close["issues"][0]["acquisition"]
+    assert superseded["run_id"] == "run-new"
+    assert superseded["state"] == ItemOutcome.NO_MATCH.value
+    assert superseded["attempt_count"] == 1
+
+
+def test_refresh_run_items_do_not_annotate_wanted_issues(wanted_db):
+    _seed_wanted_issues(wanted_db, ["issue-refresh"])
+    ledger = RunLedger(wanted_db)
+    ledger.create_run("refresh-run", command_kind="refresh", trigger="manual")
+    ledger.accept_item("refresh-run", entity_type="series", entity_id="issue-refresh")
+
+    result = series_service.get_wanted(SimpleNamespace(config=None), limit=10, offset=0)
+    assert result["issues"][0]["acquisition"] is None
+
+
+def test_membership_filter_unchanged_snatched_not_returned(wanted_db):
+    _seed_wanted_issues(wanted_db, ["issue-wanted", "issue-snatched"])
+    with wanted_db.begin() as conn:
+        conn.execute(
+            update(issues).where(issues.c.IssueID == "issue-snatched").values(Status="Snatched")
+        )
+
+    ledger = RunLedger(wanted_db)
+    ledger.create_run("run-snatch", command_kind="search", trigger="manual")
+    ledger.accept_item("run-snatch", entity_type="issue", entity_id="issue-snatched")
+    assert ledger.claim_item("run-snatch", "issue", "issue-snatched") is True
+    ledger.record_outcome("run-snatch", "issue", "issue-snatched", ItemOutcome.SUCCEEDED)
+
+    result = series_service.get_wanted(SimpleNamespace(config=None), limit=50, offset=0)
+    assert result["pagination"]["total"] == 1
+    assert [row["IssueID"] for row in result["issues"]] == ["issue-wanted"]
+
+
+def test_latest_item_selection_prefers_most_recently_updated(wanted_db):
+    _seed_wanted_issues(wanted_db, ["issue-order"])
+    ledger = RunLedger(wanted_db)
+    ledger.create_run("run-a", command_kind="search", trigger="manual")
+    ledger.accept_item("run-a", entity_type="issue", entity_id="issue-order")
+    assert ledger.claim_item("run-a", "issue", "issue-order") is True
+    ledger.record_outcome("run-a", "issue", "issue-order", ItemOutcome.FAILED, reason="old")
+
+    ledger.create_run("run-b", command_kind="search", trigger="manual")
+    ledger.accept_item("run-b", entity_type="issue", entity_id="issue-order")
+    assert ledger.claim_item("run-b", "issue", "issue-order") is True
+    ledger.record_outcome("run-b", "issue", "issue-order", ItemOutcome.NO_MATCH, reason="new")
+
+    latest = series_queries.get_latest_search_items_by_entity_ids(["issue-order"])
+    assert latest["issue-order"]["run_id"] == "run-b"
+    assert latest["issue-order"]["state"] == ItemOutcome.NO_MATCH.value
+    assert latest["issue-order"]["reason"] == "new"
+
+
+def test_live_searching_state_while_accepted_or_running(wanted_db):
+    _seed_wanted_issues(wanted_db, ["issue-live"])
+    ledger = RunLedger(wanted_db)
+    ledger.create_run("run-live", command_kind="search", trigger="manual")
+    ledger.accept_item("run-live", entity_type="issue", entity_id="issue-live")
+
+    accepted = series_service.get_wanted(SimpleNamespace(config=None), limit=10, offset=0)
+    assert accepted["issues"][0]["acquisition"]["state"] == ItemOutcome.ACCEPTED.value
+
+    assert ledger.claim_item("run-live", "issue", "issue-live") is True
+    running = series_service.get_wanted(SimpleNamespace(config=None), limit=10, offset=0)
+    assert running["issues"][0]["acquisition"]["state"] == ItemOutcome.RUNNING.value
+    assert running["issues"][0]["acquisition"]["attempt_count"] == 1
+
+
+def test_get_latest_search_items_empty_input():
+    assert series_queries.get_latest_search_items_by_entity_ids([]) == {}
+    assert series_queries.get_latest_search_items_by_entity_ids(None) == {}

--- a/tests/unit/test_wanted_filter_pagination.py
+++ b/tests/unit/test_wanted_filter_pagination.py
@@ -172,10 +172,16 @@ def test_get_wanted_service_forwards_search(monkeypatch):
         }
 
     monkeypatch.setattr(series_service.series_queries, "get_wanted_issues", fake_get_wanted_issues)
+    monkeypatch.setattr(
+        series_service.series_queries,
+        "get_latest_search_items_by_entity_ids",
+        lambda entity_ids: {},
+    )
     result = series_service.get_wanted(SimpleNamespace(config=None), limit=50, offset=0, search="Saga")
     assert captured == {"limit": 50, "offset": 0, "search": "Saga"}
     assert result["pagination"]["total"] == 1
     assert result["issues"][0]["IssueID"] == "1"
+    assert result["issues"][0]["acquisition"] is None
 
 
 def test_wanted_route_forwards_q_as_search(monkeypatch):


### PR DESCRIPTION
## Summary

- Annotate each Wanted row from the latest search `acquisition_run_items` row (`state`, `attempt_count`, `reason`, `run_id`, timestamps) so operators see searching / no-match / try counts without opening Activity.
- UI Status column uses approved operator copy only (`searching…`, `no match · N tries`, `never searched`); no progress % or fabricated `next_attempt_at` countdowns.
- Annotation is sticky after a run closes until a newer run supersedes it. Wanted membership is unchanged (`Status == 'Wanted'`, still leaves on snatch).

Closes #490

## Scope

- In: `/api/wanted` annotation attachment, Wanted Status cell, focused tests, minor changeset
- Out: Activity timeline, band actions, narrative table, membership rule

## Test plan

- [x] `uv run pytest tests/unit/test_wanted_annotations.py tests/unit/test_wanted_filter_pagination.py -v`
- [x] `npm run test:run -- tests/unit/lib/wantedAnnotation.test.ts tests/pages/WantedPage.test.tsx tests/components/QueueTableSelection.test.tsx` (frontend)
- [x] `npm run lint`
- [ ] Manual: Wanted page shows never searched / searching… / sticky no match after a closed run