### PR TITLE
feat: Global activity status indicator (quiet counts)

### DIFF
--- a/.changeset/quiet-global-status-indicator.md
+++ b/.changeset/quiet-global-status-indicator.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+The bottom status bar now shows quiet activity counts (`M in flight`, optional `⚠ K need attention`, or `idle`) instead of the old DDL `queue: N active` line. Click the activity text to open Activity.

--- a/frontend/src/components/layout/AppStatusBar.tsx
+++ b/frontend/src/components/layout/AppStatusBar.tsx
@@ -1,32 +1,37 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useDownloadQueue } from "@/hooks/useActivity";
+import { Link } from "react-router-dom";
 import { useDashboard } from "@/hooks/useDashboard";
+import { useActivityStatus } from "@/hooks/useActivityStatus";
 import { apiRequest } from "@/lib/api";
+import {
+  formatQuietStatus,
+  liveAnnouncement,
+  type ActivityApiState,
+  type ActivityStatusSnapshot,
+  type StatusSegment,
+} from "@/lib/activityStatus";
 
 const STATUS_POLL_MS = 30 * 1000;
-const STATUS_QUEUE_QUERY = {
-  limit: 1,
-  offset: 0,
-  sort: "updated",
-  order: "desc" as const,
-};
 
 interface HealthResponse {
   status: string;
 }
 
