### PR TITLE
docs: Prefer operator-facing prose in Changesets release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,8 @@
 
 ## Release Impact
 
-- [ ] User-visible app change; changeset added with `npm run changeset`
-- [ ] No app release impact; no changeset needed
+- [ ] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
+- [ ] No app release impact; no changeset needed (omit rather than "No user-visible behaviour changes.")
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,11 @@ Default HTTP port is **8090**. Vite dev proxy targets `http://localhost:8090` (o
 
 ## Releases
 
-Releases are automated via Changesets. See the `releases` skill (`.claude/skills/releases/SKILL.md`) for the full workflow.
+Releases are automated via Changesets. See the `releases` skill (`.claude/skills/releases/SKILL.md`) for the full workflow. Human-facing prose rules live in `CONTRIBUTING.md` → *Writing a changeset (operator-facing)*.
 
 **When a refactor earns a changeset:** when it changes something an *operator* could observe. Pure internal restructuring with verified-identical behaviour does not get one, and neither does tooling/CI-only work — `changeset-status.yml` treats a missing changeset as an allowed warning for exactly that. A change only a *contributor* can observe (a new lint gate, a type that now rejects a bad key) is documented here, not in the changelog.
+
+**How to write the summary:** Changeset text is **operator-facing** by default — outcome-first prose naming what the operator can see or do. Avoid ticket-only, filename-only, or internals-as-headline bullets. In-app What's New / update notes render `CHANGELOG.md` with only a mechanical transform (no editorial filter). Never land a changeset whose whole body is "No user-visible behaviour changes." — omit the changeset instead and let the next operator-visible change carry the version bump.
 
 ## Branch & PR Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,28 @@ How it works:
 
 Version files (`package.json`, `pyproject.toml`, `frontend/package.json`, and lockfiles) are updated automatically — never edit versions by hand outside release automation.
 
+### Writing a changeset (operator-facing)
+
+Changeset summary text is copied into `CHANGELOG.md` and shown to operators in-app (What's New / update notes) with only a **mechanical** transform — strip commit hashes, drop bucket headings, flatten links. There is **no** editorial filter in the app. Write every entry as if an operator will read it after upgrading.
+
+| Do | Don't |
+|----|--------|
+| Outcome first: what the operator can see or do differently | Ticket-only or filename-only bullets (`Fix #123`, `Update search.py`) |
+| Name the UI surface or behaviour (`Settings → API`, Wanted filter, manual import) | Internals as the headline (`Make METRON_PASSWORD writable`, `Route through series_kind`) |
+| Skip the changeset when nothing an operator can observe changed | Ship a release whose only line is "No user-visible behaviour changes." |
+
+Examples:
+
+- **Good:** `The Metron Password field in Settings → API now actually saves.`
+- **Good:** `Wanted filtering now searches the full queue, not only the currently loaded page.`
+- **Bad:** `Make METRON_PASSWORD writable in the config registry.`
+- **Bad:** `No user-visible behaviour changes.` — omit the changeset instead; let the next operator-visible change carry the bump.
+
+When to add one:
+
+- **Add a changeset** when an *operator* could notice a change (UI, settings behaviour, downloads, migration outcomes, defaults that affect running installs).
+- **Omit the changeset** for pure internal restructuring with verified-identical behaviour, tooling/CI-only work, docs, or contributor-only gates (lint rules, types). CI treats a missing changeset as an allowed warning.
+
 ## Reporting Issues
 
 - Use the [Bug Report](https://github.com/frankieramirez/comicarr/issues/new?template=bug_report.md) template


### PR DESCRIPTION
## Summary

Document that Changesets entries are operator-facing release notes (in-app What’s New has no editorial filter). Closes #476.

## Changes

- Add outcome-first prose rules and examples under CONTRIBUTING.md Releases
- Mirror the rule for agents in CLAUDE.md
- Tighten the PR template release checklist to omit empty “no user-visible” entries

## Test plan

- [x] Docs-only; no runtime or CI behaviour change
- [ ] Skim CONTRIBUTING.md “Writing a changeset” for clarity with a real recent changelog bullet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release guidance for writing concise, outcome-focused changeset summaries.
  * Documented when changesets are required or should be omitted.
  * Added examples and contributor guidance for user-visible and operator-facing changes.
* **Chores**
  * Updated the pull request checklist to align with the revised changeset requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->