### PR TITLE
feat: Add activity event write facade

### DIFF
--- a/comicarr/app/activity/__init__.py
+++ b/comicarr/app/activity/__init__.py
@@ -8,8 +8,26 @@
 #  (at your option) any later version.
 
 """Activity Center domain — narrative timeline, attention band, open-work reads,
-and age-based retention of activity_events.
+age-based retention, and the sole write facade for activity_events.
 
-Query-backed HTTP reads (#485); daily 90-day purge (#489). Write facade,
-producers, and UI land in sibling issues.
+Query-backed HTTP reads (#485); daily 90-day purge (#489); write facade (#479).
+Producers call :func:`comicarr.app.activity.events.record_activity` (and
+:func:`publish_activity` after a shared-conn commit). Do not insert into
+``activity_events`` or publish the ``activity`` SSE envelope elsewhere.
 """
+
+from comicarr.app.activity.events import (
+    LEGAL_CELLS,
+    is_legal_cell,
+    publish_activity,
+    record_activity,
+    severity_for,
+)
+
+__all__ = [
+    "LEGAL_CELLS",
+    "is_legal_cell",
+    "publish_activity",
+    "record_activity",
+    "severity_for",
+]

--- a/comicarr/app/activity/events.py
+++ b/comicarr/app/activity/events.py
@@ -17,9 +17,10 @@ Contract (Activity Center ADR §7 / #479):
 
 * When ``conn`` is supplied, the insert co-commits in the caller's transaction
   and this module does **not** publish. The caller publishes after their
-  commit succeeds (Core has no after-commit hook).
+  commit succeeds (Core has no after-commit hook). Insert failures propagate
+  so the caller can roll back the transaction they own.
 * When ``conn`` is omitted, this module owns a short transaction, commits, then
-  publishes best-effort.
+  publishes best-effort. Insert failures are logged and swallowed (``None``).
 * Journal-backed producers pass ``won`` from ``record_transition``; ``won=False``
   is a full no-op (no insert, no publish) so concurrent losers stay silent.
 * Illegal ``(activity, status, subject_type)`` cells and missing ``reason_code``
@@ -287,7 +288,9 @@ def record_activity(
     conn:
         Optional caller-owned SQLAlchemy connection. When provided, the insert
         joins that transaction and **publish is left to the caller** after their
-        commit (call :func:`publish_activity` with the returned payload).
+        commit (call :func:`publish_activity` with the returned payload). Insert
+        failures **propagate** on this path so the caller can roll back; only
+        the owned-transaction path (``conn=None``) swallows them.
     won:
         Journal-backed gate. Pass ``record_transition``'s return value. When
         False, this is a full no-op (no insert, no publish).
@@ -332,11 +335,13 @@ def record_activity(
     if created_at is not None:
         values["created_at"] = created_at
 
-    try:
-        if conn is not None:
-            # Co-commit: caller owns durability and post-commit publish.
-            return _insert_row(conn, values)
+    if conn is not None:
+        # Co-commit: caller owns the transaction, so a failed insert must
+        # surface. Swallowing it here would leave the caller's transaction
+        # poisoned and fail later at an unrelated statement or commit().
+        return _insert_row(conn, values)
 
+    try:
         engine = get_engine()
         with engine.begin() as owned_conn:
             payload = _insert_row(owned_conn, values)

--- a/comicarr/app/activity/events.py
+++ b/comicarr/app/activity/events.py
@@ -1,0 +1,348 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Activity Center write facade — sole legal writer of ``activity_events``.
+
+Producers call :func:`record_activity` (and, when they own the transaction,
+:func:`publish_activity` after commit). Do not insert into ``activity_events``
+directly and do not call ``event_bus.publish_sync("activity", …)`` elsewhere.
+
+Contract (Activity Center ADR §7 / #479):
+
+* When ``conn`` is supplied, the insert co-commits in the caller's transaction
+  and this module does **not** publish. The caller publishes after their
+  commit succeeds (Core has no after-commit hook).
+* When ``conn`` is omitted, this module owns a short transaction, commits, then
+  publishes best-effort.
+* Journal-backed producers pass ``won`` from ``record_transition``; ``won=False``
+  is a full no-op (no insert, no publish) so concurrent losers stay silent.
+* Illegal ``(activity, status, subject_type)`` cells and missing ``reason_code``
+  when severity ≠ ``normal`` are rejected (no-op + warning).
+* Publish never announces a row that is not durable.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy import insert
+
+from comicarr import logger
+from comicarr.app.core.runtime import get_runtime_if_initialized
+from comicarr.db import get_engine
+from comicarr.tables import activity_events
+
+# ---------------------------------------------------------------------------
+# Vocabulary (Activity Center ADR §4, amended by #426/#427/#430/#432)
+# ---------------------------------------------------------------------------
+
+ACTIVITIES = frozenset({"search", "grab", "download", "import", "refresh", "add", "tag"})
+
+STATUSES = frozenset(
+    {
+        "started",
+        "succeeded",
+        "no_match",
+        "cancelled",
+        "failed",
+        "blocked",
+        "needs_attention",
+    }
+)
+
+SUBJECT_TYPES = frozenset({"issue", "annual", "series", "arc", "run"})
+
+# Severity is a pure function of status — never stored.
+_SEVERITY_BY_STATUS = {
+    "started": "normal",
+    "succeeded": "normal",
+    "no_match": "normal",
+    "cancelled": "normal",
+    "failed": "action_required",
+    "blocked": "action_required",
+    "needs_attention": "action_required",
+}
+
+ACTION_REQUIRED_STATUSES = frozenset(status for status, severity in _SEVERITY_BY_STATUS.items() if severity != "normal")
+
+# Activities that join the pipeline journal and therefore require release_key.
+_RELEASE_KEY_ACTIVITIES = frozenset({"download", "import"})
+
+# Legal (activity, status, subject_type) cells. Summary of the #426 table with
+# later amendments:
+#   - tag row (#430)
+#   - refresh × arc, grab × cancelled, import × cancelled, download × cancelled
+#   - dropped: search.no_match @ issue, all retrying, search.blocked @ run
+#   - grab.cancelled @ series (pack reverse producer)
+LEGAL_CELLS = frozenset(
+    {
+        # search — run brackets + per-issue trouble (no per-issue no_match)
+        ("search", "started", "run"),
+        ("search", "succeeded", "run"),
+        ("search", "cancelled", "issue"),
+        ("search", "cancelled", "annual"),
+        ("search", "failed", "issue"),
+        ("search", "failed", "annual"),
+        ("search", "blocked", "issue"),
+        ("search", "blocked", "annual"),
+        ("search", "needs_attention", "issue"),
+        ("search", "needs_attention", "annual"),
+        # grab
+        ("grab", "succeeded", "issue"),
+        ("grab", "succeeded", "annual"),
+        ("grab", "failed", "issue"),
+        ("grab", "failed", "annual"),
+        ("grab", "blocked", "issue"),
+        ("grab", "blocked", "annual"),
+        ("grab", "cancelled", "issue"),
+        ("grab", "cancelled", "annual"),
+        ("grab", "cancelled", "series"),
+        # download — no started (live state, not narrated)
+        ("download", "succeeded", "issue"),
+        ("download", "succeeded", "annual"),
+        ("download", "failed", "issue"),
+        ("download", "failed", "annual"),
+        ("download", "cancelled", "issue"),
+        ("download", "cancelled", "annual"),
+        # import
+        ("import", "started", "issue"),
+        ("import", "started", "annual"),
+        ("import", "succeeded", "issue"),
+        ("import", "succeeded", "annual"),
+        ("import", "failed", "issue"),
+        ("import", "failed", "annual"),
+        ("import", "needs_attention", "issue"),
+        ("import", "needs_attention", "annual"),
+        ("import", "cancelled", "issue"),
+        ("import", "cancelled", "annual"),
+        # refresh
+        ("refresh", "started", "series"),
+        ("refresh", "started", "issue"),
+        ("refresh", "started", "arc"),
+        ("refresh", "succeeded", "series"),
+        ("refresh", "succeeded", "issue"),
+        ("refresh", "succeeded", "arc"),
+        ("refresh", "failed", "series"),
+        ("refresh", "failed", "issue"),
+        ("refresh", "failed", "arc"),
+        # add
+        ("add", "started", "series"),
+        ("add", "started", "arc"),
+        ("add", "succeeded", "series"),
+        ("add", "succeeded", "arc"),
+        ("add", "failed", "series"),
+        ("add", "failed", "arc"),
+        # tag — metatagger only @ issue|series
+        ("tag", "started", "issue"),
+        ("tag", "started", "series"),
+        ("tag", "succeeded", "issue"),
+        ("tag", "succeeded", "series"),
+        ("tag", "failed", "issue"),
+        ("tag", "failed", "series"),
+        ("tag", "needs_attention", "issue"),
+        ("tag", "needs_attention", "series"),
+    }
+)
+
+SSE_EVENT_TYPE = "activity"
+
+_PAYLOAD_KEYS = (
+    "event_id",
+    "created_at",
+    "activity",
+    "status",
+    "subject_type",
+    "subject_id",
+    "subject_label",
+    "reason_code",
+    "reason_detail",
+    "provider",
+    "run_id",
+    "release_key",
+    "parent_series_id",
+    "scope_type",
+    "scope_id",
+)
+
+
+def severity_for(status: str) -> str:
+    """Return the severity rung for ``status`` (pure function; not stored)."""
+    return _SEVERITY_BY_STATUS.get(status, "action_required")
+
+
+def is_legal_cell(activity: str, status: str, subject_type: str) -> bool:
+    """True iff ``(activity, status, subject_type)`` is a narratable cell."""
+    return (activity, status, subject_type) in LEGAL_CELLS
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def _validate(
+    activity: str,
+    status: str,
+    subject_type: str,
+    *,
+    reason_code,
+    release_key,
+    run_id,
+    provider,
+    scope_type,
+    scope_id,
+) -> str | None:
+    """Return a rejection reason string, or None if the write is allowed."""
+    if activity not in ACTIVITIES:
+        return "unknown activity %r" % (activity,)
+    if status not in STATUSES:
+        return "unknown status %r" % (status,)
+    if subject_type not in SUBJECT_TYPES:
+        return "unknown subject_type %r" % (subject_type,)
+    if not is_legal_cell(activity, status, subject_type):
+        return "illegal cell (%s, %s, %s)" % (activity, status, subject_type)
+    if severity_for(status) != "normal" and not reason_code:
+        return "reason_code required when severity is not normal (status=%s)" % status
+    if activity in _RELEASE_KEY_ACTIVITIES and not release_key:
+        return "release_key required for activity %r" % (activity,)
+    # ADR field contract: run_id is search-only (removed from grab).
+    if run_id and activity != "search":
+        return "run_id is only valid for activity 'search'"
+    # Grab without a source is unreadable (#426).
+    if activity == "grab" and not provider:
+        return "provider required for activity 'grab'"
+    # scope_* only applies to run subjects (ADR §4).
+    if (scope_type or scope_id) and subject_type != "run":
+        return "scope_type/scope_id are only valid when subject_type is 'run'"
+    if (scope_type is None) != (scope_id is None):
+        return "scope_type and scope_id must be provided together"
+    return None
+
+
+def _row_payload(event_id, created_at, values: dict) -> dict:
+    payload = {"event_id": event_id, "created_at": created_at}
+    payload.update(values)
+    # Stable key order / explicit nulls for optional columns.
+    return {key: payload.get(key) for key in _PAYLOAD_KEYS}
+
+
+def _insert_row(conn, values: dict) -> dict:
+    """Insert one narrative row on ``conn`` and return the typed payload."""
+    created_at = values.get("created_at") or _now_iso()
+    insert_values = dict(values)
+    insert_values["created_at"] = created_at
+    result = conn.execute(insert(activity_events).values(**insert_values))
+    event_id = result.inserted_primary_key[0]
+    return _row_payload(event_id, created_at, insert_values)
+
+
+def publish_activity(payload: dict | None) -> bool:
+    """Best-effort ``activity`` SSE publish of an already-durable row.
+
+    Never raises. Returns True only when ``publish_sync`` was invoked and
+    returned truthy. Refuses empty payloads so a missing row is never announced.
+    """
+    if not payload or not payload.get("event_id"):
+        return False
+    try:
+        ctx = get_runtime_if_initialized()
+        event_bus = getattr(ctx, "event_bus", None) if ctx is not None else None
+        if event_bus is None:
+            return False
+        typed = {key: payload.get(key) for key in _PAYLOAD_KEYS}
+        return bool(event_bus.publish_sync(SSE_EVENT_TYPE, typed))
+    except Exception as e:
+        logger.fdebug("[ACTIVITY] publish failed (best-effort): %s" % e)
+        return False
+
+
+def record_activity(
+    activity: str,
+    status: str,
+    subject_type: str,
+    subject_id: str,
+    subject_label: str,
+    *,
+    reason_code: str | None = None,
+    reason_detail: str | None = None,
+    provider: str | None = None,
+    run_id: str | None = None,
+    release_key: str | None = None,
+    parent_series_id: str | None = None,
+    scope_type: str | None = None,
+    scope_id: str | None = None,
+    conn=None,
+    won: bool = True,
+    created_at: str | None = None,
+) -> dict | None:
+    """Insert a narrative activity row and publish after durable commit.
+
+    Parameters
+    ----------
+    conn:
+        Optional caller-owned SQLAlchemy connection. When provided, the insert
+        joins that transaction and **publish is left to the caller** after their
+        commit (call :func:`publish_activity` with the returned payload).
+    won:
+        Journal-backed gate. Pass ``record_transition``'s return value. When
+        False, this is a full no-op (no insert, no publish).
+    """
+    if not won:
+        return None
+
+    if not subject_id or not subject_label:
+        logger.warn("[ACTIVITY] rejected write: subject_id and subject_label are required")
+        return None
+
+    rejection = _validate(
+        activity,
+        status,
+        subject_type,
+        reason_code=reason_code,
+        release_key=release_key,
+        run_id=run_id,
+        provider=provider,
+        scope_type=scope_type,
+        scope_id=scope_id,
+    )
+    if rejection is not None:
+        logger.warn("[ACTIVITY] rejected write: %s" % rejection)
+        return None
+
+    values = {
+        "activity": activity,
+        "status": status,
+        "subject_type": subject_type,
+        "subject_id": str(subject_id),
+        "subject_label": subject_label,
+        "reason_code": reason_code,
+        "reason_detail": reason_detail,
+        "provider": provider,
+        "run_id": run_id,
+        "release_key": release_key,
+        "parent_series_id": parent_series_id,
+        "scope_type": scope_type,
+        "scope_id": scope_id,
+    }
+    if created_at is not None:
+        values["created_at"] = created_at
+
+    try:
+        if conn is not None:
+            # Co-commit: caller owns durability and post-commit publish.
+            return _insert_row(conn, values)
+
+        engine = get_engine()
+        with engine.begin() as owned_conn:
+            payload = _insert_row(owned_conn, values)
+        # Commit succeeded — only now announce.
+        publish_activity(payload)
+        return payload
+    except Exception as e:
+        logger.error("[ACTIVITY] failed to record activity: %s" % e)
+        return None

--- a/comicarr/tables.py
+++ b/comicarr/tables.py
@@ -723,7 +723,8 @@ ai_chat_attachments = Table(
 # Derived live state stays on acquisition_runs / acquisition_run_items /
 # pipeline_journal; this table only stores timestamped history the ledgers
 # cannot express. Retention: comicarr.app.activity.retention (90-day age purge).
-# Read APIs live under comicarr.app.activity; writers land in later issues.
+# Read APIs live under comicarr.app.activity; sole writer is
+# comicarr.app.activity.events.record_activity (#479).
 activity_events = Table(
     "activity_events",
     metadata,

--- a/frontend/tests/components/VersionChip.test.tsx
+++ b/frontend/tests/components/VersionChip.test.tsx
@@ -29,22 +29,25 @@ describe("VersionChip", () => {
   });
 
   it("shows quiet-dot cue when behind and opens popover", async () => {
+    // latest_version must differ from package APP_VERSION (currently 0.22.0)
+    // so the pill label and popover target do not both match the same text.
+    const latestVersion = "0.99.0";
     server.use(
       http.get("/api/system/version", () =>
         HttpResponse.json({
           update_state: "behind",
-          latest_version: "0.22.0",
+          latest_version: latestVersion,
           release_version: "0.21.0",
           install_type: "docker",
         }),
       ),
       http.get("/api/system/release-notes", ({ request }) => {
         const url = new URL(request.url);
-        expect(url.searchParams.get("through")).toBe("0.22.0");
+        expect(url.searchParams.get("through")).toBe(latestVersion);
         return HttpResponse.json({
           sections: [
             {
-              version: "0.22.0",
+              version: latestVersion,
               bullets: ["Brand new remote release note."],
             },
           ],
@@ -61,14 +64,14 @@ describe("VersionChip", () => {
     await user.click(pill);
 
     expect(await screen.findByText("Update available")).toBeTruthy();
-    expect(await screen.findByText("0.22.0")).toBeTruthy();
+    expect(await screen.findByText(latestVersion)).toBeTruthy();
     expect(
       await screen.findByText(/Brand new remote release note/),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: /How to update/i })).toBeTruthy();
     const release = screen.getByRole("link", { name: /Release/i });
     expect(release.getAttribute("href")).toBe(
-      "https://github.com/frankieramirez/comicarr/releases/tag/v0.22.0",
+      `https://github.com/frankieramirez/comicarr/releases/tag/v${latestVersion}`,
     );
   });
 
@@ -110,7 +113,7 @@ describe("VersionChip", () => {
       http.get("/api/system/version", () =>
         HttpResponse.json({
           update_state: "behind",
-          latest_version: "0.22.0",
+          latest_version: "0.99.0",
           install_type: "docker",
         }),
       ),

--- a/tests/unit/test_activity_write_facade.py
+++ b/tests/unit/test_activity_write_facade.py
@@ -1,0 +1,484 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Activity event write facade (#479).
+
+Seams under test (public facade only):
+
+* ``record_activity`` — durable insert; co-commit when ``conn`` is supplied
+* ``publish_activity`` — best-effort ``activity`` SSE after commit
+* journal ``won`` gate — no write / no publish when the transition lost
+* legal-cell rejection and ``reason_code`` invariant
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import func, select
+
+import comicarr
+from comicarr import db
+from comicarr.tables import activity_events, metadata
+
+
+@pytest.fixture
+def activity_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+@pytest.fixture
+def mock_event_bus(monkeypatch):
+    bus = MagicMock(name="event_bus")
+    bus.publish_sync.return_value = True
+    runtime = SimpleNamespace(event_bus=bus, disposed=False)
+    monkeypatch.setattr(
+        "comicarr.app.activity.events.get_runtime_if_initialized",
+        lambda: runtime,
+    )
+    return bus
+
+
+def _count_events(engine):
+    with engine.connect() as conn:
+        return conn.execute(select(func.count()).select_from(activity_events)).scalar_one()
+
+
+def _all_events(engine):
+    with engine.connect() as conn:
+        return [dict(row._mapping) for row in conn.execute(select(activity_events)).all()]
+
+
+# ---------------------------------------------------------------------------
+# Own-transaction write + post-commit publish
+# ---------------------------------------------------------------------------
+
+
+def test_record_activity_owns_transaction_and_publishes_after_commit(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    row = record_activity(
+        activity="import",
+        status="succeeded",
+        subject_type="issue",
+        subject_id="iss-1",
+        subject_label="Saga #1",
+        release_key="iss-1|ddl",
+        parent_series_id="series-1",
+        provider="DDL",
+    )
+
+    assert row is not None
+    assert row["event_id"] is not None
+    assert row["activity"] == "import"
+    assert row["status"] == "succeeded"
+    assert row["subject_type"] == "issue"
+    assert row["subject_id"] == "iss-1"
+    assert row["subject_label"] == "Saga #1"
+    assert row["release_key"] == "iss-1|ddl"
+    assert row["parent_series_id"] == "series-1"
+    assert row["provider"] == "DDL"
+    assert "created_at" in row and row["created_at"]
+
+    assert _count_events(activity_db) == 1
+    mock_event_bus.publish_sync.assert_called_once_with("activity", row)
+
+
+def test_record_activity_does_not_publish_when_insert_would_not_be_durable(activity_db, mock_event_bus, monkeypatch):
+    """Publish must not fire if the owned write fails (invert ai log_activity bug)."""
+    from comicarr.app.activity import events
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(events, "_insert_row", boom)
+
+    row = events.record_activity(
+        activity="add",
+        status="succeeded",
+        subject_type="series",
+        subject_id="s-1",
+        subject_label="Saga",
+    )
+
+    assert row is None
+    assert _count_events(activity_db) == 0
+    mock_event_bus.publish_sync.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Co-commit with caller transaction
+# ---------------------------------------------------------------------------
+
+
+def test_record_activity_co_commits_on_caller_conn_without_publishing(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import publish_activity, record_activity
+
+    with activity_db.begin() as conn:
+        row = record_activity(
+            activity="import",
+            status="started",
+            subject_type="issue",
+            subject_id="iss-2",
+            subject_label="Saga #2",
+            release_key="iss-2|nzb",
+            conn=conn,
+        )
+        # Still open: publish must wait for the caller's commit.
+        mock_event_bus.publish_sync.assert_not_called()
+        assert row is not None
+        assert row["event_id"] is not None
+
+    # After commit the row is durable; caller publishes.
+    assert _count_events(activity_db) == 1
+    publish_activity(row)
+    mock_event_bus.publish_sync.assert_called_once_with("activity", row)
+
+
+def test_record_activity_rolls_back_with_caller_transaction(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    try:
+        with activity_db.begin() as conn:
+            record_activity(
+                activity="grab",
+                status="succeeded",
+                subject_type="issue",
+                subject_id="iss-3",
+                subject_label="Saga #3",
+                provider="NZBGeek",
+                conn=conn,
+            )
+            raise RuntimeError("caller aborted")
+    except RuntimeError:
+        pass
+
+    assert _count_events(activity_db) == 0
+    mock_event_bus.publish_sync.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Journal won gate
+# ---------------------------------------------------------------------------
+
+
+def test_record_activity_noops_when_journal_won_is_false(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    row = record_activity(
+        activity="import",
+        status="succeeded",
+        subject_type="issue",
+        subject_id="iss-4",
+        subject_label="Saga #4",
+        release_key="iss-4|ddl",
+        won=False,
+    )
+
+    assert row is None
+    assert _count_events(activity_db) == 0
+    mock_event_bus.publish_sync.assert_not_called()
+
+
+def test_record_activity_writes_when_won_is_true(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    row = record_activity(
+        activity="download",
+        status="succeeded",
+        subject_type="issue",
+        subject_id="iss-5",
+        subject_label="Saga #5",
+        release_key="iss-5|ddl",
+        won=True,
+    )
+
+    assert row is not None
+    assert _count_events(activity_db) == 1
+    mock_event_bus.publish_sync.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Legal cells
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "activity,status,subject_type",
+    [
+        ("search", "no_match", "issue"),  # dropped per #427
+        ("search", "blocked", "run"),  # dropped per ADR
+        ("search", "retrying", "issue"),  # retrying withdrawn
+        ("download", "started", "issue"),  # no download.started
+        ("grab", "started", "issue"),
+        ("system", "succeeded", "series"),  # no system activity
+        ("tag", "succeeded", "run"),  # tag only @ issue|series
+        ("import", "succeeded", "series"),  # import is issue/annual
+    ],
+)
+def test_record_activity_rejects_illegal_cells(activity_db, mock_event_bus, activity, status, subject_type):
+    from comicarr.app.activity.events import record_activity
+
+    kwargs = {
+        "activity": activity,
+        "status": status,
+        "subject_type": subject_type,
+        "subject_id": "x-1",
+        "subject_label": "X",
+    }
+    if activity in ("download", "import"):
+        kwargs["release_key"] = "x-1|p"
+    if status in ("failed", "blocked", "needs_attention", "retrying"):
+        kwargs["reason_code"] = "test_reason"
+
+    row = record_activity(**kwargs)
+
+    assert row is None
+    assert _count_events(activity_db) == 0
+    mock_event_bus.publish_sync.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "activity,status,subject_type,extra",
+    [
+        ("search", "succeeded", "run", {"run_id": "run-1", "scope_type": "series", "scope_id": "s-1"}),
+        ("grab", "cancelled", "series", {"provider": "DDL", "reason_code": None}),
+        ("tag", "needs_attention", "issue", {"reason_code": "corrupt_archive"}),
+        ("refresh", "succeeded", "arc", {}),
+        ("download", "cancelled", "issue", {"release_key": "iss|p", "reason_code": "ignored_by_operator"}),
+        ("import", "cancelled", "issue", {"release_key": "iss|p", "reason_code": "ignored_by_operator"}),
+    ],
+)
+def test_record_activity_accepts_blessed_cells(activity_db, mock_event_bus, activity, status, subject_type, extra):
+    from comicarr.app.activity.events import record_activity
+
+    row = record_activity(
+        activity=activity,
+        status=status,
+        subject_type=subject_type,
+        subject_id="id-1",
+        subject_label="Label",
+        **extra,
+    )
+
+    assert row is not None
+    assert row["activity"] == activity
+    assert row["status"] == status
+    assert row["subject_type"] == subject_type
+    mock_event_bus.publish_sync.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# reason_code invariant (severity pure function of status)
+# ---------------------------------------------------------------------------
+
+
+def test_reason_code_required_when_severity_not_normal(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity, severity_for
+
+    assert severity_for("failed") == "action_required"
+    assert severity_for("succeeded") == "normal"
+
+    row = record_activity(
+        activity="import",
+        status="failed",
+        subject_type="issue",
+        subject_id="iss-f",
+        subject_label="Saga #F",
+        release_key="iss-f|ddl",
+        # reason_code omitted
+    )
+
+    assert row is None
+    assert _count_events(activity_db) == 0
+    mock_event_bus.publish_sync.assert_not_called()
+
+
+def test_reason_code_accepted_for_action_required(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    row = record_activity(
+        activity="import",
+        status="failed",
+        subject_type="issue",
+        subject_id="iss-f2",
+        subject_label="Saga #F2",
+        release_key="iss-f2|ddl",
+        reason_code="import_failed",
+        reason_detail="permission denied",
+    )
+
+    assert row is not None
+    assert row["reason_code"] == "import_failed"
+    assert row["reason_detail"] == "permission denied"
+    mock_event_bus.publish_sync.assert_called_once()
+
+
+def test_reason_code_optional_for_normal_severity(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    row = record_activity(
+        activity="add",
+        status="succeeded",
+        subject_type="series",
+        subject_id="s-9",
+        subject_label="Saga",
+    )
+
+    assert row is not None
+    assert row.get("reason_code") is None
+
+
+# ---------------------------------------------------------------------------
+# Field contract extras
+# ---------------------------------------------------------------------------
+
+
+def test_download_and_import_require_release_key(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    assert (
+        record_activity(
+            activity="download",
+            status="succeeded",
+            subject_type="issue",
+            subject_id="iss-r",
+            subject_label="Saga #R",
+        )
+        is None
+    )
+    assert (
+        record_activity(
+            activity="import",
+            status="started",
+            subject_type="issue",
+            subject_id="iss-r",
+            subject_label="Saga #R",
+        )
+        is None
+    )
+    assert _count_events(activity_db) == 0
+    mock_event_bus.publish_sync.assert_not_called()
+
+
+def test_run_id_only_valid_for_search(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    assert (
+        record_activity(
+            activity="grab",
+            status="succeeded",
+            subject_type="issue",
+            subject_id="iss-1",
+            subject_label="Saga #1",
+            provider="NZBGeek",
+            run_id="run-should-not-apply",
+        )
+        is None
+    )
+    assert _count_events(activity_db) == 0
+
+
+def test_grab_requires_provider(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    assert (
+        record_activity(
+            activity="grab",
+            status="succeeded",
+            subject_type="issue",
+            subject_id="iss-1",
+            subject_label="Saga #1",
+        )
+        is None
+    )
+    assert _count_events(activity_db) == 0
+
+
+def test_scope_fields_only_on_run_subjects(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    assert (
+        record_activity(
+            activity="add",
+            status="succeeded",
+            subject_type="series",
+            subject_id="s-1",
+            subject_label="Saga",
+            scope_type="series",
+            scope_id="s-1",
+        )
+        is None
+    )
+    assert _count_events(activity_db) == 0
+
+
+def test_publish_activity_is_best_effort_without_runtime(activity_db, monkeypatch):
+    from comicarr.app.activity.events import publish_activity, record_activity
+
+    monkeypatch.setattr(
+        "comicarr.app.activity.events.get_runtime_if_initialized",
+        lambda: None,
+    )
+
+    row = record_activity(
+        activity="add",
+        status="succeeded",
+        subject_type="arc",
+        subject_id="arc-1",
+        subject_label="Infinity Gauntlet",
+        # own-txn path will try publish after insert; runtime missing → swallow
+    )
+    # When runtime is missing during record_activity own-txn publish, row still
+    # persists (best-effort publish never undoes durability).
+    assert row is not None
+    assert _count_events(activity_db) == 1
+
+    # Explicit publish with no bus is also a quiet no-op.
+    assert publish_activity(row) is False
+
+
+def test_publish_activity_never_announces_empty_payload(mock_event_bus):
+    from comicarr.app.activity.events import publish_activity
+
+    assert publish_activity(None) is False
+    assert publish_activity({}) is False
+    mock_event_bus.publish_sync.assert_not_called()
+
+
+def test_persists_denorm_and_conditional_fields(activity_db, mock_event_bus):
+    from comicarr.app.activity.events import record_activity
+
+    row = record_activity(
+        activity="search",
+        status="succeeded",
+        subject_type="run",
+        subject_id="run-42",
+        subject_label="Wanted search",
+        run_id="run-42",
+        scope_type="series",
+        scope_id="series-9",
+        parent_series_id="series-9",
+        provider=None,
+    )
+
+    stored = _all_events(activity_db)[0]
+    assert stored["run_id"] == "run-42"
+    assert stored["scope_type"] == "series"
+    assert stored["scope_id"] == "series-9"
+    assert stored["parent_series_id"] == "series-9"
+    assert stored["subject_label"] == "Wanted search"
+    assert row["event_id"] == stored["event_id"]

--- a/tests/unit/test_activity_write_facade.py
+++ b/tests/unit/test_activity_write_facade.py
@@ -170,6 +170,62 @@ def test_record_activity_rolls_back_with_caller_transaction(activity_db, mock_ev
     mock_event_bus.publish_sync.assert_not_called()
 
 
+def test_record_activity_propagates_insert_failure_on_caller_conn(
+    activity_db, mock_event_bus, monkeypatch
+):
+    """Co-commit insert failures must reach the caller, not be swallowed.
+
+    The caller owns the transaction; a masked failure would poison it and
+    resurface as an unrelated error at their next statement or commit().
+    """
+    from comicarr.app.activity import events
+
+    def _boom(conn, values):
+        raise RuntimeError("insert exploded")
+
+    monkeypatch.setattr(events, "_insert_row", _boom)
+
+    with activity_db.begin() as conn:
+        with pytest.raises(RuntimeError, match="insert exploded"):
+            events.record_activity(
+                activity="grab",
+                status="succeeded",
+                subject_type="issue",
+                subject_id="iss-9",
+                subject_label="Saga #9",
+                provider="NZBGeek",
+                conn=conn,
+            )
+
+    assert _count_events(activity_db) == 0
+    mock_event_bus.publish_sync.assert_not_called()
+
+
+def test_record_activity_swallows_insert_failure_on_owned_transaction(
+    activity_db, mock_event_bus, monkeypatch
+):
+    """Owned-transaction path stays best-effort: it rolls back and returns None."""
+    from comicarr.app.activity import events
+
+    def _boom(conn, values):
+        raise RuntimeError("insert exploded")
+
+    monkeypatch.setattr(events, "_insert_row", _boom)
+
+    row = events.record_activity(
+        activity="grab",
+        status="succeeded",
+        subject_type="issue",
+        subject_id="iss-10",
+        subject_label="Saga #10",
+        provider="NZBGeek",
+    )
+
+    assert row is None
+    assert _count_events(activity_db) == 0
+    mock_event_bus.publish_sync.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Journal won gate
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TLDR

Adds the sole legal write path for Activity Center narrative rows: insert `activity_events` and publish the typed `activity` SSE envelope only after a durable commit.

## Description

- New `comicarr.app.activity.events` facade (`record_activity` / `publish_activity`) with co-commit vs owned-transaction semantics, journal `won` gate, legal-cell rejection, and `reason_code` / field-contract checks
- Package exports the write API for later producer tickets; does not convert any `GLOBAL_MESSAGES` sites
- Unit coverage for co-commit, post-commit publish, won-gate, illegal cells, and reason_code invariant

Closes #479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized activity event recording with validation for supported activities, statuses, subjects, and required fields.
  * Activity events now persist reliably and publish live notifications after successful commits.
  * Added severity classification and support for contextual event details.

* **Bug Fixes**
  * Prevented invalid activity combinations and incomplete events from being recorded.
  * Improved handling of failed notifications and database rollbacks without disrupting core operations.

* **Tests**
  * Added comprehensive coverage for persistence, validation, transactions, publishing, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->