-function countLabel(count: number, singular: string, plural = `${singular}s`) {
-  return `${count} ${count === 1 ? singular : plural}`;
+function apiColor(api: ActivityApiState): string | undefined {
+  if (api === "online") return "var(--status-active)";
+  if (api === "offline") return "var(--status-error)";
+  return undefined;
 }
 
 /**
- * A compact, independently refreshed summary of the application's live state.
- * Dashboard data shares React Query's cache with the dashboard page, avoiding
- * duplicate requests when both are visible.
+ * Compact global status line: library · api · idle|M in flight · optional attention.
+ * Activity Center ADR §9 Variant A (quiet counts). Polls status every 30s;
+ * shared SSE invalidates the activity status query (no second EventSource).
  */
 export default function AppStatusBar() {
   const dashboard = useDashboard();
-  const queue = useDownloadQueue(STATUS_QUEUE_QUERY);
+  const activity = useActivityStatus();
   const health = useQuery<HealthResponse>({
     queryKey: ["app", "health"],
     queryFn: () => apiRequest<HealthResponse>("GET", "/api/health"),
@@ -34,48 +39,247 @@ export default function AppStatusBar() {
     refetchInterval: STATUS_POLL_MS,
   });
 
-  const libraryStatus = dashboard.isPending
-    ? "loading…"
-    : dashboard.data
-      ? countLabel(dashboard.data.stats.total_series ?? 0, "series", "series")
-      : "unavailable";
-  const queueStatus = queue.isPending
-    ? "loading…"
-    : queue.data
-      ? `${queue.data.pagination.total} active`
-      : "unavailable";
-  const apiStatus = health.isPending
-    ? "checking…"
+  const libraryPending = dashboard.isPending;
+  const libraryFailed = !dashboard.isPending && !dashboard.data;
+  const librarySeries = dashboard.data?.stats.total_series ?? 0;
+
+  const api: ActivityApiState = health.isPending
+    ? "checking"
     : health.data?.status === "ok"
       ? "online"
-      : "unavailable";
-  const apiStatusColor =
-    apiStatus === "online"
-      ? "var(--status-active)"
-      : apiStatus === "unavailable"
-        ? "var(--status-error)"
-        : undefined;
+      : "offline";
+
+  const activityPending = activity.isPending;
+  const activityFailed = !activity.isPending && !activity.data;
+  const inFlight = activity.data?.in_flight ?? 0;
+  const attention = activity.data?.attention ?? 0;
+
+  const ready = !libraryPending && !health.isPending && !activityPending;
+
+  const snapshot: ActivityStatusSnapshot | null = ready
+    ? {
+        librarySeries: libraryFailed ? null : librarySeries,
+        api,
+        inFlight: activityFailed ? 0 : inFlight,
+        attention: activityFailed ? 0 : attention,
+      }
+    : null;
+
+  const liveText = useStatusLiveRegion(snapshot);
+
+  // Loading shell: same layout, provisional values until queries settle.
+  if (!ready) {
+    return (
+      <StatusShell liveText="">
+        <LibrarySegment
+          text={
+            libraryPending ? "loading…" : libraryFailed ? "unavailable" : null
+          }
+          seriesCount={libraryFailed || libraryPending ? null : librarySeries}
+        />
+        <Sep />
+        <ApiSegment api={api} />
+        <Sep />
+        <span className="text-foreground">
+          {activityPending ? "loading…" : activityFailed ? "unavailable" : "…"}
+        </span>
+      </StatusShell>
+    );
+  }
+
+  // Activity endpoint failed but library/api may still be up — show partial line.
+  if (activityFailed && !(libraryFailed && api === "offline")) {
+    return (
+      <StatusShell liveText={liveText}>
+        <LibrarySegment
+          text={libraryFailed ? "unavailable" : null}
+          seriesCount={libraryFailed ? null : librarySeries}
+        />
+        <Sep />
+        <ApiSegment api={api} />
+        <Sep />
+        <Link
+          to="/activity"
+          className="text-foreground hover:underline"
+          title="Activity status unavailable — open Activity"
+        >
+          unavailable
+        </Link>
+      </StatusShell>
+    );
+  }
+
+  const meta = formatQuietStatus(snapshot!);
 
   return (
+    <StatusShell liveText={liveText}>
+      {meta.segments.map((segment, index) => (
+        <SegmentView
+          key={`${segment.role}-${index}`}
+          segment={segment}
+          api={api}
+        />
+      ))}
+    </StatusShell>
+  );
+}
+
+function StatusShell({
+  children,
+  liveText,
+}: {
+  children: ReactNode;
+  liveText: string;
+}) {
+  return (
     <div
-      className="flex min-w-0 items-center gap-3 font-mono text-[11px] text-muted-foreground"
+      className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[11px] text-muted-foreground"
       aria-label="Application status"
-      aria-live="polite"
     >
-      <span title="Active series in your library">
-        library: <span className="text-foreground">{libraryStatus}</span>
-      </span>
-      <span aria-hidden="true">·</span>
-      <span title="Connection to the Comicarr API">
-        api:{" "}
-        <span className="text-foreground" style={{ color: apiStatusColor }}>
-          {apiStatus}
-        </span>
-      </span>
-      <span aria-hidden="true">·</span>
-      <span title="Active direct downloads">
-        queue: <span className="text-foreground">{queueStatus}</span>
+      {children}
+      {/* Outer row is not aria-live; dedicated polite region for policy events only. */}
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        {liveText}
       </span>
     </div>
   );
+}
+
+function Sep() {
+  return <span aria-hidden="true">·</span>;
+}
+
+function LibrarySegment({
+  text,
+  seriesCount,
+}: {
+  text: string | null;
+  seriesCount: number | null;
+}) {
+  const display =
+    text ?? (seriesCount === 1 ? "1 series" : `${seriesCount ?? 0} series`);
+  return (
+    <span title="Active series in your library">
+      library: <span className="text-foreground">{display}</span>
+    </span>
+  );
+}
+
+function ApiSegment({ api }: { api: ActivityApiState }) {
+  const display = api === "checking" ? "checking…" : api;
+  return (
+    <span title="Connection to the Comicarr API">
+      api:{" "}
+      <span className="text-foreground" style={{ color: apiColor(api) }}>
+        {display}
+      </span>
+    </span>
+  );
+}
+
+function SegmentView({
+  segment,
+  api,
+}: {
+  segment: StatusSegment;
+  api: ActivityApiState;
+}) {
+  if (segment.role === "separator") {
+    return <Sep />;
+  }
+
+  if (segment.role === "library") {
+    // segment.text is "library: N series" — split for styling
+    const value = segment.text.replace(/^library:\s*/, "");
+    return (
+      <span title="Active series in your library">
+        library: <span className="text-foreground">{value}</span>
+      </span>
+    );
+  }
+
+  if (segment.role === "api") {
+    const value = segment.text.replace(/^api:\s*/, "");
+    return (
+      <span title="Connection to the Comicarr API">
+        api:{" "}
+        <span className="text-foreground" style={{ color: apiColor(api) }}>
+          {value}
+        </span>
+      </span>
+    );
+  }
+
+  if (segment.role === "attention") {
+    return (
+      <Link
+        to={segment.href ?? "/activity"}
+        className="font-semibold hover:underline"
+        style={{ color: "var(--status-error)" }}
+        title="Needs attention → Activity"
+      >
+        {segment.text}
+      </Link>
+    );
+  }
+
+  // activity | idle
+  const title =
+    segment.text === "unreachable"
+      ? "Server unreachable — open Activity"
+      : segment.text === "idle"
+        ? "No open work → Activity"
+        : "Open work (searches + open pipeline stages) → Activity";
+
+  if (segment.href) {
+    return (
+      <Link
+        to={segment.href}
+        className="text-foreground hover:underline"
+        title={title}
+      >
+        {segment.text}
+      </Link>
+    );
+  }
+
+  return <span className="text-foreground">{segment.text}</span>;
+}
+
+/**
+ * Dedicated polite live region: offline/recovery, attention changes, idle↔busy.
+ * Mid-flight count ticks stay silent. Snapshot fields are tracked as primitives
+ * so object identity churn does not re-fire announcements.
+ */
+function useStatusLiveRegion(snapshot: ActivityStatusSnapshot | null): string {
+  const [text, setText] = useState("");
+  const prevRef = useRef<ActivityStatusSnapshot | null>(null);
+
+  const librarySeries = snapshot?.librarySeries ?? null;
+  const api = snapshot?.api;
+  const inFlight = snapshot?.inFlight;
+  const attention = snapshot?.attention;
+  const ready = snapshot !== null;
+
+  useEffect(() => {
+    if (
+      !ready ||
+      api === undefined ||
+      inFlight === undefined ||
+      attention === undefined
+    ) {
+      return;
+    }
+    const next: ActivityStatusSnapshot = {
+      librarySeries,
+      api,
+      inFlight,
+      attention,
+    };
+    const announcement = liveAnnouncement(prevRef.current, next);
+    prevRef.current = next;
+    setText(announcement);
+  }, [ready, librarySeries, api, inFlight, attention]);
+
+  return text;
 }

--- a/frontend/src/hooks/useActivityStatus.ts
+++ b/frontend/src/hooks/useActivityStatus.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/api";
+
+export const ACTIVITY_STATUS_QUERY_KEY = ["activity", "status"] as const;
+
+const STATUS_POLL_MS = 30 * 1000;
+
+/** Derived open-work counts from GET /api/activity/status (never narrative). */
+export interface ActivityStatusResponse {
+  in_flight: number;
+  attention: number;
+}
+
+/**
+ * Quiet-count inputs for the global status indicator.
+ * Polls every 30s; shared SSE invalidates this key via useServerEvents.
+ */
+export function useActivityStatus() {
+  return useQuery<ActivityStatusResponse>({
+    queryKey: ACTIVITY_STATUS_QUERY_KEY,
+    queryFn: () =>
+      apiRequest<ActivityStatusResponse>("GET", "/api/activity/status"),
+    staleTime: 15 * 1000,
+    refetchInterval: STATUS_POLL_MS,
+  });
+}

--- a/frontend/src/hooks/useServerEvents.ts
+++ b/frontend/src/hooks/useServerEvents.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/components/ui/toast";
+import { ACTIVITY_STATUS_QUERY_KEY } from "@/hooks/useActivityStatus";
 import type {
   AddByIdEventData,
   SchedulerMessageEventData,
@@ -37,6 +38,10 @@ export function useServerEvents(enabled = true): UseServerEventsReturn {
     }
 
     let isMounted = true;
+
+    const invalidateActivityStatus = () => {
+      queryClient.invalidateQueries({ queryKey: ACTIVITY_STATUS_QUERY_KEY });
+    };
 
     const setupEventSource = () => {
       if (!isMounted) return;
@@ -194,9 +199,8 @@ export function useServerEvents(enabled = true): UseServerEventsReturn {
         try {
           const data: SearchProgressEventData = JSON.parse(e.data);
           console.log("[SSE] search_progress event:", data);
-
-          // Don't show toast for progress events, just log them
-          // Could be used to update a progress bar in the UI later
+          // Do not invalidate activity status here — progress is high-frequency.
+          // search_complete + activity + 30s poll cover open-work refresh.
         } catch (error) {
           console.error("[SSE] Error parsing search_progress event:", error);
         }
@@ -209,6 +213,7 @@ export function useServerEvents(enabled = true): UseServerEventsReturn {
         try {
           const data: SearchCompleteEventData = JSON.parse(e.data);
           console.log("[SSE] search_complete event:", data);
+          invalidateActivityStatus();
 
           const resultCount = data.result_count || 0;
           addToast({
@@ -219,6 +224,12 @@ export function useServerEvents(enabled = true): UseServerEventsReturn {
         } catch (error) {
           console.error("[SSE] Error parsing search_complete event:", error);
         }
+      });
+
+      // Event: activity — narrative/open-work updates (Activity Center).
+      // Full toast latch lands with the live-updates ticket; status poll works alone.
+      evtSource.addEventListener("activity", () => {
+        invalidateActivityStatus();
       });
 
       // Event: storyarc_added - Story arc add/refresh completion
@@ -298,6 +309,7 @@ export function useServerEvents(enabled = true): UseServerEventsReturn {
           if (data.tables === "both") {
             queryClient.invalidateQueries({ queryKey: ["series"] });
             queryClient.invalidateQueries({ queryKey: ["wanted"] });
+            invalidateActivityStatus();
             // Also invalidate specific series detail if we have comicid
             if (data.comicid) {
               queryClient.invalidateQueries({
@@ -306,10 +318,12 @@ export function useServerEvents(enabled = true): UseServerEventsReturn {
             }
           } else if (data.tables === "tables") {
             queryClient.invalidateQueries({ queryKey: ["series"] });
+            invalidateActivityStatus();
           } else if (data.tables === "tabs") {
             queryClient.invalidateQueries({ queryKey: ["series"] });
             queryClient.invalidateQueries({ queryKey: ["wanted"] });
             queryClient.invalidateQueries({ queryKey: ["upcoming"] });
+            invalidateActivityStatus();
           }
 
           // Dispatch custom event for ComicCard to handle navigation

--- a/frontend/src/lib/activityStatus.ts
+++ b/frontend/src/lib/activityStatus.ts
@@ -1,0 +1,132 @@
+/**
+ * Quiet-count status line for AppStatusBar (Activity Center ADR §9, Variant A).
+ * Pure composition — no React, no I/O.
+ */
+
+export type ActivityApiState = "online" | "offline" | "checking";
+
+export interface ActivityStatusSnapshot {
+  /** GET /api/dashboard → stats.total_series; null when unavailable */
+  librarySeries: number | null;
+  /** GET /api/health */
+  api: ActivityApiState;
+  /**
+   * GET /api/activity/status → in_flight
+   * (accepted|running run items + OPEN_STAGES journal)
+   */
+  inFlight: number;
+  /** GET /api/activity/status → attention (unresolved band count) */
+  attention: number;
+}
+
+export type StatusSegmentRole =
+  "library" | "api" | "activity" | "attention" | "separator" | "idle";
+
+export interface StatusSegment {
+  role: StatusSegmentRole;
+  text: string;
+  href?: string;
+}
+
+export interface QuietStatusMeta {
+  line: string;
+  segments: StatusSegment[];
+}
+
+function seriesLabel(n: number): string {
+  return n === 1 ? "1 series" : `${n} series`;
+}
+
+function libraryText(s: ActivityStatusSnapshot): string {
+  if (s.librarySeries === null) return "library: unavailable";
+  return `library: ${seriesLabel(s.librarySeries)}`;
+}
+
+function apiText(s: ActivityStatusSnapshot): string {
+  return `api: ${s.api === "checking" ? "checking…" : s.api}`;
+}
+
+/**
+ * Compose the quiet-count status line and segment roles.
+ * Attention segment only when K > 0. Activity/idle/attention/unreachable link to /activity.
+ */
+export function formatQuietStatus(s: ActivityStatusSnapshot): QuietStatusMeta {
+  const segments: StatusSegment[] = [];
+  segments.push({ role: "library", text: libraryText(s) });
+  segments.push({ role: "separator", text: "·" });
+  segments.push({ role: "api", text: apiText(s) });
+  segments.push({ role: "separator", text: "·" });
+
+  if (s.api === "offline" && s.librarySeries === null) {
+    segments.push({
+      role: "activity",
+      text: "unreachable",
+      href: "/activity",
+    });
+  } else if (s.inFlight === 0 && s.attention === 0) {
+    segments.push({
+      role: "idle",
+      text: "idle",
+      href: "/activity",
+    });
+  } else {
+    if (s.inFlight > 0) {
+      segments.push({
+        role: "activity",
+        text: `${s.inFlight} in flight`,
+        href: "/activity",
+      });
+    } else {
+      segments.push({
+        role: "idle",
+        text: "idle",
+        href: "/activity",
+      });
+    }
+    if (s.attention > 0) {
+      segments.push({ role: "separator", text: "·" });
+      segments.push({
+        role: "attention",
+        text: `⚠ ${s.attention} need attention`,
+        href: "/activity",
+      });
+    }
+  }
+
+  return {
+    line: segments.map((seg) => seg.text).join(" "),
+    segments,
+  };
+}
+
+/**
+ * aria-live policy: announce offline/recovery, attention appear/change/clear,
+ * and idle↔busy only — not mid-flight count ticks.
+ */
+export function liveAnnouncement(
+  prev: ActivityStatusSnapshot | null,
+  next: ActivityStatusSnapshot,
+): string {
+  if (!prev) {
+    if (next.api === "offline") return "API offline";
+    if (next.attention > 0) return `${next.attention} need attention`;
+    return "";
+  }
+  if (prev.api !== next.api) {
+    if (next.api === "offline") return "API offline";
+    if (next.api === "online" && prev.api === "offline") return "API online";
+  }
+  if (prev.attention !== next.attention) {
+    if (next.attention === 0) return "Attention cleared";
+    return `${next.attention} need attention`;
+  }
+  const prevBusy = prev.inFlight > 0;
+  const nextBusy = next.inFlight > 0;
+  if (!prevBusy && nextBusy) {
+    return `${next.inFlight} in flight`;
+  }
+  if (prevBusy && !nextBusy && next.attention === 0) {
+    return "Idle";
+  }
+  return "";
+}

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -552,6 +552,10 @@ export function mockApiResponse(
   if (m === "GET" && url === "/api/health") {
     return { status: "ok" };
   }
+  if (m === "GET" && url === "/api/activity/status") {
+    // Quiet-count inputs for AppStatusBar (Variant A). Fixture: light open work.
+    return { in_flight: 2, attention: 0 };
+  }
   if (m === "GET" && url === "/api/dashboard") {
     return dashboardPayload();
   }

--- a/frontend/tests/components/AppStatusBar.test.tsx
+++ b/frontend/tests/components/AppStatusBar.test.tsx
@@ -6,20 +6,73 @@ import { renderMinimal, screen } from "../test-utils";
 import AppStatusBar from "@/components/layout/AppStatusBar";
 
 describe("AppStatusBar", () => {
-  it("shows live library, API, and queue status", async () => {
+  it("shows library, api, and quiet in-flight counts", async () => {
     renderMinimal(<AppStatusBar />);
 
     await waitFor(() => {
       expect(screen.getByText("10 series")).toBeTruthy();
       expect(screen.getByText("online")).toBeTruthy();
-      expect(screen.getByText("2 active")).toBeTruthy();
+      expect(screen.getByText("2 in flight")).toBeTruthy();
     });
 
+    expect(screen.queryByText("2 active")).toBeNull();
+    expect(screen.queryByText(/queue:/i)).toBeNull();
     expect(screen.queryByText("production")).toBeNull();
     expect(screen.queryByText("healthy")).toBeNull();
+
+    // Activity segment links to /activity; library/api do not.
+    const activityLink = screen.getByRole("link", { name: "2 in flight" });
+    expect(activityLink.getAttribute("href")).toBe("/activity");
+    expect(screen.queryByRole("link", { name: /10 series/ })).toBeNull();
+    expect(screen.queryByRole("link", { name: /online/ })).toBeNull();
+
+    // Outer row is not aria-live; dedicated polite region is.
+    const status = screen.getByLabelText("Application status");
+    expect(status.getAttribute("aria-live")).toBeNull();
+    expect(status.querySelector("[aria-live='polite']")).toBeTruthy();
   });
 
-  it("reports unavailable services instead of retaining stale placeholder text", async () => {
+  it("shows idle when open-work counts are empty", async () => {
+    server.use(
+      http.get("/api/activity/status", () =>
+        HttpResponse.json({ in_flight: 0, attention: 0 }),
+      ),
+    );
+
+    renderMinimal(<AppStatusBar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("idle")).toBeTruthy();
+    });
+    expect(screen.queryByText(/in flight/)).toBeNull();
+    expect(screen.queryByText(/need attention/)).toBeNull();
+    expect(
+      screen.getByRole("link", { name: "idle" }).getAttribute("href"),
+    ).toBe("/activity");
+  });
+
+  it("shows attention segment only when K > 0", async () => {
+    server.use(
+      http.get("/api/activity/status", () =>
+        HttpResponse.json({ in_flight: 3, attention: 2 }),
+      ),
+    );
+
+    renderMinimal(<AppStatusBar />);
+
+    await waitFor(() => {
+      expect(screen.getByText("3 in flight")).toBeTruthy();
+      expect(screen.getByText("⚠ 2 need attention")).toBeTruthy();
+    });
+
+    expect(
+      screen
+        .getByRole("link", { name: "⚠ 2 need attention" })
+        .getAttribute("href"),
+    ).toBe("/activity");
+  });
+
+  it("shows unreachable when library and api are both down", async () => {
     server.use(
       http.get("/api/dashboard", () =>
         HttpResponse.json({ detail: "Database unavailable" }, { status: 503 }),
@@ -27,15 +80,21 @@ describe("AppStatusBar", () => {
       http.get("/api/health", () =>
         HttpResponse.json({ detail: "Service unavailable" }, { status: 503 }),
       ),
-      http.get("/api/downloads/queue", () =>
-        HttpResponse.json({ detail: "Queue unavailable" }, { status: 503 }),
+      http.get("/api/activity/status", () =>
+        HttpResponse.json({ detail: "Status unavailable" }, { status: 503 }),
       ),
     );
 
     renderMinimal(<AppStatusBar />);
 
     await waitFor(() => {
-      expect(screen.getAllByText("unavailable")).toHaveLength(3);
+      expect(screen.getByText("unavailable")).toBeTruthy();
+      expect(screen.getByText("offline")).toBeTruthy();
+      expect(screen.getByText("unreachable")).toBeTruthy();
     });
+
+    expect(
+      screen.getByRole("link", { name: "unreachable" }).getAttribute("href"),
+    ).toBe("/activity");
   });
 });

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -141,6 +141,10 @@ export const handlers = [
 
   http.get("/api/health", () => HttpResponse.json({ status: "ok" })),
 
+  http.get("/api/activity/status", () =>
+    HttpResponse.json({ in_flight: 2, attention: 0 }),
+  ),
+
   http.get("/api/downloads/queue", () =>
     HttpResponse.json({
       queue: [],
@@ -346,11 +350,21 @@ export const handlers = [
   }),
 
   http.get("/api/import/comic/progress", () =>
-    HttpResponse.json({ status: null, progress: {}, scan_id: null, results: null }),
+    HttpResponse.json({
+      status: null,
+      progress: {},
+      scan_id: null,
+      results: null,
+    }),
   ),
 
   http.get("/api/import/manga/progress", () =>
-    HttpResponse.json({ status: null, progress: {}, scan_id: null, results: null }),
+    HttpResponse.json({
+      status: null,
+      progress: {},
+      scan_id: null,
+      results: null,
+    }),
   ),
 
   http.put("/api/config", () => {

--- a/frontend/tests/unit/lib/activityStatus.test.ts
+++ b/frontend/tests/unit/lib/activityStatus.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatQuietStatus,
+  liveAnnouncement,
+  type ActivityStatusSnapshot,
+} from "@/lib/activityStatus";
+
+function snap(
+  partial: Partial<ActivityStatusSnapshot> = {},
+): ActivityStatusSnapshot {
+  return {
+    librarySeries: 412,
+    api: "online",
+    inFlight: 0,
+    attention: 0,
+    ...partial,
+  };
+}
+
+describe("formatQuietStatus", () => {
+  it("renders idle when open-work and attention are zero", () => {
+    const meta = formatQuietStatus(snap({}));
+    expect(meta.line).toBe("library: 412 series · api: online · idle");
+    expect(meta.segments.find((s) => s.role === "idle")?.href).toBe(
+      "/activity",
+    );
+    expect(meta.segments.some((s) => s.role === "attention")).toBe(false);
+  });
+
+  it("renders M in flight for non-zero open work", () => {
+    const meta = formatQuietStatus(snap({ inFlight: 5 }));
+    expect(meta.line).toBe("library: 412 series · api: online · 5 in flight");
+    expect(meta.segments.find((s) => s.role === "activity")?.href).toBe(
+      "/activity",
+    );
+  });
+
+  it("appends attention only when K > 0", () => {
+    const withAttention = formatQuietStatus(
+      snap({ inFlight: 3, attention: 2 }),
+    );
+    expect(withAttention.line).toBe(
+      "library: 412 series · api: online · 3 in flight · ⚠ 2 need attention",
+    );
+    expect(
+      withAttention.segments.find((s) => s.role === "attention")?.href,
+    ).toBe("/activity");
+
+    const noAttention = formatQuietStatus(snap({ inFlight: 3, attention: 0 }));
+    expect(noAttention.line).toBe(
+      "library: 412 series · api: online · 3 in flight",
+    );
+    expect(noAttention.segments.some((s) => s.role === "attention")).toBe(
+      false,
+    );
+  });
+
+  it("keeps idle when only attention is non-zero", () => {
+    const meta = formatQuietStatus(snap({ inFlight: 0, attention: 1 }));
+    expect(meta.line).toBe(
+      "library: 412 series · api: online · idle · ⚠ 1 need attention",
+    );
+  });
+
+  it("renders unreachable when library and api are both down", () => {
+    const meta = formatQuietStatus(
+      snap({ librarySeries: null, api: "offline" }),
+    );
+    expect(meta.line).toBe("library: unavailable · api: offline · unreachable");
+    expect(meta.segments.find((s) => s.role === "activity")?.href).toBe(
+      "/activity",
+    );
+    expect(meta.segments.some((s) => s.role === "attention")).toBe(false);
+  });
+
+  it("uses singular series label for one series", () => {
+    const meta = formatQuietStatus(snap({ librarySeries: 1 }));
+    expect(meta.line).toBe("library: 1 series · api: online · idle");
+  });
+
+  it("does not make library or api segments links", () => {
+    const meta = formatQuietStatus(snap({ inFlight: 2, attention: 1 }));
+    expect(
+      meta.segments.find((s) => s.role === "library")?.href,
+    ).toBeUndefined();
+    expect(meta.segments.find((s) => s.role === "api")?.href).toBeUndefined();
+  });
+});
+
+describe("liveAnnouncement", () => {
+  it("is silent for mid-flight count ticks", () => {
+    expect(liveAnnouncement(snap({ inFlight: 3 }), snap({ inFlight: 4 }))).toBe(
+      "",
+    );
+  });
+
+  it("announces idle↔busy edges", () => {
+    expect(liveAnnouncement(snap({}), snap({ inFlight: 2 }))).toBe(
+      "2 in flight",
+    );
+    expect(liveAnnouncement(snap({ inFlight: 2 }), snap({}))).toBe("Idle");
+  });
+
+  it("announces attention appear/change/clear", () => {
+    expect(liveAnnouncement(snap({}), snap({ attention: 2 }))).toBe(
+      "2 need attention",
+    );
+    expect(
+      liveAnnouncement(snap({ attention: 2 }), snap({ attention: 3 })),
+    ).toBe("3 need attention");
+    expect(liveAnnouncement(snap({ attention: 2 }), snap({}))).toBe(
+      "Attention cleared",
+    );
+  });
+
+  it("announces offline and recovery", () => {
+    expect(
+      liveAnnouncement(snap({}), snap({ api: "offline", librarySeries: null })),
+    ).toBe("API offline");
+    expect(
+      liveAnnouncement(snap({ api: "offline", librarySeries: null }), snap({})),
+    ).toBe("API online");
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the DDL `queue: N active` line on the global status bar with Activity Center quiet counts (`idle` / `M in flight` / optional `⚠ K need attention` / `unreachable`), matching ADR §9 Variant A.

Closes #487

## Changes

- Poll `GET /api/activity/status` every 30s via `useActivityStatus`; shared SSE invalidates that query (no second EventSource)
- Pure `formatQuietStatus` / `liveAnnouncement` helper with unit tests for idle, attention, offline, and a11y policy
- Activity / attention / idle / unreachable link to `/activity`; library and api stay plain text; outer row is not `aria-live`

## Test plan

- [ ] Status bar shows `idle` when open-work counts are zero
- [ ] With in-flight work, bar shows `M in flight` and links to `/activity`
- [ ] With attention > 0, bar appends `⚠ K need attention` only then
- [ ] When dashboard + health fail, bar shows `unreachable`
- [ ] No second SSE connection; poll alone still updates within ~30s
- [ ] `cd frontend && npm run test:run -- tests/unit/lib/activityStatus.test.ts tests/components/AppStatusBar.test.tsx`
- [ ] `cd frontend && npm run typecheck && npm run lint`