### PR TITLE
fix: Terminalize pipeline_journal on failed-download paths

### DIFF
--- a/.changeset/journal-failed-terminals.md
+++ b/.changeset/journal-failed-terminals.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Failed downloads now terminalize `pipeline_journal` so needs-attention and in-flight counts stay honest when a download fails or auto-retry re-searches.

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -1458,7 +1458,12 @@ def _ddl_downloader_loop(queue, link_type_failure, active_item):
                         conn.execute(delete(ddl_info).where(ddl_info.c.ID == item["id"]))
                     comicarr.DDL_STUCK_NOTIFIED.discard(item["id"])
                     comicarr.search.FailedMark(
-                        item["issueid"], item["comicid"], item["id"], ddzstat["filename"], item["site"]
+                        item["issueid"],
+                        item["comicid"],
+                        item["id"],
+                        ddzstat["filename"],
+                        item["site"],
+                        journal_release_key=item.get("journal_release_key"),
                     )
             active_item["value"] = None
         else:

--- a/comicarr/failed.py
+++ b/comicarr/failed.py
@@ -28,6 +28,101 @@ import comicarr
 from comicarr import db, helpers, logger
 from comicarr.tables import annuals, comics, failed, issues, nzblog
 
+# Producer-contract fail_reason tokens (#430 A6 / #482). Token-only — never
+# concatenate exception text. Band membership is stage + R9 status only; these
+# codes feed narrative reason_code alignment and machine diagnostics.
+FAIL_REASON_RESEARCHING = "download_failed_researching"
+FAIL_REASON_NO_AUTO_HANDLING = "download_failed_no_auto_handling"
+
+# R9 resolution stamp: auto re-search enqueued (or operator retry). Keeps the
+# failed journal row off the needs-attention band without rewriting stage.
+STATUS_RETRIED = "retried"
+
+
+def resolve_failed_release_key(
+    journal_release_key=None,
+    issueid=None,
+    provider=None,
+    nzbname=None,
+    hash=None,
+    discriminant=None,
+):
+    """Prefer a propagated journal_release_key; else derive under existing rules.
+
+    Returns None when no resolvable identity exists so callers skip the journal
+    write rather than invent a colliding key.
+    """
+    if journal_release_key not in (None, ""):
+        return str(journal_release_key)
+
+    from comicarr.app.downloads import journal
+
+    if issueid is None and provider in (None, "") and nzbname in (None, "") and hash in (None, ""):
+        return None
+    return journal.release_key(
+        issueid,
+        provider,
+        nzbname=nzbname,
+        hash=hash,
+        discriminant=discriminant,
+    )
+
+
+def terminalize_failed_download(
+    release_key,
+    fail_reason,
+    *,
+    status=None,
+    issueid=None,
+    provider=None,
+    nzbname=None,
+    hash=None,
+    payload=None,
+    conn=None,
+    **fields,
+):
+    """Advance pipeline_journal to terminal `failed` for a failed-download seam.
+
+    When ``status`` is provided (e.g. STATUS_RETRIED after FAILED_AUTO enqueue),
+    it is stamped in the same ``mark_failed`` write so band membership and the
+    stage transition stay transactionally honest. Returns the ``won`` signal
+    from ``journal.mark_failed`` (False when the key is missing or the row was
+    already terminal).
+    """
+    if release_key in (None, ""):
+        return False
+    if fail_reason in (None, ""):
+        logger.warn("[FAILED-DOWNLOAD] terminalize skipped: empty fail_reason for release_key=%s" % release_key)
+        return False
+
+    from comicarr.app.downloads import journal
+
+    write_fields = dict(fields)
+    if issueid not in (None, ""):
+        write_fields.setdefault("issueid", issueid)
+    if provider not in (None, ""):
+        write_fields.setdefault("provider", provider)
+    if nzbname not in (None, ""):
+        write_fields.setdefault("nzbname", nzbname)
+    if hash not in (None, ""):
+        write_fields.setdefault("hash", hash)
+    if status is not None:
+        write_fields["status"] = status
+
+    won = journal.mark_failed(
+        release_key,
+        fail_reason,
+        payload=payload,
+        conn=conn,
+        **write_fields,
+    )
+    if won:
+        logger.fdebug(
+            "[FAILED-DOWNLOAD] journal terminalized release_key=%s fail_reason=%s status=%s"
+            % (release_key, fail_reason, status)
+        )
+    return won
+
 
 class FailedProcessor(object):
     """Handles Failed downloads that are passed from SABnzbd thus far"""
