### PR TITLE
feat: Add Settings About Updates group and Check now

### DIFF
--- a/.changeset/settings-about-updates.md
+++ b/.changeset/settings-about-updates.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Settings → About now has an **Updates** group: turn automatic release checks on or off, choose whether to announce releases through enabled notifiers, see why update status looks quiet (including air-gapped or rate-limited installs), and run **Check now** even when automatic checks are off.

--- a/comicarr/app/config/registry.py
+++ b/comicarr/app/config/registry.py
@@ -268,7 +268,12 @@ _KEYS: tuple[ConfigKey, ...] = (
     ConfigKey("GIT_USER", str, "Git", "frankieramirez"),
     ConfigKey("GIT_TOKEN", str, "Git", None),
     ConfigKey("GIT_BRANCH", str, "Git", None),
-    ConfigKey("CHECK_GITHUB", bool, "Git", True),
+    # Operator-facing: Settings → About → Updates "Check for updates".
+    # Controls automatic checks only; force-check ignores this switch.
+    ConfigKey("CHECK_GITHUB", bool, "Git", True, readable=True, writable=True),
+    # Operator-facing: Settings → About → Updates "Announce releases to notifiers".
+    # Fan-out lives in a follow-on ticket; the key must be Settings-writable here.
+    ConfigKey("ANNOUNCE_RELEASES", bool, "Git", False, readable=True, writable=True),
     ConfigKey("ENFORCE_PERMS", bool, "Perms", False),
     ConfigKey("CHMOD_DIR", str, "Perms", "0777"),
     ConfigKey("CHMOD_FILE", str, "Perms", "0660"),

--- a/comicarr/app/system/router.py
+++ b/comicarr/app/system/router.py
@@ -278,6 +278,16 @@ def get_version(ctx: AppContext = Depends(get_context)):
     return system_service.get_version_info(ctx)
 
 
+@router.post("/system/version/check", dependencies=[Depends(require_session)])
+def check_version_now(ctx: AppContext = Depends(get_context)):
+    """Force a single release check (ignores automatic-check off).
+
+    Used by Settings → About → Updates "Check now". Off for automatic checks
+    means no unsolicited traffic, not refusal of an operator-initiated check.
+    """
+    return system_service.force_version_check(ctx)
+
+
 @router.get("/system/logs", dependencies=[Depends(require_session)])
 def get_logs(ctx: AppContext = Depends(get_context)):
     """Return recent log entries."""

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -537,6 +537,25 @@ def get_version_info(ctx):
     }
 
 
+def force_version_check(ctx):
+    """Run one release check, ignoring the automatic-check switch.
+
+    ``CHECK_GITHUB`` off means no unsolicited traffic, not "refuse when asked".
+    Auth is the caller's responsibility (router uses require_session).
+    """
+    import comicarr
+
+    # Deliberately does not consult CHECK_GITHUB — Settings "Check now" must
+    # work while automatic checks are off (Settings → About → Updates).
+    runner = comicarr.versioncheckit.CheckVersion()
+    check_result = runner.run(scheduled_job=False) or {}
+    info = get_version_info(ctx)
+    message = check_result.get("message")
+    if message:
+        info = {**info, "message": message}
+    return info
+
+
 def get_build_identity(ctx):
     """Return deploy identity without treating runtime fallbacks as verified."""
     declared_build_id = (os.environ.get("COMICARR_BUILD_ID") or "").strip() or None

