### PR TITLE
feat: Post-upgrade What's New modal, About archive, LAST_SEEN_VERSION

### DIFF
--- a/.changeset/whats-new-modal-archive.md
+++ b/.changeset/whats-new-modal-archive.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+After an upgrade, Comicarr shows a What's New modal once until you acknowledge it, and keeps a permanent What's new history under Settings → About.

--- a/comicarr/app/config/registry.py
+++ b/comicarr/app/config/registry.py
@@ -276,6 +276,9 @@ _KEYS: tuple[ConfigKey, ...] = (
     ConfigKey("ANNOUNCE_RELEASES", bool, "Git", False, readable=True, writable=True),
     # Install-wide dedup for outbound release announces; not a Settings field.
     ConfigKey("LAST_ANNOUNCED_VERSION", str, "Git", None),
+    # Install-wide What's New acknowledgement (#449 / #474); not Settings-writable.
+    # Written only by seed (key absent) and dismiss (Got it / Mark as read).
+    ConfigKey("LAST_SEEN_VERSION", str, "Git", None),
     ConfigKey("ENFORCE_PERMS", bool, "Perms", False),
     ConfigKey("CHMOD_DIR", str, "Perms", "0777"),
     ConfigKey("CHMOD_FILE", str, "Perms", "0660"),

--- a/comicarr/app/system/router.py
+++ b/comicarr/app/system/router.py
@@ -304,6 +304,30 @@ def get_release_notes(
     return system_service.get_release_notes(ctx, after=after, through=through)
 
 
+@router.get("/system/whats-new/archive", dependencies=[Depends(require_session)])
+def get_whats_new_archive(ctx: AppContext = Depends(get_context)):
+    """Permanent Settings → About What's new archive.
+
+    Sections are newest-first, floored at the pending range when unread so
+    modal overflow is never shorter than this list, and padded toward ~10
+    historical rows when quiet (#451 / #474).
+    """
+    return system_service.get_whats_new_archive(ctx)
+
+
+@router.post("/system/whats-new/dismiss", dependencies=[Depends(require_session)])
+def dismiss_whats_new(ctx: AppContext = Depends(get_context)):
+    """Acknowledge post-upgrade notes — LAST_SEEN_VERSION = current.
+
+    Used by the modal "Got it" and About "Mark as read". Does not run on
+    overflow navigation alone.
+    """
+    result = system_service.dismiss_whats_new(ctx)
+    if not result.get("success"):
+        return JSONResponse(status_code=400, content=result)
+    return result
+
+
 @router.post("/system/version/check", dependencies=[Depends(require_session)])
 def check_version_now(ctx: AppContext = Depends(get_context)):
     """Force a single release check (ignores automatic-check off).

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -525,6 +525,12 @@ def get_version_info(ctx):
         update_reason = None
     elif update_reason is None:
         update_reason = "never_checked"
+    from comicarr.app.system.whats_new import resolve_pending_whats_new
+
+    # Seed LAST_SEEN_VERSION when absent (fresh install / first boot after
+    # feature); may write once. Pending compare itself is read-only.
+    pending_whats_new = resolve_pending_whats_new(ctx)
+
     return {
         "current_version": ctx.current_version,
         "current_version_name": ctx.current_version_name,
@@ -536,6 +542,7 @@ def get_version_info(ctx):
         "install_type": ctx.install_type,
         "current_branch": ctx.current_branch,
         "build": get_build_identity(ctx),
+        "pending_whats_new": pending_whats_new,
     }
 
 
@@ -548,6 +555,20 @@ def get_release_notes(ctx, after, through):
     from comicarr.changelog_notes import get_release_notes as _get_notes
 
     return _get_notes(ctx, after=after, through=through)
+
+
+def dismiss_whats_new(ctx):
+    """Acknowledge What's New — write LAST_SEEN_VERSION = current."""
+    from comicarr.app.system.whats_new import dismiss_whats_new as _dismiss
+
+    return _dismiss(ctx)
+
+
+def get_whats_new_archive(ctx):
+    """Settings → About archive: floored/padded sections + pending range."""
+    from comicarr.app.system.whats_new import get_archive_notes
+
+    return get_archive_notes(ctx)
 
 
 def force_version_check(ctx):

--- a/comicarr/app/system/whats_new.py
+++ b/comicarr/app/system/whats_new.py
@@ -1,0 +1,227 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Post-upgrade What's New: LAST_SEEN_VERSION detect, seed, dismiss, archive.
+
+Install-wide state (decision #449). Detect is pure comparison; write only on
+seed (key absent) or dismiss (Got it / Mark as read). Archive depth (#451):
+floor at the pending range so modal overflow is never shorter than About;
+when quiet, pad toward ~10 historical rows.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from packaging.version import InvalidVersion, Version
+
+import comicarr
+from comicarr import logger
+
+# About archive pad when nothing (or little) is pending (#451).
+ARCHIVE_FLOOR = 10
+
+
+@dataclass(frozen=True)
+class DetectResult:
+    """Outcome of pure last_seen vs current comparison (no I/O)."""
+
+    kind: str  # "seed" | "pending" | "quiet"
+    pending: dict[str, str] | None = None
+
+
+def _strip_v(text: str | None) -> str | None:
+    if text is None:
+        return None
+    text = str(text).strip()
+    if not text:
+        return None
+    if text[:1] in ("v", "V"):
+        text = text[1:]
+    return text or None
+
+
+def _parse(text: str | None) -> Version | None:
+    stripped = _strip_v(text)
+    if not stripped:
+        return None
+    try:
+        return Version(stripped)
+    except InvalidVersion:
+        return None
+
+
+def detect_pending(*, current: str | None, last_seen: str | None) -> DetectResult:
+    """Pure compare of release versions. Never writes.
+
+    | Condition | kind |
+    |-----------|------|
+    | last_seen absent/empty | seed |
+    | current > last_seen | pending ``(last_seen, current]`` ends as {from, to} |
+    | current == last_seen | quiet |
+    | current < last_seen | quiet (do not write) |
+    """
+    current_s = _strip_v(current)
+    last_s = _strip_v(last_seen)
+
+    if not last_s:
+        # Fresh install / first boot after feature ships — seed, no notes.
+        if current_s and _parse(current_s) is not None:
+            return DetectResult(kind="seed")
+        return DetectResult(kind="quiet")
+
+    current_v = _parse(current_s)
+    last_v = _parse(last_s)
+    if current_v is None or last_v is None:
+        return DetectResult(kind="quiet")
+
+    if current_v > last_v:
+        return DetectResult(
+            kind="pending",
+            pending={"from": last_s, "to": current_s},
+        )
+    # equal or downgrade
+    return DetectResult(kind="quiet")
+
+
+def _record_last_seen(version: str) -> None:
+    """Persist LAST_SEEN_VERSION to config.ini under DATA_DIR."""
+    try:
+        comicarr.CONFIG.LAST_SEEN_VERSION = version
+        ok = comicarr.CONFIG.writeconfig(values={"last_seen_version": version})
+        # Some Config.writeconfig paths return False on failure without raising.
+        if ok is False:
+            raise RuntimeError("writeconfig returned False for last_seen_version")
+    except Exception as e:
+        logger.warn("[WHATS_NEW] Could not persist LAST_SEEN_VERSION=%s: %s" % (version, e))
+        raise
+
+
+def resolve_pending_whats_new(ctx) -> dict[str, str] | None:
+    """Detect pending range; seed when key is absent. Returns pending or None.
+
+    Seed writes ``LAST_SEEN_VERSION = current`` immediately and returns None
+    (no notes on fresh install / first boot after this feature ships).
+    Pending and quiet paths do not write.
+
+    Seed failures are logged and treated as quiet so ``/api/system/version``
+    still returns update state (same resilience idea as announce dedup).
+    """
+    from comicarr.app.system.service import get_release_version
+
+    current = get_release_version()
+    last_seen = getattr(comicarr.CONFIG, "LAST_SEEN_VERSION", None)
+    result = detect_pending(current=current, last_seen=last_seen)
+
+    if result.kind == "seed":
+        version = _strip_v(current)
+        if version:
+            try:
+                _record_last_seen(version)
+            except Exception as e:
+                logger.warn("[WHATS_NEW] Seed failed for %s: %s" % (version, e))
+        return None
+
+    return result.pending
+
+
+def dismiss_whats_new(ctx) -> dict[str, Any]:
+    """Operator acknowledgement — set LAST_SEEN_VERSION = current."""
+    from comicarr.app.system.service import get_release_version
+
+    current = _strip_v(get_release_version())
+    if not current or _parse(current) is None:
+        return {"success": False, "error": "current release version unavailable"}
+
+    _record_last_seen(current)
+    return {"success": True, "last_seen_version": current}
+
+
+def archive_sections(
+    sections: list[dict],
+    *,
+    current: str | None,
+    last_seen: str | None,
+    floor: int = ARCHIVE_FLOOR,
+) -> list[dict]:
+    """Slice changelog sections for Settings → About What's new.
+
+    Newest-first, versions ``<= current``. Depth is ``max(pending_count, floor)``
+    so the archive is never shorter than the modal's overflow target, and still
+    reads as history when nothing is unread.
+    """
+    current_v = _parse(current)
+    if current_v is None:
+        return []
+
+    last_v = _parse(last_seen)
+
+    up_to: list[tuple[Version, dict]] = []
+    for section in sections:
+        ver = _parse(section.get("version"))
+        if ver is None:
+            continue
+        if ver <= current_v:
+            up_to.append((ver, section))
+
+    up_to.sort(key=lambda item: item[0], reverse=True)
+
+    pending_count = 0
+    if last_v is not None:
+        pending_count = sum(1 for ver, _ in up_to if ver > last_v)
+    # When last_seen is missing we treat as seeded/quiet for archive purposes.
+    depth = max(pending_count, floor)
+    return [section for _, section in up_to[:depth]]
+
+
+def get_archive_notes(ctx) -> dict[str, Any]:
+    """Structured About archive: floored/padded sections + pending range."""
+    from comicarr.app.system.service import get_release_version
+    from comicarr.changelog_notes import (
+        get_cached_release_body,
+        parse_changelog_text,
+        parse_release_body,
+        read_local_changelog,
+    )
+
+    current = _strip_v(get_release_version())
+    last_seen = _strip_v(getattr(comicarr.CONFIG, "LAST_SEEN_VERSION", None))
+
+    # Resolve (and seed if needed) so pending matches the modal path.
+    pending = resolve_pending_whats_new(ctx)
+    # Re-read after possible seed.
+    last_seen = _strip_v(getattr(comicarr.CONFIG, "LAST_SEEN_VERSION", None))
+
+    text = read_local_changelog(getattr(ctx, "prog_dir", None))
+    sections = parse_changelog_text(text) if text else []
+
+    # Optional cache fill for a remote version not yet in local CHANGELOG
+    # (same rules as get_release_notes; rare for post-upgrade path).
+    cached = get_cached_release_body()
+    if cached and current:
+        cached_version = cached.get("version")
+        known = {s["version"] for s in sections}
+        if cached_version and cached_version not in known:
+            remote = parse_release_body(cached.get("body"), version=cached_version)
+            if remote and remote.get("bullets"):
+                sections.append(remote)
+
+    rows = archive_sections(
+        sections,
+        current=current,
+        last_seen=last_seen,
+        floor=ARCHIVE_FLOOR,
+    )
+    return {
+        "sections": rows,
+        "pending": pending,
+        "current": current,
+        "last_seen": last_seen,
+    }

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -5,6 +5,7 @@ import AppSidebar from "@/components/layout/AppSidebar";
 import AppStatusBar from "@/components/layout/AppStatusBar";
 import { useAiStatus } from "@/hooks/useAiStatus";
 import { ActivityFeedDrawer } from "@/components/ai/ActivityFeedDrawer";
+import WhatsNewModal from "@/components/whats-new/WhatsNewModal";
 import { Bell } from "lucide-react";
 import { isMockEnabled } from "@/lib/mockData";
 
@@ -101,6 +102,8 @@ export default function Layout({ children }: LayoutProps) {
       </main>
 
       <ActivityFeedDrawer open={activityOpen} onOpenChange={setActivityOpen} />
+      {/* Post-upgrade What's New — only when pending_whats_new is set (#474). */}
+      <WhatsNewModal />
     </SidebarProvider>
   );
 }

--- a/frontend/src/components/settings/AboutTab.tsx
+++ b/frontend/src/components/settings/AboutTab.tsx
@@ -5,6 +5,7 @@ import { useToast } from "@/components/ui/toast";
 import { useForceVersionCheck, useVersionInfo } from "@/hooks/useVersion";
 import { formatAppVersion } from "@/lib/version";
 import { formatUpdateDiagnostic } from "@/lib/updateStatus";
+import WhatsNewArchive from "@/components/whats-new/WhatsNewArchive";
 import type { Config } from "@/types";
 import type {
   SettingsFormData,
@@ -108,14 +109,9 @@ export function AboutTab({ config, formData, onChange }: AboutTabProps) {
 
       <SettingGroup
         title="What's new"
-        description="Release notes for this install will appear here."
+        description="Release notes for this install, newest first."
       >
-        <div
-          className="rounded-lg border px-3 py-3 text-[12.5px] text-muted-foreground"
-          style={{ borderColor: "var(--border)", background: "var(--card)" }}
-        >
-          Release history is not available in this build yet.
-        </div>
+        <WhatsNewArchive />
       </SettingGroup>
 
       <SettingGroup

--- a/frontend/src/components/whats-new/ReleaseNotesList.tsx
+++ b/frontend/src/components/whats-new/ReleaseNotesList.tsx
@@ -1,0 +1,76 @@
+import { cn } from "@/lib/utils";
+import type { ReleaseNotesSection } from "@/types/version";
+
+/** Multi-paragraph bullet bodies from the mechanical transform (#450). */
+export function BulletBody({ text }: { text: string }) {
+  const paras = text.split(/\n{2,}/);
+  return (
+    <>
+      {paras.map((p, i) => (
+        <p key={i} className={i > 0 ? "mt-1.5" : undefined}>
+          {p.replace(/\n/g, " ")}
+        </p>
+      ))}
+    </>
+  );
+}
+
+export function VersionSection({
+  section,
+  density = "comfortable",
+  hideHeading = false,
+}: {
+  section: ReleaseNotesSection;
+  density?: "comfortable" | "compact";
+  hideHeading?: boolean;
+}) {
+  const compact = density === "compact";
+  return (
+    <section>
+      {!hideHeading && (
+        <div className="flex items-baseline gap-2">
+          <h3
+            className={cn(
+              "font-mono font-semibold text-foreground",
+              compact ? "text-[12px]" : "text-[13px]",
+            )}
+          >
+            {section.version}
+          </h3>
+        </div>
+      )}
+
+      {section.bullets.length === 0 ? (
+        <p
+          className={cn(
+            "mt-1 italic text-muted-foreground/70",
+            compact ? "text-[11px]" : "text-[12px]",
+          )}
+        >
+          No notes recorded for this release.
+        </p>
+      ) : (
+        <ul
+          className={cn(
+            "mt-1.5 space-y-1.5 text-muted-foreground",
+            compact
+              ? "text-[11.5px] leading-snug"
+              : "text-[12.5px] leading-relaxed",
+          )}
+        >
+          {section.bullets.map((b, i) => (
+            <li key={i} className="flex gap-2">
+              <span
+                aria-hidden
+                className="mt-[0.45em] h-1 w-1 shrink-0 rounded-full bg-muted-foreground/50"
+              />
+              <div className="min-w-0">
+                <BulletBody text={b} />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/whats-new/WhatsNewArchive.tsx
+++ b/frontend/src/components/whats-new/WhatsNewArchive.tsx
@@ -1,0 +1,198 @@
+/**
+ * Permanent Settings → About "What's new" archive (#474 / #451).
+ *
+ * Server floors depth at the pending range and pads toward ~10 when quiet.
+ * Always shows version headings. "Mark as read" writes LAST_SEEN_VERSION.
+ */
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useDismissWhatsNew, useWhatsNewArchive } from "@/hooks/useWhatsNew";
+import { VersionSection } from "@/components/whats-new/ReleaseNotesList";
+import { countBullets } from "@/lib/releaseNotes";
+import { cn } from "@/lib/utils";
+import type { ReleaseNotesSection } from "@/types/version";
+
+function isUnread(
+  version: string,
+  pending: { from: string; to: string } | null | undefined,
+): boolean {
+  if (!pending) return false;
+  // Server already sliced; treat pending range as unread for the badge.
+  // Compare as strings only when equal ends; full semver compare is server-side.
+  // Prefer a simple check: versions in the returned set with pending flag from API.
+  // Here we mark the top pending slice using from/to inclusive of to, exclusive of from.
+  return (
+    versionCompare(version, pending.from) > 0 &&
+    versionCompare(version, pending.to) <= 0
+  );
+}
+
+/** Lightweight semver compare for UI badges (x.y.z only). */
+function versionCompare(a: string, b: string): number {
+  const pa = a
+    .replace(/^v/i, "")
+    .split(".")
+    .map((n) => parseInt(n, 10) || 0);
+  const pb = b
+    .replace(/^v/i, "")
+    .split(".")
+    .map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+export default function WhatsNewArchive() {
+  const archiveQuery = useWhatsNewArchive();
+  const dismiss = useDismissWhatsNew();
+  const sections = archiveQuery.data?.sections ?? [];
+  const pending = archiveQuery.data?.pending ?? null;
+  const current = archiveQuery.data?.current;
+
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  // Expand newest on first successful load.
+  const defaultExpanded = expanded ?? sections[0]?.version ?? null;
+
+  if (archiveQuery.isLoading) {
+    return (
+      <div
+        className="rounded-lg border px-3 py-3 text-[12.5px] text-muted-foreground"
+        style={{ borderColor: "var(--border)", background: "var(--card)" }}
+      >
+        Loading release history…
+      </div>
+    );
+  }
+
+  if (archiveQuery.isError) {
+    return (
+      <div
+        className="rounded-lg border px-3 py-3 text-[12.5px] text-muted-foreground"
+        style={{ borderColor: "var(--border)", background: "var(--card)" }}
+      >
+        Could not load release history.
+      </div>
+    );
+  }
+
+  const pendingCount = pending
+    ? sections.filter((s) => isUnread(s.version, pending)).length
+    : 0;
+  const pendingBullets = pending
+    ? countBullets(sections.filter((s) => isUnread(s.version, pending)))
+    : 0;
+
+  return (
+    <div className="rounded-md border border-border">
+      <div
+        className={cn(
+          "flex items-start justify-between gap-4 border-b border-border px-4 py-3",
+          pending && "bg-primary/5",
+        )}
+      >
+        <div>
+          <div className="flex items-center gap-2">
+            {pending && pendingCount > 0 && (
+              <span
+                data-testid="whats-new-unread"
+                className="rounded-sm bg-primary/15 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider text-primary"
+              >
+                {pendingCount} unread
+              </span>
+            )}
+          </div>
+          <p
+            className="text-[11.5px] text-muted-foreground"
+            data-testid="whats-new-archive-summary"
+          >
+            {pending
+              ? `You upgraded from ${pending.from}. ${pendingCount} release${pendingCount === 1 ? "" : "s"} · ${pendingBullets} change${pendingBullets === 1 ? "" : "s"}.`
+              : current
+                ? `Running ${current}. Nothing unread — recent history below.`
+                : "Release notes for this install."}
+          </p>
+        </div>
+        {pending && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => void dismiss.mutateAsync()}
+            disabled={dismiss.isPending}
+          >
+            {dismiss.isPending ? "Saving…" : "Mark as read"}
+          </Button>
+        )}
+      </div>
+
+      {sections.length === 0 ? (
+        <p className="px-4 py-6 text-center text-[12px] text-muted-foreground">
+          No release notes to show.
+        </p>
+      ) : (
+        <div className="divide-y divide-border">
+          {sections.map((s) => (
+            <ArchiveRow
+              key={s.version}
+              section={s}
+              unread={isUnread(s.version, pending)}
+              open={(expanded ?? defaultExpanded) === s.version}
+              onToggle={() =>
+                setExpanded((cur) => {
+                  const openId = cur ?? defaultExpanded;
+                  return openId === s.version ? "" : s.version;
+                })
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ArchiveRow({
+  section,
+  unread,
+  open,
+  onToggle,
+}: {
+  section: ReleaseNotesSection;
+  unread: boolean;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 px-4 py-2 text-left hover:bg-secondary/50"
+      >
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <span className="font-mono text-[12px] font-medium">
+          {section.version}
+        </span>
+        {unread && (
+          <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-primary" />
+        )}
+        <span className="ml-auto font-mono text-[10px] text-muted-foreground">
+          {section.bullets.length} change
+          {section.bullets.length === 1 ? "" : "s"}
+        </span>
+      </button>
+      {open && (
+        <div className="px-4 pb-4 pl-9">
+          <VersionSection section={section} density="compact" hideHeading />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/whats-new/WhatsNewModal.tsx
+++ b/frontend/src/components/whats-new/WhatsNewModal.tsx
@@ -1,0 +1,137 @@
+/**
+ * Post-upgrade What's New modal (#474 / #451).
+ *
+ * Opens on first authenticated layout paint when pending_whats_new is set.
+ * Cap is by version (never mid-version). Overflow navigates to Settings →
+ * About without dismissing. Only "Got it" writes LAST_SEEN_VERSION.
+ */
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, Sparkles } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useReleaseNotes } from "@/hooks/useReleaseNotes";
+import { useDismissWhatsNew } from "@/hooks/useWhatsNew";
+import { useVersionInfo } from "@/hooks/useVersion";
+import { VersionSection } from "@/components/whats-new/ReleaseNotesList";
+import { countBullets } from "@/lib/releaseNotes";
+
+/** Max versions shown in the interrupt; never split a release's bullets. */
+export const MODAL_VERSION_CAP = 3;
+
+/** Deep-link target for overflow — About tab, no dismiss. */
+export const WHATS_NEW_ARCHIVE_PATH = "/settings?section=about";
+
+export default function WhatsNewModal() {
+  const { status, data } = useVersionInfo();
+  const pending =
+    status === "success" ? (data?.pending_whats_new ?? null) : null;
+  const from = pending?.from ?? null;
+  const to = pending?.to ?? null;
+
+  const notesQuery = useReleaseNotes(from, to, Boolean(pending));
+  const dismiss = useDismissWhatsNew();
+
+  // Open from first paint when pending — flipping open in an effect races
+  // Base UI enter transitions. Session-local close (X) does not dismiss.
+  const [open, setOpen] = useState(true);
+  const navigate = useNavigate();
+
+  if (!pending || !from || !to || !open) return null;
+
+  const sections = notesQuery.data?.sections ?? [];
+  const single = sections.length === 1;
+  const shown = sections.slice(0, MODAL_VERSION_CAP);
+  const overflow = Math.max(0, sections.length - shown.length);
+  const bullets = countBullets(sections);
+
+  const handleGotIt = async () => {
+    try {
+      await dismiss.mutateAsync();
+      setOpen(false);
+    } catch {
+      // Keep the modal open so a failed write does not clear the cue for this session.
+    }
+  };
+
+  const handleOverflow = () => {
+    // Navigation only — must not write LAST_SEEN_VERSION (#451).
+    setOpen(false);
+    navigate(WHATS_NEW_ARCHIVE_PATH);
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(next) => {
+        // X / overlay closes for this session only; does not dismiss.
+        if (!next) setOpen(false);
+      }}
+    >
+      <DialogContent className="max-w-2xl p-0 overflow-hidden gap-0">
+        <DialogHeader className="border-b border-border bg-primary/10 px-6 py-4 text-left">
+          <div className="flex items-center gap-2 text-[10px] font-mono uppercase tracking-wider text-primary">
+            <Sparkles className="h-3.5 w-3.5" />
+            Comicarr updated
+          </div>
+          <DialogTitle className="mt-1.5 font-mono text-lg">
+            {from} → {to}
+          </DialogTitle>
+          <p className="mt-0.5 text-[12px] text-muted-foreground">
+            {notesQuery.isLoading
+              ? "Loading release notes…"
+              : sections.length === 1
+                ? `${bullets} change${bullets === 1 ? "" : "s"} in this release.`
+                : sections.length === 0
+                  ? "No release notes recorded for this upgrade."
+                  : `${bullets} changes across ${sections.length} releases you skipped.`}
+          </p>
+        </DialogHeader>
+
+        <div className="max-h-[55vh] overflow-y-auto px-6 py-5 space-y-6">
+          {notesQuery.isLoading ? (
+            <p className="text-[12px] text-muted-foreground">Loading…</p>
+          ) : (
+            <>
+              {shown.map((s) => (
+                <VersionSection
+                  key={s.version}
+                  section={s}
+                  hideHeading={single}
+                />
+              ))}
+              {overflow > 0 && (
+                <button
+                  type="button"
+                  onClick={handleOverflow}
+                  className="flex items-center gap-1 text-[12px] text-primary hover:underline"
+                >
+                  …and {overflow} earlier release{overflow === 1 ? "" : "s"}
+                  <ArrowRight className="h-3 w-3" />
+                </button>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-3 border-t border-border px-6 py-3">
+          <span className="text-[11px] text-muted-foreground">
+            Dismissing marks {to} as seen for every user of this install.
+          </span>
+          <Button
+            size="sm"
+            onClick={() => void handleGotIt()}
+            disabled={dismiss.isPending}
+          >
+            {dismiss.isPending ? "Saving…" : "Got it"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/hooks/useWhatsNew.ts
+++ b/frontend/src/hooks/useWhatsNew.ts
@@ -1,0 +1,69 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { apiRequest } from "@/lib/api";
+import { VERSION_QUERY_KEY } from "@/hooks/useVersion";
+import type {
+  WhatsNewArchiveResponse,
+  WhatsNewDismissResponse,
+} from "@/types/version";
+
+export const WHATS_NEW_ARCHIVE_QUERY_KEY = [
+  "system",
+  "whats-new",
+  "archive",
+] as const;
+
+async function fetchArchive(): Promise<WhatsNewArchiveResponse> {
+  return apiRequest<WhatsNewArchiveResponse>(
+    "GET",
+    "/api/system/whats-new/archive",
+  );
+}
+
+async function postDismiss(): Promise<WhatsNewDismissResponse> {
+  return apiRequest<WhatsNewDismissResponse>(
+    "POST",
+    "/api/system/whats-new/dismiss",
+  );
+}
+
+/** Permanent Settings → About archive (server floor/pad). */
+export function useWhatsNewArchive(options?: {
+  enabled?: boolean;
+}): UseQueryResult<WhatsNewArchiveResponse> {
+  const enabled = options?.enabled ?? true;
+  return useQuery({
+    queryKey: WHATS_NEW_ARCHIVE_QUERY_KEY,
+    queryFn: fetchArchive,
+    enabled,
+    staleTime: 60 * 1000,
+    retry: false,
+  });
+}
+
+/**
+ * Got it / Mark as read — writes LAST_SEEN_VERSION = current on the server.
+ * Invalidates version (pending clears) and the archive list.
+ */
+export function useDismissWhatsNew(): UseMutationResult<
+  WhatsNewDismissResponse,
+  Error,
+  void
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: postDismiss,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: VERSION_QUERY_KEY });
+      void queryClient.invalidateQueries({
+        queryKey: WHATS_NEW_ARCHIVE_QUERY_KEY,
+      });
+    },
+  });
+}

--- a/frontend/src/lib/releaseNotes.ts
+++ b/frontend/src/lib/releaseNotes.ts
@@ -1,0 +1,5 @@
+import type { ReleaseNotesSection } from "@/types/version";
+
+export function countBullets(sections: ReleaseNotesSection[]): number {
+  return sections.reduce((n, s) => n + s.bullets.length, 0);
+}

--- a/frontend/src/lib/updateStatus.ts
+++ b/frontend/src/lib/updateStatus.ts
@@ -18,6 +18,14 @@ export function formatUnknownUpdateReason(reason: UpdateReason): string {
   return UNKNOWN_REASON_COPY[reason] ?? "Update status is unavailable";
 }
 
+/** Open-closed pending range ends for post-upgrade What's New (#474). */
+export interface PendingWhatsNew {
+  /** Exclusive lower bound (LAST_SEEN_VERSION). */
+  from: string;
+  /** Inclusive upper bound (current release). */
+  to: string;
+}
+
 export interface VersionInfo {
   current_version?: string | null;
   latest_version?: string | null;
@@ -26,6 +34,8 @@ export interface VersionInfo {
   update_reason?: UpdateReason;
   install_type?: string | null;
   message?: string | null;
+  /** When set, show the post-upgrade modal / unread archive state. */
+  pending_whats_new?: PendingWhatsNew | null;
 }
 
 /** One-line diagnostic for the Updates group (not a second badge). */

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useConfig, useUpdateConfig } from "@/hooks/useConfig";
 import { useToast } from "@/components/ui/toast";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -48,12 +49,48 @@ const SECTIONS: { id: SectionId; label: string }[] = [
   { id: "about", label: "About" },
 ];
 
+const SECTION_IDS = new Set(SECTIONS.map((s) => s.id));
+
+function parseSectionParam(raw: string | null): SectionId | null {
+  if (!raw) return null;
+  return SECTION_IDS.has(raw as SectionId) ? (raw as SectionId) : null;
+}
+
 export default function SettingsPage() {
   const { data: config, isLoading, error } = useConfig();
   const updateConfigMutation = useUpdateConfig();
   const { addToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const [section, setSection] = useState<SectionId>("general");
+  const sectionFromUrl = parseSectionParam(searchParams.get("section"));
+  const [section, setSectionState] = useState<SectionId>(
+    () => sectionFromUrl ?? "general",
+  );
+
+  // Honour ?section=about (modal overflow → archive) without losing local nav.
+  useEffect(() => {
+    if (sectionFromUrl && sectionFromUrl !== section) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- URL is the source of truth for deep links
+      setSectionState(sectionFromUrl);
+    }
+  }, [sectionFromUrl, section]);
+
+  const setSection = (id: SectionId) => {
+    setSectionState(id);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (id === "general") {
+          next.delete("section");
+        } else {
+          next.set("section", id);
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
   const [formData, setFormData] = useState<SettingsFormData>({});
   const [originalData, setOriginalData] = useState<SettingsFormData>({});
   const [regeneratedApiKey, setRegeneratedApiKey] = useState<string | null>(

--- a/frontend/src/types/version.ts
+++ b/frontend/src/types/version.ts
@@ -13,3 +13,17 @@ export interface ReleaseNotesSection {
 export interface ReleaseNotesResponse {
   sections: ReleaseNotesSection[];
 }
+
+/** Settings → About archive (server floors/pads depth). */
+export interface WhatsNewArchiveResponse {
+  sections: ReleaseNotesSection[];
+  pending: { from: string; to: string } | null;
+  current: string | null;
+  last_seen: string | null;
+}
+
+export interface WhatsNewDismissResponse {
+  success: boolean;
+  last_seen_version?: string;
+  error?: string;
+}

--- a/frontend/tests/components/WhatsNewArchive.test.tsx
+++ b/frontend/tests/components/WhatsNewArchive.test.tsx
@@ -1,0 +1,88 @@
+import { createElement } from "react";
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import userEvent from "@testing-library/user-event";
+import { server } from "../mocks/server";
+import { render, screen, waitFor } from "../test-utils";
+import WhatsNewArchive from "@/components/whats-new/WhatsNewArchive";
+
+describe("WhatsNewArchive", () => {
+  it("shows recent history when nothing is pending", async () => {
+    server.use(
+      http.get("/api/system/whats-new/archive", () =>
+        HttpResponse.json({
+          sections: [
+            { version: "0.21.0", bullets: ["a"] },
+            { version: "0.20.12", bullets: ["b"] },
+          ],
+          pending: null,
+          current: "0.21.0",
+          last_seen: "0.21.0",
+        }),
+      ),
+    );
+
+    render(createElement(WhatsNewArchive));
+
+    const summary = await screen.findByTestId("whats-new-archive-summary");
+    expect(summary.textContent).toMatch(/Running 0\.21\.0\. Nothing unread/);
+    expect(screen.getByRole("button", { name: /0\.21\.0/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Mark as read" })).toBeNull();
+  });
+
+  it("shows unread badge and Mark as read when pending", async () => {
+    server.use(
+      http.get("/api/system/whats-new/archive", () =>
+        HttpResponse.json({
+          sections: [
+            { version: "0.21.0", bullets: ["new thing"] },
+            { version: "0.20.12", bullets: ["older"] },
+          ],
+          pending: { from: "0.20.12", to: "0.21.0" },
+          current: "0.21.0",
+          last_seen: "0.20.12",
+        }),
+      ),
+    );
+    let dismissCalls = 0;
+    server.use(
+      http.post("/api/system/whats-new/dismiss", () => {
+        dismissCalls += 1;
+        return HttpResponse.json({
+          success: true,
+          last_seen_version: "0.21.0",
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(createElement(WhatsNewArchive));
+
+    expect((await screen.findByTestId("whats-new-unread")).textContent).toBe(
+      "1 unread",
+    );
+    expect(
+      screen.getByTestId("whats-new-archive-summary").textContent,
+    ).toMatch(/You upgraded from 0\.20\.12/);
+    await user.click(screen.getByRole("button", { name: "Mark as read" }));
+    await waitFor(() => {
+      expect(dismissCalls).toBe(1);
+    });
+  });
+
+  it("always shows version rows in the archive list", async () => {
+    server.use(
+      http.get("/api/system/whats-new/archive", () =>
+        HttpResponse.json({
+          sections: [{ version: "0.21.0", bullets: ["solo"] }],
+          pending: { from: "0.20.12", to: "0.21.0" },
+          current: "0.21.0",
+          last_seen: "0.20.12",
+        }),
+      ),
+    );
+
+    render(createElement(WhatsNewArchive));
+    expect(await screen.findByRole("button", { name: /0\.21\.0/ })).toBeTruthy();
+  });
+});

--- a/frontend/tests/components/WhatsNewModal.test.tsx
+++ b/frontend/tests/components/WhatsNewModal.test.tsx
@@ -1,0 +1,130 @@
+import { createElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import userEvent from "@testing-library/user-event";
+import { server } from "../mocks/server";
+import { render, screen, waitFor } from "../test-utils";
+import WhatsNewModal, {
+  MODAL_VERSION_CAP,
+  WHATS_NEW_ARCHIVE_PATH,
+} from "@/components/whats-new/WhatsNewModal";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const SECTIONS = [
+  { version: "0.21.0", bullets: ["one"] },
+  { version: "0.20.12", bullets: ["two"] },
+  { version: "0.20.11", bullets: ["three"] },
+  { version: "0.20.10", bullets: ["four"] },
+  { version: "0.20.9", bullets: ["five"] },
+];
+
+function stubPending(sections = SECTIONS) {
+  server.use(
+    http.get("/api/system/version", () =>
+      HttpResponse.json({
+        release_version: "0.21.0",
+        update_state: "current",
+        pending_whats_new: { from: "0.20.8", to: "0.21.0" },
+      }),
+    ),
+    http.get("/api/system/release-notes", () =>
+      HttpResponse.json({ sections }),
+    ),
+  );
+}
+
+describe("WhatsNewModal", () => {
+  it("renders nothing when there is no pending range", async () => {
+    server.use(
+      http.get("/api/system/version", () =>
+        HttpResponse.json({
+          release_version: "0.21.0",
+          pending_whats_new: null,
+        }),
+      ),
+    );
+
+    render(createElement(WhatsNewModal));
+    await waitFor(() => {
+      expect(screen.queryByText("Comicarr updated")).toBeNull();
+    });
+  });
+
+  it("caps at MODAL_VERSION_CAP versions and shows overflow without dismissing", async () => {
+    stubPending();
+    const user = userEvent.setup();
+    let dismissCalls = 0;
+    server.use(
+      http.post("/api/system/whats-new/dismiss", () => {
+        dismissCalls += 1;
+        return HttpResponse.json({
+          success: true,
+          last_seen_version: "0.21.0",
+        });
+      }),
+    );
+
+    render(createElement(WhatsNewModal));
+
+    expect(await screen.findByText("Comicarr updated")).toBeTruthy();
+    expect(screen.getByText("0.20.8 → 0.21.0")).toBeTruthy();
+    // Wait for notes; version headings for the first three releases only.
+    expect(await screen.findByRole("heading", { name: "0.21.0" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "0.20.12" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "0.20.11" })).toBeTruthy();
+    // Cap: 4th version not shown as a heading in the modal body.
+    expect(screen.queryByRole("heading", { name: "0.20.10" })).toBeNull();
+    expect(screen.getByText("one")).toBeTruthy();
+    expect(screen.queryByText("four")).toBeNull();
+
+    const overflow = SECTIONS.length - MODAL_VERSION_CAP;
+    const overflowBtn = await screen.findByRole("button", {
+      name: new RegExp(`and ${overflow} earlier releases`, "i"),
+    });
+    await user.click(overflowBtn);
+
+    expect(dismissCalls).toBe(0);
+    expect(mockNavigate).toHaveBeenCalledWith(WHATS_NEW_ARCHIVE_PATH);
+  });
+
+  it("suppresses per-version heading on a single-release jump", async () => {
+    stubPending([{ version: "0.21.0", bullets: ["only change"] }]);
+    render(createElement(WhatsNewModal));
+
+    expect(await screen.findByText("only change")).toBeTruthy();
+    // Header already names the range; body heading for the sole section is omitted.
+    expect(screen.queryByRole("heading", { name: "0.21.0" })).toBeNull();
+  });
+
+  it("Got it posts dismiss", async () => {
+    stubPending([{ version: "0.21.0", bullets: ["change"] }]);
+    const user = userEvent.setup();
+    let dismissCalls = 0;
+    server.use(
+      http.post("/api/system/whats-new/dismiss", () => {
+        dismissCalls += 1;
+        return HttpResponse.json({
+          success: true,
+          last_seen_version: "0.21.0",
+        });
+      }),
+    );
+
+    render(createElement(WhatsNewModal));
+    expect(await screen.findByText("Got it")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Got it" }));
+
+    await waitFor(() => {
+      expect(dismissCalls).toBe(1);
+    });
+  });
+});

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -379,6 +379,22 @@ export const handlers = [
     return HttpResponse.json({ sections: [] });
   }),
 
+  http.get("/api/system/whats-new/archive", () => {
+    return HttpResponse.json({
+      sections: [],
+      pending: null,
+      current: "1.0.0",
+      last_seen: "1.0.0",
+    });
+  }),
+
+  http.post("/api/system/whats-new/dismiss", () => {
+    return HttpResponse.json({
+      success: true,
+      last_seen_version: "1.0.0",
+    });
+  }),
+
   http.post("/api/system/version/check", () => {
     return HttpResponse.json({
       current_version: "1.0.0",

--- a/frontend/tests/pages/SettingsPage.test.ts
+++ b/frontend/tests/pages/SettingsPage.test.ts
@@ -130,6 +130,15 @@ describe("SettingsPage", () => {
           latest_version: "0.22.0",
           update_state: "behind",
           update_reason: null,
+          pending_whats_new: null,
+        }),
+      ),
+      http.get("/api/system/whats-new/archive", () =>
+        HttpResponse.json({
+          sections: [{ version: "0.21.0", bullets: ["notes"] }],
+          pending: null,
+          current: "0.21.0",
+          last_seen: "0.21.0",
         }),
       ),
     );
@@ -148,7 +157,9 @@ describe("SettingsPage", () => {
     expect(screen.getByRole("button", { name: "Check now" })).toBeTruthy();
     // Order: Updates before What's new before build rows.
     const updates = screen.getByText("Updates");
+    // SettingGroup title (exact); archive no longer duplicates an h2.
     const whatsNew = screen.getByText("What's new");
+    expect(await screen.findByTestId("whats-new-archive-summary")).toBeTruthy();
     const build = screen.getByText("Build / environment");
     expect(
       updates.compareDocumentPosition(whatsNew) &

--- a/tests/unit/test_release_announce.py
+++ b/tests/unit/test_release_announce.py
@@ -39,7 +39,7 @@ def test_last_announced_version_is_install_wide_and_separate_from_settings():
     assert REGISTRY["LAST_ANNOUNCED_VERSION"].readable is False
     assert REGISTRY["LAST_ANNOUNCED_VERSION"].writable is False
     assert REGISTRY["LAST_ANNOUNCED_VERSION"].section == "Git"
-    assert "LAST_SEEN_VERSION" not in REGISTRY
+    # LAST_SEEN_VERSION is owned by What's New (#474), not announce dedup.
 
 
 class TestShouldAnnounceRelease:

--- a/tests/unit/test_whats_new.py
+++ b/tests/unit/test_whats_new.py
@@ -1,0 +1,218 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Post-upgrade What's New: LAST_SEEN_VERSION, modal pending range, About archive.
+
+Seams (issue #474 / decisions #449 + #451):
+- ``comicarr.app.system.whats_new.detect_pending`` — pure compare, no write
+- ``resolve_pending_whats_new`` — seed-on-absent write + derived pending range
+- ``dismiss_whats_new`` — write LAST_SEEN_VERSION = current only
+- ``archive_sections`` — floor at pending, pad toward ~10 when quiet
+- Registry: LAST_SEEN_VERSION install-wide, not Settings-exposed
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import comicarr
+from comicarr.app.config.registry import REGISTRY
+from comicarr.app.core.context import AppContext
+from comicarr.app.system import service as system_service
+from comicarr.app.system import whats_new
+
+
+def test_last_seen_version_is_install_wide_and_not_settings():
+    key = REGISTRY["LAST_SEEN_VERSION"]
+    assert key.default is None
+    assert key.readable is False
+    assert key.writable is False
+    assert key.section == "Git"
+    assert key.type is str
+
+
+class TestDetectPending:
+    """Pure comparison — never writes."""
+
+    def test_absent_last_seen_is_seed(self):
+        result = whats_new.detect_pending(current="0.21.0", last_seen=None)
+        assert result.kind == "seed"
+        assert result.pending is None
+
+    def test_empty_last_seen_is_seed(self):
+        result = whats_new.detect_pending(current="0.21.0", last_seen="")
+        assert result.kind == "seed"
+        assert result.pending is None
+
+    def test_upgrade_yields_pending_open_closed_range(self):
+        result = whats_new.detect_pending(current="0.21.0", last_seen="0.20.4")
+        assert result.kind == "pending"
+        assert result.pending == {"from": "0.20.4", "to": "0.21.0"}
+
+    def test_equal_is_quiet(self):
+        result = whats_new.detect_pending(current="0.21.0", last_seen="0.21.0")
+        assert result.kind == "quiet"
+        assert result.pending is None
+
+    def test_downgrade_is_quiet(self):
+        result = whats_new.detect_pending(current="0.20.0", last_seen="0.21.0")
+        assert result.kind == "quiet"
+        assert result.pending is None
+
+    def test_missing_current_is_quiet(self):
+        result = whats_new.detect_pending(current=None, last_seen="0.20.0")
+        assert result.kind == "quiet"
+        assert result.pending is None
+
+    def test_invalid_semver_is_quiet(self):
+        result = whats_new.detect_pending(current="not-a-version", last_seen="0.20.0")
+        assert result.kind == "quiet"
+
+
+class TestResolveAndDismiss:
+    @pytest.fixture
+    def ctx(self, monkeypatch):
+        config = MagicMock()
+        config.LAST_SEEN_VERSION = None
+        context = AppContext(
+            prog_dir="/tmp/comicarr_test",
+            data_dir="/tmp/comicarr_test/data",
+            db_file=":memory:",
+            config=config,
+            scheduler=MagicMock(),
+        )
+        monkeypatch.setattr(comicarr, "CONFIG", config, raising=False)
+        return context
+
+    def test_seed_writes_current_and_returns_null(self, ctx):
+        with patch.object(system_service, "get_release_version", return_value="0.21.0"):
+            pending = whats_new.resolve_pending_whats_new(ctx)
+
+        assert pending is None
+        assert comicarr.CONFIG.LAST_SEEN_VERSION == "0.21.0"
+        comicarr.CONFIG.writeconfig.assert_called_once_with(
+            values={"last_seen_version": "0.21.0"}
+        )
+
+    def test_pending_does_not_write(self, ctx):
+        comicarr.CONFIG.LAST_SEEN_VERSION = "0.20.0"
+        with patch.object(system_service, "get_release_version", return_value="0.21.0"):
+            pending = whats_new.resolve_pending_whats_new(ctx)
+
+        assert pending == {"from": "0.20.0", "to": "0.21.0"}
+        comicarr.CONFIG.writeconfig.assert_not_called()
+
+    def test_equal_quiet_does_not_write(self, ctx):
+        comicarr.CONFIG.LAST_SEEN_VERSION = "0.21.0"
+        with patch.object(system_service, "get_release_version", return_value="0.21.0"):
+            pending = whats_new.resolve_pending_whats_new(ctx)
+
+        assert pending is None
+        comicarr.CONFIG.writeconfig.assert_not_called()
+
+    def test_downgrade_quiet_does_not_write(self, ctx):
+        comicarr.CONFIG.LAST_SEEN_VERSION = "0.22.0"
+        with patch.object(system_service, "get_release_version", return_value="0.21.0"):
+            pending = whats_new.resolve_pending_whats_new(ctx)
+
+        assert pending is None
+        assert comicarr.CONFIG.LAST_SEEN_VERSION == "0.22.0"
+        comicarr.CONFIG.writeconfig.assert_not_called()
+
+    def test_dismiss_writes_current(self, ctx):
+        comicarr.CONFIG.LAST_SEEN_VERSION = "0.20.0"
+        with patch.object(system_service, "get_release_version", return_value="0.21.0"):
+            result = whats_new.dismiss_whats_new(ctx)
+
+        assert result == {"success": True, "last_seen_version": "0.21.0"}
+        assert comicarr.CONFIG.LAST_SEEN_VERSION == "0.21.0"
+        comicarr.CONFIG.writeconfig.assert_called_once_with(
+            values={"last_seen_version": "0.21.0"}
+        )
+
+
+class TestVersionInfoIncludesPending:
+    @pytest.fixture
+    def ctx(self, monkeypatch):
+        config = MagicMock()
+        config.LAST_SEEN_VERSION = "0.20.0"
+        context = AppContext(
+            prog_dir="/tmp/comicarr_test",
+            data_dir="/tmp/comicarr_test/data",
+            db_file=":memory:",
+            config=config,
+            scheduler=MagicMock(),
+            update_state="current",
+            update_reason=None,
+        )
+        monkeypatch.setattr(comicarr, "CONFIG", config, raising=False)
+        return context
+
+    def test_get_version_info_exposes_pending_whats_new(self, ctx):
+        with patch.object(system_service, "get_release_version", return_value="0.21.0"):
+            info = system_service.get_version_info(ctx)
+        assert info["pending_whats_new"] == {"from": "0.20.0", "to": "0.21.0"}
+        comicarr.CONFIG.writeconfig.assert_not_called()
+
+    def test_get_version_info_null_when_caught_up(self, ctx):
+        comicarr.CONFIG.LAST_SEEN_VERSION = "0.21.0"
+        with patch.object(system_service, "get_release_version", return_value="0.21.0"):
+            info = system_service.get_version_info(ctx)
+        assert info["pending_whats_new"] is None
+
+
+class TestArchiveSections:
+    SECTIONS = [
+        {"version": "0.21.0", "bullets": ["a"]},
+        {"version": "0.20.12", "bullets": ["b"]},
+        {"version": "0.20.11", "bullets": ["c"]},
+        {"version": "0.20.10", "bullets": ["d"]},
+        {"version": "0.20.9", "bullets": ["e"]},
+        {"version": "0.20.8", "bullets": ["f"]},
+        {"version": "0.20.7", "bullets": ["g"]},
+        {"version": "0.20.6", "bullets": ["h"]},
+        {"version": "0.20.5", "bullets": ["i"]},
+        {"version": "0.20.4", "bullets": ["j"]},
+        {"version": "0.20.3", "bullets": ["k"]},
+        {"version": "0.19.0", "bullets": ["l"]},
+    ]
+
+    def test_pads_to_floor_when_nothing_pending(self):
+        rows = whats_new.archive_sections(
+            self.SECTIONS,
+            current="0.21.0",
+            last_seen="0.21.0",
+            floor=10,
+        )
+        assert len(rows) == 10
+        assert rows[0]["version"] == "0.21.0"
+        assert rows[-1]["version"] == "0.20.4"
+
+    def test_floors_at_pending_when_unread_exceeds_floor(self):
+        # last_seen 0.19.0 → 11 pending versions up through 0.21.0
+        rows = whats_new.archive_sections(
+            self.SECTIONS,
+            current="0.21.0",
+            last_seen="0.19.0",
+            floor=10,
+        )
+        assert len(rows) == 11
+        assert rows[0]["version"] == "0.21.0"
+        assert rows[-1]["version"] == "0.20.3"
+
+    def test_pads_when_pending_shorter_than_floor(self):
+        rows = whats_new.archive_sections(
+            self.SECTIONS,
+            current="0.21.0",
+            last_seen="0.20.11",
+            floor=10,
+        )
+        # 2 pending (0.21.0, 0.20.12) but pad to 10
+        assert len(rows) == 10
+        assert {r["version"] for r in rows[:2]} == {"0.21.0", "0.20.12"}


### PR DESCRIPTION
## Summary

After an upgrade, Comicarr shows a capped What's New modal once until acknowledged, keeps a permanent What's new archive under Settings → About, and records acknowledgement as install-wide `LAST_SEEN_VERSION`.

Closes #474

## Changes
- Add install-wide `LAST_SEEN_VERSION` with seed/detect/dismiss (write only on seed or Got it / Mark as read)
- Expose `pending_whats_new` on version API, plus dismiss and server-floored archive endpoints
- Modal caps at 3 versions with overflow to Settings → About (no dismiss on overflow); About panel is permanent history

## Test plan
- [ ] Fresh install / first boot after feature: key seeds, no modal
- [ ] Upgrade with last_seen behind current: modal shows; Got it clears pending
- [ ] Multi-version jump: modal shows at most 3 versions; overflow opens About without clearing unread
- [ ] Settings → About shows archive floored at pending / padded when quiet; Mark as read clears
- [ ] Version chip still only means update-available, not unread notes
- [ ] Unit/frontend tests for whats-new paths pass in CI