@@ -42,10 +137,13 @@ class FailedProcessor(object):
         prov=None,
         queue=None,
         oneoffinfo=None,
+        journal_release_key=None,
     ):
         """
         nzb_name : Full name of the nzb file that has returned as a fail.
         nzb_folder: Full path to the folder of the failed download.
+        journal_release_key: Canonical pipeline_journal key when already known
+            (PP claim / download_info). Preferred over re-derivation.
         """
         self.nzb_name = nzb_name
         self.nzb_folder = nzb_folder
@@ -72,6 +170,7 @@ class FailedProcessor(object):
         if queue:
             self.queue = queue
         self.valreturn = []
+        self.journal_release_key = journal_release_key
 
     def _log(self, message, level=logger):  # .message):
         """
@@ -157,7 +256,7 @@ class FailedProcessor(object):
         if all([self.id == nzbiss["ID"], self.prov == nzbiss["PROVIDER"]]):
             logger.info(
                 "ID %s for provider %s already exists as a Failed item. Continuing the search..."
-                % (nzbiss["ID"], nzbiss["Provider"])
+                % (nzbiss["ID"], nzbiss["PROVIDER"])
             )
 
         if self.prov is None:
@@ -259,7 +358,18 @@ class FailedProcessor(object):
         logger.info(module + " Successfully marked as Failed.")
         self._log("Successfully marked as Failed.")
 
+        # Complete the journal ledger at this seam (#457 / #482). Prefer the
+        # propagated claim key; fall back under existing release_key rules.
+        self.issueid = issueid
         if comicarr.CONFIG.FAILED_AUTO:
+            # mark_failed + R9 status=retried in one write: auto re-search is
+            # enqueued (mode=retry) so the row must stay off the attention band.
+            self._terminalize_journal(
+                FAIL_REASON_RESEARCHING,
+                status=STATUS_RETRIED,
+                issueid=issueid,
+                nzbname=nzbname,
+            )
             failed_msg = "%s (%s) #%s failed to download. Retrying the search but ignoring the bad result." % (
                 issuenzb["ComicName"],
                 issuenzb["ComicYear"],
@@ -289,6 +399,13 @@ class FailedProcessor(object):
 
             return self.queue.put(self.valreturn)
         else:
+            # No further system work — leave R9 status null so the band sees it.
+            self._terminalize_journal(
+                FAIL_REASON_NO_AUTO_HANDLING,
+                status=None,
+                issueid=issueid,
+                nzbname=nzbname,
+            )
             failed_msg = "%s (%s) #%s failed to download." % (
                 issuenzb["ComicName"],
                 issuenzb["ComicYear"],
@@ -368,6 +485,38 @@ class FailedProcessor(object):
                 )
                 return "nope"
 
+    def _resolved_release_key(self, issueid=None, nzbname=None):
+        return resolve_failed_release_key(
+            journal_release_key=self.journal_release_key,
+            issueid=issueid if issueid is not None else self.issueid,
+            provider=self.prov,
+            nzbname=nzbname if nzbname is not None else self.nzb_name,
+            hash=self.id if self.prov and str(self.prov).lower() in {"32p", "wwt", "dem"} else None,
+        )
+
+    def _terminalize_journal(self, fail_reason, *, status=None, issueid=None, nzbname=None):
+        rkey = self._resolved_release_key(issueid=issueid, nzbname=nzbname)
+        if rkey is None:
+            logger.fdebug(
+                "[FAILED-DOWNLOAD] journal terminalize skipped — release_key not resolvable "
+                "(issueid=%s provider=%s)" % (issueid or self.issueid, self.prov)
+            )
+            return False
+        return terminalize_failed_download(
+            rkey,
+            fail_reason,
+            status=status,
+            issueid=issueid if issueid is not None else self.issueid,
+            provider=self.prov,
+            nzbname=nzbname if nzbname is not None else self.nzb_name,
+            payload={
+                "issueid": issueid if issueid is not None else self.issueid,
+                "comicid": self.comicid,
+                "provider": self.prov,
+                "nzbname": nzbname if nzbname is not None else self.nzb_name,
+            },
+        )
+
     def markFailed(self):
         # use this to forcibly mark a single issue as being Failed (ie. if a search result is sent to a client, but the result
         # ends up passing in a 404 or something that makes it so that the download can't be initiated).
@@ -418,5 +567,9 @@ class FailedProcessor(object):
             "DateFailed": helpers.now(),
         }
         db.upsert("failed", Vals, ctrlVal)
+
+        # Terminalize when key is resolvable. No FAILED_AUTO enqueue here —
+        # leave R9 status null so unresolved failures stay on the band.
+        self._terminalize_journal(FAIL_REASON_NO_AUTO_HANDLING, status=None)
 
         logger.info(module + " Successfully marked as Failed.")

--- a/comicarr/process.py
+++ b/comicarr/process.py
@@ -54,6 +54,50 @@ class Process(object):
         # (manual/API/ComicRN) — the markers then fall back to re-derivation.
         self.journal_release_key = journal_release_key
 
+    def _terminalize_handling_disabled(self):
+        """Mark the journal failed when failed-download handling is off.
+
+        Prefer the PP claim key; fall back under existing release_key rules
+        from download_info / issue identity.
+        """
+        from comicarr import failed as failed_mod
+
+        info = self.download_info if isinstance(self.download_info, dict) else {}
+        issueid = self.issueid or info.get("issueid")
+        provider = info.get("provider")
+        nzbname = self.nzb_name or info.get("nzbname")
+        h = info.get("hash")
+        rkey = failed_mod.resolve_failed_release_key(
+            journal_release_key=self.journal_release_key,
+            issueid=issueid,
+            provider=provider,
+            nzbname=nzbname,
+            hash=h,
+            discriminant=info or None,
+        )
+        if rkey is None:
+            logger.fdebug(
+                "[PROCESS] journal terminalize skipped — release_key not resolvable "
+                "(issueid=%s provider=%s)" % (issueid, provider)
+            )
+            return False
+        return failed_mod.terminalize_failed_download(
+            rkey,
+            failed_mod.FAIL_REASON_NO_AUTO_HANDLING,
+            status=None,
+            issueid=issueid,
+            provider=provider,
+            nzbname=nzbname,
+            hash=h,
+            payload={
+                "issueid": issueid,
+                "comicid": self.comicid or info.get("comicid"),
+                "provider": provider,
+                "nzbname": nzbname,
+                "failed": True,
+            },
+        )
+
     def post_process(self):
         if self.failed == "0":
             self.failed = False
@@ -103,7 +147,14 @@ class Process(object):
                 nzbid = self.download_info["id"]
                 provider = self.download_info["provider"]
                 FailProcess = comicarr.failed.FailedProcessor(
-                    nzb_name=self.nzb_name, nzb_folder=self.nzb_folder, queue=ppqueue, prov=provider, id=nzbid
+                    nzb_name=self.nzb_name,
+                    nzb_folder=self.nzb_folder,
+                    queue=ppqueue,
+                    prov=provider,
+                    id=nzbid,
+                    issueid=self.issueid,
+                    comicid=self.comicid,
+                    journal_release_key=self.journal_release_key,
                 )
                 FailProcess.Process()
                 failchk = ppqueue.get()
@@ -118,6 +169,10 @@ class Process(object):
                     logger.error("mode is unsupported: " + failchk[0]["mode"])
             else:
                 logger.warn("Failed Download Handling is not enabled. Leaving Failed Download as-is.")
+                # Still terminalize the journal so a stuck open stage is not
+                # counted as in-flight forever (#457 / #482). No further work
+                # is scheduled — leave R9 status null (on band).
+                self._terminalize_handling_disabled()
 
         if retry_outside:
             PostProcess = comicarr.postprocessor.PostProcessor("Manual Run", self.nzb_folder, queue=ppqueue)

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -3538,6 +3538,7 @@ def searcher(
                     nzbname=nzbname,
                     prov=nzbprov,
                     oneoffinfo=comicinfo,
+                    journal_release_key=journal_release_key,
                 )
             else:
                 logger.error(
@@ -4104,7 +4105,7 @@ def notify_snatch(sent_to, comicname, comyear, IssueNumber, nzbprov, pack):
     return
 
 
-def FailedMark(IssueID, ComicID, id, nzbname, prov, oneoffinfo=None):
+def FailedMark(IssueID, ComicID, id, nzbname, prov, oneoffinfo=None, journal_release_key=None):
     # Used to pass a failed attempt at sending a download to a client, to the failed
     # handler, and then back again to continue searching.
 
@@ -4117,6 +4118,7 @@ def FailedMark(IssueID, ComicID, id, nzbname, prov, oneoffinfo=None):
         nzb_name=nzbname,
         prov=prov,
         oneoffinfo=oneoffinfo,
+        journal_release_key=journal_release_key,
     )
     FailProcess.markFailed()
 

--- a/tests/unit/test_failed_journal_terminals.py
+++ b/tests/unit/test_failed_journal_terminals.py
@@ -1,0 +1,293 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""#482 — complete pipeline_journal terminals for failed-download paths.
+
+Band predicate is UNCHANGED (#457):
+  stage IN (failed, manual_review)
+  AND (status IS NULL OR status NOT IN (retried, ignored, imported))
+
+These tests pin:
+  * terminal Process (FAILED_AUTO off) → band +1, not in read_open()
+  * FAILED_AUTO after enqueue stamp → band unchanged (status=retried)
+  * handling-disabled process.py path → open stage leaves OPEN_STAGES
+  * markFailed terminalizes when release_key is resolvable
+"""
+
+import queue as queuelib
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+import comicarr
+from comicarr import failed as failed_mod
+from comicarr.app.downloads import journal
+from comicarr.db import get_engine, shutdown_engine
+from comicarr.tables import comics, issues, metadata, nzblog, pipeline_journal
+
+# Settled needs-attention band predicate (#437 / #457). Do not widen.
+_BAND_OFF = ("retried", "ignored", "imported")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    shutdown_engine()
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    if not hasattr(comicarr, "LOG_LEVEL") or comicarr.LOG_LEVEL is None:
+        monkeypatch.setattr(comicarr, "LOG_LEVEL", 0, raising=False)
+    monkeypatch.setattr(comicarr, "GLOBAL_MESSAGES", None, raising=False)
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(FAILED_DOWNLOAD_HANDLING=True, FAILED_AUTO=False, HIGHCOUNT=0),
+        raising=False,
+    )
+    engine = get_engine()
+    metadata.create_all(engine)
+    yield
+    shutdown_engine()
+
+
+def _row(key):
+    with get_engine().connect() as conn:
+        r = conn.execute(select(pipeline_journal).where(pipeline_journal.c.release_key == key)).fetchone()
+        return dict(r._mapping) if r else None
+
+
+def _band_rows():
+    """Single-table needs-attention band (predicate fixed by #457)."""
+    rows = []
+    with get_engine().connect() as conn:
+        for r in conn.execute(select(pipeline_journal)):
+            m = dict(r._mapping)
+            if m["stage"] not in (journal.FAILED, journal.MANUAL_REVIEW):
+                continue
+            if m.get("status") in _BAND_OFF:
+                continue
+            rows.append(m)
+    return rows
+
+
+def _seed_watchlist_and_nzblog(*, issueid="1001", comicid="C1", nzbname="Saga.001", provider="NZBGeek", nzb_id="nzo-1"):
+    with get_engine().begin() as conn:
+        conn.execute(
+            comics.insert().values(
+                ComicID=comicid,
+                ComicName="Saga",
+                ComicYear="2012",
+                Status="Active",
+            )
+        )
+        conn.execute(
+            issues.insert().values(
+                IssueID=issueid,
+                ComicID=comicid,
+                ComicName="Saga",
+                Issue_Number="1",
+                Status="Snatched",
+            )
+        )
+        conn.execute(
+            nzblog.insert().values(
+                IssueID=issueid,
+                NZBName=nzbname,
+                PROVIDER=provider,
+                ID=nzb_id,
+            )
+        )
+
+
+def _open_downloaded(key, *, issueid="1001", provider="NZBGeek", nzbname="Saga.001"):
+    journal.record_transition(
+        key,
+        journal.SNATCHED,
+        issueid=issueid,
+        provider=provider,
+        nzbname=nzbname,
+    )
+    journal.record_transition(key, journal.DOWNLOADED)
+    assert _row(key)["stage"] == journal.DOWNLOADED
+    assert key in {r["release_key"] for r in journal.read_open()}
+
+
+def test_process_terminal_no_auto_lands_on_band_and_leaves_open_stages():
+    """FAILED_AUTO off → mark_failed with null status → band +1, not in flight."""
+    issueid = "1001"
+    provider = "NZBGeek"
+    nzbname = "Saga.001"
+    key = journal.release_key(issueid, provider)
+    _seed_watchlist_and_nzblog(issueid=issueid, provider=provider, nzbname=nzbname)
+    _open_downloaded(key, issueid=issueid, provider=provider, nzbname=nzbname)
+
+    band_before = len(_band_rows())
+    open_before = len(journal.read_open())
+
+    q = queuelib.Queue()
+    proc = failed_mod.FailedProcessor(
+        nzb_name=nzbname,
+        nzb_folder="/tmp/saga",
+        id="nzo-1",
+        issueid=issueid,
+        comicid="C1",
+        prov=provider,
+        queue=q,
+        journal_release_key=key,
+    )
+    proc.Process()
+    result = q.get()
+
+    assert result[0]["mode"] == "stop"
+    row = _row(key)
+    assert row["stage"] == journal.FAILED
+    assert row["fail_reason"] == failed_mod.FAIL_REASON_NO_AUTO_HANDLING
+    assert row["status"] is None
+    assert key not in {r["release_key"] for r in journal.read_open()}
+    assert len(journal.read_open()) == open_before - 1
+    assert len(_band_rows()) == band_before + 1
+
+
+def test_process_failed_auto_stamps_retried_off_band():
+    """FAILED_AUTO on → mark_failed + status=retried in one act → band unchanged."""
+    issueid = "1002"
+    provider = "NZBGeek"
+    nzbname = "Saga.002"
+    key = journal.release_key(issueid, provider)
+    _seed_watchlist_and_nzblog(issueid=issueid, provider=provider, nzbname=nzbname, nzb_id="nzo-2")
+    _open_downloaded(key, issueid=issueid, provider=provider, nzbname=nzbname)
+
+    comicarr.CONFIG.FAILED_AUTO = True
+    band_before = len(_band_rows())
+    open_before = len(journal.read_open())
+
+    q = queuelib.Queue()
+    proc = failed_mod.FailedProcessor(
+        nzb_name=nzbname,
+        nzb_folder="/tmp/saga",
+        id="nzo-2",
+        issueid=issueid,
+        comicid="C1",
+        prov=provider,
+        queue=q,
+        journal_release_key=key,
+    )
+    proc.Process()
+    result = q.get()
+
+    assert result[0]["mode"] == "retry"
+    row = _row(key)
+    assert row["stage"] == journal.FAILED
+    assert row["fail_reason"] == failed_mod.FAIL_REASON_RESEARCHING
+    assert row["status"] == failed_mod.STATUS_RETRIED
+    assert key not in {r["release_key"] for r in journal.read_open()}
+    assert len(journal.read_open()) == open_before - 1
+    assert len(_band_rows()) == band_before  # off-band via status=retried
+
+
+def test_handling_disabled_process_terminalizes_open_stage(monkeypatch):
+    """FAILED_DOWNLOAD_HANDLING off still terminalizes so OPEN_STAGES drain."""
+    from comicarr import process as process_mod
+
+    issueid = "1003"
+    provider = "sabnzbd"
+    nzbname = "Batman.001"
+    key = journal.release_key(issueid, provider)
+    _open_downloaded(key, issueid=issueid, provider=provider, nzbname=nzbname)
+
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(FAILED_DOWNLOAD_HANDLING=False, FAILED_AUTO=False, HIGHCOUNT=0),
+        raising=False,
+    )
+
+    band_before = len(_band_rows())
+    open_before = len(journal.read_open())
+
+    p = process_mod.Process(
+        nzbname,
+        "/downloads/Batman",
+        failed=True,
+        issueid=issueid,
+        comicid="C-bat",
+        download_info={"id": "nzo-bat", "provider": provider},
+        journal_release_key=key,
+    )
+    p.post_process()
+
+    row = _row(key)
+    assert row["stage"] == journal.FAILED
+    assert row["fail_reason"] == failed_mod.FAIL_REASON_NO_AUTO_HANDLING
+    assert row["status"] is None
+    assert key not in {r["release_key"] for r in journal.read_open()}
+    assert len(journal.read_open()) == open_before - 1
+    assert len(_band_rows()) == band_before + 1
+
+
+def test_mark_failed_path_terminalizes_when_key_resolvable():
+    issueid = "1004"
+    provider = "NZBGeek"
+    nzbname = "Saga.004"
+    key = journal.release_key(issueid, provider)
+    _seed_watchlist_and_nzblog(issueid=issueid, provider=provider, nzbname=nzbname, nzb_id="nzo-4")
+    _open_downloaded(key, issueid=issueid, provider=provider, nzbname=nzbname)
+
+    band_before = len(_band_rows())
+
+    proc = failed_mod.FailedProcessor(
+        nzb_name=nzbname,
+        id="nzo-4",
+        issueid=issueid,
+        comicid="C1",
+        prov=provider,
+        journal_release_key=key,
+    )
+    proc.markFailed()
+
+    row = _row(key)
+    assert row["stage"] == journal.FAILED
+    assert row["fail_reason"] == failed_mod.FAIL_REASON_NO_AUTO_HANDLING
+    assert row["status"] is None
+    assert key not in {r["release_key"] for r in journal.read_open()}
+    assert len(_band_rows()) == band_before + 1
+
+
+def test_terminalize_skips_when_release_key_unresolvable(monkeypatch):
+    """No invented keys: unresolvable identity is a no-op, not a collision."""
+    called = []
+
+    def _boom(*_a, **_k):
+        called.append(True)
+        raise AssertionError("mark_failed must not run without a resolvable key")
+
+    monkeypatch.setattr(journal, "mark_failed", _boom)
+    assert failed_mod.resolve_failed_release_key() is None
+    assert failed_mod.terminalize_failed_download(None, failed_mod.FAIL_REASON_NO_AUTO_HANDLING) is False
+    assert called == []
+
+
+def test_prefer_propagated_journal_release_key_over_rederive():
+    canonical = "canonical|key|from|claim"
+    assert (
+        failed_mod.resolve_failed_release_key(
+            journal_release_key=canonical,
+            issueid="999",
+            provider="other",
+        )
+        == canonical
+    )
+
+
+def test_fail_reason_tokens_are_token_only_not_exception_text():
+    """Producer-contract codes must stay machine tokens (no str(e) concat)."""
+    assert failed_mod.FAIL_REASON_RESEARCHING == "download_failed_researching"
+    assert failed_mod.FAIL_REASON_NO_AUTO_HANDLING == "download_failed_no_auto_handling"
+    assert " " not in failed_mod.FAIL_REASON_RESEARCHING
+    assert ":" not in failed_mod.FAIL_REASON_NO_AUTO_HANDLING


