### PR TITLE
test: Prove ledger retention policy and document ops

### DIFF
--- a/docs/operations/ledger-retention.md
+++ b/docs/operations/ledger-retention.md
@@ -1,0 +1,128 @@
+# Ledger retention
+
+Daily job that bounds the five unbounded operational ledgers. Parameters are
+**module constants only** (no Settings knobs). This note is self-contained for
+operators and implementers; it does not depend on research-branch inventory
+files.
+
+| | |
+| --- | --- |
+| Job id | `ledger_retention` |
+| Display name | **Ledger Retention** |
+| Cadence | Daily (scheduler `max_instances=1`, coalesce) |
+| Entrypoint | `comicarr.app.acquisition.retention.run_ledger_retention` |
+| Soft-fail | Logs errors and returns; does not crash the process |
+
+Narrative Activity event retention is a **separate** job
+(`activity_retention` / **Activity Event Retention**). Do not conflate the two.
+
+## Decision sources
+
+- [Decide ledger deletion eligibility and delete order](https://github.com/frankieramirez/comicarr/issues/463)
+- [Decide per-table ledger retention parameters](https://github.com/frankieramirez/comicarr/issues/464)
+- [Decide UX when pruned ledger rows are missing](https://github.com/frankieramirez/comicarr/issues/465)
+
+## Parameter table and hybrid / age formulas
+
+Hybrid predicate (items, runs, maintenance, AI):
+
+```text
+eligible AND age > horizon AND row NOT IN (
+  newest N eligible rows ordered by age_column DESC, pk DESC
+)
+```
+
+In plain language: **keep** a row if it is **younger than the age horizon OR
+among the newest N eligible rows**; **delete** only when it is **older than the
+horizon AND outside the newest N**.
+
+Age-only (`pipeline_journal`): `eligible AND age > 365 days` (no count floor).
+
+| Table | Eligible set | Policy | Age column | Steady-state intent |
+| --- | --- | --- | --- | --- |
+| `acquisition_run_items` | Terminal outcomes only (`accepted` / `running` never) | **90 days OR newest 50,000** terminal rows | `completed_at`, fallback `updated_at` | Small libs keep ~90d history; large libs hard-capped ~50k terminals |
+| `acquisition_runs` | Completed runs with **zero** remaining items | **90 days OR newest 2,000** such runs | `completed_at`, fallback `updated_at` | Headers track item history; health “latest run” still has recent depth |
+| `pipeline_journal` | `post_processed` + **resolved** `failed` / `manual_review` only | **365 days age only** | `updated_date` | Mild growth O(release_keys); avoid burst-evicting older series’ last grab |
+| `acquisition_maintenance_events` | All rows | **90 days OR newest 5,000** | `created_at` | Recent fence audit + cap on repair-loop spikes |
+| `ai_activity_log` | All rows | **90 days OR newest 10,000** | `timestamp` | Recent AI feed; empty is honest |
+
+Constants live in `comicarr/app/acquisition/retention.py`
+(`ITEMS_AGE_DAYS`, `ITEMS_KEEP_NEWEST`, …). They are **not** config registry
+keys and are **not** operator-tunable.
+
+## Eligibility floors (what may never be deleted)
+
+| Class | Eligible to delete? |
+| --- | --- |
+| `acquisition_run_items` with `state IN (accepted, running)` | **Never** — recovery floor |
+| Other (terminal) item states | Yes, under parameters |
+| Runs that still have any items, or are not complete (`completed_at` null) | **Never** |
+| Completed runs with zero remaining items | Yes, under parameters |
+| `pipeline_journal` open stages | **Never** — recovery / open work |
+| Unresolved `failed` / `manual_review` (needs-attention band predicate) | **Never** |
+| `post_processed` and **resolved** terminals (`status` in `retried` / `ignored` / `imported`) | Yes, under parameters |
+| `acquisition_maintenance_events` | All rows (parameter-eligible) |
+| `ai_activity_log` | All rows (parameter-eligible) |
+
+There is **no** “keep newest row per entity” immortality for Wanted sticky
+annotations. Annotation loss after the item horizon is intentional honesty
+(see UX below).
+
+## Delete order and batching
+
+One shared daily pass, **in this order**:
+
+1. Eligible terminal `acquisition_run_items`
+2. Eligible completed `acquisition_runs` with zero remaining items
+3. Eligible `pipeline_journal` terminals
+4. `acquisition_maintenance_events`
+5. `ai_activity_log`
+
+Each table step uses private batch size **500** rows per `DELETE`, looping until
+dry for that step. Batch size is a module constant (`DELETE_BATCH_SIZE`), not
+config. One transaction per table step so a late failure does not roll back
+earlier tables.
+
+## VACUUM (out-of-band only)
+
+The sweep **never** runs `VACUUM` (or equivalent) in-process. Reclaiming free
+pages after large deletes is an **operator** concern for the database
+deployment (SQLite: out-of-band `VACUUM` / maintenance window; Postgres:
+autovacuum or scheduled maintenance). Do not treat vacuum as a product feature
+or Settings control.
+
+## Job wiring
+
+- Registered via `_add_recurring_job` in `comicarr/__init__.py` with id
+  `ledger_retention`
+- Display name in `SCHEDULER_JOB_NAMES`: **Ledger Retention**
+  (`comicarr/app/system/service.py`)
+- Independent of `SEARCH_INTERVAL`, DB Updater, and narrative retention
+
+## UX when pruned rows are missing (#465)
+
+Missing ledger rows after retention are **data absence**, not a special
+“pruned” product state. No tombstones.
+
+| Surface | After prune |
+| --- | --- |
+| `GET /api/search/runs/{id}` for a pruned run | Existing **404** / “search run not found” |
+| Acquisition health “latest run” | Newest **remaining** run for that kind, or **omit** the kind — never invent healthy history from empty |
+| AI activity list | Rows vanish; **empty list is honest** (not an error, no retention banner) |
+| Wanted sticky annotation | When latest terminal item is gone → **null acquisition** → never-searched presentation (`— never searched`) |
+| Needs-attention band | Unresolved rows never prune; band empty only when no open trouble remains |
+| Timeline completed-run progress | Ledger-backed progress sources simply disappear for pruned runs (no ghost counters) |
+
+Live nonterminal work stays correct because eligibility forbids pruning it.
+
+## Operator checklist
+
+1. Confirm the job appears as **Ledger Retention** in scheduler / system job
+   listings after upgrade.
+2. After the first daily run on a large library, expect deleted-row counts in
+   logs (`[LEDGER-RETENTION] Sweep complete: …`). Soft-fail logs
+   `[LEDGER-RETENTION] Sweep failed: …` without taking down the process.
+3. If free disk does not return after large purges, schedule **out-of-band**
+   database maintenance (VACUUM / autovacuum) — not an in-app action.
+4. Do not expect Wanted sticky history or AI feed depth beyond the parameter
+   table; empty / never-searched is correct after the horizon.

--- a/tests/unit/test_ledger_retention.py
+++ b/tests/unit/test_ledger_retention.py
@@ -7,11 +7,12 @@
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 
-"""Unit tests for the daily ledger retention sweep (#480).
+"""Unit tests for the daily ledger retention sweep (#480 / #481).
 
-Full policy matrix and ops notes land in #481; this file pins the public
-entrypoint, eligibility floors, hybrid/age math, delete order, and batching
-at the `run_ledger_retention` seam.
+Seams under test:
+- ``run_ledger_retention`` public entrypoint (eligibility, hybrid/age math,
+  delete order, batching, no VACUUM)
+- Module constants match the #464 parameter table
 """
 
 import datetime
@@ -172,7 +173,14 @@ def test_constants_match_parameter_table():
     assert retention.AI_KEEP_NEWEST == 10_000
 
 
-def test_never_deletes_nonterminal_items_or_incomplete_runs():
+def test_never_deletes_accepted_or_running_items(monkeypatch):
+    """Recovery floor: nonterminal item states are immortal (#463 / #481).
+
+    Keep floor is zeroed so age alone would delete terminals; accepted/running
+    must still survive (eligibility, not newest-N).
+    """
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
     _insert_run("live", RunState.RUNNING.value, completed_at=None, updated_at=_iso(200))
     _insert_item("live", ItemOutcome.ACCEPTED.value, completed_at=None, updated_at=_iso(200), entity_id="a")
     _insert_item("live", ItemOutcome.RUNNING.value, completed_at=None, updated_at=_iso(200), entity_id="b")
@@ -181,10 +189,48 @@ def test_never_deletes_nonterminal_items_or_incomplete_runs():
     summary = retention.run_ledger_retention(now=FIXED_NOW)
 
     assert summary is not None
-    assert _item_states() == sorted(
-        [ItemOutcome.ACCEPTED.value, ItemOutcome.RUNNING.value, ItemOutcome.SUCCEEDED.value]
-    )
+    assert summary["acquisition_run_items"] == 1
+    assert _item_states() == sorted([ItemOutcome.ACCEPTED.value, ItemOutcome.RUNNING.value])
     assert _run_ids() == ["live"]
+
+
+def test_never_deletes_incomplete_runs_or_runs_with_remaining_items(monkeypatch):
+    """Incomplete runs and any run that still has items stay forever (#463)."""
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+
+    # Incomplete: no completed_at, even if ancient.
+    _insert_run("pending-old", RunState.PENDING.value, completed_at=None, updated_at=_iso(400))
+    _insert_run("running-old", RunState.RUNNING.value, completed_at=None, updated_at=_iso(400))
+
+    # Completed but still has a terminal item kept only because we leave it
+    # after lowering keep floor to 0… actually with floor 0 the item ages out.
+    # Keep an accepted item so the completed run cannot empty itself.
+    _insert_run("done-with-live", RunState.COMPLETED.value, completed_at=_iso(400), updated_at=_iso(400))
+    _insert_item(
+        "done-with-live",
+        ItemOutcome.ACCEPTED.value,
+        completed_at=None,
+        updated_at=_iso(400),
+        entity_id="still-live",
+    )
+    # Completed with only an old terminal item: item is eligible and will purge,
+    # then the empty completed run may purge — separate test covers that path.
+    _insert_run("done-with-terminal", RunState.COMPLETED.value, completed_at=_iso(10), updated_at=_iso(10))
+    _insert_item(
+        "done-with-terminal",
+        ItemOutcome.SUCCEEDED.value,
+        completed_at=_iso(10),
+        updated_at=_iso(10),
+        entity_id="kept-young",
+    )
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+
+    assert summary is not None
+    assert set(_run_ids()) == {"pending-old", "running-old", "done-with-live", "done-with-terminal"}
+    assert ItemOutcome.ACCEPTED.value in _item_states()
+    assert ItemOutcome.SUCCEEDED.value in _item_states()
 
 
 def test_empty_finished_failed_run_is_eligible(monkeypatch):
@@ -241,45 +287,109 @@ def test_deletes_old_terminal_items_then_empty_completed_runs(monkeypatch):
 
 
 def test_never_deletes_open_or_unresolved_journal_rows():
+    """Open stages and unresolved failed/manual_review are immortal (#463)."""
     _insert_journal("open-snatched", journal.SNATCHED, _journal_ts(400))
+    _insert_journal("open-downloaded", journal.DOWNLOADED, _journal_ts(400))
     _insert_journal("failed-open", journal.FAILED, _journal_ts(400), status=None)
-    _insert_journal("review-open", journal.MANUAL_REVIEW, _journal_ts(400), status=journal.MANUAL_REVIEW)
+    _insert_journal("review-open", journal.MANUAL_REVIEW, _journal_ts(400), status=None)
+    _insert_journal("review-band-status", journal.MANUAL_REVIEW, _journal_ts(400), status=journal.MANUAL_REVIEW)
     _insert_journal("pp-old", journal.POST_PROCESSED, _journal_ts(400))
     _insert_journal("failed-resolved", journal.FAILED, _journal_ts(400), status=journal.STATUS_IGNORED)
+    _insert_journal("review-resolved", journal.MANUAL_REVIEW, _journal_ts(400), status=journal.STATUS_IMPORTED)
     _insert_journal("pp-recent", journal.POST_PROCESSED, _journal_ts(30))
 
     summary = retention.run_ledger_retention(now=FIXED_NOW)
 
-    assert summary["pipeline_journal"] == 2
-    assert _journal_keys() == sorted(["open-snatched", "failed-open", "review-open", "pp-recent"])
+    # Three eligible old terminals deleted (pp-old, failed-resolved, review-resolved).
+    assert summary["pipeline_journal"] == 3
+    assert _journal_keys() == sorted(
+        [
+            "open-snatched",
+            "open-downloaded",
+            "failed-open",
+            "review-open",
+            "review-band-status",
+            "pp-recent",
+        ]
+    )
 
 
-def test_hybrid_keep_newest_floor_even_when_old():
-    # keep_newest=2 for this assertion via monkeypatch of the constant.
+def test_journal_age_only_keeps_eligible_under_365_days(monkeypatch):
+    """Journal has no newest-N floor: only age past 365d on eligible terminals."""
+    # Even with keep floors zeroed on other tables, journal ignores count floors.
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+
+    _insert_journal("pp-364", journal.POST_PROCESSED, _journal_ts(364))
+    _insert_journal("pp-366", journal.POST_PROCESSED, _journal_ts(366))
+    _insert_journal("failed-resolved-100", journal.FAILED, _journal_ts(100), status=journal.STATUS_RETRIED)
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+
+    assert summary["pipeline_journal"] == 1
+    assert _journal_keys() == sorted(["pp-364", "failed-resolved-100"])
+
+
+def test_hybrid_keep_newest_floor_even_when_old(monkeypatch):
     # Five old terminal items; newest 2 (by age desc, pk desc) must remain.
-    original = retention.ITEMS_KEEP_NEWEST
-    retention.ITEMS_KEEP_NEWEST = 2
-    try:
-        _insert_run("batch", RunState.COMPLETED.value, completed_at=_iso(200), updated_at=_iso(200))
-        ids = []
-        for day in (200, 190, 180, 170, 160):
-            ids.append(
-                _insert_item(
-                    "batch",
-                    ItemOutcome.SUCCEEDED.value,
-                    completed_at=_iso(day),
-                    updated_at=_iso(day),
-                    entity_id="i-%s" % day,
-                )
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 2)
+    _insert_run("batch", RunState.COMPLETED.value, completed_at=_iso(200), updated_at=_iso(200))
+    ids = []
+    for day in (200, 190, 180, 170, 160):
+        ids.append(
+            _insert_item(
+                "batch",
+                ItemOutcome.SUCCEEDED.value,
+                completed_at=_iso(day),
+                updated_at=_iso(day),
+                entity_id="i-%s" % day,
             )
-        summary = retention.run_ledger_retention(now=FIXED_NOW)
-        assert summary["acquisition_run_items"] == 3
-        with get_engine().connect() as conn:
-            remaining = sorted(row.item_id for row in conn.execute(select(acquisition_run_items.c.item_id)))
-        # Newest by age: day 160 then 170 (largest completed_at, then pk).
-        assert remaining == sorted(ids[-2:])
-    finally:
-        retention.ITEMS_KEEP_NEWEST = original
+        )
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+    assert summary["acquisition_run_items"] == 3
+    with get_engine().connect() as conn:
+        remaining = sorted(row.item_id for row in conn.execute(select(acquisition_run_items.c.item_id)))
+    # Newest by age: day 160 then 170 (largest completed_at, then pk).
+    assert remaining == sorted(ids[-2:])
+
+
+def test_hybrid_keeps_young_rows_even_outside_newest_n(monkeypatch):
+    """Hybrid: younger-than-horizon rows survive even when keep_newest is 0."""
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "MAINTENANCE_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "AI_KEEP_NEWEST", 0)
+
+    _insert_run("old", RunState.COMPLETED.value, completed_at=_iso(100), updated_at=_iso(100))
+    _insert_item(
+        "old",
+        ItemOutcome.SUCCEEDED.value,
+        completed_at=_iso(100),
+        updated_at=_iso(100),
+        entity_id="old-i",
+    )
+    _insert_run("young", RunState.COMPLETED.value, completed_at=_iso(5), updated_at=_iso(5))
+    _insert_item(
+        "young",
+        ItemOutcome.SUCCEEDED.value,
+        completed_at=_iso(5),
+        updated_at=_iso(5),
+        entity_id="young-i",
+    )
+    _insert_maintenance(_iso(100), reason="old-m")
+    _insert_maintenance(_iso(5), reason="young-m")
+    _insert_ai(_iso(100), action="old-ai")
+    _insert_ai(_iso(5), action="young-ai")
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+
+    assert summary["acquisition_run_items"] == 1
+    assert summary["acquisition_runs"] == 1
+    assert summary["acquisition_maintenance_events"] == 1
+    assert summary["ai_activity_log"] == 1
+    assert _run_ids() == ["young"]
+    assert _count(acquisition_maintenance_events) == 1
+    assert _count(ai_activity_log) == 1
 
 
 def test_maintenance_and_ai_are_fully_eligible_under_hybrid(monkeypatch):
@@ -330,7 +440,7 @@ def test_soft_fail_logs_and_does_not_raise(monkeypatch, caplog):
     assert result is None
 
 
-def test_delete_order_items_before_runs(monkeypatch):
+def test_delete_order_items_runs_journal_maintenance_ai(monkeypatch):
     order = []
 
     def wrap(name, original):
@@ -368,3 +478,53 @@ def test_delete_order_items_before_runs(monkeypatch):
 
     retention.run_ledger_retention(now=FIXED_NOW)
     assert order == ["items", "runs", "journal", "maintenance", "ai"]
+
+
+def test_sweep_does_not_invoke_vacuum(monkeypatch):
+    """VACUUM is out-of-band ops only — never a product feature of the sweep."""
+    vacuum_calls = []
+
+    class _TrackingConn:
+        def __init__(self, real):
+            self._real = real
+
+        def execute(self, *args, **kwargs):
+            statement = str(args[0]) if args else ""
+            if "vacuum" in statement.lower():
+                vacuum_calls.append(statement)
+            return self._real.execute(*args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(self._real, name)
+
+    real_begin = get_engine().begin
+
+    class _TrackingBegin:
+        def __enter__(self):
+            self._cm = real_begin()
+            self._conn = _TrackingConn(self._cm.__enter__())
+            return self._conn
+
+        def __exit__(self, *exc):
+            return self._cm.__exit__(*exc)
+
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(get_engine(), "begin", lambda: _TrackingBegin())
+
+    _insert_run("v", RunState.COMPLETED.value, completed_at=_iso(120), updated_at=_iso(120))
+    _insert_item(
+        "v",
+        ItemOutcome.SUCCEEDED.value,
+        completed_at=_iso(120),
+        updated_at=_iso(120),
+        entity_id="v1",
+    )
+    retention.run_ledger_retention(now=FIXED_NOW)
+    assert vacuum_calls == []
+
+    # Source-level guard: module must not reference VACUUM.
+    import inspect
+
+    source = inspect.getsource(retention)
+    assert "vacuum" not in source.lower()

--- a/tests/unit/test_ledger_retention_ux.py
+++ b/tests/unit/test_ledger_retention_ux.py
@@ -1,0 +1,443 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""UX fallback contracts after ledger retention prunes rows (#465 / #481).
+
+Seams under test (existing product surfaces only — no full UI e2e):
+
+- ``search_service.get_run`` — pruned run id → existing 404 / missing contract
+- ``dashboard_queries.get_recent_ai_activity`` — empty list is honest, not an error
+- ``health.get_acquisition_health`` — latest run falls back to newest remaining
+  or omits the kind; never invents healthy history from empty
+- ``series_service.get_wanted`` — pruned latest terminal → null acquisition
+  (never-searched presentation per Wanted pure helper)
+- ``activity.queries.list_attention_band`` / journal band — unresolved rows
+  survive; empty band only when no unresolved trouble remains
+
+Decision-only Timeline progress / Wanted sticky / band presentation rules are
+pinned as documented fixture contracts below (no tombstones; inherit empty
+contracts when those surfaces ship).
+"""
+
+import datetime
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import func, insert, select
+
+import comicarr
+from comicarr.app.acquisition import retention
+from comicarr.app.acquisition.models import ItemOutcome
+from comicarr.app.acquisition.runs import RunLedger
+from comicarr.app.activity import queries as activity_queries
+from comicarr.app.core.context import AppContext
+from comicarr.app.dashboard import queries as dashboard_queries
+from comicarr.app.downloads import journal
+from comicarr.app.search import health
+from comicarr.app.search import service as search_service
+from comicarr.app.series import service as series_service
+from comicarr.db import get_engine, shutdown_engine
+from comicarr.tables import (
+    acquisition_run_items,
+    acquisition_runs,
+    ai_activity_log,
+    comics,
+    issues,
+    metadata,
+    pipeline_journal,
+)
+
+FIXED_NOW = datetime.datetime(2026, 8, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(), raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    shutdown_engine()
+    metadata.create_all(get_engine())
+    yield
+    shutdown_engine()
+
+
+def _ctx():
+    return AppContext(config=SimpleNamespace())
+
+
+def _iso(days_ago):
+    return (FIXED_NOW - datetime.timedelta(days=days_ago)).isoformat()
+
+
+def _journal_ts(days_ago):
+    return (FIXED_NOW - datetime.timedelta(days=days_ago)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _seed_wanted_issue(issue_id="issue-prune"):
+    with get_engine().begin() as conn:
+        conn.execute(
+            insert(comics),
+            {
+                "ComicID": "comic-1",
+                "ComicName": "Batman",
+                "ComicSortName": "Batman",
+                "ComicPublisher": "DC",
+                "Status": "Active",
+                "Have": 0,
+                "Total": 1,
+                "ContentType": "comic",
+            },
+        )
+        conn.execute(
+            insert(issues),
+            {
+                "IssueID": issue_id,
+                "ComicID": "comic-1",
+                "Issue_Number": "1",
+                "Status": "Wanted",
+                "DateAdded": "2026-01-01",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Existing API / service seams
+# ---------------------------------------------------------------------------
+
+
+def test_pruned_run_id_uses_existing_missing_contract(monkeypatch):
+    """GET run for a pruned id is 404 / search run not found — no ghost payload."""
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+
+    ledger = RunLedger(get_engine())
+    ledger.create_run("pruned-run", command_kind="search", trigger="manual")
+    ledger.accept_item("pruned-run", entity_type="issue", entity_id="iss-1")
+    assert ledger.claim_item("pruned-run", "issue", "iss-1") is True
+    ledger.record_outcome("pruned-run", "issue", "iss-1", ItemOutcome.SUCCEEDED)
+    run = ledger.get_run("pruned-run")
+    assert run is not None
+    assert run["completed_at"] is not None
+
+    # Age the completed timestamps past the 90d hybrid horizon.
+    with get_engine().begin() as conn:
+        conn.execute(
+            acquisition_runs.update()
+            .where(acquisition_runs.c.run_id == "pruned-run")
+            .values(completed_at=_iso(120), updated_at=_iso(120), created_at=_iso(120))
+        )
+        conn.execute(
+            acquisition_run_items.update()
+            .where(acquisition_run_items.c.run_id == "pruned-run")
+            .values(completed_at=_iso(120), updated_at=_iso(120), created_at=_iso(120))
+        )
+
+    before = search_service.get_run(_ctx(), "pruned-run")
+    assert before["success"] is True
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+    assert summary["acquisition_runs"] == 1
+
+    missing = search_service.get_run(_ctx(), "pruned-run")
+    assert missing == {
+        "success": False,
+        "error": "search run not found",
+        "status_code": 404,
+    }
+
+
+def test_ai_feed_empty_list_is_honest_after_prune(monkeypatch):
+    """Empty AI feed after full prune is a valid empty list, not an error."""
+    monkeypatch.setattr(retention, "AI_KEEP_NEWEST", 0)
+
+    with get_engine().begin() as conn:
+        conn.execute(
+            insert(ai_activity_log),
+            [
+                {
+                    "timestamp": _iso(100),
+                    "feature_type": "chat",
+                    "action_description": "old",
+                    "success": "true",
+                },
+                {
+                    "timestamp": _iso(5),
+                    "feature_type": "chat",
+                    "action_description": "young",
+                    "success": "true",
+                },
+            ],
+        )
+
+    assert len(dashboard_queries.get_recent_ai_activity(limit=10)) == 2
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+    assert summary["ai_activity_log"] == 1
+
+    remaining = dashboard_queries.get_recent_ai_activity(limit=10)
+    assert len(remaining) == 1
+    assert remaining[0]["action_description"] == "young"
+
+    # Prune the last young row by forcing age past horizon with keep floor 0.
+    with get_engine().begin() as conn:
+        conn.execute(
+            ai_activity_log.update().values(timestamp=_iso(100)),
+        )
+    summary2 = retention.run_ledger_retention(now=FIXED_NOW)
+    assert summary2["ai_activity_log"] == 1
+
+    empty = dashboard_queries.get_recent_ai_activity(limit=10)
+    assert empty == []
+
+
+def test_acquisition_health_falls_back_to_newest_remaining_or_omits(monkeypatch):
+    """Latest-run health uses remaining rows only — never invents history."""
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+
+    ledger = RunLedger(get_engine())
+
+    ledger.create_run("old-search", command_kind="search", trigger="scheduler")
+    ledger.accept_item("old-search", entity_type="issue", entity_id="a")
+    assert ledger.claim_item("old-search", "issue", "a") is True
+    ledger.record_outcome("old-search", "issue", "a", ItemOutcome.NO_MATCH)
+
+    ledger.create_run("new-search", command_kind="search", trigger="manual")
+    ledger.accept_item("new-search", entity_type="issue", entity_id="b")
+    assert ledger.claim_item("new-search", "issue", "b") is True
+    ledger.record_outcome("new-search", "issue", "b", ItemOutcome.SUCCEEDED)
+
+    with get_engine().begin() as conn:
+        conn.execute(
+            acquisition_runs.update()
+            .where(acquisition_runs.c.run_id == "old-search")
+            .values(
+                completed_at=_iso(120),
+                updated_at=_iso(120),
+                created_at=_iso(120),
+            )
+        )
+        conn.execute(
+            acquisition_run_items.update()
+            .where(acquisition_run_items.c.run_id == "old-search")
+            .values(completed_at=_iso(120), updated_at=_iso(120), created_at=_iso(120))
+        )
+        # Keep new-search young so hybrid age keeps it.
+        conn.execute(
+            acquisition_runs.update()
+            .where(acquisition_runs.c.run_id == "new-search")
+            .values(completed_at=_iso(5), updated_at=_iso(5), created_at=_iso(5))
+        )
+        conn.execute(
+            acquisition_run_items.update()
+            .where(acquisition_run_items.c.run_id == "new-search")
+            .values(completed_at=_iso(5), updated_at=_iso(5), created_at=_iso(5))
+        )
+
+    before = health.get_acquisition_health(engine=get_engine())
+    assert before["search"]["run_id"] == "new-search"
+
+    retention.run_ledger_retention(now=FIXED_NOW)
+
+    after = health.get_acquisition_health(engine=get_engine())
+    assert "search" in after
+    assert after["search"]["run_id"] == "new-search"
+    assert after["search"]["completion"]["state"] == "completed"
+
+    # Age out the remaining run entirely → kind omitted, not invented healthy.
+    with get_engine().begin() as conn:
+        conn.execute(
+            acquisition_runs.update()
+            .where(acquisition_runs.c.run_id == "new-search")
+            .values(completed_at=_iso(120), updated_at=_iso(120))
+        )
+        conn.execute(
+            acquisition_run_items.update()
+            .where(acquisition_run_items.c.run_id == "new-search")
+            .values(completed_at=_iso(120), updated_at=_iso(120))
+        )
+    retention.run_ledger_retention(now=FIXED_NOW)
+
+    empty_health = health.get_acquisition_health(engine=get_engine())
+    assert empty_health == {} or "search" not in empty_health
+
+
+def test_wanted_sticky_falls_back_to_null_when_latest_terminal_pruned(monkeypatch):
+    """Pruned latest terminal item → null acquisition (never-searched glyph)."""
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+
+    _seed_wanted_issue("issue-sticky")
+    ledger = RunLedger(get_engine())
+    ledger.create_run("run-sticky", command_kind="search", trigger="manual")
+    ledger.accept_item("run-sticky", entity_type="issue", entity_id="issue-sticky")
+    assert ledger.claim_item("run-sticky", "issue", "issue-sticky") is True
+    ledger.record_outcome("run-sticky", "issue", "issue-sticky", ItemOutcome.NO_MATCH, reason="none")
+
+    annotated = series_service.get_wanted(SimpleNamespace(config=None), limit=10, offset=0)
+    assert annotated["issues"][0]["acquisition"] is not None
+    assert annotated["issues"][0]["acquisition"]["state"] == ItemOutcome.NO_MATCH.value
+
+    with get_engine().begin() as conn:
+        conn.execute(
+            acquisition_runs.update()
+            .where(acquisition_runs.c.run_id == "run-sticky")
+            .values(completed_at=_iso(120), updated_at=_iso(120), created_at=_iso(120))
+        )
+        conn.execute(
+            acquisition_run_items.update()
+            .where(acquisition_run_items.c.run_id == "run-sticky")
+            .values(completed_at=_iso(120), updated_at=_iso(120), created_at=_iso(120))
+        )
+
+    retention.run_ledger_retention(now=FIXED_NOW)
+
+    after = series_service.get_wanted(SimpleNamespace(config=None), limit=10, offset=0)
+    assert after["issues"][0]["IssueID"] == "issue-sticky"
+    assert after["issues"][0]["acquisition"] is None
+
+
+def test_needs_attention_band_keeps_unresolved_after_journal_retention():
+    """Unresolved band rows survive; resolved old terminals may leave."""
+    with get_engine().begin() as conn:
+        conn.execute(
+            insert(pipeline_journal),
+            [
+                {
+                    "release_key": "open-failed",
+                    "stage": journal.FAILED,
+                    "stage_rank": journal.STAGE_RANK[journal.FAILED],
+                    "updated_date": _journal_ts(400),
+                    "status": None,
+                },
+                {
+                    "release_key": "open-review",
+                    "stage": journal.MANUAL_REVIEW,
+                    "stage_rank": journal.STAGE_RANK[journal.MANUAL_REVIEW],
+                    "updated_date": _journal_ts(400),
+                    "status": None,
+                },
+                {
+                    "release_key": "resolved-old",
+                    "stage": journal.FAILED,
+                    "stage_rank": journal.STAGE_RANK[journal.FAILED],
+                    "updated_date": _journal_ts(400),
+                    "status": journal.STATUS_IGNORED,
+                },
+                {
+                    "release_key": "pp-old",
+                    "stage": journal.POST_PROCESSED,
+                    "stage_rank": journal.STAGE_RANK[journal.POST_PROCESSED],
+                    "updated_date": _journal_ts(400),
+                    "status": None,
+                },
+            ],
+        )
+
+    before = activity_queries.list_attention_band()
+    assert {row["release_key"] for row in before} == {"open-failed", "open-review"}
+
+    summary = retention.run_ledger_retention(now=FIXED_NOW)
+    assert summary["pipeline_journal"] == 2
+
+    after = activity_queries.list_attention_band()
+    assert {row["release_key"] for row in after} == {"open-failed", "open-review"}
+
+
+def test_needs_attention_band_empty_only_when_no_unresolved_work():
+    """Empty band is honest empty — no synthetic 'unknown trouble' tombstone."""
+    assert activity_queries.list_attention_band() == []
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper / documented-fixture contracts for decision-only surfaces (#465)
+# ---------------------------------------------------------------------------
+
+
+def test_decision_only_wanted_null_acquisition_is_never_searched_presentation():
+    """Fixture contract: null acquisition maps to the never-searched glyph.
+
+    Frontend pure helper ``formatWantedAcquisitionAnnotation(null)`` is the
+    product seam; this documents the backend payload shape retention produces.
+    """
+    pruned_row = {
+        "IssueID": "issue-x",
+        "Status": "Wanted",
+        "acquisition": None,
+    }
+    # No tombstone field, no "pruned" flag — same shape as never-searched.
+    assert "pruned" not in pruned_row
+    assert pruned_row["acquisition"] is None
+
+
+def test_decision_only_timeline_progress_has_no_synthetic_counters_for_missing_run():
+    """Fixture contract: missing run yields no ghost '17 of 42' progress.
+
+    Timeline progress UI is still decision-only for some surfaces; when a run
+    id is absent the existing missing contract applies — no synthetic counters.
+    """
+    missing = search_service.get_run(_ctx(), "never-existed-run")
+    assert missing["success"] is False
+    assert missing["status_code"] == 404
+    assert "run" not in missing or missing.get("run") is None
+    # No fabricated progress fields on the error payload.
+    for key in ("accepted_count", "terminal_count", "processed", "of"):
+        assert key not in missing
+
+
+def test_decision_only_band_empty_means_no_unresolved_trouble():
+    """Fixture contract: empty attention band is data absence, not a tombstone."""
+    empty = activity_queries.list_attention_band()
+    assert empty == []
+    # No synthetic placeholder rows.
+    assert not any(isinstance(row, dict) and row.get("pruned") for row in empty)
+
+
+def test_no_tombstone_rows_written_by_sweep(monkeypatch):
+    """Retention deletes rows; it does not insert placeholder / pruned markers."""
+    monkeypatch.setattr(retention, "ITEMS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "RUNS_KEEP_NEWEST", 0)
+    monkeypatch.setattr(retention, "AI_KEEP_NEWEST", 0)
+
+    ledger = RunLedger(get_engine())
+    ledger.create_run("gone", command_kind="search", trigger="manual")
+    ledger.accept_item("gone", entity_type="issue", entity_id="g1")
+    assert ledger.claim_item("gone", "issue", "g1") is True
+    ledger.record_outcome("gone", "issue", "g1", ItemOutcome.FAILED)
+
+    with get_engine().begin() as conn:
+        conn.execute(
+            acquisition_runs.update()
+            .where(acquisition_runs.c.run_id == "gone")
+            .values(completed_at=_iso(200), updated_at=_iso(200), created_at=_iso(200))
+        )
+        conn.execute(
+            acquisition_run_items.update()
+            .where(acquisition_run_items.c.run_id == "gone")
+            .values(completed_at=_iso(200), updated_at=_iso(200), created_at=_iso(200))
+        )
+        conn.execute(
+            insert(ai_activity_log),
+            {
+                "timestamp": _iso(200),
+                "feature_type": "chat",
+                "action_description": "old",
+                "success": "true",
+            },
+        )
+
+    retention.run_ledger_retention(now=FIXED_NOW)
+
+    assert ledger.get_run("gone") is None
+    assert dashboard_queries.get_recent_ai_activity() == []
+    # Tables empty — no tombstone substitute rows.
+    with get_engine().connect() as conn:
+        assert conn.execute(select(func.count()).select_from(acquisition_runs)).scalar() == 0
+        assert conn.execute(select(func.count()).select_from(acquisition_run_items)).scalar() == 0
+        assert conn.execute(select(func.count()).select_from(ai_activity_log)).scalar() == 0


### PR DESCRIPTION
## Summary

Closes #481. Locks in the settled ledger-retention policy with unit tests and a self-contained ops note. No product UI work and no separate Changeset.

## Changes
- Expand eligibility, hybrid/age math, delete-order, batching, and no-VACUUM coverage for `run_ledger_retention`
- Add UX fallback contracts for pruned runs (404), AI empty feed, acquisition health latest-run fallback, Wanted sticky → never-searched, and needs-attention band
- Add `docs/operations/ledger-retention.md` (parameters, floors, order, batching, out-of-band VACUUM, job id `ledger_retention`)

## Test plan
- [x] `pytest tests/unit/test_ledger_retention.py tests/unit/test_ledger_retention_ux.py -v`
- [x] `pytest tests/unit -q` (full unit suite)
- [ ] CI green