--- a/frontend/src/components/settings/AboutTab.tsx
+++ b/frontend/src/components/settings/AboutTab.tsx
@@ -1,0 +1,144 @@
+import { SettingGroup } from "./SettingGroup";
+import { SettingField } from "./SettingField";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
+import { useForceVersionCheck, useVersionInfo } from "@/hooks/useVersion";
+import { formatAppVersion } from "@/lib/version";
+import { formatUpdateDiagnostic } from "@/lib/updateStatus";
+import type { Config } from "@/types";
+import type {
+  SettingsFormData,
+  WritableConfig,
+} from "../../types/config.generated";
+
+interface AboutTabProps {
+  config: Config;
+  formData: SettingsFormData;
+  onChange: <K extends keyof WritableConfig>(
+    key: K,
+    value: NonNullable<WritableConfig[K]>,
+  ) => void;
+}
+
+export function AboutTab({ config, formData, onChange }: AboutTabProps) {
+  const { addToast } = useToast();
+  const versionQuery = useVersionInfo();
+  const forceCheck = useForceVersionCheck();
+
+  const checkForUpdates = formData.check_github ?? true;
+  const announceReleases = formData.announce_releases ?? false;
+  const diagnostic = formatUpdateDiagnostic(versionQuery.data);
+
+  const handleCheckNow = async () => {
+    try {
+      const result = await forceCheck.mutateAsync();
+      const summary = formatUpdateDiagnostic(result);
+      const toastType =
+        result.update_state === "unknown"
+          ? "info"
+          : result.update_state === "behind"
+            ? "info"
+            : "success";
+      addToast({ type: toastType, message: summary });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message:
+          err instanceof Error ? err.message : "Could not check for updates",
+      });
+    }
+  };
+
+  const buildRows: Array<[string, string]> = [
+    ["version", formatAppVersion(false)],
+    ["config path", config.config_path || "/config/config.ini"],
+    ["data directory", config.data_dir || "—"],
+    ["python", config.python_version || "—"],
+  ];
+
+  return (
+    <div className="space-y-6">
+      <SettingGroup
+        title="Updates"
+        description="Automatic release checks and outbound announcements."
+      >
+        <SettingField
+          label="Check for updates"
+          type="checkbox"
+          checked={checkForUpdates}
+          onChange={(checked) => onChange("check_github", checked as boolean)}
+          helpText="When enabled, Comicarr checks for new releases automatically on a schedule. Turn off to stop automatic checks; you can still use Check now."
+        />
+        <SettingField
+          label="Announce releases to notifiers"
+          type="checkbox"
+          checked={announceReleases}
+          onChange={(checked) =>
+            onChange("announce_releases", checked as boolean)
+          }
+          helpText="When enabled, send a message through enabled notifiers when a new release is available. Uses enabled notifiers only; does not reuse snatch or grab flags."
+        />
+
+        <div
+          className="rounded-lg border px-3 py-2.5"
+          style={{
+            borderColor: "var(--border)",
+            background: "var(--card)",
+          }}
+          data-testid="update-diagnostic"
+        >
+          <div className="text-[11px] uppercase tracking-[0.05em] text-muted-foreground">
+            Status
+          </div>
+          <div className="mt-0.5 text-[13px]">{diagnostic}</div>
+        </div>
+
+        <div className="flex items-center gap-2 pt-1">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleCheckNow}
+            disabled={forceCheck.isPending}
+          >
+            {forceCheck.isPending ? "Checking…" : "Check now"}
+          </Button>
+        </div>
+      </SettingGroup>
+
+      <SettingGroup
+        title="What's new"
+        description="Release notes for this install will appear here."
+      >
+        <div
+          className="rounded-lg border px-3 py-3 text-[12.5px] text-muted-foreground"
+          style={{ borderColor: "var(--border)", background: "var(--card)" }}
+        >
+          Release history is not available in this build yet.
+        </div>
+      </SettingGroup>
+
+      <SettingGroup
+        title="Build / environment"
+        description="Install identity and paths for this instance."
+      >
+        <div
+          className="rounded-[6px] border divide-y"
+          style={{ borderColor: "var(--border)" }}
+        >
+          {buildRows.map(([k, v]) => (
+            <div
+              key={k}
+              className="grid gap-1 sm:gap-0 sm:items-center px-3.5 py-2.5 font-mono text-[11.5px] grid-cols-1 sm:[grid-template-columns:160px_1fr]"
+            >
+              <div className="text-muted-foreground tracking-[0.05em] uppercase text-[10px]">
+                {k}
+              </div>
+              <div className="truncate break-all">{v}</div>
+            </div>
+          ))}
+        </div>
+      </SettingGroup>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useVersion.ts
+++ b/frontend/src/hooks/useVersion.ts
@@ -1,0 +1,36 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { apiRequest } from "@/lib/api";
+import type { VersionInfo } from "@/lib/updateStatus";
+
+export const VERSION_QUERY_KEY = ["system", "version"] as const;
+
+export function useVersionInfo(): UseQueryResult<VersionInfo> {
+  return useQuery({
+    queryKey: VERSION_QUERY_KEY,
+    queryFn: () => apiRequest<VersionInfo>("GET", "/api/system/version"),
+    staleTime: 10 * 60 * 1000,
+    retry: 1,
+  });
+}
+
+export function useForceVersionCheck(): UseMutationResult<
+  VersionInfo,
+  Error,
+  void
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () =>
+      apiRequest<VersionInfo>("POST", "/api/system/version/check"),
+    onSuccess: (data) => {
+      queryClient.setQueryData(VERSION_QUERY_KEY, data);
+    },
+  });
+}

