### PR TITLE
feat: Activity Center timeline UI and detail deep-links

### DIFF
--- a/.changeset/activity-center-timeline-ui.md
+++ b/.changeset/activity-center-timeline-ui.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Activity now opens on a Timeline tab (with Direct Downloads and Download History beside it). A pinned needs-attention band shows actionable failures above a ledger-style feed of plain-language stories, and series/issue detail pages deep-link into a scoped Activity view.

--- a/frontend/src/components/activity/timeline/AttentionBand.tsx
+++ b/frontend/src/components/activity/timeline/AttentionBand.tsx
@@ -1,0 +1,183 @@
+/**
+ * Pinned needs-attention band above the chronological feed.
+ *
+ * Red + actions live only here (Activity Center ADR §2 / #432). Stream rows
+ * for the same trouble are muted history with no actions.
+ */
+
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { AlertTriangle } from "lucide-react";
+import RelativeTime from "@/components/ui/RelativeTime";
+import { useToast } from "@/components/ui/toast";
+import {
+  useBandResolution,
+  type BandResolutionAction,
+} from "@/hooks/useActivity";
+import { bandLabel, bandSentence, reasonDetailLine } from "./sentences";
+import type { BandItem } from "./types";
+
+const ACTIONS: Record<"failed" | "manual_review", BandResolutionAction[]> = {
+  failed: ["retry", "ignore"],
+  manual_review: ["import", "search-again", "ignore"],
+};
+
+const ACTION_LABEL: Record<BandResolutionAction, string> = {
+  retry: "retry",
+  ignore: "ignore",
+  import: "import",
+  "search-again": "search again",
+};
+
+function stageKey(stage: string): "failed" | "manual_review" | null {
+  if (stage === "failed") return "failed";
+  if (stage === "manual_review") return "manual_review";
+  return null;
+}
+
+function BandAction({
+  label,
+  busy,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  busy: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="rounded-[4px] border px-2 py-1 font-mono text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-60"
+      style={{ borderColor: "var(--border)" }}
+    >
+      {busy ? `${label}…` : label}
+    </button>
+  );
+}
+
+export function AttentionBand({ items }: { items: BandItem[] }) {
+  const { mutateAsync, isPending, variables } = useBandResolution();
+  const { addToast } = useToast();
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+
+  if (items.length === 0) return null;
+
+  const handleAction = async (item: BandItem, action: BandResolutionAction) => {
+    const key = `${item.release_key}:${action}`;
+    setPendingKey(key);
+    try {
+      await mutateAsync({ releaseKey: item.release_key, action });
+      addToast({
+        type: "success",
+        message:
+          action === "ignore"
+            ? "Ignored — cleared from needs attention."
+            : action === "import"
+              ? "Import queued."
+              : action === "search-again"
+                ? "Search started again."
+                : "Retry started.",
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : `Unable to ${ACTION_LABEL[action]}.`,
+      });
+    } finally {
+      setPendingKey(null);
+    }
+  };
+
+  return (
+    <section
+      aria-label="Needs attention"
+      className="border-b"
+      style={{
+        borderColor: "var(--border)",
+        background:
+          "var(--status-error-bg, color-mix(in oklab, var(--status-error) 12%, transparent))",
+      }}
+    >
+      <div className="flex items-center gap-2 px-5 pt-3 pb-1.5">
+        <AlertTriangle
+          className="h-3.5 w-3.5"
+          style={{ color: "var(--status-error)" }}
+        />
+        <span
+          className="font-mono text-[11px] uppercase tracking-[0.1em]"
+          style={{ color: "var(--status-error)" }}
+        >
+          {items.length} need{items.length === 1 ? "s" : ""} attention
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          clears only by action
+        </span>
+      </div>
+
+      <ul className="px-5 pb-3">
+        {items.map((item) => {
+          const label = bandLabel(item);
+          const stage = stageKey(String(item.stage));
+          const actions = stage ? ACTIONS[stage] : [];
+          const reason = reasonDetailLine(item.fail_reason);
+          const issueHref = item.issueid
+            ? `/activity?scope_type=issue&scope_id=${encodeURIComponent(item.issueid)}`
+            : null;
+
+          return (
+            <li
+              key={item.release_key}
+              className="flex flex-wrap items-baseline gap-x-3 gap-y-1 py-1.5"
+            >
+              <span className="text-[13px] font-medium">
+                {issueHref ? (
+                  <Link to={issueHref} className="hover:text-[var(--primary)]">
+                    {bandSentence(String(item.stage), label)}
+                  </Link>
+                ) : (
+                  bandSentence(String(item.stage), label)
+                )}
+              </span>
+              {reason.phrase && (
+                <span className="text-[12px] text-muted-foreground">
+                  {reason.phrase}
+                  {reason.rawCode && (
+                    <span className="ml-1.5 font-mono text-[10px] opacity-70">
+                      {reason.rawCode}
+                    </span>
+                  )}
+                </span>
+              )}
+              <RelativeTime value={item.updated_date} />
+              <span className="ml-auto flex items-center gap-1.5">
+                {actions.map((action) => {
+                  const key = `${item.release_key}:${action}`;
+                  const busy =
+                    isPending &&
+                    variables?.releaseKey === item.release_key &&
+                    variables?.action === action;
+                  return (
+                    <BandAction
+                      key={action}
+                      label={ACTION_LABEL[action]}
+                      busy={busy || pendingKey === key}
+                      disabled={isPending}
+                      onClick={() => void handleAction(item, action)}
+                    />
+                  );
+                })}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/activity/timeline/TimelineView.tsx
+++ b/frontend/src/components/activity/timeline/TimelineView.tsx
@@ -1,0 +1,415 @@
+/**
+ * Timeline tab — Variant A (Ledger) chrome.
+ *
+ * Absolute HH:MM gutter, severity dots (green open / red closed-in-trouble /
+ * else none), sentence + RelativeTime, sticky day rules, page size 25 stories.
+ * Always-collapsed; group-of-one is a plain row. Filters: free-text + activity
+ * dropdown only (band owns needs-attention).
+ */
+
+import { Fragment, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import EmptyState from "@/components/ui/EmptyState";
+import ErrorDisplay from "@/components/ui/ErrorDisplay";
+import FilterField from "@/components/ui/FilterField";
+import RelativeTime from "@/components/ui/RelativeTime";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useActivityBand, useActivityTimeline } from "@/hooks/useActivity";
+import { AttentionBand } from "./AttentionBand";
+import { reasonDetailLine, runProgress, storyHeadline } from "./sentences";
+import {
+  buildFeed,
+  clockOf,
+  dayKey,
+  dayLabel,
+  isOpen,
+  subjectHref,
+  storyHasTrouble,
+} from "./stories";
+import type { Story } from "./types";
+
+const STORY_PAGE_SIZE = 25;
+
+const ACTIVITIES = [
+  "all",
+  "search",
+  "grab",
+  "download",
+  "import",
+  "refresh",
+  "add",
+  "tag",
+] as const;
+
+function SeverityDot({ open, trouble }: { open: boolean; trouble: boolean }) {
+  if (open) {
+    return (
+      <span
+        aria-label="In progress"
+        className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full"
+        style={{ background: "var(--status-active)" }}
+      />
+    );
+  }
+  if (trouble) {
+    return (
+      <span
+        aria-label="Needs attention (history)"
+        className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full"
+        style={{ background: "var(--status-error)" }}
+      />
+    );
+  }
+  return (
+    <span
+      aria-hidden
+      className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full"
+      style={{ background: "transparent" }}
+    />
+  );
+}
+
+function Headline({ story }: { story: Story }) {
+  const text = storyHeadline(story);
+  const href = subjectHref(story);
+  const label = story.subject_label;
+
+  if (!href || !label || story.subject_type === "run") {
+    return <span>{text}</span>;
+  }
+
+  // Inline entity link: replace the first occurrence of the subject label.
+  const idx = text.indexOf(label);
+  if (idx < 0) {
+    return (
+      <span>
+        {text}{" "}
+        <Link to={href} className="font-medium hover:text-[var(--primary)]">
+          {label}
+        </Link>
+      </span>
+    );
+  }
+
+  return (
+    <span>
+      {text.slice(0, idx)}
+      <Link to={href} className="font-medium hover:text-[var(--primary)]">
+        {label}
+      </Link>
+      {text.slice(idx + label.length)}
+    </span>
+  );
+}
+
+function DetailLine({ story }: { story: Story }) {
+  const closer = story.closer;
+  if (!closer) return null;
+  const line = reasonDetailLine(closer.reason_code, closer.reason_detail);
+  if (!line.phrase && !line.detail) return null;
+  return (
+    <div className="text-[12px] text-muted-foreground">
+      {line.phrase}
+      {line.rawCode && (
+        <span className="ml-2 font-mono text-[10px] opacity-70">
+          {line.rawCode}
+        </span>
+      )}
+      {line.detail && (
+        <span className="ml-2 font-mono text-[10px] opacity-70">
+          {line.detail}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function FirstRunEmpty({ scoped }: { scoped: boolean }) {
+  return (
+    <div className="px-5 py-10">
+      <EmptyState
+        variant="custom"
+        eyebrow={
+          scoped ? "TIMELINE · SCOPED · EMPTY" : "TIMELINE · NOTHING YET"
+        }
+        title={
+          scoped ? "No activity for this scope yet" : "Nothing has happened yet"
+        }
+        description={
+          scoped
+            ? "Searches, grabs and imports for this series or issue will show up here as they happen."
+            : "Add a series and mark issues as wanted — searches, grabs and imports will show up here as they happen."
+        }
+        action={
+          scoped
+            ? { label: "Back to all activity", to: "/activity" }
+            : { label: "Add a series", to: "/search" }
+        }
+      />
+    </div>
+  );
+}
+
+export function TimelineView({
+  scope_type,
+  scope_id,
+}: {
+  scope_type?: string | null;
+  scope_id?: string | null;
+}) {
+  const [query, setQuery] = useState("");
+  const [activity, setActivity] = useState<string>("all");
+  const [page, setPage] = useState(0);
+
+  const timeline = useActivityTimeline({ scope_type, scope_id });
+  const band = useActivityBand({ scope_type, scope_id });
+
+  const bandItems = band.data?.results ?? [];
+  const events = useMemo(
+    () => timeline.data?.pages.flatMap((p) => p.results) ?? [],
+    [timeline.data?.pages],
+  );
+
+  const nodes = useMemo(() => buildFeed(events), [events]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return nodes.filter((story) => {
+      if (activity !== "all") {
+        if (!story.events.some((e) => e.activity === activity)) return false;
+      }
+      if (!q) return true;
+      return (
+        story.subject_label.toLowerCase().includes(q) ||
+        storyHeadline(story).toLowerCase().includes(q)
+      );
+    });
+  }, [nodes, query, activity]);
+
+  const start = page * STORY_PAGE_SIZE;
+  const pageNodes = filtered.slice(start, start + STORY_PAGE_SIZE);
+  const hasMoreStories = start + STORY_PAGE_SIZE < filtered.length;
+  const hasMoreEvents = Boolean(timeline.hasNextPage);
+
+  const isInitialLoading =
+    (timeline.isLoading || band.isLoading) && !timeline.data && !band.data;
+  // Keep last-good data on poll/refetch failure; only hard-error on first load.
+  const hardError =
+    !timeline.data && !band.data ? (timeline.error ?? band.error) : null;
+
+  const scoped = Boolean(scope_type?.trim()) && Boolean(scope_id?.trim());
+
+  if (isInitialLoading) {
+    return (
+      <div className="space-y-2 px-5 py-4">
+        {[0, 1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-11" />
+        ))}
+      </div>
+    );
+  }
+
+  if (hardError) {
+    return (
+      <div className="px-5 py-4">
+        <ErrorDisplay
+          error={hardError}
+          title="Unable to load activity timeline"
+          onRetry={() => {
+            void timeline.refetch();
+            void band.refetch();
+          }}
+        />
+      </div>
+    );
+  }
+
+  // Empty state replaces toolbar on first run (no events, no band).
+  if (nodes.length === 0 && bandItems.length === 0) {
+    return (
+      <>
+        {scoped && (
+          <div className="border-b border-border px-5 py-2 font-mono text-[11px] text-muted-foreground">
+            Scoped to {scope_type}:{scope_id}
+          </div>
+        )}
+        <FirstRunEmpty scoped={scoped} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <AttentionBand items={bandItems} />
+
+      {scoped && (
+        <div className="flex items-center gap-2 border-b border-border px-5 py-2 font-mono text-[11px] text-muted-foreground">
+          <span>
+            Scoped to {scope_type}:{scope_id}
+          </span>
+          <Link to="/activity" className="ml-auto hover:text-foreground">
+            clear scope
+          </Link>
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 border-b border-border px-5 py-2.5">
+        <div className="max-w-sm flex-1">
+          <FilterField
+            placeholder="Filter timeline…"
+            aria-label="Filter timeline"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setPage(0);
+            }}
+            shortcut="/"
+          />
+        </div>
+        <select
+          aria-label="Filter by activity"
+          value={activity}
+          onChange={(e) => {
+            setActivity(e.target.value);
+            setPage(0);
+          }}
+          className="rounded-[5px] border bg-transparent px-2 py-1.5 font-mono text-[11px] text-muted-foreground"
+          style={{ borderColor: "var(--border)" }}
+        >
+          {ACTIVITIES.map((a) => (
+            <option key={a} value={a}>
+              {a === "all" ? "all activities" : a}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div role="feed" aria-label="Activity timeline">
+        {pageNodes.map((story, index) => {
+          const prev = pageNodes[index - 1];
+          const showDay =
+            !prev || dayKey(prev.opened_at) !== dayKey(story.opened_at);
+          const open = isOpen(story);
+          const trouble = storyHasTrouble(story);
+          const multi = story.events.length > 1;
+
+          return (
+            <Fragment key={story.key}>
+              {showDay && (
+                <div
+                  className="sticky top-0 z-10 border-b border-border px-5 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+                  style={{ background: "var(--background)" }}
+                >
+                  {dayLabel(story.opened_at)}
+                </div>
+              )}
+
+              <div
+                className="flex items-start gap-3 border-b px-5 py-2 hover:bg-[var(--secondary)]"
+                style={{ borderColor: "var(--border-soft, var(--border))" }}
+              >
+                <span className="mt-[2px] w-10 shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
+                  {clockOf(story.opened_at)}
+                </span>
+                <SeverityDot open={open} trouble={trouble} />
+
+                <div className="min-w-0 flex-1">
+                  <div className="text-[13px] leading-snug">
+                    <Headline story={story} />
+                    {runProgress(story) && (
+                      <span className="ml-2 font-mono text-[11px] text-muted-foreground">
+                        {runProgress(story)}
+                      </span>
+                    )}
+                    {multi && (
+                      <span
+                        className="ml-2 font-mono text-[10px] text-muted-foreground"
+                        title={`${story.events.length} events in this story`}
+                      >
+                        · {story.events.length}
+                      </span>
+                    )}
+                  </div>
+                  <DetailLine story={story} />
+                </div>
+
+                <RelativeTime value={story.opened_at} />
+              </div>
+            </Fragment>
+          );
+        })}
+
+        {pageNodes.length === 0 && (
+          <div className="px-5 py-8">
+            <EmptyState
+              variant="custom"
+              eyebrow={
+                nodes.length === 0 ? "TIMELINE · EMPTY" : "TIMELINE · FILTERED"
+              }
+              title={
+                nodes.length === 0
+                  ? "No timeline events yet"
+                  : "Nothing matches"
+              }
+              description={
+                nodes.length === 0
+                  ? "Items that need attention stay in the band above until you act on them."
+                  : "Try a different filter."
+              }
+            />
+          </div>
+        )}
+      </div>
+
+      {(filtered.length > 0 || hasMoreEvents) && (
+        <div className="flex items-center gap-3 px-5 py-2.5">
+          <span className="font-mono text-[10px] text-muted-foreground">
+            {filtered.length === 0
+              ? "0 stories"
+              : `${start + 1}–${Math.min(start + STORY_PAGE_SIZE, filtered.length)} of ${filtered.length}${hasMoreEvents ? "+" : ""} stories`}
+          </span>
+          <div className="ml-auto flex gap-1.5">
+            <button
+              type="button"
+              disabled={page === 0}
+              onClick={() => setPage((p) => p - 1)}
+              className="rounded-[4px] border px-2 py-1 font-mono text-[10px] text-muted-foreground disabled:opacity-40"
+              style={{ borderColor: "var(--border)" }}
+            >
+              prev
+            </button>
+            <button
+              type="button"
+              disabled={
+                (!hasMoreStories && !hasMoreEvents) ||
+                timeline.isFetchingNextPage
+              }
+              onClick={() => {
+                if (hasMoreStories) {
+                  setPage((p) => p + 1);
+                  return;
+                }
+                // Story window is exhausted for this event pack — pull more
+                // events; grouping re-runs and the operator can page again.
+                if (hasMoreEvents) {
+                  void timeline.fetchNextPage();
+                }
+              }}
+              className="rounded-[4px] border px-2 py-1 font-mono text-[10px] text-muted-foreground disabled:opacity-40"
+              style={{ borderColor: "var(--border)" }}
+            >
+              {timeline.isFetchingNextPage
+                ? "loading…"
+                : hasMoreStories
+                  ? "next"
+                  : "older"}
+            </button>
+          </div>
+        </div>
+      )}
+      <p className="px-5 pb-4 font-mono text-[10px] text-muted-foreground">
+        older than 90 days is deleted · see download history for the full ledger
+      </p>
+    </>
+  );
+}

--- a/frontend/src/components/activity/timeline/index.ts
+++ b/frontend/src/components/activity/timeline/index.ts
@@ -1,0 +1,30 @@
+export { AttentionBand } from "./AttentionBand";
+export { TimelineView } from "./TimelineView";
+export {
+  buildFeed,
+  clockOf,
+  dayKey,
+  dayLabel,
+  isOpen,
+  subjectHref,
+  storyHasTrouble,
+} from "./stories";
+export {
+  bandLabel,
+  bandSentence,
+  reasonDetailLine,
+  reasonPhrase,
+  runProgress,
+  sentenceFor,
+  storyHeadline,
+} from "./sentences";
+export type {
+  Activity,
+  BandItem,
+  BandPage,
+  FeedNode,
+  Story,
+  TimelineEvent,
+  TimelinePage,
+} from "./types";
+export { severityOf } from "./types";

--- a/frontend/src/components/activity/timeline/sentences.ts
+++ b/frontend/src/components/activity/timeline/sentences.ts
@@ -1,0 +1,215 @@
+/**
+ * Client sentence templates + reason_code lexicon for the Activity timeline.
+ *
+ * Producers write data, never prose (Activity Center ADR §4). Unmapped reason
+ * codes degrade to a generic phrase — never a snake_case token as the primary
+ * line (#427).
+ */
+
+import type { Story, TimelineEvent } from "./types";
+
+const REASON_LEXICON: Record<string, string> = {
+  downloader_unreachable: "downloader unreachable",
+  no_acquisition_route: "no complete acquisition route is ready",
+  provider_error: "provider returned an error",
+  disk_full: "not enough space on the destination volume",
+  checksum_mismatch: "the downloaded file failed its integrity check",
+  unmatched_series: "couldn't match the file to a series",
+  ambiguous_issue: "more than one issue matches this file",
+  bad_archive: "the archive wouldn't open",
+  missing_metadata: "the file carries no usable metadata",
+  path_conflict: "a file already exists at the destination",
+  ignored_by_operator: "you ignored this",
+  search_lock_held: "another search was already running",
+  download_failed: "the download failed",
+  import_failed: "import failed",
+};
+
+const UNMAPPED_REASON_PHRASE = "something went wrong";
+
+/**
+ * Lexicon lookup. Unmapped codes return a generic phrase (not the raw token).
+ * Pass `includeRaw` via `reasonDetailLine` when the expand/detail line needs
+ * the original code.
+ */
+export function reasonPhrase(code?: string | null): string | null {
+  if (!code) return null;
+  return REASON_LEXICON[code] ?? UNMAPPED_REASON_PHRASE;
+}
+
+/** Secondary detail line: mapped phrase, plus raw token when unmapped. */
+export function reasonDetailLine(
+  code?: string | null,
+  detail?: string | null,
+): { phrase: string | null; rawCode: string | null; detail: string | null } {
+  if (!code && !detail) {
+    return { phrase: null, rawCode: null, detail: null };
+  }
+  if (!code) {
+    return { phrase: null, rawCode: null, detail: detail ?? null };
+  }
+  const mapped = REASON_LEXICON[code];
+  if (mapped) {
+    return { phrase: mapped, rawCode: null, detail: detail ?? null };
+  }
+  return {
+    phrase: UNMAPPED_REASON_PHRASE,
+    rawCode: code,
+    detail: detail ?? null,
+  };
+}
+
+function plural(n: number, one: string, many: string): string {
+  return `${n} ${n === 1 ? one : many}`;
+}
+
+/**
+ * Run-scoped search sentences carry counts when present; a fruitless sweep
+ * still says how many it looked at (#432 anti-silence).
+ */
+function runSentence(event: TimelineEvent): string {
+  const c = event.counts;
+  if (event.status === "started") {
+    if (!c || c.accepted === 0) return "Nothing to search";
+    return `Searching ${plural(c.accepted, "wanted issue", "wanted issues")}`;
+  }
+  if (event.status === "succeeded") {
+    if (!c) return "Search finished";
+    const parts: string[] = [];
+    if (c.grabbed > 0) parts.push(`grabbed ${c.grabbed}`);
+    if (c.no_match > 0) parts.push(`no results for ${c.no_match}`);
+    if (c.failed > 0) parts.push(`${c.failed} failed`);
+    const tail = parts.length > 0 ? ` — ${parts.join(", ")}` : "";
+    return `Searched ${plural(c.accepted, "wanted issue", "wanted issues")}${tail}`;
+  }
+  if (event.status === "blocked") return "Search blocked";
+  if (event.status === "cancelled") return "Search stopped";
+  if (event.status === "no_match") return "Search found nothing";
+  if (event.status === "failed") return "Couldn't finish search";
+  return "Search finished";
+}
+
+/**
+ * Voice rule (#426): Comicarr is the implicit subject; failures read
+ * "Couldn't ⟨verb⟩", never "⟨Noun⟩ failed".
+ */
+export function sentenceFor(event: TimelineEvent): string {
+  const label = event.subject_label;
+
+  if (event.subject_type === "run") return runSentence(event);
+
+  switch (`${event.activity}.${event.status}`) {
+    case "search.no_match":
+      return `No results for ${label}`;
+    case "search.failed":
+    case "search.blocked":
+      return `Couldn't search for ${label}`;
+    case "search.needs_attention":
+      return `${label} needs attention`;
+    case "search.cancelled":
+      return `Stopped searching for ${label}`;
+    case "search.started":
+      return `Searching for ${label}`;
+    case "search.succeeded":
+      return `Searched for ${label}`;
+
+    case "grab.succeeded":
+      return event.provider
+        ? `Grabbed ${label} from ${event.provider}`
+        : `Grabbed ${label}`;
+    case "grab.failed":
+      return `Couldn't grab ${label}`;
+    case "grab.blocked":
+      return `Couldn't send ${label} to the downloader`;
+    case "grab.cancelled":
+      return `Stopped grabbing ${label}`;
+
+    case "download.succeeded":
+      return `Downloaded ${label}`;
+    case "download.failed":
+      return `Couldn't download ${label}`;
+    case "download.cancelled":
+      return `Stopped downloading ${label}`;
+
+    case "import.started":
+      return `Importing ${label}`;
+    case "import.succeeded":
+      return `Imported ${label}`;
+    case "import.failed":
+      return `Couldn't import ${label}`;
+    case "import.needs_attention":
+      return `Stopped on ${label} — needs your decision`;
+    case "import.cancelled":
+      return `Stopped importing ${label}`;
+
+    case "tag.started":
+      return `Tagging ${label}`;
+    case "tag.succeeded":
+      return `Tagged ${label}`;
+    case "tag.failed":
+      return `Couldn't tag ${label}`;
+    case "tag.needs_attention":
+      return `Tagging stopped on ${label} — needs your decision`;
+
+    case "refresh.succeeded":
+      return event.counts?.accepted
+        ? `Refreshed ${label} — ${plural(event.counts.accepted, "new issue", "new issues")}`
+        : `Refreshed ${label}`;
+    case "refresh.failed":
+      return `Couldn't refresh ${label}`;
+    case "refresh.started":
+      return `Refreshing ${label}`;
+
+    case "add.succeeded":
+      return event.subject_type === "arc"
+        ? `Added story arc ${label}${event.counts ? ` — ${plural(event.counts.accepted, "issue", "issues")}` : ""}`
+        : `Added ${label}${event.counts ? ` — ${plural(event.counts.accepted, "issue", "issues")}` : ""}`;
+    case "add.failed":
+      return `Couldn't add ${label}`;
+    case "add.started":
+      return `Adding ${label}`;
+
+    default:
+      return `${label} — ${event.activity} ${event.status}`;
+  }
+}
+
+/**
+ * Header while open uses the furthest advance sentence; once closed, the
+ * closer's own sentence (Activity Center ADR §5). Live journal stage is out
+ * of scope for this ticket (status indicator owns derived open-work).
+ */
+export function storyHeadline(story: Story): string {
+  if (story.closer) return sentenceFor(story.closer);
+  const last = story.events[story.events.length - 1];
+  return last ? sentenceFor(last) : story.subject_label;
+}
+
+/** Determinate per-run progress when counts are present; never a percentage. */
+export function runProgress(story: Story): string | null {
+  if (story.closer || story.subject_type !== "run") return null;
+  const counts = story.events[0]?.counts;
+  if (!counts || counts.resolved == null) return null;
+  return `${counts.resolved} of ${counts.accepted} resolved`;
+}
+
+/** Band phrasing — work queue, so it says what you must decide. */
+export function bandSentence(stage: string, label: string): string {
+  return stage === "manual_review"
+    ? `Stopped on ${label} — needs your decision`
+    : `Couldn't finish ${label}`;
+}
+
+export function bandLabel(item: {
+  subject_label?: string | null;
+  nzbname?: string | null;
+  issueid?: string | null;
+  release_key: string;
+}): string {
+  return (
+    item.subject_label?.trim() ||
+    item.nzbname?.trim() ||
+    (item.issueid ? `issue ${item.issueid}` : "") ||
+    item.release_key
+  );
+}

--- a/frontend/src/components/activity/timeline/stories.ts
+++ b/frontend/src/components/activity/timeline/stories.ts
@@ -1,0 +1,214 @@
+/**
+ * Story grouping for the Activity timeline (#428 / Activity Center ADR §5).
+ *
+ * Rules:
+ *  - identity is `(subject_type, subject_id)`, never `release_key`
+ *  - opened by an advance; closed by the terminal-pair allowlist
+ *  - always collapsed; a group of one degenerates to a plain row
+ *  - position is the opening row's `created_at`; nothing re-sorts
+ *  - a retry opens a second story, never reopening the first
+ *
+ * Run-scoped search: `search.started @ run` is treated as an opener so a
+ * started/succeeded pair does not render as two unrelated rows (prototype
+ * extension kept for production readability).
+ */
+
+import type { FeedNode, Story, TimelineEvent } from "./types";
+import { severityOf } from "./types";
+
+/** Issue/annual/series advances that open or extend a multi-event story. */
+const ISSUE_ADVANCES = new Set([
+  "grab.succeeded",
+  "download.succeeded",
+  "import.started",
+  "tag.started",
+]);
+
+/**
+ * Normative terminal-pair allowlist (Activity Center ADR §5).
+ * Terminality is a function of the `(activity, status)` pair.
+ */
+const ISSUE_TERMINALS = new Set([
+  "grab.failed",
+  "grab.blocked",
+  "grab.cancelled",
+  "download.failed",
+  "download.cancelled",
+  "import.succeeded",
+  "import.failed",
+  "import.needs_attention",
+  "import.cancelled",
+  "tag.succeeded",
+  "tag.failed",
+  "tag.needs_attention",
+]);
+
+const RUN_TERMINALS = new Set([
+  "search.succeeded",
+  "search.failed",
+  "search.blocked",
+  "search.cancelled",
+  "search.no_match",
+]);
+
+function cellOf(event: TimelineEvent): string {
+  return `${event.activity}.${event.status}`;
+}
+
+function isAdvance(event: TimelineEvent): boolean {
+  if (event.subject_type === "run") {
+    return cellOf(event) === "search.started";
+  }
+  return ISSUE_ADVANCES.has(cellOf(event));
+}
+
+function isTerminal(event: TimelineEvent): boolean {
+  if (event.subject_type === "run") {
+    return RUN_TERMINALS.has(cellOf(event));
+  }
+  if (ISSUE_TERMINALS.has(cellOf(event))) return true;
+  // Non-normal severity that is not an advance always closes (#428 trouble rule).
+  return severityOf(String(event.status)) === "action_required";
+}
+
+function subjectKey(event: TimelineEvent): string {
+  return `${event.subject_type}:${event.subject_id}`;
+}
+
+/**
+ * Group a page of narrative events into always-collapsed stories.
+ * Events may arrive newest-first from the API; processing is chronological.
+ */
+export function buildFeed(events: TimelineEvent[]): FeedNode[] {
+  const ascending = [...events].sort((a, b) => {
+    if (a.created_at < b.created_at) return -1;
+    if (a.created_at > b.created_at) return 1;
+    // Stable tie-break: lower event_id first when both are numeric-ish.
+    return String(a.event_id).localeCompare(String(b.event_id), undefined, {
+      numeric: true,
+    });
+  });
+
+  const open = new Map<string, Story>();
+  const nodes: Story[] = [];
+
+  for (const event of ascending) {
+    const key = subjectKey(event);
+    const current = open.get(key);
+
+    if (current) {
+      current.events.push(event);
+      if (isTerminal(event)) {
+        current.closer = event;
+        open.delete(key);
+      }
+      continue;
+    }
+
+    const story: Story = {
+      key: `${key}@${event.created_at}@${event.event_id}`,
+      subject_type: String(event.subject_type),
+      subject_id: String(event.subject_id),
+      subject_label: event.subject_label,
+      parent_series_id: event.parent_series_id,
+      opened_at: event.created_at,
+      events: [event],
+      closer: null,
+    };
+
+    if (isAdvance(event)) {
+      open.set(key, story);
+      nodes.push(story);
+      continue;
+    }
+
+    // Not an advance and no open story: plain row (group of one).
+    story.closer = event;
+    nodes.push(story);
+  }
+
+  // Newest stories first; position is opening created_at (never re-sorted by closer).
+  return nodes.sort((a, b) => {
+    if (a.opened_at < b.opened_at) return 1;
+    if (a.opened_at > b.opened_at) return -1;
+    return b.key.localeCompare(a.key);
+  });
+}
+
+export function storyHasTrouble(story: Story): boolean {
+  const closer = story.closer;
+  if (!closer) return false;
+  return severityOf(String(closer.status)) === "action_required";
+}
+
+export function isOpen(story: Story): boolean {
+  return story.closer === null;
+}
+
+/** Local calendar day key for sticky day rules. */
+export function dayKey(iso: string): string {
+  const date = parseTimelineDate(iso);
+  if (!date) return iso;
+  return date.toDateString();
+}
+
+export function dayLabel(iso: string, now: Date = new Date()): string {
+  const date = parseTimelineDate(iso);
+  if (!date) return iso;
+
+  const today = new Date(now);
+  const yesterday = new Date(now);
+  yesterday.setDate(today.getDate() - 1);
+
+  if (date.toDateString() === today.toDateString()) return "TODAY";
+  if (date.toDateString() === yesterday.toDateString()) return "YESTERDAY";
+  return date
+    .toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    })
+    .toUpperCase();
+}
+
+export function clockOf(iso: string): string {
+  const date = parseTimelineDate(iso);
+  if (!date) return "—";
+  return date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+/** Accept both ISO and SQLite-style `YYYY-MM-DD HH:MM:SS` timestamps. */
+export function parseTimelineDate(value: string): Date | null {
+  if (!value) return null;
+  const normalized = value.includes("T") ? value : value.replace(" ", "T");
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/** Deep-link for a subject when enough identity remains. */
+export function subjectHref(story: {
+  subject_type: string;
+  subject_id: string;
+  parent_series_id?: string | null;
+}): string | null {
+  const id = story.subject_id;
+  if (!id) return null;
+  switch (story.subject_type) {
+    case "series":
+      return `/library/${encodeURIComponent(id)}`;
+    case "issue":
+    case "annual": {
+      const seriesId = story.parent_series_id;
+      if (!seriesId) return null;
+      return `/library/${encodeURIComponent(seriesId)}/issue/${encodeURIComponent(id)}`;
+    }
+    case "arc":
+      return `/story-arcs/${encodeURIComponent(id)}`;
+    default:
+      return null;
+  }
+}

--- a/frontend/src/components/activity/timeline/types.ts
+++ b/frontend/src/components/activity/timeline/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Activity Center timeline types.
+ *
+ * Field contract mirrors activity_events / band DTOs (Activity Center ADR).
+ * Severity is a pure function of status — never stored.
+ */
+
+export type Activity =
+  "search" | "grab" | "download" | "import" | "refresh" | "add" | "tag";
+
+/** `retrying` is deliberately absent — #432. */
+export type EventStatus =
+  | "started"
+  | "succeeded"
+  | "no_match"
+  | "cancelled"
+  | "failed"
+  | "blocked"
+  | "needs_attention";
+
+export type SubjectType = "issue" | "annual" | "series" | "arc" | "run";
+
+export type Severity = "normal" | "action_required";
+
+/** Severity is a pure function of status (#426) — never stored. */
+export function severityOf(status: string): Severity {
+  return status === "failed" ||
+    status === "blocked" ||
+    status === "needs_attention"
+    ? "action_required"
+    : "normal";
+}
+
+/** Optional run counts when producers embed them (not a DB column today). */
+export interface RunCounts {
+  accepted: number;
+  grabbed: number;
+  no_match: number;
+  failed: number;
+  /** Present only while the run is open — determinate per-run progress. */
+  resolved?: number;
+}
+
+export interface TimelineEvent {
+  event_id: number | string;
+  created_at: string;
+  activity: Activity | string;
+  status: EventStatus | string;
+  subject_type: SubjectType | string;
+  subject_id: string;
+  /** Denormalized — the timeline must survive deletion of its subject. */
+  subject_label: string;
+  reason_code?: string | null;
+  reason_detail?: string | null;
+  provider?: string | null;
+  run_id?: string | null;
+  release_key?: string | null;
+  parent_series_id?: string | null;
+  scope_type?: string | null;
+  scope_id?: string | null;
+  /** Not on the table; optional future/envelope field for run brackets. */
+  counts?: RunCounts | null;
+}
+
+/**
+ * Needs-attention band row from pipeline_journal (derived ledger, not narrative).
+ * Field names match the journal row shape from GET /api/activity/band.
+ */
+export interface BandItem {
+  release_key: string;
+  stage: "failed" | "manual_review" | string;
+  issueid?: string | null;
+  provider?: string | null;
+  nzbname?: string | null;
+  fail_reason?: string | null;
+  updated_date: string;
+  status?: string | null;
+  /** Optional display helpers when present on an enriched DTO. */
+  subject_label?: string | null;
+}
+
+/**
+ * One subject's story (#428). Identity is `(subject_type, subject_id)`.
+ * Opened by an advance, closed by a terminal allowlist pair. Always collapsed.
+ */
+export interface Story {
+  key: string;
+  subject_type: string;
+  subject_id: string;
+  subject_label: string;
+  parent_series_id?: string | null;
+  /** Opening event's created_at — position, and it never re-sorts. */
+  opened_at: string;
+  events: TimelineEvent[];
+  /** Null while open; the closing event once closed. */
+  closer: TimelineEvent | null;
+}
+
+export type FeedNode = Story;
+
+export interface TimelinePage {
+  results: TimelineEvent[];
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
+export interface BandPage {
+  results: BandItem[];
+  total: number;
+}

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -1,6 +1,38 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { apiRequest } from "@/lib/api";
+import type {
+  BandPage,
+  TimelinePage,
+} from "@/components/activity/timeline/types";
 import type { PaginationMeta } from "@/types";
+
+/** Permanent 30s poll for open timeline/band surfaces (Activity Center ADR §8). */
+export const ACTIVITY_POLL_MS = 30_000;
+
+/** Event page size for infinite timeline fetches (story page of 25 is client-side). */
+export const TIMELINE_EVENT_PAGE_SIZE = 100;
+
+export type ActivityScope = {
+  scope_type?: string | null;
+  scope_id?: string | null;
+};
+
+export type BandResolutionAction =
+  "retry" | "search-again" | "ignore" | "import";
+
+interface BandResolutionResult {
+  success: boolean;
+  error?: string;
+  message?: string;
+  status?: string;
+  action?: string;
+  release_key?: string;
+}
 
 export interface HistoryItem {
   IssueID: string;
@@ -112,6 +144,100 @@ export function useRequeueDownload() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["downloads", "queue"] });
+    },
+  });
+}
+
+function scopeParams(scope?: ActivityScope): URLSearchParams {
+  const params = new URLSearchParams();
+  const type = scope?.scope_type?.trim();
+  const id = scope?.scope_id?.trim();
+  if (type && id) {
+    params.set("scope_type", type);
+    params.set("scope_id", id);
+  }
+  return params;
+}
+
+/**
+ * Narrative timeline events (newest first). Pages *events* via infinite query;
+ * story grouping of 25 is a client concern. Polls every 30s while mounted.
+ */
+export function useActivityTimeline(options: ActivityScope = {}) {
+  const scope_type = options.scope_type?.trim() || undefined;
+  const scope_id = options.scope_id?.trim() || undefined;
+  const limit = TIMELINE_EVENT_PAGE_SIZE;
+
+  return useInfiniteQuery({
+    queryKey: ["activity", "timeline", { limit, scope_type, scope_id }],
+    queryFn: ({ pageParam }) => {
+      const params = scopeParams({ scope_type, scope_id });
+      params.set("limit", String(limit));
+      params.set("offset", String(pageParam));
+      return apiRequest<TimelinePage>(
+        "GET",
+        `/api/activity/timeline?${params.toString()}`,
+      );
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.has_more ? lastPage.offset + lastPage.limit : undefined,
+    staleTime: ACTIVITY_POLL_MS,
+    refetchInterval: ACTIVITY_POLL_MS,
+  });
+}
+
+/**
+ * Needs-attention band from pipeline_journal (derived, never narrative).
+ * Polls every 30s while mounted.
+ */
+export function useActivityBand(scope: ActivityScope = {}) {
+  const scope_type = scope.scope_type?.trim() || undefined;
+  const scope_id = scope.scope_id?.trim() || undefined;
+
+  return useQuery<BandPage>({
+    queryKey: ["activity", "band", { scope_type, scope_id }],
+    queryFn: () => {
+      const params = scopeParams({ scope_type, scope_id });
+      const qs = params.toString();
+      return apiRequest<BandPage>(
+        "GET",
+        qs ? `/api/activity/band?${qs}` : "/api/activity/band",
+      );
+    },
+    staleTime: ACTIVITY_POLL_MS,
+    refetchInterval: ACTIVITY_POLL_MS,
+  });
+}
+
+/**
+ * Operator exits for band rows via POST /api/downloads/needs-attention/...
+ * Invalidates band + timeline on success.
+ */
+export function useBandResolution() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    BandResolutionResult,
+    Error,
+    { releaseKey: string; action: BandResolutionAction }
+  >({
+    mutationFn: async ({ releaseKey, action }) => {
+      const result = await apiRequest<BandResolutionResult>(
+        "POST",
+        `/api/downloads/needs-attention/${encodeURIComponent(releaseKey)}/${action}`,
+      );
+      if (!result.success) {
+        throw new Error(
+          result.error || result.message || `Unable to ${action} this item.`,
+        );
+      }
+      return result;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["activity", "band"] });
+      void queryClient.invalidateQueries({
+        queryKey: ["activity", "timeline"],
+      });
     },
   });
 }

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -14,6 +14,7 @@ import {
   type QueueItem,
 } from "@/hooks/useActivity";
 import { useDebounce } from "@/hooks/use-debounce";
+import { TimelineView } from "@/components/activity/timeline";
 import { DataTable } from "@/components/data-table/DataTable";
 import { useTableState } from "@/components/data-table/useTableState";
 import { useServerPage } from "@/components/data-table/useServerPage";
@@ -29,7 +30,7 @@ import PageHeader, { Tab, TabRow } from "@/components/layout/PageHeader";
 import { useToast } from "@/components/ui/toast";
 import type { PaginationMeta } from "@/types";
 
-type ActivityView = "queue" | "history";
+type ActivityView = "timeline" | "queue" | "history";
 const PAGE_SIZE = 25;
 
 function statusPillMeta(status: string) {
@@ -108,41 +109,58 @@ function StatusPill({ status }: { status: string }) {
 
 export default function ActivityPage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const rawView = searchParams.get("view");
+  // Timeline is the default landing tab (#429 / #486). Queue keeps working via
+  // ?view=queue; history via ?view=history.
   const currentView: ActivityView =
-    searchParams.get("view") === "history" ? "history" : "queue";
+    rawView === "history" || rawView === "queue" ? rawView : "timeline";
+
+  const scope_type = searchParams.get("scope_type");
+  const scope_id = searchParams.get("scope_id");
 
   const setView = (view: ActivityView) => {
     setSearchParams((current) => {
       const next = new URLSearchParams(current);
-      if (view === "history") next.set("view", "history");
-      else next.delete("view");
+      if (view === "timeline") next.delete("view");
+      else next.set("view", view);
       return next;
     });
   };
 
+  const meta =
+    currentView === "timeline"
+      ? "what Comicarr has been doing"
+      : currentView === "queue"
+        ? "live direct downloads"
+        : "download history";
+
   return (
     <div className="page-transition">
-      <PageHeader
-        title="Activity"
-        meta={
-          currentView === "queue" ? "live download queue" : "download history"
-        }
-      />
+      <PageHeader title="Activity" meta={meta} />
 
       <TabRow>
         <Tab
+          active={currentView === "timeline"}
+          label="Timeline"
+          onClick={() => setView("timeline")}
+        />
+        <Tab
           active={currentView === "queue"}
-          label="Queue"
+          label="Direct Downloads"
           onClick={() => setView("queue")}
         />
         <Tab
           active={currentView === "history"}
-          label="History"
+          label="Download History"
           onClick={() => setView("history")}
         />
       </TabRow>
 
-      {currentView === "queue" ? <QueueView /> : <HistoryView />}
+      {currentView === "timeline" && (
+        <TimelineView scope_type={scope_type} scope_id={scope_id} />
+      )}
+      {currentView === "queue" && <QueueView />}
+      {currentView === "history" && <HistoryView />}
     </div>
   );
 }

--- a/frontend/src/pages/IssueDetailPage.tsx
+++ b/frontend/src/pages/IssueDetailPage.tsx
@@ -1,5 +1,5 @@
 import { Link, useParams } from "react-router-dom";
-import { ChevronRight, Library } from "lucide-react";
+import { Activity, ChevronRight, Library } from "lucide-react";
 import StatusBadge from "@/components/StatusBadge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useIssueDetail } from "@/hooks/useIssueDetail";
@@ -161,6 +161,23 @@ export default function IssueDetailPage() {
           >
             series:{comicId} · issue:{issueId}
           </p>
+
+          {issueId ? (
+            <div className="pt-1">
+              <Link
+                to={`/activity?scope_type=issue&scope_id=${encodeURIComponent(issueId)}`}
+                className="inline-flex items-center gap-1.5 rounded-[5px] border px-3 py-1.5 text-[12px] font-semibold transition-colors hover:text-foreground"
+                style={{
+                  borderColor: "var(--border)",
+                  color: "var(--muted-foreground)",
+                }}
+                aria-label="View activity for this issue"
+              >
+                <Activity className="h-3.5 w-3.5" />
+                Activity
+              </Link>
+            </div>
+          ) : null}
         </div>
       </div>
 

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
+  Activity,
   MoreHorizontal,
   Pause,
   Play,
@@ -455,6 +456,17 @@ export default function SeriesDetailPage() {
               />
               Refresh
             </button>
+            {comicId ? (
+              <Link
+                to={`/activity?scope_type=series&scope_id=${encodeURIComponent(comicId)}`}
+                className={ghostBtn}
+                style={{ borderColor: "var(--border)" }}
+                aria-label="View activity for this series"
+              >
+                <Activity className="h-3.5 w-3.5" />
+                Activity
+              </Link>
+            ) : null}
             <button
               type="button"
               onClick={handlePauseResume}

--- a/frontend/tests/pages/ActivityPage.test.tsx
+++ b/frontend/tests/pages/ActivityPage.test.tsx
@@ -21,7 +21,156 @@ const queueItem = {
   submit_date: "2026-07-10 08:35",
 };
 
+function emptyTimelineHandlers() {
+  return [
+    http.get("/api/activity/timeline", () =>
+      HttpResponse.json({
+        results: [],
+        total: 0,
+        limit: 100,
+        offset: 0,
+        has_more: false,
+      }),
+    ),
+    http.get("/api/activity/band", () =>
+      HttpResponse.json({ results: [], total: 0 }),
+    ),
+  ];
+}
+
 describe("ActivityPage", () => {
+  it("defaults to the Timeline tab and renames Queue / History", async () => {
+    server.use(...emptyTimelineHandlers());
+    render(<ActivityPage />, { route: "/activity", useMemoryRouter: true });
+
+    expect(await screen.findByText("Nothing has happened yet")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Timeline" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Direct Downloads" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Download History" }),
+    ).toBeTruthy();
+    // Queue-specific chrome must not be the default landing surface.
+    expect(
+      screen.queryByRole("textbox", { name: "Filter queue activity" }),
+    ).toBeNull();
+  });
+
+  it("renders Variant A timeline rows, band actions, and scoped query params", async () => {
+    let timelineUrl: URL | undefined;
+    let bandUrl: URL | undefined;
+    const resolveCalls: string[] = [];
+
+    server.use(
+      http.get("/api/activity/timeline", ({ request }) => {
+        timelineUrl = new URL(request.url);
+        return HttpResponse.json({
+          results: [
+            {
+              event_id: 1,
+              created_at: "2026-07-10 10:00:00",
+              activity: "grab",
+              status: "succeeded",
+              subject_type: "issue",
+              subject_id: "iss-1",
+              subject_label: "Saga #1",
+              parent_series_id: "ser-1",
+              provider: "DDL",
+            },
+            {
+              event_id: 2,
+              created_at: "2026-07-10 10:05:00",
+              activity: "import",
+              status: "succeeded",
+              subject_type: "issue",
+              subject_id: "iss-1",
+              subject_label: "Saga #1",
+              parent_series_id: "ser-1",
+            },
+            {
+              event_id: 3,
+              created_at: "2026-07-10 11:00:00",
+              activity: "add",
+              status: "succeeded",
+              subject_type: "series",
+              subject_id: "ser-2",
+              subject_label: "Invincible",
+            },
+          ],
+          total: 3,
+          limit: 100,
+          offset: 0,
+          has_more: false,
+        });
+      }),
+      http.get("/api/activity/band", ({ request }) => {
+        bandUrl = new URL(request.url);
+        return HttpResponse.json({
+          results: [
+            {
+              release_key: "rk-failed-1",
+              stage: "failed",
+              issueid: "iss-9",
+              nzbname: "Broken.cbz",
+              fail_reason: "download_failed",
+              updated_date: "2026-07-10 12:00:00",
+              status: null,
+            },
+          ],
+          total: 1,
+        });
+      }),
+      http.post(
+        "/api/downloads/needs-attention/:releaseKey/retry",
+        ({ params }) => {
+          resolveCalls.push(String(params.releaseKey));
+          return HttpResponse.json({
+            success: true,
+            status: "retried",
+            action: "retry",
+            release_key: params.releaseKey,
+          });
+        },
+      ),
+    );
+
+    const user = userEvent.setup();
+    render(<ActivityPage />, {
+      route: "/activity?scope_type=series&scope_id=ser-1",
+      useMemoryRouter: true,
+    });
+
+    // Multi-event story collapses to the closer sentence (inline entity link).
+    expect(
+      await screen.findByText((_content, node) => {
+        const text = node?.textContent ?? "";
+        return (
+          node?.tagName === "SPAN" &&
+          text.includes("Imported") &&
+          text.includes("Saga #1")
+        );
+      }),
+    ).toBeTruthy();
+    // Group-of-one plain row for the series add.
+    expect(screen.getByRole("link", { name: "Invincible" })).toBeTruthy();
+    expect(screen.getByText(/Added/)).toBeTruthy();
+    // Always-collapsed multi-event story: no phase trail expansion chrome.
+    expect(screen.queryByRole("button", { name: /^2$/ })).toBeNull();
+
+    expect(timelineUrl?.searchParams.get("scope_type")).toBe("series");
+    expect(timelineUrl?.searchParams.get("scope_id")).toBe("ser-1");
+    expect(bandUrl?.searchParams.get("scope_type")).toBe("series");
+    expect(bandUrl?.searchParams.get("scope_id")).toBe("ser-1");
+
+    expect(screen.getByLabelText("Needs attention")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "retry" }));
+    await waitFor(() => {
+      expect(resolveCalls).toEqual(["rk-failed-1"]);
+    });
+    expect(await screen.findByText(/Retry started/)).toBeTruthy();
+  });
+
   it("labels terminal and manual-review queue rows truthfully and only retries failed DDL work after confirmation", async () => {
     const queueRows = [
       {
@@ -65,7 +214,10 @@ describe("ActivityPage", () => {
       }),
     );
     const user = userEvent.setup();
-    render(<ActivityPage />, { route: "/activity", useMemoryRouter: true });
+    render(<ActivityPage />, {
+      route: "/activity?view=queue",
+      useMemoryRouter: true,
+    });
 
     await screen.findByText("Failed Series");
     expect(screen.getByLabelText(/failed: terminal/i)).toBeTruthy();
@@ -118,7 +270,10 @@ describe("ActivityPage", () => {
     );
 
     const user = userEvent.setup();
-    render(<ActivityPage />, { route: "/activity", useMemoryRouter: true });
+    render(<ActivityPage />, {
+      route: "/activity?view=queue",
+      useMemoryRouter: true,
+    });
     await screen.findByText("Absolute Flash");
 
     await user.click(screen.getByRole("button", { name: "Next" }));
@@ -169,7 +324,10 @@ describe("ActivityPage", () => {
     );
 
     const user = userEvent.setup();
-    render(<ActivityPage />, { route: "/activity", useMemoryRouter: true });
+    render(<ActivityPage />, {
+      route: "/activity?view=queue",
+      useMemoryRouter: true,
+    });
 
     await screen.findByText("Absolute Flash");
     await user.type(

--- a/frontend/tests/pages/IssueDetailPage.test.tsx
+++ b/frontend/tests/pages/IssueDetailPage.test.tsx
@@ -106,6 +106,13 @@ describe("IssueDetailPage", () => {
         (link) => link.getAttribute("href") === "/library/series-9",
       ),
     ).toBe(true);
+
+    const activityLink = screen.getByRole("link", {
+      name: "View activity for this issue",
+    });
+    expect(activityLink.getAttribute("href")).toBe(
+      "/activity?scope_type=issue&scope_id=issue-23",
+    );
   });
 
   it("shows a clear not-found state for unknown issue ids", async () => {

--- a/frontend/tests/pages/SeriesDetailPage.test.tsx
+++ b/frontend/tests/pages/SeriesDetailPage.test.tsx
@@ -201,6 +201,21 @@ describe("SeriesDetailPage", () => {
     );
   });
 
+  it("deep-links to scoped Activity without embedding a feed", async () => {
+    renderDetail();
+    await screen.findByText("Absolute Batman");
+
+    const activityLink = screen.getByRole("link", {
+      name: "View activity for this series",
+    });
+    expect(activityLink.getAttribute("href")).toBe(
+      "/activity?scope_type=series&scope_id=1",
+    );
+    // No embedded timeline feed on the detail page.
+    expect(screen.queryByLabelText("Activity timeline")).toBeNull();
+    expect(screen.queryByLabelText("Needs attention")).toBeNull();
+  });
+
   it("uses the canonical summary and shows annuals, evidence, and intent separately", async () => {
     const user = userEvent.setup();
     renderDetail();

--- a/frontend/tests/unit/lib/activitySentences.test.ts
+++ b/frontend/tests/unit/lib/activitySentences.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  reasonDetailLine,
+  reasonPhrase,
+  sentenceFor,
+  storyHeadline,
+} from "@/components/activity/timeline/sentences";
+import type { Story, TimelineEvent } from "@/components/activity/timeline/types";
+
+function event(partial: Partial<TimelineEvent> = {}): TimelineEvent {
+  return {
+    event_id: 1,
+    created_at: "2026-07-10 12:00:00",
+    activity: "import",
+    status: "succeeded",
+    subject_type: "issue",
+    subject_id: "iss-1",
+    subject_label: "Saga #1",
+    ...partial,
+  };
+}
+
+describe("sentenceFor", () => {
+  it("uses couldn't-voice for failures", () => {
+    expect(
+      sentenceFor(event({ activity: "download", status: "failed" })),
+    ).toBe("Couldn't download Saga #1");
+  });
+
+  it("includes provider on grab.succeeded", () => {
+    expect(
+      sentenceFor(
+        event({
+          activity: "grab",
+          status: "succeeded",
+          provider: "GetComics",
+        }),
+      ),
+    ).toBe("Grabbed Saga #1 from GetComics");
+  });
+});
+
+describe("reasonPhrase", () => {
+  it("maps known codes and degrades unmapped codes without snake_case primary", () => {
+    expect(reasonPhrase("disk_full")).toBe(
+      "not enough space on the destination volume",
+    );
+    expect(reasonPhrase("totally_unknown_code_xyz")).toBe(
+      "something went wrong",
+    );
+    expect(reasonPhrase(null)).toBeNull();
+  });
+
+  it("exposes the raw token only as expand detail for unmapped codes", () => {
+    const line = reasonDetailLine("weird_token", "extra");
+    expect(line.phrase).toBe("something went wrong");
+    expect(line.rawCode).toBe("weird_token");
+    expect(line.detail).toBe("extra");
+
+    const mapped = reasonDetailLine("disk_full", null);
+    expect(mapped.phrase).toContain("not enough space");
+    expect(mapped.rawCode).toBeNull();
+  });
+});
+
+describe("storyHeadline", () => {
+  it("uses the closer sentence when closed and the last event when open", () => {
+    const closed: Story = {
+      key: "k",
+      subject_type: "issue",
+      subject_id: "iss-1",
+      subject_label: "Saga #1",
+      opened_at: "2026-07-10 10:00:00",
+      events: [
+        event({ activity: "grab", status: "succeeded", event_id: 1 }),
+        event({
+          activity: "import",
+          status: "failed",
+          event_id: 2,
+          created_at: "2026-07-10 10:10:00",
+        }),
+      ],
+      closer: event({
+        activity: "import",
+        status: "failed",
+        event_id: 2,
+        created_at: "2026-07-10 10:10:00",
+      }),
+    };
+    expect(storyHeadline(closed)).toBe("Couldn't import Saga #1");
+
+    const open: Story = {
+      ...closed,
+      closer: null,
+      events: [event({ activity: "grab", status: "succeeded" })],
+    };
+    expect(storyHeadline(open)).toBe("Grabbed Saga #1");
+  });
+});

--- a/frontend/tests/unit/lib/activityStories.test.ts
+++ b/frontend/tests/unit/lib/activityStories.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFeed,
+  isOpen,
+  subjectHref,
+  storyHasTrouble,
+} from "@/components/activity/timeline/stories";
+import type { TimelineEvent } from "@/components/activity/timeline/types";
+
+function event(
+  overrides: Partial<TimelineEvent> &
+    Pick<TimelineEvent, "event_id" | "created_at" | "activity" | "status">,
+): TimelineEvent {
+  return {
+    subject_type: "issue",
+    subject_id: "iss-1",
+    subject_label: "Saga #1",
+    parent_series_id: "ser-1",
+    ...overrides,
+  };
+}
+
+describe("buildFeed", () => {
+  it("renders a group-of-one as a plain closed row", () => {
+    const nodes = buildFeed([
+      event({
+        event_id: 1,
+        created_at: "2026-07-10 12:00:00",
+        activity: "add",
+        status: "succeeded",
+        subject_type: "series",
+        subject_id: "ser-1",
+        subject_label: "Saga",
+      }),
+    ]);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].events).toHaveLength(1);
+    expect(nodes[0].closer?.activity).toBe("add");
+    expect(isOpen(nodes[0])).toBe(false);
+  });
+
+  it("groups advances into one story and closes on a terminal pair", () => {
+    const nodes = buildFeed([
+      event({
+        event_id: 1,
+        created_at: "2026-07-10 10:00:00",
+        activity: "grab",
+        status: "succeeded",
+        provider: "DDL",
+      }),
+      event({
+        event_id: 2,
+        created_at: "2026-07-10 10:05:00",
+        activity: "download",
+        status: "succeeded",
+      }),
+      event({
+        event_id: 3,
+        created_at: "2026-07-10 10:10:00",
+        activity: "import",
+        status: "succeeded",
+      }),
+    ]);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].events).toHaveLength(3);
+    expect(nodes[0].opened_at).toBe("2026-07-10 10:00:00");
+    expect(nodes[0].closer?.activity).toBe("import");
+    expect(nodes[0].closer?.status).toBe("succeeded");
+    expect(isOpen(nodes[0])).toBe(false);
+  });
+
+  it("opens a second story after a terminal close (retry never reopens)", () => {
+    const nodes = buildFeed([
+      event({
+        event_id: 1,
+        created_at: "2026-07-10 10:00:00",
+        activity: "grab",
+        status: "succeeded",
+      }),
+      event({
+        event_id: 2,
+        created_at: "2026-07-10 10:05:00",
+        activity: "download",
+        status: "failed",
+        reason_code: "download_failed",
+      }),
+      event({
+        event_id: 3,
+        created_at: "2026-07-10 11:00:00",
+        activity: "grab",
+        status: "succeeded",
+      }),
+    ]);
+
+    expect(nodes).toHaveLength(2);
+    // Newest-first feed order.
+    expect(nodes[0].opened_at).toBe("2026-07-10 11:00:00");
+    expect(isOpen(nodes[0])).toBe(true);
+    expect(nodes[1].opened_at).toBe("2026-07-10 10:00:00");
+    expect(storyHasTrouble(nodes[1])).toBe(true);
+  });
+
+  it("keeps position by opening time (nothing re-sorts on closer)", () => {
+    const nodes = buildFeed([
+      event({
+        event_id: 1,
+        created_at: "2026-07-10 09:00:00",
+        activity: "grab",
+        status: "succeeded",
+        subject_id: "iss-a",
+        subject_label: "A",
+      }),
+      event({
+        event_id: 2,
+        created_at: "2026-07-10 10:00:00",
+        activity: "add",
+        status: "succeeded",
+        subject_type: "series",
+        subject_id: "ser-x",
+        subject_label: "X",
+      }),
+      event({
+        event_id: 3,
+        created_at: "2026-07-10 11:00:00",
+        activity: "import",
+        status: "succeeded",
+        subject_id: "iss-a",
+        subject_label: "A",
+      }),
+    ]);
+
+    // Opening times: A@09, X@10. Closer for A is 11 — A still sorts by open.
+    expect(nodes.map((n) => n.subject_label)).toEqual(["X", "A"]);
+    expect(nodes[1].opened_at).toBe("2026-07-10 09:00:00");
+    expect(nodes[1].closer?.created_at).toBe("2026-07-10 11:00:00");
+  });
+
+  it("groups run search.started with its terminal closer", () => {
+    const nodes = buildFeed([
+      event({
+        event_id: 1,
+        created_at: "2026-07-10 08:00:00",
+        activity: "search",
+        status: "started",
+        subject_type: "run",
+        subject_id: "run-1",
+        subject_label: "Wanted backlog",
+      }),
+      event({
+        event_id: 2,
+        created_at: "2026-07-10 08:30:00",
+        activity: "search",
+        status: "succeeded",
+        subject_type: "run",
+        subject_id: "run-1",
+        subject_label: "Wanted backlog",
+      }),
+    ]);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].events).toHaveLength(2);
+    expect(nodes[0].closer?.status).toBe("succeeded");
+  });
+
+  it("accepts newest-first API order without mis-grouping", () => {
+    const nodes = buildFeed([
+      event({
+        event_id: 3,
+        created_at: "2026-07-10 10:10:00",
+        activity: "import",
+        status: "succeeded",
+      }),
+      event({
+        event_id: 1,
+        created_at: "2026-07-10 10:00:00",
+        activity: "grab",
+        status: "succeeded",
+      }),
+      event({
+        event_id: 2,
+        created_at: "2026-07-10 10:05:00",
+        activity: "download",
+        status: "succeeded",
+      }),
+    ]);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].events.map((e) => e.event_id)).toEqual([1, 2, 3]);
+  });
+});
+
+describe("subjectHref", () => {
+  it("builds series and issue deep links when identity is complete", () => {
+    expect(
+      subjectHref({
+        subject_type: "series",
+        subject_id: "ser-1",
+      }),
+    ).toBe("/library/ser-1");
+    expect(
+      subjectHref({
+        subject_type: "issue",
+        subject_id: "iss-1",
+        parent_series_id: "ser-1",
+      }),
+    ).toBe("/library/ser-1/issue/iss-1");
+    expect(
+      subjectHref({
+        subject_type: "issue",
+        subject_id: "iss-1",
+        parent_series_id: null,
+      }),
+    ).toBeNull();
+    expect(
+      subjectHref({
+        subject_type: "run",
+        subject_id: "run-1",
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Activity: Timeline landing, needs-attention band, and detail deep-links

Activity opens on a Timeline tab (Variant A ledger) with a pinned needs-attention band and plain-language stories; series and issue pages deep-link into scoped Activity instead of embedding a feed.

### Changes
- Tabs: **Timeline** (default) · **Direct Downloads** · **Download History**; client story grouping, sentence lexicon, free-text + activity filters, 30s poll
- Pinned band actions wire to needs-attention resolution APIs; red chrome stays on the band only
- Series/issue detail pages add an Activity deep-link only (`scope_type` / `scope_id`)

Closes #486