### PR TITLE
feat: Add 90-day activity_events retention job

### DIFF
--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -1076,6 +1076,19 @@ def start(ctx):
             )
             IMPORTINBOX_SCHEDULER.pause()
 
+            # Narrative activity_events age retention (ADR §10 / #489). Always
+            # on: age-only purge, no config key, independent of acquisition gate.
+            from comicarr.app.activity import retention as activity_retention
+
+            _add_recurring_job(
+                func=activity_retention.run,
+                # id must be a string constant (scheduler config AST test).
+                id="activity_retention",
+                name=activity_retention.JOB_NAME,
+                next_run_time=datetime.datetime.utcnow(),
+                trigger=IntervalTrigger(hours=24, minutes=0, timezone="UTC"),
+            )
+
             # A schema failure, persistent repair fence, or explicit operator
             # override suppresses every producer/consumer that can claim or
             # hand off acquisition work. The scheduler itself still starts so

--- a/comicarr/app/activity/__init__.py
+++ b/comicarr/app/activity/__init__.py
@@ -1,0 +1,10 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Activity Center domain — narrative events, retention, later read/write seams."""

--- a/comicarr/app/activity/retention.py
+++ b/comicarr/app/activity/retention.py
@@ -1,0 +1,68 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Daily age-based purge of narrative activity_events (#489 / ADR §10).
+
+Age only: DELETE WHERE created_at < now - 90 days.
+No count ceiling, no severity tier, no config key, no narrative of the sweep.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy import delete
+
+from comicarr import logger
+from comicarr.app.common.dates import normalize_utc_datetime
+from comicarr.db import get_engine
+from comicarr.tables import activity_events
+
+RETENTION_DAYS = 90
+JOB_ID = "activity_retention"
+JOB_NAME = "Activity Event Retention"
+
+
+def _cutoff_iso(now: datetime.datetime | None = None) -> str:
+    """Return the exclusive ISO cutoff matching how created_at is written (UTC isoformat)."""
+    if now is None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+    else:
+        now = normalize_utc_datetime(now)
+    return (now - datetime.timedelta(days=RETENTION_DAYS)).isoformat()
+
+
+def purge_expired_activity_events(now: datetime.datetime | None = None, engine=None) -> int:
+    """Delete activity_events older than RETENTION_DAYS.
+
+    ``created_at`` is stored as a UTC ISO-8601 string (same shape as other modern
+    ledgers). Lexicographic comparison is timezone-safe for that format.
+
+    Returns the number of deleted rows.
+    """
+    engine = engine or get_engine()
+    cutoff = _cutoff_iso(now)
+    stmt = delete(activity_events).where(activity_events.c.created_at < cutoff)
+    with engine.begin() as conn:
+        result = conn.execute(stmt)
+        return int(result.rowcount or 0)
+
+
+def run() -> int:
+    """APScheduler entry point for the daily retention job."""
+    try:
+        deleted = purge_expired_activity_events()
+    except Exception as e:
+        logger.error("[ACTIVITY-RETENTION] Purge failed: %s" % e)
+        raise
+    if deleted:
+        logger.info("[ACTIVITY-RETENTION] Deleted %s activity_events older than %s days" % (deleted, RETENTION_DAYS))
+    else:
+        logger.fdebug("[ACTIVITY-RETENTION] No activity_events older than %s days" % RETENTION_DAYS)
+    return deleted

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -67,6 +67,7 @@ SCHEDULER_JOB_NAMES = {
     "monitor": "Folder Monitor",
     "importinbox": "Import Inbox Scanner",
     "ddl_health": "DDL Health Check",
+    "activity_retention": "Activity Event Retention",
 }
 
 SETUP_PERSISTENCE_ERROR = "Failed to persist initial credentials"

--- a/comicarr/tables.py
+++ b/comicarr/tables.py
@@ -722,7 +722,8 @@ ai_chat_attachments = Table(
 # Append-only Activity Center narrative rows (Activity Center ADR).
 # Derived live state stays on acquisition_runs / acquisition_run_items /
 # pipeline_journal; this table only stores timestamped history the ledgers
-# cannot express. Writers, APIs, and retention land in later issues.
+# cannot express. Retention: comicarr.app.activity.retention (90-day age purge).
+# Writers and APIs land in later issues.
 activity_events = Table(
     "activity_events",
     metadata,

--- a/tests/unit/test_activity_retention.py
+++ b/tests/unit/test_activity_retention.py
@@ -1,0 +1,100 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Activity narrative table 90-day retention (#489)."""
+
+import datetime
+
+import pytest
+from sqlalchemy import insert, select
+
+import comicarr
+from comicarr.app.activity.retention import (
+    JOB_ID,
+    JOB_NAME,
+    RETENTION_DAYS,
+    purge_expired_activity_events,
+)
+from comicarr.app.system import service as system_service
+from comicarr.db import get_engine, shutdown_engine
+from comicarr.tables import activity_events, metadata
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", None, raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    shutdown_engine()
+    metadata.create_all(get_engine())
+    yield
+    shutdown_engine()
+
+
+def _iso(days_ago, *, now):
+    return (now - datetime.timedelta(days=days_ago)).isoformat()
+
+
+def _insert_event(created_at, *, subject_id="sub-1"):
+    engine = get_engine()
+    with engine.begin() as conn:
+        conn.execute(
+            insert(activity_events).values(
+                created_at=created_at,
+                activity="search",
+                status="succeeded",
+                subject_type="series",
+                subject_id=subject_id,
+                subject_label="Test Series",
+            )
+        )
+
+
+def _remaining_subject_ids():
+    with get_engine().connect() as conn:
+        rows = conn.execute(select(activity_events.c.subject_id)).all()
+    return {row.subject_id for row in rows}
+
+
+def test_purge_deletes_rows_older_than_retention_window():
+    now = datetime.datetime(2026, 8, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    _insert_event(_iso(91, now=now), subject_id="old-91")
+    _insert_event(_iso(100, now=now), subject_id="old-100")
+    _insert_event(_iso(1, now=now), subject_id="recent-1")
+
+    deleted = purge_expired_activity_events(now=now)
+
+    assert deleted == 2
+    assert _remaining_subject_ids() == {"recent-1"}
+
+
+def test_purge_keeps_recent_and_exact_cutoff_rows():
+    """Age predicate is strict less-than: created_at == cutoff is kept."""
+    now = datetime.datetime(2026, 8, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    cutoff = (now - datetime.timedelta(days=RETENTION_DAYS)).isoformat()
+    _insert_event(cutoff, subject_id="exactly-90")
+    _insert_event(_iso(89, now=now), subject_id="recent-89")
+    _insert_event(_iso(0, now=now), subject_id="today")
+    _insert_event(_iso(91, now=now), subject_id="old-91")
+
+    deleted = purge_expired_activity_events(now=now)
+
+    assert deleted == 1
+    assert _remaining_subject_ids() == {"exactly-90", "recent-89", "today"}
+
+
+def test_purge_does_not_touch_empty_table():
+    deleted = purge_expired_activity_events(now=datetime.datetime(2026, 8, 1, tzinfo=datetime.timezone.utc))
+    assert deleted == 0
+    assert _remaining_subject_ids() == set()
+
+
+def test_scheduler_job_name_matches_retention_module():
+    assert JOB_ID == "activity_retention"
+    assert system_service.SCHEDULER_JOB_NAMES[JOB_ID] == JOB_NAME

--- a/tests/unit/test_scheduler_configuration.py
+++ b/tests/unit/test_scheduler_configuration.py
@@ -36,6 +36,7 @@ _RECURRING_JOB_IDS = {
     "monitor",
     "importinbox",
     "ddl_health",
+    "activity_retention",
 }
 
 


### PR DESCRIPTION
## Summary

Daily scheduler job that deletes `activity_events` older than 90 days (Activity Center ADR §10 / #489). Age-only purge, no config key, no other ledgers, no changeset.

- New `comicarr/app/activity/retention.py` with `purge_expired_activity_events()` and APScheduler `run()` entrypoint
- 9th recurring job (`activity_retention` / Activity Event Retention) + `SCHEDULER_JOB_NAMES` entry
- Unit tests for age predicate and keep-recent rows

## Test plan

- [x] `uv run pytest tests/unit/test_activity_retention.py tests/unit/test_scheduler_configuration.py -v`
- [x] Full unit suite (pre-existing schema head-revision failures on main unrelated)
- [x] `uv run ruff format --check` / modern ruff clean on touched paths

Closes #489