### PR TITLE
feat: Add Activity timeline, band, and open-work read APIs

### DIFF
--- a/comicarr/app/activity/__init__.py
+++ b/comicarr/app/activity/__init__.py
@@ -1,0 +1,14 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Activity Center domain — narrative timeline, attention band, open-work reads.
+
+Write facade, producers, retention, and UI land in sibling issues. This package
+owns query-backed HTTP reads only (#485).
+"""

--- a/comicarr/app/activity/queries.py
+++ b/comicarr/app/activity/queries.py
@@ -1,0 +1,207 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""SQLAlchemy Core projections for Activity Center read surfaces.
+
+Authority rule (Activity Center ADR §3): derived state is authoritative for
+every count. These queries never aggregate ``activity_events`` for open-work
+or attention numbers — only ordered time slices of that table are allowed.
+"""
+
+from sqlalchemy import and_, func, or_, select, union
+
+from comicarr import db
+from comicarr.app.acquisition.models import ItemOutcome
+from comicarr.app.core.database import paginated_query
+from comicarr.app.downloads.journal import FAILED, MANUAL_REVIEW, OPEN_STAGES
+from comicarr.tables import acquisition_run_items, activity_events, annuals, issues, pipeline_journal
+
+# Pagination pages *events* (not pre-grouped stories). Story grouping of 25 is
+# a UI concern; the client may request more events than stories to fill a page.
+TIMELINE_LIMIT_MIN = 1
+TIMELINE_LIMIT_MAX = 100
+TIMELINE_LIMIT_DEFAULT = 50
+
+TIMELINE_SCOPE_TYPES = frozenset({"issue", "annual", "series"})
+
+# R9 resolution statuses that remove a journal row from the needs-attention band.
+BAND_RESOLVED_STATUSES = ("retried", "ignored", "imported")
+BAND_TROUBLE_STAGES = (FAILED, MANUAL_REVIEW)
+
+IN_FLIGHT_ITEM_STATES = (ItemOutcome.ACCEPTED.value, ItemOutcome.RUNNING.value)
+
+
+def _clamp_timeline_limit(limit):
+    if limit is None:
+        return TIMELINE_LIMIT_DEFAULT
+    try:
+        value = int(limit)
+    except (TypeError, ValueError) as e:
+        raise ValueError("limit must be an integer") from e
+    if value < TIMELINE_LIMIT_MIN:
+        return TIMELINE_LIMIT_MIN
+    if value > TIMELINE_LIMIT_MAX:
+        return TIMELINE_LIMIT_MAX
+    return value
+
+
+def _normalize_offset(offset):
+    if offset is None:
+        return 0
+    try:
+        value = int(offset)
+    except (TypeError, ValueError) as e:
+        raise ValueError("offset must be an integer") from e
+    return max(0, value)
+
+
+def _normalize_scope(scope_type, scope_id):
+    """Return (scope_type, scope_id) or (None, None). Raise on partial/invalid."""
+    has_type = scope_type is not None and str(scope_type).strip() != ""
+    has_id = scope_id is not None and str(scope_id).strip() != ""
+    if not has_type and not has_id:
+        return None, None
+    if not has_type or not has_id:
+        raise ValueError("scope_type and scope_id must be provided together")
+    normalized_type = str(scope_type).strip().lower()
+    if normalized_type not in TIMELINE_SCOPE_TYPES:
+        raise ValueError("scope_type must be one of: issue, annual, series")
+    return normalized_type, str(scope_id).strip()
+
+
+def _timeline_scope_condition(scope_type, scope_id):
+    if scope_type in ("issue", "annual"):
+        return and_(
+            activity_events.c.subject_type == scope_type,
+            activity_events.c.subject_id == scope_id,
+        )
+    # series rollup: parent_series_id + series subject + series-scoped run events
+    return or_(
+        activity_events.c.parent_series_id == scope_id,
+        and_(
+            activity_events.c.subject_type == "series",
+            activity_events.c.subject_id == scope_id,
+        ),
+        and_(
+            activity_events.c.subject_type == "run",
+            activity_events.c.scope_type == "series",
+            activity_events.c.scope_id == scope_id,
+        ),
+    )
+
+
+def list_timeline_events(limit=None, offset=None, scope_type=None, scope_id=None):
+    """Return a newest-first page of narrative events.
+
+    Pages events ordered by ``created_at`` (then ``event_id``). Does not
+    pre-group into stories — clients group by ``(subject_type, subject_id)``
+    per the Activity Center ADR.
+    """
+    scope_type, scope_id = _normalize_scope(scope_type, scope_id)
+    page_limit = _clamp_timeline_limit(limit)
+    page_offset = _normalize_offset(offset)
+
+    stmt = select(activity_events)
+    if scope_type is not None:
+        stmt = stmt.where(_timeline_scope_condition(scope_type, scope_id))
+    stmt = stmt.order_by(
+        activity_events.c.created_at.desc(),
+        activity_events.c.event_id.desc(),
+    )
+    return paginated_query(stmt, limit=page_limit, offset=page_offset)
+
+
+def unresolved_band_condition():
+    """R9 needs-attention predicate (Activity Center ADR §2).
+
+    ``stage IN ('failed', 'manual_review')`` and status is null or not a
+    resolution status (``retried`` / ``ignored`` / ``imported``).
+    """
+    return and_(
+        pipeline_journal.c.stage.in_(BAND_TROUBLE_STAGES),
+        or_(
+            pipeline_journal.c.status.is_(None),
+            pipeline_journal.c.status.notin_(BAND_RESOLVED_STATUSES),
+        ),
+    )
+
+
+def _series_member_issue_ids(series_id):
+    """Issue/annual IssueIDs belonging to a series (for band scope)."""
+    issue_ids = select(issues.c.IssueID).where(issues.c.ComicID == series_id)
+    annual_ids = select(annuals.c.IssueID).where(annuals.c.ComicID == series_id)
+    return union(issue_ids, annual_ids).subquery()
+
+
+def _band_scope_condition(scope_type, scope_id):
+    if scope_type in ("issue", "annual"):
+        return pipeline_journal.c.issueid == scope_id
+    # series: journal rows whose issueid is a member of the series
+    members = _series_member_issue_ids(scope_id)
+    return pipeline_journal.c.issueid.in_(select(members.c.IssueID))
+
+
+def list_attention_band(scope_type=None, scope_id=None):
+    """Return unresolved needs-attention journal rows, newest first."""
+    scope_type, scope_id = _normalize_scope(scope_type, scope_id)
+    stmt = select(pipeline_journal).where(unresolved_band_condition())
+    if scope_type is not None:
+        stmt = stmt.where(_band_scope_condition(scope_type, scope_id))
+    stmt = stmt.order_by(
+        pipeline_journal.c.updated_date.desc(),
+        pipeline_journal.c.release_key.desc(),
+    )
+    return db.select_all(stmt)
+
+
+def count_attention_band(scope_type=None, scope_id=None):
+    """Count unresolved needs-attention journal rows (derived ledger only)."""
+    scope_type, scope_id = _normalize_scope(scope_type, scope_id)
+    stmt = (
+        select(func.count().label("attention_count")).select_from(pipeline_journal).where(unresolved_band_condition())
+    )
+    if scope_type is not None:
+        stmt = stmt.where(_band_scope_condition(scope_type, scope_id))
+    row = db.select_one(stmt)
+    return int((row or {}).get("attention_count", 0) or 0)
+
+
+def count_in_flight_run_items():
+    """Count accepted|running acquisition_run_items."""
+    stmt = (
+        select(func.count().label("item_count"))
+        .select_from(acquisition_run_items)
+        .where(acquisition_run_items.c.state.in_(IN_FLIGHT_ITEM_STATES))
+    )
+    row = db.select_one(stmt)
+    return int((row or {}).get("item_count", 0) or 0)
+
+
+def count_open_journal_stages():
+    """Count pipeline_journal rows still in OPEN_STAGES."""
+    stmt = (
+        select(func.count().label("journal_count"))
+        .select_from(pipeline_journal)
+        .where(pipeline_journal.c.stage.in_(OPEN_STAGES))
+    )
+    row = db.select_one(stmt)
+    return int((row or {}).get("journal_count", 0) or 0)
+
+
+def get_open_work_counts():
+    """Quiet-count DTO inputs from derived ledgers only.
+
+    ``in_flight`` = accepted|running run items + OPEN_STAGES journal rows.
+    ``attention`` = unresolved band count.
+    Never reads ``activity_events``.
+    """
+    return {
+        "in_flight": count_in_flight_run_items() + count_open_journal_stages(),
+        "attention": count_attention_band(),
+    }

--- a/comicarr/app/activity/router.py
+++ b/comicarr/app/activity/router.py
@@ -1,0 +1,86 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Activity Center HTTP read surface.
+
+Endpoints:
+
+* ``GET /api/activity/timeline`` — narrative events, newest first
+* ``GET /api/activity/band`` — needs-attention journal rows (R9 predicate)
+* ``GET /api/activity/status`` — derived open-work counts (never narrative)
+
+**Pagination choice:** timeline pages *events* ordered by ``created_at``.
+Story grouping (25 stories per UI page) is a client concern so the API can
+support arbitrary story sizes without re-querying. Clients pass optional
+``scope_type`` + ``scope_id`` for series rollup or issue/annual exact match
+(Activity Center ADR §§5–6).
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from comicarr.app.activity import service
+from comicarr.app.activity.queries import TIMELINE_LIMIT_DEFAULT, TIMELINE_LIMIT_MAX, TIMELINE_LIMIT_MIN
+from comicarr.app.core.security import require_session
+
+router = APIRouter(prefix="/api/activity", tags=["activity"])
+
+
+def _scope_error(exc):
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/timeline", dependencies=[Depends(require_session)])
+def get_timeline(
+    limit: int = Query(TIMELINE_LIMIT_DEFAULT, ge=TIMELINE_LIMIT_MIN, le=TIMELINE_LIMIT_MAX),
+    offset: int = Query(0, ge=0),
+    scope_type: str | None = Query(None, max_length=32),
+    scope_id: str | None = Query(None, max_length=255),
+):
+    """Return a page of narrative activity events (newest first).
+
+    Pages events, not pre-grouped stories. Optional ``scope_type`` /
+    ``scope_id`` filters: ``issue``/``annual`` exact subject match; ``series``
+    rollup via ``parent_series_id``, series subject rows, and series-scoped
+    run events.
+    """
+    try:
+        return service.get_timeline(
+            limit=limit,
+            offset=offset,
+            scope_type=scope_type,
+            scope_id=scope_id,
+        )
+    except ValueError as e:
+        _scope_error(e)
+
+
+@router.get("/band", dependencies=[Depends(require_session)])
+def get_attention_band(
+    scope_type: str | None = Query(None, max_length=32),
+    scope_id: str | None = Query(None, max_length=255),
+):
+    """Return unresolved needs-attention pipeline_journal rows.
+
+    Predicate: stage in (failed, manual_review) and status is null or not in
+    (retried, ignored, imported). When scoped, intersected with that scope.
+    """
+    try:
+        return service.get_attention_band(scope_type=scope_type, scope_id=scope_id)
+    except ValueError as e:
+        _scope_error(e)
+
+
+@router.get("/status", dependencies=[Depends(require_session)])
+def get_status():
+    """Return derived open-work counts for the quiet-counts status indicator.
+
+    ``in_flight`` = accepted|running run items + OPEN_STAGES journal.
+    ``attention`` = unresolved band count. Never aggregates activity_events.
+    """
+    return service.get_status()

--- a/comicarr/app/activity/service.py
+++ b/comicarr/app/activity/service.py
@@ -1,0 +1,33 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Activity Center read service — shapes query results for HTTP handlers."""
+
+from comicarr.app.activity import queries
+
+
+def get_timeline(limit=None, offset=None, scope_type=None, scope_id=None):
+    """Paginated narrative timeline events (not pre-grouped stories)."""
+    return queries.list_timeline_events(
+        limit=limit,
+        offset=offset,
+        scope_type=scope_type,
+        scope_id=scope_id,
+    )
+
+
+def get_attention_band(scope_type=None, scope_id=None):
+    """Needs-attention band rows with a stable list envelope."""
+    rows = queries.list_attention_band(scope_type=scope_type, scope_id=scope_id)
+    return {"results": rows, "total": len(rows)}
+
+
+def get_status():
+    """Open-work counts for the global quiet-counts status indicator."""
+    return queries.get_open_work_counts()

--- a/comicarr/app/main.py
+++ b/comicarr/app/main.py
@@ -399,6 +399,7 @@ def create_app():
     async def health_check():
         return JSONResponse(content={"status": "ok"})
 
+    from comicarr.app.activity.router import router as activity_router
     from comicarr.app.ai.router import router as ai_router
     from comicarr.app.dashboard.router import router as dashboard_router
     from comicarr.app.downloads.router import router as downloads_router
@@ -412,6 +413,7 @@ def create_app():
 
     app.include_router(system_router)
     app.include_router(ai_router)
+    app.include_router(activity_router)
     app.include_router(dashboard_router)
     app.include_router(weekly_router)
     app.include_router(metadata_router)

--- a/tests/unit/test_activity_read_apis.py
+++ b/tests/unit/test_activity_read_apis.py
@@ -1,0 +1,438 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Tests for Activity Center timeline, band, and open-work read APIs (#485).
+
+Pagination choice (documented for clients): the API pages *events* ordered by
+created_at, not pre-grouped stories. Client-side story grouping (25 stories)
+remains a UI concern per the Activity Center ADR.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import insert
+
+import comicarr
+from comicarr import db
+from comicarr.tables import (
+    acquisition_run_items,
+    activity_events,
+    annuals,
+    issues,
+    metadata,
+    pipeline_journal,
+)
+
+
+@pytest.fixture
+def activity_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+def _event(**overrides):
+    base = {
+        "created_at": "2026-07-10 12:00:00",
+        "activity": "import",
+        "status": "succeeded",
+        "subject_type": "issue",
+        "subject_id": "iss-1",
+        "subject_label": "Saga #1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _journal(**overrides):
+    base = {
+        "release_key": "rk-1",
+        "issueid": "iss-1",
+        "provider": "DDL",
+        "stage": "failed",
+        "stage_rank": 60,
+        "updated_date": "2026-07-10 12:00:00",
+        "status": None,
+        "fail_reason": "download_failed",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Timeline
+# ---------------------------------------------------------------------------
+
+
+def test_timeline_returns_empty_page(activity_db):
+    from comicarr.app.activity import queries
+
+    page = queries.list_timeline_events(limit=25, offset=0)
+
+    assert page["results"] == []
+    assert page["total"] == 0
+    assert page["limit"] == 25
+    assert page["offset"] == 0
+    assert page["has_more"] is False
+
+
+def test_timeline_orders_newest_first_and_paginates(activity_db):
+    from comicarr.app.activity import queries
+
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(activity_events),
+            [
+                _event(created_at="2026-07-10 10:00:00", subject_id="a", subject_label="A"),
+                _event(created_at="2026-07-10 12:00:00", subject_id="b", subject_label="B"),
+                _event(created_at="2026-07-10 11:00:00", subject_id="c", subject_label="C"),
+            ],
+        )
+
+    page = queries.list_timeline_events(limit=2, offset=0)
+    assert [row["subject_id"] for row in page["results"]] == ["b", "c"]
+    assert page["total"] == 3
+    assert page["has_more"] is True
+
+    page2 = queries.list_timeline_events(limit=2, offset=2)
+    assert [row["subject_id"] for row in page2["results"]] == ["a"]
+    assert page2["has_more"] is False
+
+
+def test_timeline_clamps_limit_to_pagination_bounds(activity_db):
+    from comicarr.app.activity import queries
+
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(activity_events),
+            [
+                _event(subject_id=str(i), subject_label="E%s" % i, created_at="2026-07-10 12:%02d:00" % i)
+                for i in range(5)
+            ],
+        )
+
+    # Below minimum and above maximum are clamped (service/query seam).
+    page_low = queries.list_timeline_events(limit=0, offset=0)
+    assert page_low["limit"] == queries.TIMELINE_LIMIT_MIN
+    assert len(page_low["results"]) == queries.TIMELINE_LIMIT_MIN
+
+    page_high = queries.list_timeline_events(limit=10_000, offset=0)
+    assert page_high["limit"] == queries.TIMELINE_LIMIT_MAX
+    assert len(page_high["results"]) == 5
+
+
+def test_timeline_issue_and_annual_scope_exact_subject_match(activity_db):
+    from comicarr.app.activity import queries
+
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(activity_events),
+            [
+                _event(subject_type="issue", subject_id="iss-1", subject_label="Target issue"),
+                _event(subject_type="issue", subject_id="iss-2", subject_label="Other issue"),
+                _event(subject_type="annual", subject_id="iss-1", subject_label="Same id annual"),
+                _event(subject_type="annual", subject_id="ann-9", subject_label="Target annual"),
+            ],
+        )
+
+    issue_page = queries.list_timeline_events(scope_type="issue", scope_id="iss-1")
+    assert [row["subject_label"] for row in issue_page["results"]] == ["Target issue"]
+
+    annual_page = queries.list_timeline_events(scope_type="annual", scope_id="ann-9")
+    assert [row["subject_label"] for row in annual_page["results"]] == ["Target annual"]
+
+
+def test_timeline_series_scope_rollup(activity_db):
+    """Series scope: parent_series_id + series subject + series-scoped runs."""
+    from comicarr.app.activity import queries
+
+    # Multi-row insert requires identical keys across parameter groups.
+    rows = [
+        _event(
+            subject_type="issue",
+            subject_id="iss-1",
+            subject_label="Child issue",
+            parent_series_id="ser-1",
+            scope_type=None,
+            scope_id=None,
+        ),
+        _event(
+            subject_type="series",
+            subject_id="ser-1",
+            subject_label="Series subject",
+            parent_series_id=None,
+            scope_type=None,
+            scope_id=None,
+        ),
+        _event(
+            subject_type="run",
+            subject_id="run-1",
+            subject_label="Scoped run",
+            parent_series_id=None,
+            scope_type="series",
+            scope_id="ser-1",
+        ),
+        _event(
+            subject_type="issue",
+            subject_id="iss-99",
+            subject_label="Other series",
+            parent_series_id="ser-2",
+            scope_type=None,
+            scope_id=None,
+        ),
+        _event(
+            subject_type="run",
+            subject_id="run-2",
+            subject_label="Other scoped run",
+            parent_series_id=None,
+            scope_type="series",
+            scope_id="ser-2",
+        ),
+    ]
+    with activity_db.begin() as conn:
+        conn.execute(insert(activity_events), rows)
+
+    page = queries.list_timeline_events(scope_type="series", scope_id="ser-1")
+    labels = {row["subject_label"] for row in page["results"]}
+    assert labels == {"Child issue", "Series subject", "Scoped run"}
+
+
+def test_timeline_rejects_incomplete_scope(activity_db):
+    from comicarr.app.activity import queries
+
+    with pytest.raises(ValueError, match="scope"):
+        queries.list_timeline_events(scope_type="series", scope_id=None)
+
+    with pytest.raises(ValueError, match="scope"):
+        queries.list_timeline_events(scope_type=None, scope_id="ser-1")
+
+    with pytest.raises(ValueError, match="scope"):
+        queries.list_timeline_events(scope_type="arc", scope_id="1")
+
+
+# ---------------------------------------------------------------------------
+# Needs-attention band
+# ---------------------------------------------------------------------------
+
+
+def test_band_uses_r9_unresolved_predicate(activity_db):
+    from comicarr.app.activity import queries
+
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(pipeline_journal),
+            [
+                _journal(release_key="open-failed", stage="failed", status=None),
+                _journal(release_key="open-review", stage="manual_review", status=None, issueid="iss-2"),
+                _journal(release_key="retried", stage="failed", status="retried", issueid="iss-3"),
+                _journal(release_key="ignored", stage="failed", status="ignored", issueid="iss-4"),
+                _journal(release_key="imported", stage="manual_review", status="imported", issueid="iss-5"),
+                _journal(
+                    release_key="still-open",
+                    stage="snatched",
+                    stage_rank=10,
+                    status=None,
+                    issueid="iss-6",
+                ),
+            ],
+        )
+
+    rows = queries.list_attention_band()
+    keys = {row["release_key"] for row in rows}
+    assert keys == {"open-failed", "open-review"}
+    # Same updated_date → stable tie-break on release_key desc
+    assert [row["release_key"] for row in rows] == ["open-review", "open-failed"]
+
+
+def test_band_issue_scope_intersects(activity_db):
+    from comicarr.app.activity import queries
+
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(pipeline_journal),
+            [
+                _journal(release_key="match", issueid="iss-1", stage="failed"),
+                _journal(release_key="other", issueid="iss-2", stage="failed"),
+            ],
+        )
+
+    rows = queries.list_attention_band(scope_type="issue", scope_id="iss-1")
+    assert [row["release_key"] for row in rows] == ["match"]
+
+
+def test_band_series_scope_via_issue_and_annual_membership(activity_db):
+    from comicarr.app.activity import queries
+
+    with activity_db.begin() as conn:
+        conn.execute(insert(issues), [{"IssueID": "iss-1", "ComicID": "ser-1", "ComicName": "Saga"}])
+        conn.execute(insert(annuals), [{"IssueID": "ann-1", "ComicID": "ser-1", "ComicName": "Saga Annual"}])
+        conn.execute(insert(issues), [{"IssueID": "iss-2", "ComicID": "ser-2", "ComicName": "Other"}])
+        conn.execute(
+            insert(pipeline_journal),
+            [
+                _journal(release_key="issue-row", issueid="iss-1", stage="failed"),
+                _journal(release_key="annual-row", issueid="ann-1", stage="manual_review"),
+                _journal(release_key="other-series", issueid="iss-2", stage="failed"),
+            ],
+        )
+
+    rows = queries.list_attention_band(scope_type="series", scope_id="ser-1")
+    assert {row["release_key"] for row in rows} == {"issue-row", "annual-row"}
+
+
+# ---------------------------------------------------------------------------
+# Open-work counts (authority rule)
+# ---------------------------------------------------------------------------
+
+
+def test_open_work_counts_from_ledgers_not_narrative(activity_db):
+    """Authority rule: never aggregate activity_events for counts."""
+    from comicarr.app.activity import queries
+
+    with activity_db.begin() as conn:
+        # Narrative noise — must not affect counts
+        conn.execute(
+            insert(activity_events),
+            [
+                _event(activity="search", status="started", subject_type="run", subject_id="r1"),
+                _event(activity="grab", status="failed", subject_type="issue", subject_id="iss-1"),
+            ],
+        )
+        conn.execute(
+            insert(acquisition_run_items),
+            [
+                {
+                    "run_id": "run-1",
+                    "command_kind": "search_issue",
+                    "entity_type": "issue",
+                    "entity_id": "iss-1",
+                    "state": "accepted",
+                    "dispatch_state": "pending",
+                    "queue_priority": "routine",
+                    "attempt_count": 0,
+                    "created_at": "2026-07-10 10:00:00",
+                    "updated_at": "2026-07-10 10:00:00",
+                },
+                {
+                    "run_id": "run-1",
+                    "command_kind": "search_issue",
+                    "entity_type": "issue",
+                    "entity_id": "iss-2",
+                    "state": "running",
+                    "dispatch_state": "accepted",
+                    "queue_priority": "routine",
+                    "attempt_count": 1,
+                    "created_at": "2026-07-10 10:00:00",
+                    "updated_at": "2026-07-10 10:01:00",
+                },
+                {
+                    "run_id": "run-1",
+                    "command_kind": "search_issue",
+                    "entity_type": "issue",
+                    "entity_id": "iss-3",
+                    "state": "succeeded",
+                    "dispatch_state": "accepted",
+                    "queue_priority": "routine",
+                    "attempt_count": 1,
+                    "created_at": "2026-07-10 10:00:00",
+                    "updated_at": "2026-07-10 10:02:00",
+                    "completed_at": "2026-07-10 10:02:00",
+                },
+            ],
+        )
+        conn.execute(
+            insert(pipeline_journal),
+            [
+                _journal(
+                    release_key="open-pp",
+                    stage="post_processing",
+                    stage_rank=30,
+                    status=None,
+                    issueid="iss-10",
+                ),
+                _journal(
+                    release_key="done",
+                    stage="post_processed",
+                    stage_rank=50,
+                    status=None,
+                    issueid="iss-11",
+                ),
+                _journal(release_key="need-attn", stage="failed", status=None, issueid="iss-12"),
+                _journal(
+                    release_key="resolved",
+                    stage="failed",
+                    status="ignored",
+                    issueid="iss-13",
+                ),
+            ],
+        )
+
+    counts = queries.get_open_work_counts()
+    # 2 in-flight run items + 1 open journal stage
+    assert counts["in_flight"] == 3
+    assert counts["attention"] == 1
+    assert "activity_events" not in counts
+
+
+def test_open_work_idle_when_ledgers_empty(activity_db):
+    from comicarr.app.activity import queries
+
+    counts = queries.get_open_work_counts()
+    assert counts == {"in_flight": 0, "attention": 0}
+
+
+# ---------------------------------------------------------------------------
+# Service / router surface
+# ---------------------------------------------------------------------------
+
+
+def test_service_timeline_and_status_shapes(activity_db):
+    from comicarr.app.activity import service
+
+    with activity_db.begin() as conn:
+        conn.execute(insert(activity_events), [_event()])
+        conn.execute(
+            insert(pipeline_journal),
+            [_journal(release_key="band-1", stage="failed", status=None)],
+        )
+
+    timeline = service.get_timeline(limit=10, offset=0)
+    assert "results" in timeline
+    assert timeline["total"] == 1
+    assert timeline["results"][0]["event_id"] is not None
+
+    band = service.get_attention_band()
+    assert len(band["results"]) == 1
+    assert band["results"][0]["release_key"] == "band-1"
+
+    status = service.get_status()
+    assert status["in_flight"] == 0
+    assert status["attention"] == 1
+
+
+def test_router_registers_session_protected_routes():
+    """Auth class matches other operator APIs (require_session dependency)."""
+    from comicarr.app.activity.router import router
+    from comicarr.app.core.security import require_session
+
+    paths = {route.path for route in router.routes}
+    assert "/api/activity/timeline" in paths
+    assert "/api/activity/band" in paths
+    assert "/api/activity/status" in paths
+
+    for route in router.routes:
+        deps = getattr(route, "dependencies", None) or []
+        callables = {getattr(d, "dependency", None) for d in deps}
+        assert require_session in callables, "route %s missing require_session" % route.path

--- a/tests/unit/test_schema_migrations.py
+++ b/tests/unit/test_schema_migrations.py
@@ -347,7 +347,7 @@ def test_head_includes_ledger_retention_indexes(tmp_path):
     """#478: four retention indexes land at head; pipeline_journal_stage stays."""
 
     engine = create_engine("sqlite:///%s" % (tmp_path / "retention-indexes.db"))
-    assert upgrade_database(engine) == "0004_ledger_retention_indexes"
+    assert upgrade_database(engine) == "0005_activity_events"
 
     inspector = inspect(engine)
     expected = {
@@ -382,7 +382,7 @@ def test_upgrade_from_library_chat_creates_missing_retention_indexes(tmp_path):
         for index_name in retention_indexes:
             conn.execute(text("DROP INDEX IF EXISTS %s" % index_name))
 
-    assert upgrade_database(engine) == "0004_ledger_retention_indexes"
+    assert upgrade_database(engine) == "0005_activity_events"
     inspector = inspect(engine)
     for table_name, index_name in (
         ("acquisition_run_items", "acquisition_run_items_state_completed"),


### PR DESCRIPTION
## Summary

Query-backed Activity Center read APIs for the narrative timeline, needs-attention band, and derived open-work counts (#485).

- `GET /api/activity/timeline` — pages events (not stories); optional issue/annual/series scope with series rollup
- `GET /api/activity/band` — R9 unresolved journal rows; scoped intersection
- `GET /api/activity/status` — in-flight + attention from ledgers only (never aggregates `activity_events`)

## Test plan

- [x] `uv run pytest tests/unit/test_activity_read_apis.py -v`
- [x] `uv run ruff check comicarr/app/activity/`
- [ ] Smoke authenticated GETs against a local instance once producers fill data

Closes #485