### PR TITLE
feat: Outbound release announcements via existing notifiers

### DIFF
--- a/.changeset/outbound-release-announcements.md
+++ b/.changeset/outbound-release-announcements.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+When release announcements are enabled (`announce_releases = True` under `[Git]` in `config.ini`; default off), Comicarr sends **one** outbound message through every enabled notifier after a check finds the install behind — body is `{current} → {latest}` plus the GitHub release URL. The same remote version is not re-announced every check interval. Snatch/grab notifier flags are not reused.

--- a/comicarr/app/config/registry.py
+++ b/comicarr/app/config/registry.py
@@ -269,6 +269,11 @@ _KEYS: tuple[ConfigKey, ...] = (
     ConfigKey("GIT_TOKEN", str, "Git", None),
     ConfigKey("GIT_BRANCH", str, "Git", None),
     ConfigKey("CHECK_GITHUB", bool, "Git", True),
+    # Outbound release announcements (#475 / #453). Global gate × *_ENABLED only.
+    # Settings About → Updates (#471) exposes ANNOUNCE_RELEASES; LAST_ANNOUNCED_VERSION
+    # is install-wide dedup storage and stays out of the Settings API.
+    ConfigKey("ANNOUNCE_RELEASES", bool, "Git", False, readable=True, writable=True),
+    ConfigKey("LAST_ANNOUNCED_VERSION", str, "Git", None),
     ConfigKey("ENFORCE_PERMS", bool, "Perms", False),
     ConfigKey("CHMOD_DIR", str, "Perms", "0777"),
     ConfigKey("CHMOD_FILE", str, "Perms", "0660"),

--- a/comicarr/versioncheck.py
+++ b/comicarr/versioncheck.py
@@ -59,6 +59,7 @@ _GITHUB_REQUEST_TIMEOUT = (10, 10)
 
 # Constant owner/repo — update checks never read GIT_USER (issue #470 / #456).
 _GITHUB_RELEASES_LATEST = "https://api.github.com/repos/frankieramirez/comicarr/releases/latest"
+_GITHUB_RELEASE_TAG_URL = "https://github.com/frankieramirez/comicarr/releases/tag/v%s"
 
 UPDATE_STATE_BEHIND = "behind"
 UPDATE_STATE_CURRENT = "current"
@@ -67,6 +68,8 @@ UPDATE_STATE_UNKNOWN = "unknown"
 REASON_NEVER_CHECKED = "never_checked"
 REASON_UNREACHABLE = "unreachable"
 REASON_RATE_LIMITED = "rate_limited"
+
+RELEASE_ANNOUNCE_EVENT = "Update available"
 
 
 def _set_version_state(**fields):
@@ -464,6 +467,143 @@ def _classify_release_state(local_version, remote_version):
     return UPDATE_STATE_CURRENT
 
 
+def release_announce_message(current_version, latest_version):
+    """One template for all eleven notifiers: version arrow + release URL only."""
+    body = "%s → %s\n%s" % (
+        current_version,
+        latest_version,
+        _GITHUB_RELEASE_TAG_URL % latest_version,
+    )
+    return RELEASE_ANNOUNCE_EVENT, body
+
+
+def should_announce_release(announce_on, update_state, latest_version, last_announced_version):
+    """Whether this check should fan out a release announcement.
+
+    Contract (#453): global announce toggle × behind × dedup by remote latest.
+    Empty ``last_announced_version`` always qualifies when behind and opted in.
+    """
+    if not announce_on:
+        return False
+    if update_state != UPDATE_STATE_BEHIND:
+        return False
+    if not latest_version:
+        return False
+    last = (last_announced_version or "").strip()
+    if last and last == str(latest_version).strip():
+        return False
+    return True
+
+
+def _record_announced_version(latest_version):
+    """Persist dedup key after fan-out attempt so flaky notifiers cannot re-spam."""
+    try:
+        comicarr.CONFIG.LAST_ANNOUNCED_VERSION = latest_version
+        comicarr.CONFIG.writeconfig(values={"last_announced_version": latest_version})
+    except Exception as e:
+        logger.warn("[RELEASE_ANNOUNCE] Could not persist LAST_ANNOUNCED_VERSION=%s: %s" % (latest_version, e))
+
+
+def _fan_out_release_announce(event, body, current_version, latest_version):
+    """Send the release template through every ENABLED notifier (no snatch flags)."""
+    from comicarr import notifiers
+
+    module = "[RELEASE_ANNOUNCE]"
+    # Mattermost's non-test path requires metadata for its embed; content is in body.
+    mattermost_meta = {
+        "series": "Comicarr",
+        "issue": str(latest_version),
+        "year": str(current_version) if current_version is not None else "",
+    }
+
+    def _try(label, send):
+        try:
+            send()
+        except Exception as e:
+            logger.warn("%s %s notify failed: %s" % (module, label, e))
+
+    if comicarr.CONFIG.PROWL_ENABLED:
+        logger.info("%s Sending Prowl notification" % module)
+        _try("Prowl", lambda: notifiers.PROWL().notify(body, event, module=module))
+
+    if comicarr.CONFIG.PUSHOVER_ENABLED:
+        logger.info("%s Sending Pushover notification" % module)
+        _try("Pushover", lambda: notifiers.PUSHOVER().notify(event, message=body, module=module))
+
+    if comicarr.CONFIG.BOXCAR_ENABLED:
+        logger.info("%s Sending Boxcar notification" % module)
+        _try("Boxcar", lambda: notifiers.BOXCAR().notify(prline=event, prline2=body, module=module))
+
+    if comicarr.CONFIG.PUSHBULLET_ENABLED:
+        logger.info("%s Sending Pushbullet notification" % module)
+        _try(
+            "Pushbullet",
+            lambda: notifiers.PUSHBULLET().notify(prline=event, prline2=body, module=module),
+        )
+
+    if comicarr.CONFIG.TELEGRAM_ENABLED:
+        logger.info("%s Sending Telegram notification" % module)
+        _try("Telegram", lambda: notifiers.TELEGRAM().notify("%s - %s" % (event, body)))
+
+    if comicarr.CONFIG.SLACK_ENABLED:
+        logger.info("%s Sending Slack notification" % module)
+        _try("Slack", lambda: notifiers.SLACK().notify(event, body, module=module))
+
+    if comicarr.CONFIG.MATTERMOST_ENABLED:
+        logger.info("%s Sending Mattermost notification" % module)
+        _try(
+            "Mattermost",
+            lambda: notifiers.MATTERMOST().notify(event, body, metadata=mattermost_meta, module=module),
+        )
+
+    if comicarr.CONFIG.DISCORD_ENABLED:
+        logger.info("%s Sending Discord notification" % module)
+        # payload["content"] still carries the full body; legacy embed fields
+        # may mis-parse non-issue text and are best-effort here.
+        _try("Discord", lambda: notifiers.DISCORD().notify(event, body, module=module))
+
+    if comicarr.CONFIG.EMAIL_ENABLED:
+        logger.info("%s Sending email notification" % module)
+        _try(
+            "Email",
+            lambda: notifiers.EMAIL().notify(body, "Comicarr notification - %s" % event, module=module),
+        )
+
+    if comicarr.CONFIG.GOTIFY_ENABLED:
+        logger.info("%s Sending Gotify notification" % module)
+        _try("Gotify", lambda: notifiers.GOTIFY().notify(event, body, module=module))
+
+    if comicarr.CONFIG.MATRIX_ENABLED:
+        logger.info("%s Sending Matrix notification" % module)
+        _try("Matrix", lambda: notifiers.MATRIX().notify(event, body, module=module))
+
+
+def announce_release(current_version, latest_version):
+    """Fan out one release announcement, then record the remote latest as announced.
+
+    Write timing is after the attempt (success or partial failure) so a single
+    flaky notifier cannot re-spam every check interval (#453 / #475).
+    """
+    event, body = release_announce_message(current_version, latest_version)
+    logger.info(
+        "[RELEASE_ANNOUNCE] Announcing release %s → %s to enabled notifiers" % (current_version, latest_version)
+    )
+    try:
+        _fan_out_release_announce(event, body, current_version, latest_version)
+    except Exception as e:
+        logger.warn("[RELEASE_ANNOUNCE] Fan-out raised: %s" % e)
+    _record_announced_version(latest_version)
+
+
+def maybe_announce_release(update_state, latest_version, current_version):
+    """Hook after a release check: announce when opted in, behind, and not yet told."""
+    announce_on = bool(getattr(comicarr.CONFIG, "ANNOUNCE_RELEASES", False))
+    last_announced = getattr(comicarr.CONFIG, "LAST_ANNOUNCED_VERSION", None)
+    if not should_announce_release(announce_on, update_state, latest_version, last_announced):
+        return
+    announce_release(current_version=current_version, latest_version=latest_version)
+
+
 def _apply_update_state(update_state, update_reason=None, latest_version=None, message=None):
     """Persist update state for GET /api/system/version and return the check payload."""
     fields = {"update_state": update_state, "update_reason": update_reason}
@@ -570,12 +710,19 @@ def checkGithub(current_version=None):
     logger.info("[CHECK_GITHUB] %s" % chk_message)
 
     # No GLOBAL_MESSAGES / check_update producer — badge will poll (later ticket).
-    return _apply_update_state(
+    result = _apply_update_state(
         update_state,
         update_reason=None,
         latest_version=latest_version,
         message=chk_message,
     )
+    # Outbound announce after state is computed (#475). All install types.
+    maybe_announce_release(
+        update_state=result["update_state"],
+        latest_version=result["latest_version"],
+        current_version=result["release_version"],
+    )
+    return result
 
 
 def update():

--- a/frontend/src/types/config.generated.ts
+++ b/frontend/src/types/config.generated.ts
@@ -46,6 +46,7 @@ export interface ReadableConfig {
   mal_enabled?: boolean;
   log_dir?: string;
   log_level?: number;
+  announce_releases?: boolean;
   comic_dir?: string;
   manga_dir?: string;
   manga_destination_dir?: string;
@@ -165,6 +166,7 @@ export interface WritableConfig {
   mal_enabled?: boolean;
   mal_client_id?: string;
   log_level?: number;
+  announce_releases?: boolean;
   comic_dir?: string;
   imp_move?: boolean;
   imp_rename?: boolean;

--- a/tests/unit/test_release_announce.py
+++ b/tests/unit/test_release_announce.py
@@ -1,0 +1,397 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Outbound release announcements via enabled notifiers (#475 / #453).
+
+Seams under test:
+- ``versioncheck.should_announce_release`` — gate + dedup decision
+- ``versioncheck.announce_release`` — fan-out to ENABLED notifiers and write
+  ``LAST_ANNOUNCED_VERSION`` after the attempt
+- ``versioncheck.checkGithub`` — hooks announce after behind state is computed
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import comicarr
+from comicarr import versioncheck
+from comicarr.app.config.registry import REGISTRY
+from comicarr.app.core.context import AppContext
+from comicarr.app.system import service as system_service
+
+
+def test_announce_releases_defaults_off_and_is_settings_writable():
+    assert REGISTRY["ANNOUNCE_RELEASES"].default is False
+    assert REGISTRY["ANNOUNCE_RELEASES"].readable is True
+    assert REGISTRY["ANNOUNCE_RELEASES"].writable is True
+    assert REGISTRY["ANNOUNCE_RELEASES"].section == "Git"
+
+
+def test_last_announced_version_is_install_wide_and_separate_from_settings():
+    assert REGISTRY["LAST_ANNOUNCED_VERSION"].default is None
+    assert REGISTRY["LAST_ANNOUNCED_VERSION"].readable is False
+    assert REGISTRY["LAST_ANNOUNCED_VERSION"].writable is False
+    assert REGISTRY["LAST_ANNOUNCED_VERSION"].section == "Git"
+    assert "LAST_SEEN_VERSION" not in REGISTRY
+
+
+class TestShouldAnnounceRelease:
+    def test_no_when_announce_off(self):
+        assert (
+            versioncheck.should_announce_release(
+                announce_on=False,
+                update_state="behind",
+                latest_version="0.21.0",
+                last_announced_version=None,
+            )
+            is False
+        )
+
+    def test_no_when_current(self):
+        assert (
+            versioncheck.should_announce_release(
+                announce_on=True,
+                update_state="current",
+                latest_version="0.20.0",
+                last_announced_version=None,
+            )
+            is False
+        )
+
+    def test_no_when_unknown(self):
+        assert (
+            versioncheck.should_announce_release(
+                announce_on=True,
+                update_state="unknown",
+                latest_version="0.21.0",
+                last_announced_version=None,
+            )
+            is False
+        )
+
+    def test_no_when_already_announced_same_latest(self):
+        assert (
+            versioncheck.should_announce_release(
+                announce_on=True,
+                update_state="behind",
+                latest_version="0.21.0",
+                last_announced_version="0.21.0",
+            )
+            is False
+        )
+
+    def test_yes_when_behind_announce_on_and_never_announced(self):
+        assert (
+            versioncheck.should_announce_release(
+                announce_on=True,
+                update_state="behind",
+                latest_version="0.21.0",
+                last_announced_version=None,
+            )
+            is True
+        )
+
+    def test_yes_when_latest_moved_past_last_announced(self):
+        """Multi-release jump: only the newest latest is announced once."""
+        assert (
+            versioncheck.should_announce_release(
+                announce_on=True,
+                update_state="behind",
+                latest_version="0.21.5",
+                last_announced_version="0.20.0",
+            )
+            is True
+        )
+
+    def test_no_when_latest_missing(self):
+        assert (
+            versioncheck.should_announce_release(
+                announce_on=True,
+                update_state="behind",
+                latest_version=None,
+                last_announced_version=None,
+            )
+            is False
+        )
+
+
+class TestReleaseAnnounceMessage:
+    def test_body_is_version_arrow_and_release_url_without_notes(self):
+        event, body = versioncheck.release_announce_message("0.20.0", "0.21.0")
+        assert event == "Update available"
+        assert body == ("0.20.0 → 0.21.0\nhttps://github.com/frankieramirez/comicarr/releases/tag/v0.21.0")
+        assert "changelog" not in body.lower()
+        assert "##" not in body
+
+
+@pytest.fixture
+def announce_ctx(monkeypatch):
+    config = MagicMock(
+        GIT_USER="frankieramirez",
+        GIT_BRANCH="main",
+        GIT_TOKEN=None,
+        CHECK_GITHUB=True,
+        ANNOUNCE_RELEASES=True,
+        LAST_ANNOUNCED_VERSION=None,
+        PROWL_ENABLED=False,
+        PUSHOVER_ENABLED=False,
+        BOXCAR_ENABLED=False,
+        PUSHBULLET_ENABLED=False,
+        TELEGRAM_ENABLED=False,
+        SLACK_ENABLED=False,
+        MATTERMOST_ENABLED=False,
+        DISCORD_ENABLED=False,
+        EMAIL_ENABLED=False,
+        GOTIFY_ENABLED=False,
+        MATRIX_ENABLED=False,
+    )
+    config.writeconfig = MagicMock(return_value=True)
+    context = AppContext(
+        prog_dir="/tmp/comicarr_test",
+        data_dir="/tmp/comicarr_test/data",
+        db_file=":memory:",
+        config=config,
+        scheduler=MagicMock(),
+        current_version="aaaaaaa",
+        latest_version=None,
+        update_state="unknown",
+        update_reason="never_checked",
+    )
+    monkeypatch.setattr(comicarr, "CONFIG", config, raising=False)
+    monkeypatch.setattr(comicarr, "INSTALL_TYPE", "docker", raising=False)
+    monkeypatch.setattr(comicarr, "CURRENT_VERSION", "aaaaaaa", raising=False)
+    monkeypatch.setattr(comicarr, "GLOBAL_MESSAGES", None, raising=False)
+    with (
+        patch("comicarr.app.core.runtime.get_runtime_if_initialized", return_value=context),
+        patch.object(system_service, "get_release_version", return_value="0.20.0"),
+    ):
+        yield context, config
+
+
+def _github_response(payload, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    return response
+
+
+class TestAnnounceReleaseFanout:
+    def test_enabled_only_not_onsnatch_flags(self, announce_ctx):
+        """Gate is ANNOUNCE_RELEASES × *_ENABLED; snatch/grab flags are ignored."""
+        _ctx, config = announce_ctx
+        config.PROWL_ENABLED = True
+        config.PROWL_ONSNATCH = False  # must not matter
+        config.EMAIL_ENABLED = True
+        config.EMAIL_ONGRAB = False  # must not matter
+        config.DISCORD_ENABLED = False
+        config.DISCORD_ONSNATCH = True  # must not fire Discord
+
+        with (
+            patch("comicarr.notifiers.PROWL") as prowl_cls,
+            patch("comicarr.notifiers.EMAIL") as email_cls,
+            patch("comicarr.notifiers.DISCORD") as discord_cls,
+        ):
+            prowl = prowl_cls.return_value
+            email = email_cls.return_value
+            versioncheck.announce_release(current_version="0.20.0", latest_version="0.21.0")
+
+        prowl.notify.assert_called_once()
+        email.notify.assert_called_once()
+        discord_cls.assert_not_called()
+
+        event, body = versioncheck.release_announce_message("0.20.0", "0.21.0")
+        # Prowl: (message, event)
+        assert prowl.notify.call_args.args[0] == body
+        assert prowl.notify.call_args.args[1] == event
+        # Email: (message, subject)
+        assert email.notify.call_args.args[0] == body
+        assert "Update available" in email.notify.call_args.args[1]
+
+    def test_writes_last_announced_after_attempt_even_if_notifier_fails(self, announce_ctx):
+        _ctx, config = announce_ctx
+        config.TELEGRAM_ENABLED = True
+
+        with patch("comicarr.notifiers.TELEGRAM") as telegram_cls:
+            telegram_cls.return_value.notify.side_effect = RuntimeError("flaky webhook")
+            versioncheck.announce_release(current_version="0.20.0", latest_version="0.21.5")
+
+        config.writeconfig.assert_called_once_with(values={"last_announced_version": "0.21.5"})
+        assert config.LAST_ANNOUNCED_VERSION == "0.21.5"
+
+    def test_all_eleven_notifiers_when_enabled(self, announce_ctx):
+        _ctx, config = announce_ctx
+        for name in (
+            "PROWL",
+            "PUSHOVER",
+            "BOXCAR",
+            "PUSHBULLET",
+            "TELEGRAM",
+            "SLACK",
+            "MATTERMOST",
+            "DISCORD",
+            "EMAIL",
+            "GOTIFY",
+            "MATRIX",
+        ):
+            setattr(config, f"{name}_ENABLED", True)
+
+        patches = {
+            name: patch(f"comicarr.notifiers.{name}")
+            for name in (
+                "PROWL",
+                "PUSHOVER",
+                "BOXCAR",
+                "PUSHBULLET",
+                "TELEGRAM",
+                "SLACK",
+                "MATTERMOST",
+                "DISCORD",
+                "EMAIL",
+                "GOTIFY",
+                "MATRIX",
+            )
+        }
+        with (
+            patches["PROWL"] as p_prowl,
+            patches["PUSHOVER"] as p_push,
+            patches["BOXCAR"] as p_box,
+            patches["PUSHBULLET"] as p_pb,
+            patches["TELEGRAM"] as p_tg,
+            patches["SLACK"] as p_slack,
+            patches["MATTERMOST"] as p_mm,
+            patches["DISCORD"] as p_discord,
+            patches["EMAIL"] as p_email,
+            patches["GOTIFY"] as p_gotify,
+            patches["MATRIX"] as p_matrix,
+        ):
+            versioncheck.announce_release(current_version="0.20.0", latest_version="0.22.0")
+
+        for mock_cls in (
+            p_prowl,
+            p_push,
+            p_box,
+            p_pb,
+            p_tg,
+            p_slack,
+            p_mm,
+            p_discord,
+            p_email,
+            p_gotify,
+            p_matrix,
+        ):
+            mock_cls.return_value.notify.assert_called_once()
+
+
+class TestCheckGithubAnnounceHook:
+    def test_announces_when_behind_and_opted_in(self, announce_ctx):
+        _ctx, config = announce_ctx
+        config.ANNOUNCE_RELEASES = True
+        config.LAST_ANNOUNCED_VERSION = None
+
+        with (
+            patch.object(
+                versioncheck.requests,
+                "get",
+                return_value=_github_response({"tag_name": "v0.21.0"}),
+            ),
+            patch.object(versioncheck, "announce_release") as announce,
+        ):
+            result = versioncheck.checkGithub()
+
+        assert result["update_state"] == "behind"
+        announce.assert_called_once_with(current_version="0.20.0", latest_version="0.21.0")
+
+    def test_no_announce_when_current(self, announce_ctx):
+        _ctx, config = announce_ctx
+        config.ANNOUNCE_RELEASES = True
+
+        with (
+            patch.object(
+                versioncheck.requests,
+                "get",
+                return_value=_github_response({"tag_name": "v0.20.0"}),
+            ),
+            patch.object(versioncheck, "announce_release") as announce,
+        ):
+            result = versioncheck.checkGithub()
+
+        assert result["update_state"] == "current"
+        announce.assert_not_called()
+
+    def test_no_announce_when_opted_out(self, announce_ctx):
+        _ctx, config = announce_ctx
+        config.ANNOUNCE_RELEASES = False
+
+        with (
+            patch.object(
+                versioncheck.requests,
+                "get",
+                return_value=_github_response({"tag_name": "v0.21.0"}),
+            ),
+            patch.object(versioncheck, "announce_release") as announce,
+        ):
+            result = versioncheck.checkGithub()
+
+        assert result["update_state"] == "behind"
+        announce.assert_not_called()
+
+    def test_no_announce_when_already_announced(self, announce_ctx):
+        _ctx, config = announce_ctx
+        config.ANNOUNCE_RELEASES = True
+        config.LAST_ANNOUNCED_VERSION = "0.21.0"
+
+        with (
+            patch.object(
+                versioncheck.requests,
+                "get",
+                return_value=_github_response({"tag_name": "v0.21.0"}),
+            ),
+            patch.object(versioncheck, "announce_release") as announce,
+        ):
+            result = versioncheck.checkGithub()
+
+        assert result["update_state"] == "behind"
+        announce.assert_not_called()
+
+    def test_single_announce_on_multi_release_jump(self, announce_ctx):
+        """One check interval sees newest latest only — one fan-out for that latest."""
+        _ctx, config = announce_ctx
+        config.ANNOUNCE_RELEASES = True
+        config.LAST_ANNOUNCED_VERSION = "0.20.0"
+
+        with (
+            patch.object(
+                versioncheck.requests,
+                "get",
+                return_value=_github_response({"tag_name": "v0.21.5"}),
+            ),
+            patch.object(versioncheck, "announce_release") as announce,
+        ):
+            result = versioncheck.checkGithub()
+
+        assert result["latest_version"] == "0.21.5"
+        announce.assert_called_once_with(current_version="0.20.0", latest_version="0.21.5")
+
+    def test_announces_for_docker_install_type(self, announce_ctx):
+        _ctx, config = announce_ctx
+        comicarr.INSTALL_TYPE = "docker"
+        config.ANNOUNCE_RELEASES = True
+
+        with (
+            patch.object(
+                versioncheck.requests,
+                "get",
+                return_value=_github_response({"tag_name": "v0.21.0"}),
+            ),
+            patch.object(versioncheck, "announce_release") as announce,
+        ):
+            versioncheck.checkGithub()
+
+        announce.assert_called_once()


### PR DESCRIPTION
## Summary

When release announcements are enabled, Comicarr sends one notifier message after a check finds the install behind — version arrow plus GitHub release URL, deduped by remote latest so 6-hour checks do not spam.

## Changes

- Gate on global `ANNOUNCE_RELEASES` (default off) × each notifier’s `*_ENABLED` only; does not reuse snatch/grab flags
- Hook after semver check sets `behind`; write `LAST_ANNOUNCED_VERSION` after the fan-out attempt
- Cover off / not-behind / already-announced / multi-release jump / write-after-attempt in unit tests

Closes #475

## Test plan

- [x] `uv run pytest tests/unit/test_release_announce.py -v`
- [x] Related `test_version_state` suite
- [ ] Optional: set `announce_releases = True` under `[Git]`, enable a notifier, force a behind check, confirm one message and no re-spam on the next check