### PR TITLE
feat: Needs-attention band resolution actions

### DIFF
--- a/.changeset/needs-attention-resolution-actions.md
+++ b/.changeset/needs-attention-resolution-actions.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Failed and manual-review downloads on the needs-attention work queue can be cleared with retry, search again, ignore, or import — without rewriting pipeline stage history.

--- a/comicarr/app/downloads/journal.py
+++ b/comicarr/app/downloads/journal.py
@@ -36,7 +36,7 @@ import json
 import re
 import time
 
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.exc import IntegrityError, OperationalError
 
 from comicarr import db, logger
@@ -75,6 +75,21 @@ TERMINAL_STAGES = (POST_PROCESSED, MANUAL_REVIEW, FAILED)
 
 # Open stages: rows replay must consider as still-in-flight obligations.
 OPEN_STAGES = (RESERVED, SNATCHED, DOWNLOADED, POST_PROCESSING, MOVED)
+
+# Stages that populate the needs-attention band (Timeline work queue).
+BAND_STAGES = (FAILED, MANUAL_REVIEW)
+
+# R9 resolution stamps — written by operator actions (and FAILED_AUTO retry)
+# without rewriting stage / stage_rank. Rows with these statuses leave the band.
+STATUS_RETRIED = "retried"
+STATUS_IGNORED = "ignored"
+STATUS_IMPORTED = "imported"
+RESOLVED_STATUSES = (STATUS_RETRIED, STATUS_IGNORED, STATUS_IMPORTED)
+
+# Fresh re-snatch stages that may supersede a terminal `failed` row under the
+# same release_key (same issue|provider). DDL handoff writes RESERVED first;
+# NZB/torrent snatch (updater.foundsearch) writes SNATCHED directly.
+_RESNATCH_STAGES = (RESERVED, SNATCHED)
 
 # Synthetic one-off IssueIDs are an unpersisted CONFIG.HIGHCOUNT counter that
 # starts at 900000 (see comicarr/updater.py:1214-1220). Such an IssueID is not
@@ -393,24 +408,33 @@ def _now():
 
 
 def _try_reset_failed_attempt(conn, key, stage, new_rank, upd_values):
-    """RE-SNATCH special case: a fresh `snatched` write observed against a
-    terminal `failed` row is a NEW in-flight obligation that legitimately
-    supersedes the closed failed attempt — reset the row to snatched.
+    """RE-SNATCH special case: a fresh RESERVED or SNATCHED write observed
+    against a terminal `failed` row is a NEW in-flight obligation that
+    legitimately supersedes the closed failed attempt — reset the row.
 
     WHY this does NOT weaken the monotonic stale-replay guard: replay never