### PR DESCRIPTION
## Summary

- Completes `pipeline_journal` terminals on failed-download seams so needs-attention and in-flight counts stop lying about stuck open stages.
- Closes [#482](https://github.com/frankieramirez/comicarr/issues/482) without changing the band predicate or adding narrative-table work.

## What changed

- `FailedProcessor.Process` / `markFailed` call `journal.mark_failed` when a `release_key` is resolvable (prefer item `journal_release_key`; fallback under existing key rules).
- Handling-disabled path in `process.py` terminalizes so open stages leave `read_open()` / `OPEN_STAGES`.
- When `FAILED_AUTO` re-search is enqueued: `mark_failed` + R9 `status='retried'` in the same write (off-band).
- Terminal paths with no further work leave R9 `status` null → on band.
- `fail_reason` tokens are producer-contract codes only (`download_failed_researching` / `download_failed_no_auto_handling`).

## Tests

- Focused recovery/band/open-stage unit tests in `tests/unit/test_failed_journal_terminals.py`
- Related journal/recovery/orphaned-path suites pass
- `npm run lint` passes

## Out of scope (per ticket)

- Band predicate changes
- Narrative `download.failed` rows (producers ticket)
- Operator band actions UI / stall classifier

## Changeset

Patch — operator-visible honesty of failed/in-flight state.