--- a/frontend/src/lib/updateStatus.ts
+++ b/frontend/src/lib/updateStatus.ts
@@ -1,0 +1,45 @@
+/**
+ * Operator-facing copy for update diagnostics (Settings → About → Updates).
+ * Codes match GET /api/system/version update_reason when update_state is unknown.
+ */
+
+export type UpdateState = "behind" | "current" | "unknown" | string;
+export type UpdateReason =
+  "never_checked" | "unreachable" | "rate_limited" | string | null | undefined;
+
+const UNKNOWN_REASON_COPY: Record<string, string> = {
+  never_checked: "Not checked yet",
+  unreachable: "Could not reach the release source",
+  rate_limited: "Rate limited — will retry on the normal schedule",
+};
+
+export function formatUnknownUpdateReason(reason: UpdateReason): string {
+  if (!reason) return UNKNOWN_REASON_COPY.never_checked;
+  return UNKNOWN_REASON_COPY[reason] ?? "Update status is unavailable";
+}
+
+export interface VersionInfo {
+  current_version?: string | null;
+  latest_version?: string | null;
+  release_version?: string | null;
+  update_state?: UpdateState | null;
+  update_reason?: UpdateReason;
+  install_type?: string | null;
+  message?: string | null;
+}
+
+/** One-line diagnostic for the Updates group (not a second badge). */
+export function formatUpdateDiagnostic(info: VersionInfo | undefined): string {
+  if (!info) return "Loading update status…";
+
+  const state = info.update_state ?? "unknown";
+  if (state === "behind") {
+    const current = info.release_version || "—";
+    const latest = info.latest_version || "—";
+    return `Update available: ${current} → ${latest}`;
+  }
+  if (state === "current") {
+    return "Up to date";
+  }
+  return formatUnknownUpdateReason(info.update_reason);
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { AiTab } from "@/components/settings/AiTab";
 import { NotificationsTab } from "@/components/settings/NotificationsTab";
 import { MediaManagementTab } from "@/components/settings/MediaManagementTab";
 import { AcquisitionHealthTab } from "@/components/settings/AcquisitionHealthTab";
+import { AboutTab } from "@/components/settings/AboutTab";
 import { SaveButton } from "@/components/settings/SaveButton";
 import PageHeader from "@/components/layout/PageHeader";
 import { prepareConfigSaveData } from "@/lib/configSave";
@@ -173,8 +174,17 @@ export default function SettingsPage() {
   // config.version which used to surface git SHAs or stale install metadata.
   const version = `comicarr ${formatAppVersion()}`;
 
-  const configData: ReadableConfig = config ?? {};
-  const tabProps = { config: configData, formData, onChange: handleChange };
+  const configData: Config = config ?? {};
+  const tabProps = {
+    config: configData as ReadableConfig,
+    formData,
+    onChange: handleChange,
+  };
+  const aboutProps = {
+    config: configData,
+    formData,
+    onChange: handleChange,
+  };
   const apiTabProps = {
     ...tabProps,
     regeneratedApiKey,
@@ -255,7 +265,7 @@ export default function SettingsPage() {
               <DownloadClientsTab config={configData} />
             )}
             {section === "ai" && <AiTab {...tabProps} />}
-            {section === "about" && <AboutSection config={config ?? {}} />}
+            {section === "about" && <AboutTab {...aboutProps} />}
           </div>
         </div>
       </div>
@@ -267,41 +277,5 @@ export default function SettingsPage() {
         isSaving={updateConfigMutation.isPending}
       />
     </div>
-  );
-}
-
-function AboutSection({ config }: { config: Config }) {
-  const rows: Array<[string, string]> = [
-    ["version", formatAppVersion(false)],
-    ["config path", config.config_path || "/config/config.ini"],
-    ["data directory", config.data_dir || "—"],
-    ["python", config.python_version || "—"],
-  ];
-
-  return (
-    <section>
-      <div className="mb-4">
-        <div className="text-[13px] font-semibold tracking-tight">About</div>
-        <div className="text-[12px] text-muted-foreground mt-0.5">
-          Build and environment info.
-        </div>
-      </div>
-      <div
-        className="rounded-[6px] border divide-y"
-        style={{ borderColor: "var(--border)" }}
-      >
-        {rows.map(([k, v]) => (
-          <div
-            key={k}
-            className="grid gap-1 sm:gap-0 sm:items-center px-3.5 py-2.5 font-mono text-[11.5px] grid-cols-1 sm:[grid-template-columns:160px_1fr]"
-          >
-            <div className="text-muted-foreground tracking-[0.05em] uppercase text-[10px]">
-              {k}
-            </div>
-            <div className="truncate break-all">{v}</div>
-          </div>
-        ))}
-      </div>
-    </section>
   );
 }

--- a/frontend/src/types/config.generated.ts
+++ b/frontend/src/types/config.generated.ts
@@ -46,6 +46,8 @@ export interface ReadableConfig {
   mal_enabled?: boolean;
   log_dir?: string;
   log_level?: number;
+  check_github?: boolean;
+  announce_releases?: boolean;
   comic_dir?: string;
   manga_dir?: string;
   manga_destination_dir?: string;
@@ -165,6 +167,8 @@ export interface WritableConfig {
   mal_enabled?: boolean;
   mal_client_id?: string;
   log_level?: number;
+  check_github?: boolean;
+  announce_releases?: boolean;
   comic_dir?: string;
   imp_move?: boolean;
   imp_rename?: boolean;

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -374,6 +374,17 @@ export const handlers = [
     });
   }),
 