-    issues a fresh `snatched` transition (the snatch seam updater.foundsearch
-    does, only from a real new grab; replay re-enqueues `still` non-terminal
-    items, never a `snatched` write). So a `snatched` write seen against a
-    `failed` row is always a genuine new snatch obligation, never a stale
-    replay — resetting is correct here and the monotonic guard is left fully
-    intact for every other stage (only `failed`->`snatched` is special-cased).
+    issues a fresh RESERVED/SNATCHED transition (the snatch seam and DDL
+    handoff do, only from a real new grab; replay re-enqueues still
+    non-terminal items, never a first-stage write). So a re-snatch stage
+    seen against a `failed` row is always a genuine new obligation, never a
+    stale replay — resetting is correct here and the monotonic guard is left
+    fully intact for every other stage.
+
+    SNATCHED is included because the NZB/torrent snatch path
+    (updater.foundsearch) writes SNATCHED directly against
+    ``issueid|provider`` without an intervening RESERVED. Without that gate,
+    a same-provider operator/auto retry returns ``won=False`` and narrates
+    nothing (#483 / #437 amendment).
+
+    This helper remains the re-snatch path only — operator band exits stamp
+    R9 status without calling it (#437 / #483).
 
     Returns True iff THIS call won the reset. The UPDATE is gated with
-    `WHERE stage = FAILED` (the current terminal) so two concurrent snatched
-    writers racing one failed row yield exactly one True — the loser's gated
-    UPDATE matches 0 rows and it falls back to the monotonic no-op.
+    `WHERE stage = FAILED` so two concurrent re-snatch writers racing one
+    failed row yield exactly one True — the loser's gated UPDATE matches 0
+    rows and it falls back to the monotonic no-op.
     """
-    if stage != RESERVED:
+    if stage not in _RESNATCH_STAGES:
         return False
 
     reset = conn.execute(
@@ -441,7 +465,9 @@ def _apply_transition(conn, key, stage, new_rank, fields, payload, when):
     existing_payload = (
         sanitize_payload(load_payload(existing_row._mapping.get("payload_json"))) if existing_row is not None else None
     )
-    new_attempt = existing_row is not None and existing_row._mapping.get("stage") == FAILED and stage == RESERVED
+    new_attempt = (
+        existing_row is not None and existing_row._mapping.get("stage") == FAILED and stage in _RESNATCH_STAGES
+    )
     if new_attempt:
         # A new attempt must not inherit the previous client's acceptance id,
         # route or hash. Retain only stable release identity/context; otherwise
@@ -591,8 +617,8 @@ def _apply_transition(conn, key, stage, new_rank, fields, payload, when):
             return False
 
     # Row exists and is at/ahead of new_rank. The ONE legal exception to the
-    # monotonic no-op: a fresh `snatched` write against a terminal `failed`
-    # row is a RE-SNATCH that supersedes the closed failed attempt.
+    # monotonic no-op: a fresh RESERVED/SNATCHED write against a terminal
+    # `failed` row is a RE-SNATCH that supersedes the closed failed attempt.
     if existing[0] == FAILED and _try_reset_failed_attempt(conn, key, stage, new_rank, upd_values):
         return True
 
@@ -743,3 +769,98 @@ def read_one(release_key):
     """Cheap point lookup of a single journal row by release_key (used by the
     U6 replay snapshot-then-recheck), or None."""
     return db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == release_key))
+
+
+def read_needs_attention(*, issueid=None):
+    """Settled needs-attention band query (#437 / #457 / #483).
+
+    ``stage IN (failed, manual_review)`` and unresolved R9 status
+    (``status`` null or not in ``{retried, ignored, imported}``).
+    Newest ``updated_date`` first. Optional ``issueid`` scopes the band.
+    """
+    stmt = (
+        select(pipeline_journal)
+        .where(pipeline_journal.c.stage.in_(BAND_STAGES))
+        .where(
+            or_(
+                pipeline_journal.c.status.is_(None),
+                pipeline_journal.c.status.notin_(RESOLVED_STATUSES),
+            )
+        )
+        .order_by(pipeline_journal.c.updated_date.desc())
+    )
+    if issueid not in (None, ""):
+        stmt = stmt.where(pipeline_journal.c.issueid == str(issueid))
+    return db.select_all(stmt)
+
+
+def stamp_resolution(release_key, status, *, increment_retry=False, conn=None):
+    """Stamp an R9 resolution status without rewriting stage / stage_rank.
+
+    Legal only on band stages (``failed`` / ``manual_review``) that are not
+    already resolved. Returns True iff this call wrote the stamp.
+    """
+    if status not in RESOLVED_STATUSES:
+        raise ValueError("[JOURNAL] unknown resolution status %r" % (status,))
+    if release_key in (None, ""):
+        return False
+
+    when = _now()
+
+    def _write(active_conn):
+        row = active_conn.execute(
+            select(pipeline_journal).where(pipeline_journal.c.release_key == release_key)
+        ).fetchone()
+        if row is None:
+            return False
+        mapping = row._mapping
+        if mapping.get("stage") not in BAND_STAGES:
+            return False
+        if mapping.get("status") in RESOLVED_STATUSES:
+            return False
+        values = {"status": status, "updated_date": when}
+        if increment_retry:
+            current = mapping.get("retry_count")
+            try:
+                values["retry_count"] = int(current or 0) + 1
+            except (TypeError, ValueError):
+                values["retry_count"] = 1
+        result = active_conn.execute(
+            update(pipeline_journal)
+            .where(pipeline_journal.c.release_key == release_key)
+            .where(pipeline_journal.c.stage.in_(BAND_STAGES))
+            .where(
+                or_(
+                    pipeline_journal.c.status.is_(None),
+                    pipeline_journal.c.status.notin_(RESOLVED_STATUSES),
+                )
+            )
+            .values(**values)
+        )
+        return bool(result.rowcount)
+
+    if conn is not None:
+        return _write(conn)
+
+    attempt = 0
+    while attempt < 5:
+        try:
+            with db.get_engine().begin() as own_conn:
+                return _write(own_conn)
+        except OperationalError as e:
+            err_msg = str(e)
+            if "locked" in err_msg or "unable to open" in err_msg:
+                logger.warn(
+                    "[JOURNAL] Database locked during stamp_resolution "
+                    "(release_key=%s status=%s), retry %d: %s" % (release_key, status, attempt + 1, e)
+                )
+                attempt += 1
+                time.sleep(1)
+            else:
+                raise
+    logger.error("[JOURNAL] stamp_resolution FAILED after 5 retries (release_key=%s status=%s)" % (release_key, status))
+    raise OperationalError(
+        "Journal stamp_resolution on %s -> %s failed after 5 retries" % (release_key, status),
+        None,
+        None,
+    )

--- a/comicarr/app/downloads/router.py
+++ b/comicarr/app/downloads/router.py
@@ -18,11 +18,11 @@ from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 from starlette.responses import FileResponse
 
+from comicarr.app.core.context import AppContext, get_context
 from comicarr.app.core.security import require_session
 from comicarr.app.downloads import service as dl_service
 
 router = APIRouter(prefix="/api/downloads", tags=["downloads"])
-
 
 # ---------------------------------------------------------------------------
 # History endpoints
@@ -118,6 +118,81 @@ def process_issue(
     if not result["success"]:
         return JSONResponse(status_code=500, content={"detail": result.get("error")})
     return result
+
+
+# ---------------------------------------------------------------------------
+# Needs-attention band resolution (#483)
+# ---------------------------------------------------------------------------
+
+
+def _resolution_response(result):
+    if result.get("success"):
+        return result
+    return JSONResponse(
+        status_code=int(result.get("status_code") or 400),
+        content=result,
+    )
+
+
+@router.get("/needs-attention", dependencies=[Depends(require_session)])
+def list_needs_attention(
+    issueid: str = Query(None, max_length=100),
+):
+    """List unresolved failed / manual_review journal rows (band predicate)."""
+    return dl_service.list_needs_attention(issueid=issueid)
+
+
+@router.post("/needs-attention/{release_key:path}/retry")
+def needs_attention_retry(
+    release_key: str,
+    username: str = Depends(require_session),
+    ctx: AppContext = Depends(get_context),
+):
+    """Re-want + scoped search for a failed band row; stamp status=retried."""
+    return _resolution_response(dl_service.resolve_needs_attention(ctx, release_key, "retry", audit_identity=username))
+
+
+@router.post("/needs-attention/{release_key:path}/search-again")
+def needs_attention_search_again(
+    release_key: str,
+    username: str = Depends(require_session),
+    ctx: AppContext = Depends(get_context),
+):
+    """Re-want + scoped search for a manual_review band row; stamp status=retried."""
+    return _resolution_response(
+        dl_service.resolve_needs_attention(ctx, release_key, "search_again", audit_identity=username)
+    )
+
+
+@router.post("/needs-attention/{release_key:path}/ignore")
+def needs_attention_ignore(
+    release_key: str,
+    username: str = Depends(require_session),
+    ctx: AppContext = Depends(get_context),
+):
+    """Ignore issue (AcquisitionIntent.IGNORED) and stamp status=ignored."""
+    return _resolution_response(dl_service.resolve_needs_attention(ctx, release_key, "ignore", audit_identity=username))
+
+
+@router.post("/needs-attention/{release_key:path}/import")
+def needs_attention_import(
+    release_key: str,
+    request_body: dict = None,
+    username: str = Depends(require_session),
+    ctx: AppContext = Depends(get_context),
+):
+    """Route through validated post-process; stamp status=imported only on success."""
+    body = request_body or {}
+    return _resolution_response(
+        dl_service.resolve_needs_attention(
+            ctx,
+            release_key,
+            "import",
+            audit_identity=username,
+            nzb_name=body.get("nzb_name"),
+            nzb_folder=body.get("nzb_folder"),
+        )
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -169,6 +169,299 @@ def process_issue(comicid, folder, issueid=None):
 
 
 # ---------------------------------------------------------------------------
+# Needs-attention band (R9 resolution actions — #483)
+# ---------------------------------------------------------------------------
+
+_FAILED_ACTIONS = frozenset({"retry", "ignore"})
+_MANUAL_REVIEW_ACTIONS = frozenset({"import", "search_again", "ignore"})
+_BAND_ACTIONS = _FAILED_ACTIONS | _MANUAL_REVIEW_ACTIONS
+
+
+def list_needs_attention(*, issueid=None):
+    """Shared band query over the settled unresolved predicate."""
+    from comicarr.app.downloads import journal
+
+    return {"items": journal.read_needs_attention(issueid=issueid)}
+
+
+def _band_row_or_error(release_key):
+    from comicarr.app.downloads import journal
+
+    if release_key in (None, "") or not str(release_key).strip():
+        return None, {
+            "success": False,
+            "status": "failed",
+            "error": "Missing release_key",
+            "status_code": 400,
+        }
+    row = journal.read_one(str(release_key).strip())
+    if row is None:
+        return None, {
+            "success": False,
+            "status": "failed",
+            "error": "Journal row not found",
+            "status_code": 404,
+        }
+    stage = row.get("stage")
+    status = row.get("status")
+    if stage not in journal.BAND_STAGES:
+        return None, {
+            "success": False,
+            "status": "failed",
+            "error": "Row is not on the needs-attention band",
+            "status_code": 409,
+        }
+    if status in journal.RESOLVED_STATUSES:
+        return None, {
+            "success": False,
+            "status": "failed",
+            "error": "Row is already resolved",
+            "status_code": 409,
+        }
+    return row, None
+
+
+def _issue_id_from_row(row):
+    issueid = row.get("issueid")
+    if issueid not in (None, ""):
+        return str(issueid)
+    payload = None
+    try:
+        from comicarr.app.downloads import journal
+
+        payload = journal.load_payload(row.get("payload_json"))
+    except Exception as e:
+        logger.fdebug("[NEEDS-ATTENTION] payload decode for issueid failed: %s" % e)
+        payload = None
+    if isinstance(payload, dict):
+        for key in ("issueid", "IssueID"):
+            value = payload.get(key)
+            if value not in (None, ""):
+                return str(value)
+    return None
+
+
+def _payload_dict(row):
+    from comicarr.app.downloads import journal
+
+    payload = journal.load_payload(row.get("payload_json"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def _resolve_retry_or_search_again(ctx, row, release_key, *, action, audit_identity):
+    from comicarr.app.downloads import journal
+    from comicarr.app.search import service as search_service
+    from comicarr.app.series import queries as series_queries
+
+    issue_id = _issue_id_from_row(row)
+    if not issue_id:
+        return {
+            "success": False,
+            "status": "failed",
+            "error": "Journal row has no issueid",
+            "status_code": 400,
+        }
+
+    # Precheck before side effects: blocked search must leave the band row alone.
+    precheck = search_service._search_route_health(ctx)
+    if not precheck.get("success"):
+        return {
+            "success": False,
+            "status": "blocked",
+            "error": precheck.get("error") or precheck.get("message"),
+            "message": precheck.get("message"),
+            "status_code": 409,
+        }
+
+    # Want first so the worker sees Status=Wanted, then enqueue, then stamp
+    # off-band only after a successful queue so a failed enqueue leaves the
+    # row on the band for another try.
+    series_queries.queue_issue(issue_id, audit_identity)
+    trigger = "band_retry" if action == "retry" else "band_search_again"
+    search_result = search_service.search_issue(ctx, issue_id, trigger=trigger)
+    if not search_result.get("success"):
+        return {
+            "success": False,
+            "status": search_result.get("status") or "failed",
+            "error": search_result.get("error") or search_result.get("message"),
+            "message": search_result.get("message"),
+            "release_key": release_key,
+            "issue_id": issue_id,
+            "stamped": False,
+            "status_code": 409 if search_result.get("status") == "blocked" else 500,
+        }
+
+    stamped = journal.stamp_resolution(release_key, journal.STATUS_RETRIED, increment_retry=True)
+    return {
+        "success": True,
+        "status": "retried",
+        "action": action,
+        "release_key": release_key,
+        "issue_id": issue_id,
+        "run_id": search_result.get("run_id"),
+        "stamped": stamped,
+        "message": "Issue re-wanted and search queued",
+    }
+
+
+def _resolve_ignore(row, release_key, *, audit_identity):
+    from comicarr.app.downloads import journal
+    from comicarr.app.series import queries as series_queries
+
+    issue_id = _issue_id_from_row(row)
+    if not issue_id:
+        return {
+            "success": False,
+            "status": "failed",
+            "error": "Journal row has no issueid",
+            "status_code": 400,
+        }
+    series_queries.ignore_issue(issue_id, audit_identity)
+    stamped = journal.stamp_resolution(release_key, journal.STATUS_IGNORED)
+    return {
+        "success": True,
+        "status": "ignored",
+        "action": "ignore",
+        "release_key": release_key,
+        "issue_id": issue_id,
+        "stamped": stamped,
+        "message": "Issue ignored",
+    }
+
+
+def _resolve_import(row, release_key, *, nzb_name=None, nzb_folder=None):
+    from comicarr.app.downloads import journal
+
+    payload = _payload_dict(row)
+    name = nzb_name or payload.get("nzb_name") or payload.get("nzbname") or row.get("nzbname")
+    folder = nzb_folder or payload.get("nzb_folder")
+    if not name or not folder:
+        return {
+            "success": False,
+            "status": "failed",
+            "error": "Missing nzb_name or nzb_folder for import",
+            "status_code": 400,
+        }
+
+    # Do NOT attach journal_release_key: force_process / PP_QUEUE is the same
+    # unjournaled path as POST /api/downloads/process. Propagating the band's
+    # terminal release_key would make the PP claim lose (stage already terminal)
+    # and queue a silent no-op import.
+    item = {
+        "nzb_name": name,
+        "nzb_folder": folder,
+        "issueid": row.get("issueid") or payload.get("issueid"),
+        "comicid": payload.get("comicid"),
+        "ddl": bool(payload.get("ddl")),
+        "oneoff": bool(payload.get("oneoff")),
+    }
+    try:
+        validated = validate_postprocess_item(item)
+    except PostProcessCommandError as e:
+        return {
+            "success": False,
+            "status": "failed",
+            "error": str(e),
+            "message": str(e),
+            "status_code": 400,
+        }
+
+    result = force_process(
+        nzb_name=validated["nzb_name"],
+        nzb_folder=validated["nzb_folder"],
+        issueid=validated.get("issueid"),
+        comicid=validated.get("comicid"),
+        ddl=validated.get("ddl") or False,
+        oneoff=validated.get("oneoff") or False,
+    )
+    if not result.get("success"):
+        return {
+            "success": False,
+            "status": "failed",
+            "error": result.get("error") or "Post-process queue failed",
+            "status_code": 500,
+        }
+
+    stamped = journal.stamp_resolution(release_key, journal.STATUS_IMPORTED)
+    return {
+        "success": True,
+        "status": "imported",
+        "action": "import",
+        "release_key": release_key,
+        "stamped": stamped,
+        "message": result.get("message") or "Import queued",
+    }
+
+
+def resolve_needs_attention(
+    ctx,
+    release_key,
+    action,
+    *,
+    audit_identity,
+    nzb_name=None,
+    nzb_folder=None,
+):
+    """Apply one operator band exit without rewriting journal stage.
+
+    ``failed``: retry | ignore
+    ``manual_review``: import | search_again | ignore
+    """
+    from comicarr.app.downloads import journal
+
+    if not audit_identity or not str(audit_identity).strip():
+        return {
+            "success": False,
+            "status": "failed",
+            "error": "audit identity required",
+            "status_code": 400,
+        }
+
+    action_name = str(action or "").strip().lower()
+    if action_name not in _BAND_ACTIONS:
+        return {
+            "success": False,
+            "status": "failed",
+            "error": "Unknown action",
+            "status_code": 400,
+        }
+
+    row, err = _band_row_or_error(release_key)
+    if err is not None:
+        return err
+
+    stage = row.get("stage")
+    if stage == journal.FAILED and action_name not in _FAILED_ACTIONS:
+        return {
+            "success": False,
+            "status": "failed",
+            "error": "Action %s is not valid for failed rows" % action_name,
+            "status_code": 409,
+        }
+    if stage == journal.MANUAL_REVIEW and action_name not in _MANUAL_REVIEW_ACTIONS:
+        return {
+            "success": False,
+            "status": "failed",
+            "error": "Action %s is not valid for manual_review rows" % action_name,
+            "status_code": 409,
+        }
+
+    key = str(release_key).strip()
+    if action_name in {"retry", "search_again"}:
+        return _resolve_retry_or_search_again(ctx, row, key, action=action_name, audit_identity=audit_identity)
+    if action_name == "ignore":
+        return _resolve_ignore(row, key, audit_identity=audit_identity)
+    if action_name == "import":
+        return _resolve_import(row, key, nzb_name=nzb_name, nzb_folder=nzb_folder)
+    return {
+        "success": False,
+        "status": "failed",
+        "error": "Unknown action",
+        "status_code": 400,
+    }
+
+
+# ---------------------------------------------------------------------------
 # DDL queue management
 # ---------------------------------------------------------------------------
 

--- a/comicarr/app/search/commands.py
+++ b/comicarr/app/search/commands.py
@@ -91,6 +91,9 @@ def queue_priority_for_trigger(trigger: str, *, manual: bool = False) -> str:
         "search_all_missing",
         "issue_wanted",
         "storyarc_wanted",
+        "band_retry",
+        "band_search_again",
+        "issue_retry",
     }:
         return INTERACTIVE
     return ROUTINE

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -183,10 +183,8 @@ def add_manga(ctx, manga_id):
         return {"success": False, "error": "Error adding manga: %s" % str(e)}
 
 
-def force_search(ctx):
-    """Trigger a full search for all wanted issues with a durable outcome."""
-    from comicarr import search
-    from comicarr.app.acquisition.runs import RunLedger
+def _search_route_health(ctx):
+    """Shared get_search_health precheck for force_search and search_issue."""
     from comicarr.app.search.health import blocking_route_reason, get_search_health
 
     health = get_search_health(
@@ -204,6 +202,63 @@ def force_search(ctx):
             "status": "blocked",
             "error": blocking_route_reason(routes),
             "message": "Search blocked: no complete acquisition route is ready",
+            "routes": routes,
+        }
+    return {"success": True, "routes": routes, "health": health}
+
+
+def search_issue(ctx, issue_id, *, trigger="issue_retry"):
+    """Scoped single-issue search with the same route precheck as force_search.
+
+    Used by needs-attention band retry / search-again (#483). Does not rewrite
+    journal stage; callers stamp R9 resolution separately.
+    """
+    from comicarr.app.search.commands import enqueue_search_command
+
+    if issue_id in (None, "") or not str(issue_id).strip():
+        return {
+            "success": False,
+            "status": "failed",
+            "error": "Missing issue_id",
+            "message": "Missing issue_id",
+        }
+
+    precheck = _search_route_health(ctx)
+    if not precheck.get("success"):
+        return {
+            "success": False,
+            "status": "blocked",
+            "error": precheck.get("error"),
+            "message": precheck.get("message"),
+        }
+
+    command = enqueue_search_command(
+        {"issueid": str(issue_id).strip()},
+        trigger=trigger,
+        scope_type="issue",
+        scope_id=str(issue_id).strip(),
+    )
+    return {
+        "success": True,
+        "status": "accepted",
+        "run_id": command.run_id,
+        "issue_id": str(issue_id).strip(),
+        "message": "Search queued for issue %s" % issue_id,
+    }
+
+
+def force_search(ctx):
+    """Trigger a full search for all wanted issues with a durable outcome."""
+    from comicarr import search
+    from comicarr.app.acquisition.runs import RunLedger
+
+    precheck = _search_route_health(ctx)
+    if not precheck.get("success"):
+        return {
+            "success": False,
+            "status": "blocked",
+            "error": precheck.get("error"),
+            "message": precheck.get("message"),
         }
 
     run_id = str(uuid.uuid4())

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -223,6 +223,18 @@ def unqueue_issue(issue_id, audit_identity):
     )
 
 
+def ignore_issue(issue_id, audit_identity):
+    """Mark an issue as Ignored (operator permanent decline; not Skipped)."""
+    from comicarr.app.acquisition.models import AcquisitionIntent
+    from comicarr.app.acquisition.policy import explicit_intent_values
+
+    db.upsert(
+        "issues",
+        explicit_intent_values(AcquisitionIntent.IGNORED, audit_identity),
+        {"IssueID": issue_id},
+    )
+
+
 # ---------------------------------------------------------------------------
 # Wanted queries
 # ---------------------------------------------------------------------------

--- a/comicarr/app/system/acquisition_repair.py
+++ b/comicarr/app/system/acquisition_repair.py
@@ -248,11 +248,21 @@ class RepairService:
     # ------------------------------------------------------------------
 
     def _journal_evidence(self, conn, issue_id):
+        # Operator / auto R9 resolution stamps (#483 / #437): a row already
+        # retried, ignored, or imported must not re-propose Failed over Wanted.
+        from comicarr.app.downloads.journal import RESOLVED_STATUSES
+
         rows = list(
             conn.execute(
                 select(pipeline_journal)
                 .where(pipeline_journal.c.issueid == str(issue_id))
                 .where(pipeline_journal.c.stage.in_(tuple(_JOURNAL_EVIDENCE_STAGES)))
+                .where(
+                    or_(
+                        pipeline_journal.c.status.is_(None),
+                        pipeline_journal.c.status.notin_(tuple(RESOLVED_STATUSES)),
+                    )
+                )
                 .order_by(pipeline_journal.c.updated_date.desc(), pipeline_journal.c.stage_rank.desc())
             ).mappings()
         )

--- a/comicarr/failed.py
+++ b/comicarr/failed.py
@@ -36,6 +36,8 @@ FAIL_REASON_NO_AUTO_HANDLING = "download_failed_no_auto_handling"
 
 # R9 resolution stamp: auto re-search enqueued (or operator retry). Keeps the
 # failed journal row off the needs-attention band without rewriting stage.
+# Keep the literal here so failed.py stays free of journal import at module load;
+# journal.STATUS_RETRIED is the shared name for band/query code.
 STATUS_RETRIED = "retried"
 
 

--- a/comicarr/tables.py
+++ b/comicarr/tables.py
@@ -750,8 +750,8 @@ activity_events = Table(
 # post-process pipeline. One row per release_key. Survives process restart so
 # an in-flight item completes exactly once. stage is totally ordered via
 # stage_rank (the conditional advance-only WHERE + the PP-consumer atomic
-# claim). status/retry_count/next_retry_at are reserved-nullable for a future
-# operator status / retry-backoff layer (R9) and are unpopulated now.
+# claim). status/retry_count/next_retry_at are R9 resolution columns: operator
+# band exits and FAILED_AUTO stamp status without rewriting stage (#483).
 pipeline_journal = Table(
     "pipeline_journal",
     metadata,

--- a/tests/unit/test_needs_attention_resolution.py
+++ b/tests/unit/test_needs_attention_resolution.py
@@ -1,0 +1,481 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""#483 — needs-attention band resolution actions.
+
+Seams under test (agreed):
+  1. journal.read_needs_attention / stamp_resolution
+  2. ignore_issue intent helper
+  3. search_issue scoped entry
+  4. service actions: retry / search-again / ignore / import
+  5. acquisition_repair evidence skips resolved statuses
+  6. same-provider re-snatch: SNATCHED against failed wins
+"""
+
+import queue as queuelib
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+
+import comicarr
+from comicarr import db
+from comicarr.app.acquisition.maintenance import ensure_acquisition_schema
+from comicarr.app.core.context import AppContext
+from comicarr.app.downloads import journal
+from comicarr.app.downloads import service as dl_service
+from comicarr.app.search import service as search_service
+from comicarr.app.series import queries as series_queries
+from comicarr.app.system.acquisition_repair import RepairService
+from comicarr.db import get_engine, shutdown_engine
+from comicarr.tables import comics, issues, metadata, pipeline_journal
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    shutdown_engine()
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    if not hasattr(comicarr, "LOG_LEVEL") or comicarr.LOG_LEVEL is None:
+        monkeypatch.setattr(comicarr, "LOG_LEVEL", 0, raising=False)
+    monkeypatch.setattr(comicarr, "GLOBAL_MESSAGES", None, raising=False)
+    monkeypatch.setattr(comicarr, "PROVIDER_BLOCKLIST", {}, raising=False)
+    monkeypatch.setattr(comicarr, "SEARCH_QUEUE", queuelib.Queue(), raising=False)
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(
+            FAILED_DOWNLOAD_HANDLING=True,
+            FAILED_AUTO=False,
+            HIGHCOUNT=0,
+            DDL_LOCATION=str(tmp_path / "ddl"),
+            CACHE_DIR=str(tmp_path / "cache"),
+            DESTINATION_DIR=str(tmp_path / "library"),
+        ),
+        raising=False,
+    )
+    engine = get_engine()
+    metadata.create_all(engine)
+    assert ensure_acquisition_schema(engine).ready
+    yield
+    shutdown_engine()
+
+
+def _seed_issue(*, issueid="1001", comicid="C1", status="Failed", intent=None):
+    with get_engine().begin() as conn:
+        conn.execute(
+            comics.insert().values(
+                ComicID=comicid,
+                ComicName="Saga",
+                ComicYear="2012",
+                Status="Active",
+            )
+        )
+        conn.execute(
+            issues.insert().values(
+                IssueID=issueid,
+                ComicID=comicid,
+                ComicName="Saga",
+                Issue_Number="1",
+                Status=status,
+                AcquisitionIntent=intent,
+            )
+        )
+
+
+def _seed_failed_row(
+    *,
+    key="1001|nzbgeek",
+    issueid="1001",
+    provider="nzbgeek",
+    status=None,
+    retry_count=None,
+    payload=None,
+):
+    journal.record_transition(
+        key,
+        journal.SNATCHED,
+        payload=payload
+        or {
+            "issueid": issueid,
+            "provider": provider,
+            "nzbname": "Saga.001",
+            "comicname": "Saga",
+            "issuenumber": "1",
+        },
+        issueid=issueid,
+        provider=provider,
+        nzbname="Saga.001",
+    )
+    journal.mark_failed(key, "download_failed_no_auto_handling", issueid=issueid, provider=provider)
+    if status is not None or retry_count is not None:
+        with get_engine().begin() as conn:
+            values = {}
+            if status is not None:
+                values["status"] = status
+            if retry_count is not None:
+                values["retry_count"] = retry_count
+            conn.execute(
+                pipeline_journal.update().where(pipeline_journal.c.release_key == key).values(**values)
+            )
+    return key
+
+
+def _seed_manual_review_row(
+    *,
+    key="1001|ddl",
+    issueid="1001",
+    provider="ddl",
+    nzb_name="Saga.001.cbz",
+    nzb_folder=None,
+):
+    payload = {
+        "issueid": issueid,
+        "provider": provider,
+        "nzb_name": nzb_name,
+        "nzbname": nzb_name,
+        "nzb_folder": nzb_folder or "/tmp/pp/Saga.001",
+    }
+    journal.record_transition(
+        key,
+        journal.SNATCHED,
+        payload=payload,
+        issueid=issueid,
+        provider=provider,
+        nzbname=nzb_name,
+    )
+    journal.record_transition(key, journal.DOWNLOADED, payload=payload)
+    journal.mark_manual_review(key, "path_unsafe", payload=payload, issueid=issueid, provider=provider)
+    return key
+
+
+def _issue_row(issueid="1001"):
+    return db.select_one(select(issues).where(issues.c.IssueID == issueid))
+
+
+def _journal_row(key):
+    return journal.read_one(key)
+
+
+# ---------------------------------------------------------------------------
+# 1. Band query + stamp_resolution
+# ---------------------------------------------------------------------------
+
+
+def test_read_needs_attention_settled_predicate():
+    _seed_issue()
+    on_band = _seed_failed_row(key="1001|a")
+    off_retried = _seed_failed_row(key="1001|b", status=journal.STATUS_RETRIED)
+    off_ignored = _seed_failed_row(key="1001|c", status=journal.STATUS_IGNORED)
+    off_imported = _seed_failed_row(key="1001|d", status=journal.STATUS_IMPORTED)
+    open_key = journal.release_key("1001", "open")
+    journal.record_transition(open_key, journal.SNATCHED, issueid="1001", provider="open")
+
+    keys = {r["release_key"] for r in journal.read_needs_attention()}
+    assert on_band in keys
+    assert off_retried not in keys
+    assert off_ignored not in keys
+    assert off_imported not in keys
+    assert open_key not in keys
+
+
+def test_stamp_resolution_retried_increments_retry_count_without_stage_change():
+    _seed_issue()
+    key = _seed_failed_row()
+    before = _journal_row(key)
+    assert before["stage"] == journal.FAILED
+    assert before.get("retry_count") in (None, 0)
+
+    assert journal.stamp_resolution(key, journal.STATUS_RETRIED, increment_retry=True) is True
+
+    after = _journal_row(key)
+    assert after["stage"] == journal.FAILED
+    assert after["stage_rank"] == before["stage_rank"]
+    assert after["status"] == journal.STATUS_RETRIED
+    assert after["retry_count"] == 1
+    assert key not in {r["release_key"] for r in journal.read_needs_attention()}
+
+
+def test_stamp_resolution_rejects_open_stage():
+    key = journal.release_key("9", "p")
+    journal.record_transition(key, journal.SNATCHED, issueid="9", provider="p")
+    assert journal.stamp_resolution(key, journal.STATUS_IGNORED) is False
+    assert _journal_row(key)["stage"] == journal.SNATCHED
+    assert _journal_row(key).get("status") is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Same-provider re-snatch (SNATCHED against failed wins)
+# ---------------------------------------------------------------------------
+
+
+def test_snatched_against_failed_resets_and_wins():
+    """NZB/torrent snatch path writes SNATCHED, not RESERVED — must not silent-no-op."""
+    key = journal.release_key("500", "nzbgeek")
+    journal.record_transition(key, journal.SNATCHED, issueid="500", provider="nzbgeek")
+    journal.mark_failed(key, "gone")
+    journal.stamp_resolution(key, journal.STATUS_RETRIED, increment_retry=True)
+
+    won = journal.record_transition(
+        key,
+        journal.SNATCHED,
+        payload={"issueid": "500", "provider": "nzbgeek", "nzbname": "retry.cbz"},
+        issueid="500",
+        provider="nzbgeek",
+        nzbname="retry.cbz",
+    )
+
+    assert won is True
+    row = _journal_row(key)
+    assert row["stage"] == journal.SNATCHED
+    assert row["fail_reason"] is None
+    assert row.get("status") is None  # reset clears resolution stamp for new attempt
+
+
+# ---------------------------------------------------------------------------
+# 2. ignore_issue
+# ---------------------------------------------------------------------------
+
+
+def test_ignore_issue_sets_ignored_intent_and_status():
+    _seed_issue(status="Failed")
+    series_queries.ignore_issue("1001", "operator")
+    row = _issue_row()
+    assert row["AcquisitionIntent"] == "ignored"
+    assert row["Status"] == "Ignored"
+
+
+def test_ignore_issue_requires_audit_identity():
+    _seed_issue()
+    with pytest.raises(ValueError, match="audit identity"):
+        series_queries.ignore_issue("1001", "")
+
+
+# ---------------------------------------------------------------------------
+# 3. search_issue
+# ---------------------------------------------------------------------------
+
+
+def test_search_issue_blocked_when_no_viable_route(monkeypatch):
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+    monkeypatch.setattr(
+        "comicarr.app.search.health.get_search_health",
+        lambda *a, **k: {"viable_route": False, "routes": {}},
+    )
+    result = search_service.search_issue(ctx, "1001")
+    assert result["success"] is False
+    assert result["status"] == "blocked"
+
+
+def test_search_issue_enqueues_when_route_ready(monkeypatch):
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+    monkeypatch.setattr(
+        "comicarr.app.search.health.get_search_health",
+        lambda *a, **k: {
+            "viable_route": True,
+            "routes": {"nzb": {"ready": True, "viable": True}},
+        },
+    )
+    fake_cmd = SimpleNamespace(run_id="run-1", issueid="1001")
+    with patch("comicarr.app.search.commands.enqueue_search_command", return_value=fake_cmd) as enq:
+        result = search_service.search_issue(ctx, "1001", trigger="band_retry")
+    assert result["success"] is True
+    assert result["run_id"] == "run-1"
+    enq.assert_called_once()
+    assert enq.call_args.kwargs["trigger"] == "band_retry"
+
+
+# ---------------------------------------------------------------------------
+# 4. Service actions
+# ---------------------------------------------------------------------------
+
+
+def test_retry_failed_wants_stamps_and_searches(monkeypatch):
+    _seed_issue(status="Failed")
+    key = _seed_failed_row()
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+    monkeypatch.setattr(
+        "comicarr.app.search.health.get_search_health",
+        lambda *a, **k: {"viable_route": True, "routes": {"nzb": {"ready": True}}},
+    )
+    with patch(
+        "comicarr.app.search.commands.enqueue_search_command",
+        return_value=SimpleNamespace(run_id="r1", issueid="1001"),
+    ):
+        result = dl_service.resolve_needs_attention(ctx, key, "retry", audit_identity="op")
+
+    assert result["success"] is True
+    assert _issue_row()["Status"] == "Wanted"
+    assert _issue_row()["AcquisitionIntent"] == "wanted"
+    row = _journal_row(key)
+    assert row["status"] == journal.STATUS_RETRIED
+    assert row["retry_count"] == 1
+    assert row["stage"] == journal.FAILED
+    assert key not in {r["release_key"] for r in journal.read_needs_attention()}
+
+
+def test_retry_blocked_does_not_stamp(monkeypatch):
+    _seed_issue(status="Failed")
+    key = _seed_failed_row()
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+    monkeypatch.setattr(
+        "comicarr.app.search.health.get_search_health",
+        lambda *a, **k: {"viable_route": False, "routes": {}},
+    )
+    result = dl_service.resolve_needs_attention(ctx, key, "retry", audit_identity="op")
+    assert result["success"] is False
+    assert result["status"] == "blocked"
+    assert _journal_row(key).get("status") not in journal.RESOLVED_STATUSES
+    assert key in {r["release_key"] for r in journal.read_needs_attention()}
+
+
+def test_ignore_failed_stamps_and_sets_intent():
+    _seed_issue(status="Failed")
+    key = _seed_failed_row()
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+    result = dl_service.resolve_needs_attention(ctx, key, "ignore", audit_identity="op")
+    assert result["success"] is True
+    assert _issue_row()["AcquisitionIntent"] == "ignored"
+    assert _issue_row()["Status"] == "Ignored"
+    assert _journal_row(key)["status"] == journal.STATUS_IGNORED
+    assert _journal_row(key)["stage"] == journal.FAILED
+
+
+def test_search_again_manual_review(monkeypatch):
+    _seed_issue(status="Snatched")
+    key = _seed_manual_review_row()
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+    monkeypatch.setattr(
+        "comicarr.app.search.health.get_search_health",
+        lambda *a, **k: {"viable_route": True, "routes": {"nzb": {"ready": True}}},
+    )
+    with patch(
+        "comicarr.app.search.commands.enqueue_search_command",
+        return_value=SimpleNamespace(run_id="r2", issueid="1001"),
+    ):
+        result = dl_service.resolve_needs_attention(ctx, key, "search_again", audit_identity="op")
+    assert result["success"] is True
+    assert _issue_row()["Status"] == "Wanted"
+    assert _journal_row(key)["status"] == journal.STATUS_RETRIED
+    assert _journal_row(key)["stage"] == journal.MANUAL_REVIEW
+
+
+def test_import_stamps_only_on_success(tmp_path, monkeypatch):
+    _seed_issue()
+    root = tmp_path / "pp"
+    root.mkdir()
+    folder = root / "job"
+    folder.mkdir()
+    key = _seed_manual_review_row(nzb_folder=str(folder), nzb_name="Saga.001.cbz")
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(
+            FAILED_DOWNLOAD_HANDLING=True,
+            FAILED_AUTO=False,
+            HIGHCOUNT=0,
+            DDL_LOCATION=str(tmp_path / "ddl"),
+            CACHE_DIR=str(tmp_path / "cache"),
+            DESTINATION_DIR=str(tmp_path / "library"),
+            MANUAL_PP_FOLDER=str(root),
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(comicarr, "PP_QUEUE", queuelib.Queue(), raising=False)
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+
+    result = dl_service.resolve_needs_attention(ctx, key, "import", audit_identity="op")
+    assert result["success"] is True
+    assert _journal_row(key)["status"] == journal.STATUS_IMPORTED
+    assert _journal_row(key)["stage"] == journal.MANUAL_REVIEW
+    assert not comicarr.PP_QUEUE.empty()
+    queued = comicarr.PP_QUEUE.get_nowait()
+    assert "journal_release_key" not in queued
+
+
+def test_import_validation_failure_keeps_band(tmp_path, monkeypatch):
+    _seed_issue()
+    # folder outside any configured root / missing
+    key = _seed_manual_review_row(nzb_folder=str(tmp_path / "evil" / "path"), nzb_name="Saga.001.cbz")
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        SimpleNamespace(
+            MANUAL_PP_FOLDER=str(tmp_path / "pp"),
+            DDL_LOCATION=str(tmp_path / "ddl"),
+            CACHE_DIR=str(tmp_path / "cache"),
+            DESTINATION_DIR=str(tmp_path / "library"),
+        ),
+        raising=False,
+    )
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+    result = dl_service.resolve_needs_attention(ctx, key, "import", audit_identity="op")
+    assert result["success"] is False
+    assert "error" in result
+    assert _journal_row(key).get("status") != journal.STATUS_IMPORTED
+    assert key in {r["release_key"] for r in journal.read_needs_attention()}
+
+
+def test_retry_not_allowed_on_manual_review():
+    _seed_issue()
+    key = _seed_manual_review_row()
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+    result = dl_service.resolve_needs_attention(ctx, key, "retry", audit_identity="op")
+    assert result["success"] is False
+
+
+def test_import_not_allowed_on_failed():
+    _seed_issue()
+    key = _seed_failed_row()
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+    result = dl_service.resolve_needs_attention(ctx, key, "import", audit_identity="op")
+    assert result["success"] is False
+
+
+def test_already_resolved_returns_409_without_side_effects(monkeypatch):
+    _seed_issue(status="Failed")
+    key = _seed_failed_row(status=journal.STATUS_RETRIED, retry_count=1)
+    ctx = AppContext(config=comicarr.CONFIG, provider_blocklist={})
+    enqueued = []
+    monkeypatch.setattr(
+        "comicarr.app.search.commands.enqueue_search_command",
+        lambda *a, **k: enqueued.append(1) or SimpleNamespace(run_id="x", issueid="1001"),
+    )
+    result = dl_service.resolve_needs_attention(ctx, key, "retry", audit_identity="op")
+    assert result["success"] is False
+    assert result.get("status_code") == 409
+    assert enqueued == []
+    assert _issue_row()["Status"] == "Failed"
+    assert _journal_row(key)["status"] == journal.STATUS_RETRIED
+
+
+# ---------------------------------------------------------------------------
+# 5. Repair evidence skips resolved statuses
+# ---------------------------------------------------------------------------
+
+
+def test_journal_evidence_skips_retried_failed_row():
+    _seed_issue(status="Wanted", intent="wanted")
+    key = _seed_failed_row(status=journal.STATUS_RETRIED)
+    service = RepairService(get_engine())
+    with get_engine().connect() as conn:
+        evidence = service._journal_evidence(conn, "1001")
+    assert evidence is None or evidence.get("reason") != "journal_failed"
+    # If another journal row existed we might get different evidence; with only
+    # the resolved failed row, evidence must not propose Failed.
+    if evidence is not None:
+        assert evidence.get("target_status") != "Failed"
+    # Explicit: resolved row alone yields no journal evidence.
+    with get_engine().begin() as conn:
+        conn.execute(pipeline_journal.delete().where(pipeline_journal.c.release_key == key))
+    # re-seed only resolved failed
+    _seed_failed_row(key=key, status=journal.STATUS_RETRIED)
+    with get_engine().connect() as conn:
+        assert service._journal_evidence(conn, "1001") is None


### PR DESCRIPTION
Activity Center: Needs-attention band resolution actions

Operators can clear stuck failed and manual-review downloads from the needs-attention work queue without rewriting pipeline stage history.

## Changes
- Add band list API and resolution actions (`retry`, `search-again`, `ignore`, `import`) over the settled R9 status predicate
- Re-want + scoped `search_issue` with route health precheck; stamp `retried`/`ignored`/`imported` without changing `stage`/`stage_rank`
- Fix same-provider re-snatch so a SNATCHED write against a failed `issue|provider` key wins instead of silent no-op

Closes #483