### PR TITLE
feat: Implement daily ledger retention sweep

### DIFF
--- a/.changeset/ledger-retention-daily-sweep.md
+++ b/.changeset/ledger-retention-daily-sweep.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Comicarr now runs a daily **Ledger Retention** job that prunes old acquisition, pipeline journal, maintenance, and AI activity ledger rows under fixed age and count rules, so those tables stop growing without bound.

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -1076,6 +1076,18 @@ def start(ctx):
             )
             IMPORTINBOX_SCHEDULER.pause()
 
+            # Shared daily prune for the five unbounded operational ledgers
+            # (#480). Independent of SEARCH_INTERVAL / DB Updater / narrative
+            # retention; not paused — runs on the daily cadence from start.
+            from comicarr.app.acquisition.retention import run_ledger_retention
+
+            _add_recurring_job(
+                func=run_ledger_retention,
+                id="ledger_retention",
+                name="Ledger Retention",
+                trigger=IntervalTrigger(days=1, timezone="UTC"),
+            )
+
             # A schema failure, persistent repair fence, or explicit operator
             # override suppresses every producer/consumer that can claim or
             # hand off acquisition work. The scheduler itself still starts so

--- a/comicarr/app/acquisition/retention.py
+++ b/comicarr/app/acquisition/retention.py
@@ -1,0 +1,284 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Daily retention sweep for the five unbounded operational ledgers.
+
+Public entrypoint: ``run_ledger_retention(now=...)``. The scheduler job id is
+``ledger_retention`` (display name **Ledger Retention**). Parameters are module
+constants only — no operator knobs (#464). Eligibility and delete order match
+#463; journal stage/resolution predicates come from
+``comicarr.app.downloads.journal``.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy import and_, delete, exists, func, or_, select, true
+
+from comicarr import logger
+from comicarr.app.acquisition.models import ItemOutcome
+from comicarr.app.downloads.journal import (
+    FAILED,
+    MANUAL_REVIEW,
+    POST_PROCESSED,
+    RESOLVED_STATUSES,
+)
+from comicarr.db import get_engine
+from comicarr.tables import (
+    acquisition_maintenance_events,
+    acquisition_run_items,
+    acquisition_runs,
+    ai_activity_log,
+    pipeline_journal,
+)
+
+# ---------------------------------------------------------------------------
+# Parameters (#464) — constants only
+# ---------------------------------------------------------------------------
+
+DELETE_BATCH_SIZE = 500
+
+ITEMS_AGE_DAYS = 90
+ITEMS_KEEP_NEWEST = 50_000
+
+RUNS_AGE_DAYS = 90
+RUNS_KEEP_NEWEST = 2_000
+
+JOURNAL_AGE_DAYS = 365  # age-only; no count floor
+
+MAINTENANCE_AGE_DAYS = 90
+MAINTENANCE_KEEP_NEWEST = 5_000
+
+AI_AGE_DAYS = 90
+AI_KEEP_NEWEST = 10_000
+
+_NONTERMINAL_ITEM_STATES = (ItemOutcome.ACCEPTED.value, ItemOutcome.RUNNING.value)
+
+
+def run_ledger_retention(now=None):
+    """Run one shared daily ledger retention pass.
+
+    Delete order (#463):
+
+    1. Eligible terminal ``acquisition_run_items``
+    2. Eligible completed ``acquisition_runs`` with zero remaining items
+    3. Eligible ``pipeline_journal`` terminals
+    4. ``acquisition_maintenance_events``
+    5. ``ai_activity_log``
+
+    Fail-soft: log any error and return ``None`` without raising so the process
+    and scheduler stay up. Returns a per-table deleted-row summary on success.
+    """
+    try:
+        when = _as_utc_datetime(now)
+        engine = get_engine()
+        summary = {
+            "acquisition_run_items": 0,
+            "acquisition_runs": 0,
+            "pipeline_journal": 0,
+            "acquisition_maintenance_events": 0,
+            "ai_activity_log": 0,
+        }
+        logger.info("[LEDGER-RETENTION] Starting sweep (now=%s)" % when.isoformat())
+        # One transaction per table step so a late failure does not roll back
+        # earlier tables, and batch loops do not hold a single multi-table lock.
+        with engine.begin() as conn:
+            summary["acquisition_run_items"] = _purge_acquisition_run_items(conn, when)
+        with engine.begin() as conn:
+            summary["acquisition_runs"] = _purge_acquisition_runs(conn, when)
+        with engine.begin() as conn:
+            summary["pipeline_journal"] = _purge_pipeline_journal(conn, when)
+        with engine.begin() as conn:
+            summary["acquisition_maintenance_events"] = _purge_maintenance_events(conn, when)
+        with engine.begin() as conn:
+            summary["ai_activity_log"] = _purge_ai_activity_log(conn, when)
+        logger.info(
+            "[LEDGER-RETENTION] Sweep complete: items=%s runs=%s journal=%s "
+            "maintenance=%s ai=%s"
+            % (
+                summary["acquisition_run_items"],
+                summary["acquisition_runs"],
+                summary["pipeline_journal"],
+                summary["acquisition_maintenance_events"],
+                summary["ai_activity_log"],
+            )
+        )
+        return summary
+    except Exception as e:
+        logger.error("[LEDGER-RETENTION] Sweep failed: %s" % e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Per-table purge steps
+# ---------------------------------------------------------------------------
+
+
+def _purge_acquisition_run_items(conn, when):
+    age_expr = func.coalesce(acquisition_run_items.c.completed_at, acquisition_run_items.c.updated_at)
+    eligible = acquisition_run_items.c.state.notin_(_NONTERMINAL_ITEM_STATES)
+    cutoff = _iso_cutoff(when, ITEMS_AGE_DAYS)
+    return _batched_hybrid_delete(
+        conn,
+        table=acquisition_run_items,
+        pk_col=acquisition_run_items.c.item_id,
+        age_expr=age_expr,
+        eligible_clause=eligible,
+        cutoff=cutoff,
+        keep_newest=ITEMS_KEEP_NEWEST,
+    )
+
+
+def _purge_acquisition_runs(conn, when):
+    age_expr = func.coalesce(acquisition_runs.c.completed_at, acquisition_runs.c.updated_at)
+    has_items = exists(select(1).where(acquisition_run_items.c.run_id == acquisition_runs.c.run_id))
+    # Complete = finished work (reconcile sets completed_at when every item is
+    # terminal: completed / partial / blocked / failed). Incomplete pending
+    # and running runs never have completed_at and stay immortal (#463).
+    eligible = and_(
+        acquisition_runs.c.completed_at.isnot(None),
+        ~has_items,
+    )
+    cutoff = _iso_cutoff(when, RUNS_AGE_DAYS)
+    return _batched_hybrid_delete(
+        conn,
+        table=acquisition_runs,
+        pk_col=acquisition_runs.c.run_id,
+        age_expr=age_expr,
+        eligible_clause=eligible,
+        cutoff=cutoff,
+        keep_newest=RUNS_KEEP_NEWEST,
+    )
+
+
+def _purge_pipeline_journal(conn, when):
+    # Eligible: post_processed, or resolved failed/manual_review (#463 / #437).
+    eligible = or_(
+        pipeline_journal.c.stage == POST_PROCESSED,
+        and_(
+            pipeline_journal.c.stage.in_((FAILED, MANUAL_REVIEW)),
+            pipeline_journal.c.status.in_(RESOLVED_STATUSES),
+        ),
+    )
+    cutoff = _journal_cutoff(when, JOURNAL_AGE_DAYS)
+    return _batched_age_only_delete(
+        conn,
+        table=pipeline_journal,
+        pk_col=pipeline_journal.c.release_key,
+        age_expr=pipeline_journal.c.updated_date,
+        eligible_clause=eligible,
+        cutoff=cutoff,
+    )
+
+
+def _purge_maintenance_events(conn, when):
+    cutoff = _iso_cutoff(when, MAINTENANCE_AGE_DAYS)
+    return _batched_hybrid_delete(
+        conn,
+        table=acquisition_maintenance_events,
+        pk_col=acquisition_maintenance_events.c.event_id,
+        age_expr=acquisition_maintenance_events.c.created_at,
+        eligible_clause=true(),
+        cutoff=cutoff,
+        keep_newest=MAINTENANCE_KEEP_NEWEST,
+    )
+
+
+def _purge_ai_activity_log(conn, when):
+    cutoff = _iso_cutoff(when, AI_AGE_DAYS)
+    return _batched_hybrid_delete(
+        conn,
+        table=ai_activity_log,
+        pk_col=ai_activity_log.c.id,
+        age_expr=ai_activity_log.c.timestamp,
+        eligible_clause=true(),
+        cutoff=cutoff,
+        keep_newest=AI_KEEP_NEWEST,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch delete helpers
+# ---------------------------------------------------------------------------
+
+
+def _batched_hybrid_delete(conn, table, pk_col, age_expr, eligible_clause, cutoff, keep_newest):
+    """Delete eligible rows older than *cutoff* and outside the newest N.
+
+    Hybrid formula (#464): delete only when
+    ``eligible AND age > horizon AND not in newest N eligible (age DESC, pk DESC)``.
+    """
+    deleted_total = 0
+    while True:
+        keepers = (
+            select(pk_col.label("keep_id"))
+            .where(eligible_clause)
+            .order_by(age_expr.desc(), pk_col.desc())
+            .limit(int(keep_newest))
+        )
+        candidates = (
+            select(pk_col)
+            .where(
+                eligible_clause,
+                age_expr < cutoff,
+                pk_col.notin_(keepers),
+            )
+            .limit(DELETE_BATCH_SIZE)
+        )
+        ids = [row[0] for row in conn.execute(candidates)]
+        if not ids:
+            break
+        result = conn.execute(delete(table).where(pk_col.in_(ids)))
+        batch = result.rowcount if result.rowcount is not None else len(ids)
+        deleted_total += batch
+        if len(ids) < DELETE_BATCH_SIZE:
+            break
+    return deleted_total
+
+
+def _batched_age_only_delete(conn, table, pk_col, age_expr, eligible_clause, cutoff):
+    """Delete eligible rows older than *cutoff* (no newest-N floor)."""
+    deleted_total = 0
+    while True:
+        candidates = select(pk_col).where(eligible_clause, age_expr < cutoff).limit(DELETE_BATCH_SIZE)
+        ids = [row[0] for row in conn.execute(candidates)]
+        if not ids:
+            break
+        result = conn.execute(delete(table).where(pk_col.in_(ids)))
+        batch = result.rowcount if result.rowcount is not None else len(ids)
+        deleted_total += batch
+        if len(ids) < DELETE_BATCH_SIZE:
+            break
+    return deleted_total
+
+
+# ---------------------------------------------------------------------------
+# Time helpers
+# ---------------------------------------------------------------------------
+
+
+def _as_utc_datetime(now):
+    if now is None:
+        return datetime.datetime.now(datetime.timezone.utc)
+    if not isinstance(now, datetime.datetime):
+        raise TypeError("now must be a datetime or None")
+    if now.tzinfo is None or now.utcoffset() is None:
+        return now.replace(tzinfo=datetime.timezone.utc)
+    return now.astimezone(datetime.timezone.utc)
+
+
+def _iso_cutoff(when, days):
+    """Cutoff string for tables that store UTC ISO timestamps."""
+    return (when - datetime.timedelta(days=int(days))).isoformat()
+
+
+def _journal_cutoff(when, days):
+    """Cutoff for pipeline_journal.updated_date (``YYYY-MM-DD HH:MM:SS``)."""
+    return (when - datetime.timedelta(days=int(days))).strftime("%Y-%m-%d %H:%M:%S")

--- a/comicarr/app/downloads/journal.py
+++ b/comicarr/app/downloads/journal.py
@@ -76,6 +76,14 @@ TERMINAL_STAGES = (POST_PROCESSED, MANUAL_REVIEW, FAILED)
 # Open stages: rows replay must consider as still-in-flight obligations.
 OPEN_STAGES = (RESERVED, SNATCHED, DOWNLOADED, POST_PROCESSING, MOVED)
 
+# Operator resolution markers on the R9 `status` column (#437). The
+# needs-attention band excludes these; ledger retention may age them out with
+# other eligible terminals (post_processed + resolved failed/manual_review).
+STATUS_RETRIED = "retried"
+STATUS_IGNORED = "ignored"
+STATUS_IMPORTED = "imported"
+RESOLVED_STATUSES = (STATUS_RETRIED, STATUS_IGNORED, STATUS_IMPORTED)
+
 # Synthetic one-off IssueIDs are an unpersisted CONFIG.HIGHCOUNT counter that
 # starts at 900000 (see comicarr/updater.py:1214-1220). Such an IssueID is not
 # reproducible across a restart, so it must NOT be part of the release_key.

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -67,6 +67,7 @@ SCHEDULER_JOB_NAMES = {
     "monitor": "Folder Monitor",
     "importinbox": "Import Inbox Scanner",
     "ddl_health": "DDL Health Check",
+    "ledger_retention": "Ledger Retention",
 }
 
 SETUP_PERSISTENCE_ERROR = "Failed to persist initial credentials"

--- a/tests/unit/test_ledger_retention.py
+++ b/tests/unit/test_ledger_retention.py
@@ -1,0 +1,370 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Unit tests for the daily ledger retention sweep (#480).
+
+Full policy matrix and ops notes land in #481; this file pins the public
+entrypoint, eligibility floors, hybrid/age math, delete order, and batching
+at the `run_ledger_retention` seam.
+"""
+
+import datetime
+
+import pytest
+from sqlalchemy import insert, select
+
+import comicarr
+from comicarr.app.acquisition import retention
+from comicarr.app.acquisition.models import ItemOutcome, RunState
+from comicarr.app.downloads import journal
+from comicarr.db import get_engine, shutdown_engine
+from comicarr.tables import (
+    acquisition_maintenance_events,
+    acquisition_run_items,
+    acquisition_runs,
+    ai_activity_log,
+    metadata,
+    pipeline_journal,
+)
+
+FIXED_NOW = datetime.datetime(2026, 8, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", None, raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    shutdown_engine()
+    metadata.create_all(get_engine())
+    yield
+    shutdown_engine()
+
+
+def _iso(days_ago, hours=0):
+    return (FIXED_NOW - datetime.timedelta(days=days_ago, hours=hours)).isoformat()
+
+
+def _journal_ts(days_ago):
+    return (FIXED_NOW - datetime.timedelta(days=days_ago)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _insert_run(run_id, completion_state, completed_at=None, updated_at=None):
+    now = updated_at or _iso(0)
+    with get_engine().begin() as conn:
+        conn.execute(
+            insert(acquisition_runs).values(
+                run_id=run_id,
+                command_kind="search",
+                trigger="test",
+                dispatch_state="accepted",
+                completion_state=completion_state,
+                accepted_count=0,
+                terminal_count=0,
+                succeeded_count=0,
+                no_match_count=0,
+                blocked_count=0,
+                failed_count=0,
+                created_at=now,
+                updated_at=now,
+                completed_at=completed_at,
+            )
+        )
+
+
+def _insert_item(run_id, state, completed_at=None, updated_at=None, entity_id=None):
+    now = updated_at or _iso(0)
+    with get_engine().begin() as conn:
+        result = conn.execute(
+            insert(acquisition_run_items).values(
+                run_id=run_id,
+                command_kind="search",
+                entity_type="issue",
+                entity_id=entity_id or ("e-%s-%s" % (run_id, state)),
+                state=state,
+                dispatch_state="pending",
+                queue_priority="routine",
+                attempt_count=0,
+                created_at=now,
+                updated_at=now,
+                completed_at=completed_at,
+            )
+        )
+        return result.inserted_primary_key[0]
+
+
+def _insert_journal(release_key, stage, updated_date, status=None):
+    with get_engine().begin() as conn:
+        conn.execute(
+            insert(pipeline_journal).values(
+                release_key=release_key,
+                stage=stage,
+                stage_rank=journal.STAGE_RANK[stage],
+                updated_date=updated_date,
+                status=status,
+            )
+        )
+
+
+def _insert_maintenance(created_at, reason="test"):
+    with get_engine().begin() as conn:
+        result = conn.execute(
+            insert(acquisition_maintenance_events).values(
+                epoch=1,
+                action="acquire",
+                actor="test",
+                reason=reason,
+                created_at=created_at,
+            )
+        )
+        return result.inserted_primary_key[0]
+
+
+def _insert_ai(timestamp, action="act"):
+    with get_engine().begin() as conn:
+        result = conn.execute(
+            insert(ai_activity_log).values(
+                timestamp=timestamp,
+                feature_type="chat",
+                action_description=action,
+                success="true",
+            )
+        )
+        return result.inserted_primary_key[0]
+
+
+def _count(table):
+    with get_engine().connect() as conn:
+        return conn.execute(select(table)).fetchall().__len__()
+
+
+def _item_states():
+    with get_engine().connect() as conn:
+        return sorted(row.state for row in conn.execute(select(acquisition_run_items.c.state)))
+
+
+def _run_ids():
+    with get_engine().connect() as conn:
+        return sorted(row.run_id for row in conn.execute(select(acquisition_runs.c.run_id)))
+
+
+def _journal_keys():
+    with get_engine().connect() as conn:
+        return sorted(row.release_key for row in conn.execute(select(pipeline_journal.c.release_key)))
+
+
+def test_constants_match_parameter_table():
+    assert retention.DELETE_BATCH_SIZE == 500
+    assert retention.ITEMS_AGE_DAYS == 90
+    assert retention.ITEMS_KEEP_NEWEST == 50_000
+    assert retention.RUNS_AGE_DAYS == 90
+    assert retention.RUNS_KEEP_NEWEST == 2_000
+    assert retention.JOURNAL_AGE_DAYS == 365
+    assert retention.MAINTENANCE_AGE_DAYS == 90
+    assert retention.MAINTENANCE_KEEP_NEWEST == 5_000
+    assert retention.AI_AGE_DAYS == 90
+    assert retention.AI_KEEP_NEWEST == 10_000
+
+
+def test_never_deletes_nonterminal_items_or_incomplete_runs():
+    _insert_run("live", RunState.RUNNING.value, completed_at=None, updated_at=_iso(200))
+    _insert_item("live", ItemOutcome.ACCEPTED.value, completed_at=None, updated_at=_iso(200), entity_id="a")
+    _insert_item("live", ItemOutcome.RUNNING.value, completed_at=None, updated_at=_iso(200), entity_id="b")
+    _insert_item("live", ItemOutcome.SUCCEEDED.value, completed_at=_iso(200), updated_at=_iso(200), entity_id="c")
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+
+    assert summary is not None
+    assert _item_states() == sorted(
+        [ItemOutcome.ACCEPTED.value, ItemOutcome.RUNNING.value, ItemOutcome.SUCCEEDED.value]
+    )
+    assert _run_ids() == ["live"]
+
+
+def test_empty_finished_failed_run_is_eligible(monkeypatch):
+    """Finished empty shells (failed/partial/blocked) prune once items are gone."""
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+    _insert_run("failed-done", RunState.FAILED.value, completed_at=_iso(100), updated_at=_iso(100))
+    _insert_item(
+        "failed-done",
+        ItemOutcome.FAILED.value,
+        completed_at=_iso(100),
+        updated_at=_iso(100),
+        entity_id="f1",
+    )
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+
+    assert summary["acquisition_run_items"] == 1
+    assert summary["acquisition_runs"] == 1
+    assert _run_ids() == []
+
+
+def test_deletes_old_terminal_items_then_empty_completed_runs(monkeypatch):
+    # Small fixtures sit inside the real newest-N floors; lower floors so age
+    # past 90d is enough to delete under the hybrid formula.
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 1)
+    # After the old item is purged only one empty completed run is eligible;
+    # keep floor 0 so age alone can remove it.
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+
+    _insert_run("old-done", RunState.COMPLETED.value, completed_at=_iso(100), updated_at=_iso(100))
+    _insert_item(
+        "old-done",
+        ItemOutcome.SUCCEEDED.value,
+        completed_at=_iso(100),
+        updated_at=_iso(100),
+        entity_id="done-1",
+    )
+    _insert_run("recent-done", RunState.COMPLETED.value, completed_at=_iso(10), updated_at=_iso(10))
+    _insert_item(
+        "recent-done",
+        ItemOutcome.NO_MATCH.value,
+        completed_at=_iso(10),
+        updated_at=_iso(10),
+        entity_id="done-2",
+    )
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+
+    assert summary["acquisition_run_items"] == 1
+    assert summary["acquisition_runs"] == 1
+    assert _run_ids() == ["recent-done"]
+    assert _item_states() == [ItemOutcome.NO_MATCH.value]
+
+
+def test_never_deletes_open_or_unresolved_journal_rows():
+    _insert_journal("open-snatched", journal.SNATCHED, _journal_ts(400))
+    _insert_journal("failed-open", journal.FAILED, _journal_ts(400), status=None)
+    _insert_journal("review-open", journal.MANUAL_REVIEW, _journal_ts(400), status=journal.MANUAL_REVIEW)
+    _insert_journal("pp-old", journal.POST_PROCESSED, _journal_ts(400))
+    _insert_journal("failed-resolved", journal.FAILED, _journal_ts(400), status=journal.STATUS_IGNORED)
+    _insert_journal("pp-recent", journal.POST_PROCESSED, _journal_ts(30))
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+
+    assert summary["pipeline_journal"] == 2
+    assert _journal_keys() == sorted(["open-snatched", "failed-open", "review-open", "pp-recent"])
+
+
+def test_hybrid_keep_newest_floor_even_when_old():
+    # keep_newest=2 for this assertion via monkeypatch of the constant.
+    # Five old terminal items; newest 2 (by age desc, pk desc) must remain.
+    original = retention.ITEMS_KEEP_NEWEST
+    retention.ITEMS_KEEP_NEWEST = 2
+    try:
+        _insert_run("batch", RunState.COMPLETED.value, completed_at=_iso(200), updated_at=_iso(200))
+        ids = []
+        for day in (200, 190, 180, 170, 160):
+            ids.append(
+                _insert_item(
+                    "batch",
+                    ItemOutcome.SUCCEEDED.value,
+                    completed_at=_iso(day),
+                    updated_at=_iso(day),
+                    entity_id="i-%s" % day,
+                )
+            )
+        summary = retention.run_ledger_retention(now=FIXED_NOW)
+        assert summary["acquisition_run_items"] == 3
+        with get_engine().connect() as conn:
+            remaining = sorted(row.item_id for row in conn.execute(select(acquisition_run_items.c.item_id)))
+        # Newest by age: day 160 then 170 (largest completed_at, then pk).
+        assert remaining == sorted(ids[-2:])
+    finally:
+        retention.ITEMS_KEEP_NEWEST = original
+
+
+def test_maintenance_and_ai_are_fully_eligible_under_hybrid(monkeypatch):
+    monkeypatch.setattr(retention, "MAINTENANCE_KEEP_NEWEST", 1)
+    monkeypatch.setattr(retention, "AI_KEEP_NEWEST", 1)
+
+    _insert_maintenance(_iso(100), reason="old")
+    _insert_maintenance(_iso(5), reason="new")
+    _insert_ai(_iso(100), action="old-ai")
+    _insert_ai(_iso(5), action="new-ai")
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+
+    assert summary["acquisition_maintenance_events"] == 1
+    assert summary["ai_activity_log"] == 1
+    assert _count(acquisition_maintenance_events) == 1
+    assert _count(ai_activity_log) == 1
+
+
+def test_batching_loops_until_dry(monkeypatch):
+    monkeypatch.setattr(retention, "DELETE_BATCH_SIZE", 2)
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+    _insert_run("many", RunState.COMPLETED.value, completed_at=_iso(120), updated_at=_iso(120))
+    for i in range(5):
+        _insert_item(
+            "many",
+            ItemOutcome.FAILED.value,
+            completed_at=_iso(120),
+            updated_at=_iso(120),
+            entity_id="x-%s" % i,
+        )
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+
+    assert summary["acquisition_run_items"] == 5
+    assert _count(acquisition_run_items) == 0
+    # Empty completed run is eligible and old → deleted after items.
+    assert summary["acquisition_runs"] == 1
+
+
+def test_soft_fail_logs_and_does_not_raise(monkeypatch, caplog):
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(retention, "_purge_acquisition_run_items", boom)
+    result = retention.run_ledger_retention(now=FIXED_NOW)
+    assert result is None
+
+
+def test_delete_order_items_before_runs(monkeypatch):
+    order = []
+
+    def wrap(name, original):
+        def _inner(*args, **kwargs):
+            order.append(name)
+            return original(*args, **kwargs)
+
+        return _inner
+
+    monkeypatch.setattr(
+        retention,
+        "_purge_acquisition_run_items",
+        wrap("items", retention._purge_acquisition_run_items),
+    )
+    monkeypatch.setattr(
+        retention,
+        "_purge_acquisition_runs",
+        wrap("runs", retention._purge_acquisition_runs),
+    )
+    monkeypatch.setattr(
+        retention,
+        "_purge_pipeline_journal",
+        wrap("journal", retention._purge_pipeline_journal),
+    )
+    monkeypatch.setattr(
+        retention,
+        "_purge_maintenance_events",
+        wrap("maintenance", retention._purge_maintenance_events),
+    )
+    monkeypatch.setattr(
+        retention,
+        "_purge_ai_activity_log",
+        wrap("ai", retention._purge_ai_activity_log),
+    )
+
+    retention.run_ledger_retention(now=FIXED_NOW)
+    assert order == ["items", "runs", "journal", "maintenance", "ai"]

--- a/tests/unit/test_scheduler_configuration.py
+++ b/tests/unit/test_scheduler_configuration.py
@@ -36,6 +36,7 @@ _RECURRING_JOB_IDS = {
     "monitor",
     "importinbox",
     "ddl_health",
+    "ledger_retention",
 }
 
 


### PR DESCRIPTION
## TLDR

Adds a daily **Ledger Retention** job that prunes the five unbounded operational ledgers under fixed eligibility and age/count rules so those tables stop growing without bound.

## Description

- Implement `run_ledger_retention(now=...)` in `comicarr/app/acquisition/retention.py` with #463 eligibility, #464 hybrid constants, 500-row batched deletes, and fail-soft logging
- Register daily `ledger_retention` via `_add_recurring_job` and map it to **Ledger Retention** in `SCHEDULER_JOB_NAMES`
- Add unit pins at the public seam plus an operator-facing changeset

Closes #480