+  http.post("/api/system/version/check", () => {
+    return HttpResponse.json({
+      current_version: "1.0.0",
+      latest_version: "1.0.0",
+      release_version: "1.0.0",
+      update_state: "current",
+      update_reason: null,
+      message: "You are on the latest release",
+    });
+  }),
+
   http.get("/api/system/diagnostics", () => {
     return HttpResponse.json({
       db_empty: false,

--- a/frontend/tests/pages/SettingsPage.test.ts
+++ b/frontend/tests/pages/SettingsPage.test.ts
@@ -54,7 +54,6 @@ describe("prepareConfigSaveData", () => {
       discord_webhook_url: "https://discord.com/api/webhooks/new",
     });
   });
-
 });
 
 describe("SettingsPage", () => {
@@ -112,5 +111,82 @@ describe("SettingsPage", () => {
     await user.click(screen.getAllByRole("button", { name: "About" })[0]);
     expect(await screen.findByText(formatAppVersion(false))).toBeTruthy();
     expect(screen.queryByText("0.19.13")).toBeNull();
+  });
+
+  it("shows the Updates group with toggles, diagnostics, and Check now", async () => {
+    server.use(
+      http.get("/api/config", () =>
+        HttpResponse.json({
+          check_github: true,
+          announce_releases: false,
+          config_path: "/config/config.ini",
+          data_dir: "/data",
+          python_version: "3.12.0",
+        }),
+      ),
+      http.get("/api/system/version", () =>
+        HttpResponse.json({
+          release_version: "0.21.0",
+          latest_version: "0.22.0",
+          update_state: "behind",
+          update_reason: null,
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+
+    render(createElement(SettingsPage));
+    expect(await screen.findByText("Settings")).toBeTruthy();
+    await user.click(screen.getAllByRole("button", { name: "About" })[0]);
+
+    expect(await screen.findByText("Updates")).toBeTruthy();
+    expect(screen.getByText("Check for updates")).toBeTruthy();
+    expect(screen.getByText("Announce releases to notifiers")).toBeTruthy();
+    expect(
+      await screen.findByText("Update available: 0.21.0 → 0.22.0"),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Check now" })).toBeTruthy();
+    // Order: Updates before What's new before build rows.
+    const updates = screen.getByText("Updates");
+    const whatsNew = screen.getByText("What's new");
+    const build = screen.getByText("Build / environment");
+    expect(
+      updates.compareDocumentPosition(whatsNew) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      whatsNew.compareDocumentPosition(build) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // AUTO_UPDATE must not appear.
+    expect(screen.queryByText(/auto.?update/i)).toBeNull();
+    // No GitHub/git wording in the operator-facing labels/help in this group.
+    expect(screen.queryByText(/GitHub/i)).toBeNull();
+  });
+
+  it("shows unknown update reason in operator language", async () => {
+    server.use(
+      http.get("/api/config", () =>
+        HttpResponse.json({
+          check_github: false,
+          announce_releases: false,
+        }),
+      ),
+      http.get("/api/system/version", () =>
+        HttpResponse.json({
+          update_state: "unknown",
+          update_reason: "unreachable",
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+
+    render(createElement(SettingsPage));
+    expect(await screen.findByText("Settings")).toBeTruthy();
+    await user.click(screen.getAllByRole("button", { name: "About" })[0]);
+
+    expect(
+      await screen.findByText("Could not reach the release source"),
+    ).toBeTruthy();
   });
 });

--- a/frontend/tests/unit/lib/version.test.ts
+++ b/frontend/tests/unit/lib/version.test.ts
@@ -13,8 +13,9 @@ const repoRoot = resolve(frontendRoot, "..");
 /** Every user-facing surface that shows the app release version. */
 const VERSION_DISPLAY_CONSUMERS = [
   "src/components/layout/AppSidebar.tsx",
-  "src/pages/LoginPage.tsx",
   "src/components/onboarding/OnboardingDialog.tsx",
+  "src/components/settings/AboutTab.tsx",
+  "src/pages/LoginPage.tsx",
   "src/pages/SettingsPage.tsx",
 ] as const;
 

--- a/frontend/tests/unit/updateStatus.test.ts
+++ b/frontend/tests/unit/updateStatus.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatUnknownUpdateReason,
+  formatUpdateDiagnostic,
+} from "@/lib/updateStatus";
+
+describe("formatUnknownUpdateReason", () => {
+  it("maps never_checked to operator language", () => {
+    expect(formatUnknownUpdateReason("never_checked")).toBe("Not checked yet");
+  });
+
+  it("maps unreachable to operator language", () => {
+    expect(formatUnknownUpdateReason("unreachable")).toBe(
+      "Could not reach the release source",
+    );
+  });
+
+  it("maps rate_limited to operator language", () => {
+    expect(formatUnknownUpdateReason("rate_limited")).toBe(
+      "Rate limited — will retry on the normal schedule",
+    );
+  });
+
+  it("defaults missing reason to not checked yet", () => {
+    expect(formatUnknownUpdateReason(null)).toBe("Not checked yet");
+    expect(formatUnknownUpdateReason(undefined)).toBe("Not checked yet");
+  });
+});
+
+describe("formatUpdateDiagnostic", () => {
+  it("shows current → latest when behind", () => {
+    expect(
+      formatUpdateDiagnostic({
+        update_state: "behind",
+        release_version: "0.21.0",
+        latest_version: "0.22.0",
+      }),
+    ).toBe("Update available: 0.21.0 → 0.22.0");
+  });
+
+  it("shows up to date when current", () => {
+    expect(
+      formatUpdateDiagnostic({
+        update_state: "current",
+        release_version: "0.22.0",
+        latest_version: "0.22.0",
+      }),
+    ).toBe("Up to date");
+  });
+
+  it("shows unknown reason in operator language", () => {
+    expect(
+      formatUpdateDiagnostic({
+        update_state: "unknown",
+        update_reason: "rate_limited",
+      }),
+    ).toBe("Rate limited — will retry on the normal schedule");
+  });
+});

--- a/tests/unit/test_settings_updates_controls.py
+++ b/tests/unit/test_settings_updates_controls.py
@@ -1,0 +1,165 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Settings → About → Updates: registry exposure and force-check (#471)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import comicarr
+from comicarr.app.config.registry import REGISTRY, readable_keys, writable_keys
+from comicarr.app.core.context import AppContext
+from comicarr.app.system import service as system_service
+
+
+def test_check_github_is_readable_and_writable():
+    key = REGISTRY["CHECK_GITHUB"]
+    assert key.default is True
+    assert key.readable is True
+    assert key.writable is True
+    assert "CHECK_GITHUB" in readable_keys()
+    assert "CHECK_GITHUB" in writable_keys()
+
+
+def test_announce_releases_defaults_off_and_is_settings_exposed():
+    key = REGISTRY["ANNOUNCE_RELEASES"]
+    assert key.default is False
+    assert key.readable is True
+    assert key.writable is True
+    assert "ANNOUNCE_RELEASES" in readable_keys()
+    assert "ANNOUNCE_RELEASES" in writable_keys()
+
+
+def test_check_github_interval_stays_config_ini_only():
+    key = REGISTRY["CHECK_GITHUB_INTERVAL"]
+    assert key.readable is False
+    assert key.writable is False
+    assert "CHECK_GITHUB_INTERVAL" not in readable_keys()
+    assert "CHECK_GITHUB_INTERVAL" not in writable_keys()
+
+
+def test_auto_update_absent_from_registry():
+    assert "AUTO_UPDATE" not in REGISTRY
+
+
+def test_get_safe_config_exposes_update_policy_keys():
+    """Both toggles are readable over GET /api/config (Settings form)."""
+    config = MagicMock()
+    config.CHECK_GITHUB = False
+    config.ANNOUNCE_RELEASES = True
+    # get_safe_config walks every readable key; default MagicMock attrs are truthy
+    # and would pollute the result — only the two under test matter here.
+    ctx = AppContext(
+        prog_dir="/tmp/comicarr_test",
+        data_dir="/tmp/comicarr_test/data",
+        db_file=":memory:",
+        config=config,
+    )
+    with patch.object(system_service, "get_release_version", return_value="0.21.0"):
+        # Real get_safe_config iterates _READABLE_KEYS from the live registry.
+        result = system_service.get_safe_config(ctx)
+
+    assert result.get("check_github") is False
+    assert result.get("announce_releases") is True
+
+
+@pytest.fixture
+def ctx(monkeypatch):
+    config = MagicMock(
+        CHECK_GITHUB=False,
+        ANNOUNCE_RELEASES=False,
+        GIT_TOKEN=None,
+    )
+    context = AppContext(
+        prog_dir="/tmp/comicarr_test",
+        data_dir="/tmp/comicarr_test/data",
+        db_file=":memory:",
+        config=config,
+        scheduler=MagicMock(),
+        current_version="aaaaaaa",
+        latest_version=None,
+        update_state="unknown",
+        update_reason="never_checked",
+    )
+    monkeypatch.setattr(comicarr, "CONFIG", config, raising=False)
+    monkeypatch.setattr(comicarr, "INSTALL_TYPE", "docker", raising=False)
+    monkeypatch.setattr(comicarr, "CURRENT_VERSION", "aaaaaaa", raising=False)
+    with (
+        patch("comicarr.app.core.runtime.get_runtime_if_initialized", return_value=context),
+        patch.object(system_service, "get_release_version", return_value="0.21.0"),
+    ):
+        yield context
+
+
+class TestForceVersionCheck:
+    def test_runs_even_when_automatic_check_is_off(self, ctx):
+        """Off means no unsolicited traffic — not refuse when the operator asks."""
+        assert ctx.config.CHECK_GITHUB is False
+
+        check_payload = {
+            "status": "success",
+            "update_state": "behind",
+            "update_reason": None,
+            "latest_version": "0.22.0",
+            "release_version": "0.21.0",
+            "current_version": "aaaaaaa",
+            "install_type": "docker",
+            "message": "A new release is available",
+        }
+
+        mock_runner = MagicMock()
+        mock_runner.run.return_value = check_payload
+        mock_cls = MagicMock(return_value=mock_runner)
+
+        with patch.object(comicarr.versioncheckit, "CheckVersion", mock_cls):
+            # Simulate what CheckVersion.run does: persist state via the seam.
+            def _run(scheduled_job=True):
+                from comicarr import versioncheck
+
+                versioncheck._set_version_state(
+                    update_state="behind",
+                    update_reason=None,
+                    latest_version="0.22.0",
+                )
+                return check_payload
+
+            mock_runner.run.side_effect = _run
+            result = system_service.force_version_check(ctx)
+
+        mock_runner.run.assert_called_once_with(scheduled_job=False)
+        assert result["update_state"] == "behind"
+        assert result["latest_version"] == "0.22.0"
+        assert result["release_version"] == "0.21.0"
+        assert result["update_reason"] is None
+
+    def test_returns_unknown_reason_after_unreachable_check(self, ctx):
+        mock_runner = MagicMock()
+        mock_cls = MagicMock(return_value=mock_runner)
+
+        with patch.object(comicarr.versioncheckit, "CheckVersion", mock_cls):
+
+            def _run(scheduled_job=True):
+                from comicarr import versioncheck
+
+                versioncheck._set_version_state(
+                    update_state="unknown",
+                    update_reason="unreachable",
+                )
+                return {
+                    "status": "failure",
+                    "update_state": "unknown",
+                    "update_reason": "unreachable",
+                }
+
+            mock_runner.run.side_effect = _run
+            result = system_service.force_version_check(ctx)
+
+        assert result["update_state"] == "unknown"
+        assert result["update_reason"] == "unreachable"


### PR DESCRIPTION
## Summary

Settings → About gains an **Updates** group so operators can control automatic release checks, opt into notifier announcements, see update diagnostics (including why the chip looks quiet), and force a one-shot **Check now**.

Closes #471

## Changes
- Expose `check_github` (default on) and `announce_releases` (default off) as registry-backed Settings toggles
- Add authenticated `POST /api/system/version/check` that ignores the automatic-check off switch
- Rebuild About as Updates → What's new (stub) → Build / environment, with operator-facing unknown-reason copy

## Test plan
- [ ] Open Settings → About and confirm order: Updates, What's new, Build / environment
- [ ] Toggle **Check for updates** and **Announce releases to notifiers**, save, reload — values persist
- [ ] With checks off, click **Check now** and confirm a single check still runs
- [ ] Force unreachable / rate-limited state and confirm Status shows operator language (not raw codes)
- [ ] Confirm `AUTO_UPDATE` is absent and labels do not say GitHub/git
- [ ] `uv run pytest tests/unit/test_settings_updates_controls.py -v`
- [ ] `cd frontend && npm run test:run -- tests/pages/SettingsPage.test.ts tests/unit/updateStatus.test.ts`