### PR TITLE
feat: Wire activity producers and retire GLOBAL_MESSAGES writes

### DIFF
--- a/.changeset/activity-producers-wire.md
+++ b/.changeset/activity-producers-wire.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+The Activity timeline now records real library work as it happens — grabs, downloads, imports, series adds and refreshes, metatagging, and search run summaries — instead of the old unused global message slots. Failed downloads and completed search runs show up as plain-language rows with distinct reasons.

--- a/comicarr/app/acquisition/runs.py
+++ b/comicarr/app/acquisition/runs.py
@@ -16,6 +16,7 @@ from sqlalchemy import func, insert, select, update
 from sqlalchemy.exc import IntegrityError
 
 from comicarr.app.acquisition.models import DispatchState, ItemOutcome, RunState
+from comicarr.app.common.redaction import redact_sensitive_text
 from comicarr.db import get_engine
 from comicarr.tables import acquisition_run_items, acquisition_runs
 
@@ -55,6 +56,40 @@ def _utcnow():
 
 def _value(value):
     return value.value if hasattr(value, "value") else str(value)
+
+
+def _redact_reason(reason):
+    """Persist operator-visible reasons through the canonical redactor (#430 A2)."""
+    if reason in (None, ""):
+        return None
+    return redact_sensitive_text(str(reason))[:1000]
+
+
+def is_retry_pending(item):
+    """True when an item is awaiting another attempt (retry guard, #430 A1).
+
+    Discriminator: state is ACCEPTED and attempt_count > 0. ``next_attempt_at``
+    is never written; this is the only honest "retry pending" signal.
+    """
+    if not item:
+        return False
+    try:
+        attempts = int(item.get("attempt_count") or 0)
+    except (TypeError, ValueError):
+        attempts = 0
+    return item.get("state") == ItemOutcome.ACCEPTED.value and attempts > 0
+
+
+def _emit_run_completion_safe(run):
+    """Best-effort search run bracket; never raises into the ledger path."""
+    try:
+        from comicarr.app.activity.producers import emit_run_completion
+
+        emit_run_completion(run)
+    except Exception as e:
+        from comicarr import logger
+
+        logger.fdebug("[ACTIVITY] run completion emit skipped: %s" % e)
 
 
 def _row_dict(row):
@@ -307,7 +342,9 @@ class RunLedger:
                     completed_at=now,
                 )
             )
-        return self.get_run(run_id)
+        run = self.get_run(run_id)
+        _emit_run_completion_safe(run)
+        return run
 
     def claim_item(self, run_id, entity_type, entity_id):
         item = self.get_item(run_id, entity_type, entity_id)
@@ -330,26 +367,40 @@ class RunLedger:
             )
         return result.rowcount == 1
 
-    def record_requeue(self, run_id, entity_type, entity_id, reason, next_attempt_at=None):
+    def record_requeue(self, run_id, entity_type, entity_id, reason, next_attempt_at=None, *, replay=False):
+        """Re-accept a non-terminal item after a fault (or crash-replay).
+
+        ``replay=True`` marks crash-recovery requeues (worker restart). Any
+        future narrative producer **must** skip when the returned item has
+        ``replay=True`` so restarts are not reported as retries (#430 A4).
+        The flag is not a DB column — it is returned on the item dict only.
+        Degraded/retrying never narrates today; the flag still makes the
+        call-site decision greppable and enforceable.
+        """
         item = self.get_item(run_id, entity_type, entity_id)
         if item is None:
             raise KeyError("unknown acquisition item")
         current = ItemOutcome(item["state"])
         if current.terminal:
             raise ValueError("terminal acquisition items cannot be requeued implicitly")
+        safe_reason = _redact_reason(reason)
         with self.engine.begin() as conn:
             conn.execute(
                 update(acquisition_run_items)
                 .where(acquisition_run_items.c.item_id == item["item_id"])
                 .values(
                     state=ItemOutcome.ACCEPTED.value,
-                    reason=str(reason)[:1000] if reason else None,
+                    reason=safe_reason,
                     next_attempt_at=next_attempt_at,
                     updated_at=_utcnow(),
                 )
             )
         self.reconcile(run_id)
-        return self.get_item(run_id, entity_type, entity_id)
+        updated = self.get_item(run_id, entity_type, entity_id)
+        if updated is not None:
+            # Transient call-site contract — not persisted (#430 A4).
+            updated["replay"] = bool(replay)
+        return updated
 
     def record_outcome(self, run_id, entity_type, entity_id, outcome, reason=None):
         item = self.get_item(run_id, entity_type, entity_id)
@@ -363,6 +414,7 @@ class RunLedger:
             raise ValueError("terminal acquisition outcome cannot be replaced")
         if current is not outcome:
             now = _utcnow()
+            safe_reason = _redact_reason(reason)
             with self.engine.begin() as conn:
                 conn.execute(
                     update(acquisition_run_items)
@@ -370,7 +422,7 @@ class RunLedger:
                     .where(acquisition_run_items.c.state.in_([ItemOutcome.ACCEPTED.value, ItemOutcome.RUNNING.value]))
                     .values(
                         state=outcome.value,
-                        reason=str(reason)[:1000] if reason else None,
+                        reason=safe_reason,
                         next_attempt_at=None,
                         updated_at=now,
                         completed_at=now,
@@ -435,6 +487,8 @@ class RunLedger:
 
     def reconcile(self, run_id):
         self._require_run(run_id)
+        previous = self.get_run(run_id)
+        previous_completion = str(previous.get("completion_state") or "") if previous else ""
         with self.engine.begin() as conn:
             counts = dict(
                 tuple(row)
@@ -483,4 +537,12 @@ class RunLedger:
                     completed_at=completed_at,
                 )
             )
-        return self.get_run(run_id)
+        run = self.get_run(run_id)
+        # Narrate completion once when the run first becomes terminal (#484).
+        # In-flight progress stays derived (no search.started @ run here).
+        new_completion = str(run.get("completion_state") or "") if run else ""
+        was_open = previous_completion in ("", "pending", "running")
+        is_closed = new_completion not in ("", "pending", "running")
+        if was_open and is_closed:
+            _emit_run_completion_safe(run)
+        return run

--- a/comicarr/app/activity/__init__.py
+++ b/comicarr/app/activity/__init__.py
@@ -10,8 +10,9 @@
 """Activity Center domain — narrative timeline, attention band, open-work reads,
 age-based retention, and the sole write facade for activity_events.
 
-Query-backed HTTP reads (#485); daily 90-day purge (#489); write facade (#479).
-Producers call :func:`comicarr.app.activity.events.record_activity` (and
+Query-backed HTTP reads (#485); daily 90-day purge (#489); write facade (#479);
+production producers (#484) live in :mod:`comicarr.app.activity.producers` and
+call :func:`comicarr.app.activity.events.record_activity` (and
 :func:`publish_activity` after a shared-conn commit). Do not insert into
 ``activity_events`` or publish the ``activity`` SSE envelope elsewhere.
 """

--- a/comicarr/app/activity/producers.py
+++ b/comicarr/app/activity/producers.py
@@ -1,0 +1,421 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Activity Center production helpers — journal stage map and run brackets.
+
+Producers call these after a durable transition wins. They never write
+``GLOBAL_MESSAGES``. All narrative inserts go through
+:func:`comicarr.app.activity.events.record_activity`.
+"""
+
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import select
+
+from comicarr import logger
+from comicarr.app.activity.events import publish_activity, record_activity
+from comicarr.app.common.redaction import redact_sensitive_text
+from comicarr.db import get_engine
+from comicarr.tables import annuals, comics, issues
+
+# ---------------------------------------------------------------------------
+# pipeline_journal stage → (activity, status)
+# reserved / moved are internal (no narrative row).
+# failed: download vs import depends on prior stage rank (#426 finding 1).
+# ---------------------------------------------------------------------------
+
+# Stages that always map to a single cell (not failed).
+_STAGE_CELLS = {
+    "snatched": ("grab", "succeeded"),
+    "downloaded": ("download", "succeeded"),
+    "post_processing": ("import", "started"),
+    "post_processed": ("import", "succeeded"),
+    "manual_review": ("import", "needs_attention"),
+}
+
+# Rank threshold: at/after post_processing the failure is an import failure.
+_IMPORT_FAIL_MIN_RANK = 30  # POST_PROCESSING
+
+
+def _issue_subject(issueid, conn=None):
+    """Resolve (subject_type, subject_id, subject_label, parent_series_id) for an issueid.
+
+    Returns None when the issue cannot be resolved to a label. When ``conn`` is
+    supplied, resolve on that connection (avoids nested engines under an open
+    journal transaction).
+    """
+    if issueid in (None, ""):
+        return None
+    sid = str(issueid)
+
+    def _lookup(active_conn):
+        row = active_conn.execute(
+            select(
+                issues.c.IssueID,
+                issues.c.ComicID,
+                issues.c.ComicName,
+                issues.c.Issue_Number,
+                comics.c.ComicName.label("series_name"),
+                comics.c.ComicYear,
+            )
+            .select_from(issues.outerjoin(comics, comics.c.ComicID == issues.c.ComicID))
+            .where(issues.c.IssueID == sid)
+        ).fetchone()
+        if row is None:
+            row = active_conn.execute(
+                select(
+                    annuals.c.IssueID,
+                    annuals.c.ComicID,
+                    annuals.c.ComicName,
+                    annuals.c.Issue_Number,
+                    comics.c.ComicName.label("series_name"),
+                    comics.c.ComicYear,
+                )
+                .select_from(annuals.outerjoin(comics, comics.c.ComicID == annuals.c.ComicID))
+                .where(annuals.c.IssueID == sid)
+                .where(annuals.c.Deleted != 1)
+            ).fetchone()
+            if row is None:
+                return None
+            subject_type = "annual"
+        else:
+            subject_type = "issue"
+
+        m = dict(row._mapping)
+        name = m.get("ComicName") or m.get("series_name") or "Unknown"
+        number = m.get("Issue_Number")
+        if number not in (None, ""):
+            label = "%s #%s" % (name, number)
+        else:
+            label = str(name)
+        parent = m.get("ComicID")
+        return subject_type, sid, label, str(parent) if parent not in (None, "") else None
+
+    try:
+        if conn is not None:
+            return _lookup(conn)
+        with get_engine().connect() as owned:
+            return _lookup(owned)
+    except Exception as e:
+        logger.fdebug("[ACTIVITY] issue subject resolve failed for %s: %s" % (sid, e))
+        return None
+
+
+def _series_label(comicid, comicname=None, seriesyear=None):
+    if comicname and seriesyear not in (None, "", "None"):
+        return "%s (%s)" % (comicname, seriesyear)
+    if comicname:
+        return str(comicname)
+    if comicid in (None, ""):
+        return "series"
+    try:
+        engine = get_engine()
+        with engine.connect() as conn:
+            row = conn.execute(
+                select(comics.c.ComicName, comics.c.ComicYear).where(comics.c.ComicID == str(comicid))
+            ).fetchone()
+            if row is not None:
+                name = row._mapping.get("ComicName") or str(comicid)
+                year = row._mapping.get("ComicYear")
+                if year not in (None, "", "None"):
+                    return "%s (%s)" % (name, year)
+                return str(name)
+    except Exception as e:
+        logger.fdebug("[ACTIVITY] series label resolve failed for %s: %s" % (comicid, e))
+    return str(comicid)
+
+
+def emit_for_journal_stage(
+    stage,
+    *,
+    release_key,
+    issueid=None,
+    provider=None,
+    fail_reason=None,
+    payload=None,
+    prior_stage_rank=None,
+    conn=None,
+    won=True,
+):
+    """Emit the legal narrative cell for a won journal stage advance.
+
+    When ``conn`` is supplied the insert co-commits; the caller must
+    :func:`publish_activity` after their commit. When ``conn`` is None the
+    facade owns the transaction and publishes after commit.
+    """
+    if not won:
+        return None
+
+    cell = _STAGE_CELLS.get(stage)
+    if cell is None and stage == "failed":
+        if prior_stage_rank is not None and int(prior_stage_rank) >= _IMPORT_FAIL_MIN_RANK:
+            cell = ("import", "failed")
+        else:
+            cell = ("download", "failed")
+    if cell is None:
+        # reserved / moved / unknown — internal only
+        return None
+
+    activity, status = cell
+    subject = _issue_subject(issueid, conn=conn)
+    if subject is None:
+        # Synthetic / one-off / unresolved — still narrate if we have an id.
+        if issueid in (None, ""):
+            logger.fdebug("[ACTIVITY] skip journal emit stage=%s release_key=%s: no issueid" % (stage, release_key))
+            return None
+        subject_type, subject_id, subject_label, parent_series_id = (
+            "issue",
+            str(issueid),
+            str(issueid),
+            None,
+        )
+    else:
+        subject_type, subject_id, subject_label, parent_series_id = subject
+
+    reason_code = None
+    reason_detail = None
+    if status in ("failed", "needs_attention", "blocked"):
+        reason_code = fail_reason or ("import_failed" if activity == "import" else "download_failed")
+        if isinstance(payload, dict):
+            detail = payload.get("fail_detail")
+            if detail:
+                reason_detail = redact_sensitive_text(str(detail))[:1000]
+
+    return record_activity(
+        activity,
+        status,
+        subject_type,
+        subject_id,
+        subject_label,
+        reason_code=reason_code,
+        reason_detail=reason_detail,
+        provider=provider,
+        release_key=release_key,
+        parent_series_id=parent_series_id,
+        conn=conn,
+        won=True,
+    )
+
+
+def emit_run_completion(run):
+    """Narrate a closed acquisition search run as ``search.succeeded`` @ ``run``.
+
+    In-flight progress is derived (ledger only) — never call this while the run
+    is still open. Counts ride ``reason_detail`` as JSON for the client sentence
+    templates (not a table column; optional envelope field).
+    """
+    if not run or not run.get("run_id"):
+        return None
+    completion = str(run.get("completion_state") or "")
+    if completion in ("pending", "running", ""):
+        return None
+    # Only narrate search runs (refresh runs use series refresh.* cells).
+    if str(run.get("command_kind") or "").strip().lower() != "search":
+        return None
+
+    accepted = int(run.get("accepted_count") or 0)
+    succeeded = int(run.get("succeeded_count") or 0)
+    no_match = int(run.get("no_match_count") or 0)
+    failed = int(run.get("failed_count") or 0)
+    blocked = int(run.get("blocked_count") or 0)
+
+    counts = {
+        "accepted": accepted,
+        "grabbed": succeeded,
+        "no_match": no_match,
+        "failed": failed + blocked,
+    }
+
+    # Empty scan that never accepted items vs fruitless provider sweep.
+    if accepted == 0:
+        reason_code = "nothing_to_search"
+        subject_label = "wanted issues"
+    elif succeeded == 0 and no_match == accepted:
+        reason_code = "no_results"
+        subject_label = "wanted issues"
+    else:
+        reason_code = None
+        subject_label = "wanted issues"
+
+    scope_type = run.get("scope_type")
+    scope_id = run.get("scope_id")
+    if scope_type and scope_id:
+        # Keep scope on the run subject for series-scoped timeline filters.
+        pass
+    else:
+        scope_type = None
+        scope_id = None
+
+    return record_activity(
+        "search",
+        "succeeded",
+        "run",
+        str(run["run_id"]),
+        subject_label,
+        reason_code=reason_code,
+        reason_detail=json.dumps(counts, sort_keys=True, separators=(",", ":")),
+        run_id=str(run["run_id"]),
+        scope_type=scope_type,
+        scope_id=scope_id,
+    )
+
+
+def emit_series_activity(
+    activity,
+    status,
+    comicid,
+    *,
+    comicname=None,
+    seriesyear=None,
+    reason_code=None,
+    reason_detail=None,
+    provider=None,
+):
+    """Convenience for ``refresh.*`` / ``add.*`` @ series producers."""
+    if comicid in (None, ""):
+        return None
+    label = _series_label(comicid, comicname=comicname, seriesyear=seriesyear)
+    return record_activity(
+        activity,
+        status,
+        "series",
+        str(comicid),
+        label,
+        reason_code=reason_code,
+        reason_detail=reason_detail,
+        provider=provider,
+        parent_series_id=str(comicid),
+    )
+
+
+def emit_arc_activity(
+    activity,
+    status,
+    storyarcid,
+    storyarcname,
+    *,
+    reason_code=None,
+    reason_detail=None,
+):
+    """Convenience for ``add.*`` / ``refresh.*`` @ arc producers."""
+    if storyarcid in (None, ""):
+        return None
+    label = storyarcname or str(storyarcid)
+    return record_activity(
+        activity,
+        status,
+        "arc",
+        str(storyarcid),
+        label,
+        reason_code=reason_code,
+        reason_detail=reason_detail,
+    )
+
+
+def emit_tag_activity(
+    status,
+    *,
+    issueid=None,
+    comicid=None,
+    comicname=None,
+    seriesyear=None,
+    reason_code=None,
+    reason_detail=None,
+    subject_level="issue",
+):
+    """Metatagger narrative — always ``tag.*``, never ``refresh`` (#430 §3.1)."""
+    if subject_level == "series":
+        if comicid in (None, ""):
+            return None
+        label = _series_label(comicid, comicname=comicname, seriesyear=seriesyear)
+        return record_activity(
+            "tag",
+            status,
+            "series",
+            str(comicid),
+            label,
+            reason_code=reason_code,
+            reason_detail=reason_detail,
+            parent_series_id=str(comicid),
+        )
+
+    subject = _issue_subject(issueid) if issueid not in (None, "") else None
+    if subject is None:
+        if comicid in (None, "") and issueid in (None, ""):
+            return None
+        # Fall back to series subject when the issue row is missing.
+        if issueid not in (None, ""):
+            return record_activity(
+                "tag",
+                status,
+                "issue",
+                str(issueid),
+                str(issueid),
+                reason_code=reason_code,
+                reason_detail=reason_detail,
+                parent_series_id=str(comicid) if comicid not in (None, "") else None,
+            )
+        return emit_tag_activity(
+            status,
+            comicid=comicid,
+            comicname=comicname,
+            seriesyear=seriesyear,
+            reason_code=reason_code,
+            reason_detail=reason_detail,
+            subject_level="series",
+        )
+
+    subject_type, subject_id, subject_label, parent_series_id = subject
+    # tag is legal only @ issue|series (not annual) — map annual → issue cell.
+    if subject_type == "annual":
+        subject_type = "issue"
+    return record_activity(
+        "tag",
+        status,
+        subject_type,
+        subject_id,
+        subject_label,
+        reason_code=reason_code,
+        reason_detail=reason_detail,
+        parent_series_id=parent_series_id or (str(comicid) if comicid not in (None, "") else None),
+    )
+
+
+def emit_grab_cancelled_series(comicid, *, reason_code="pack_reversed", count=None):
+    """Pack-reversal producer — ``grab.cancelled`` @ series (#430)."""
+    if comicid in (None, ""):
+        return None
+    label = _series_label(comicid)
+    detail = None
+    if count is not None:
+        detail = json.dumps({"accepted": int(count)}, sort_keys=True, separators=(",", ":"))
+    return record_activity(
+        "grab",
+        "cancelled",
+        "series",
+        str(comicid),
+        label,
+        reason_code=reason_code,
+        reason_detail=detail,
+        parent_series_id=str(comicid),
+    )
+
+
+# Re-export publish for shared-conn call sites that co-commit then publish.
+__all__ = [
+    "emit_arc_activity",
+    "emit_for_journal_stage",
+    "emit_grab_cancelled_series",
+    "emit_run_completion",
+    "emit_series_activity",
+    "emit_tag_activity",
+    "publish_activity",
+]

--- a/comicarr/app/downloads/journal.py
+++ b/comicarr/app/downloads/journal.py
@@ -268,6 +268,9 @@ _PAYLOAD_KEYS = frozenset(
         "oneoff",
         "journal_release_key",
         "download_info",
+        # Sanitised diagnostic text for fail_reason detail / narrative
+        # reason_detail (#430 A5). Never a credential; redacted at write sites.
+        "fail_detail",
     }
 )
 _DOWNLOAD_INFO_KEYS = frozenset({"provider", "id", "nzo_id", "NZBID", "hash", "nzbname", "clientmode"})
@@ -633,6 +636,70 @@ def _apply_transition(conn, key, stage, new_rank, fields, payload, when):
     return False
 
 
+def _prior_context(conn, release_key):
+    """Return (stage_rank, issueid, provider) for an existing journal row, or Nones."""
+    row = conn.execute(
+        select(
+            pipeline_journal.c.stage_rank,
+            pipeline_journal.c.issueid,
+            pipeline_journal.c.provider,
+        ).where(pipeline_journal.c.release_key == release_key)
+    ).fetchone()
+    if row is None:
+        return None, None, None
+    m = row._mapping
+    return m.get("stage_rank"), m.get("issueid"), m.get("provider")
+
+
+def _emit_activity_for_won_transition(
+    stage,
+    release_key,
+    fields,
+    payload,
+    *,
+    prior_rank,
+    prior_issueid,
+    prior_provider,
+    conn=None,
+):
+    """Best-effort narrative emit after a won journal advance (#484).
+
+    Returns the activity payload (or None). Never raises into the journal path
+    — a narrative failure must not undo a durable stage transition. When
+    ``conn`` is supplied the insert co-commits; the caller publishes after
+    their commit (or the facade-owned path publishes after its begin() exits).
+    """
+    try:
+        from comicarr.app.activity.producers import emit_for_journal_stage
+
+        issueid = fields.get("issueid") if fields else None
+        if issueid in (None, ""):
+            issueid = prior_issueid
+        if issueid in (None, "") and isinstance(payload, dict):
+            issueid = payload.get("issueid")
+        provider = fields.get("provider") if fields else None
+        if provider in (None, ""):
+            provider = prior_provider
+        if provider in (None, "") and isinstance(payload, dict):
+            provider = payload.get("provider")
+        fail_reason = fields.get("fail_reason") if fields else None
+
+        return emit_for_journal_stage(
+            stage,
+            release_key=release_key,
+            issueid=issueid,
+            provider=provider,
+            fail_reason=fail_reason,
+            payload=payload,
+            prior_stage_rank=prior_rank,
+            conn=conn,
+            won=True,
+        )
+    except Exception as e:
+        logger.fdebug("[JOURNAL] activity emit skipped for release_key=%s stage=%s: %s" % (release_key, stage, e))
+        return None
+
+
 def record_transition(release_key, stage, payload=None, conn=None, **fields):
     """Forward-only conditional advance for one release_key.
 
@@ -645,6 +712,10 @@ def record_transition(release_key, stage, payload=None, conn=None, **fields):
     or beyond `stage` (a regression, a terminal row, or a concurrent winner).
     The U4 PP-consumer atomic claim relies on exactly one concurrent
     downloaded -> post_processing caller getting True.
+
+    When this call wins, the matching Activity Center cell is co-committed
+    (or written in the same own-transaction) and published after durability
+    on the facade-owned path (#484 / ADR §7).
 
     `conn`: optional caller-supplied Connection. When given, the write joins
     the caller's transaction (so it rolls back with it) — used by the DDL/PP
@@ -665,19 +736,54 @@ def record_transition(release_key, stage, payload=None, conn=None, **fields):
 
     # Caller-supplied connection: participate in the caller's transaction.
     if conn is not None:
+        prior_rank, prior_issueid, prior_provider = _prior_context(conn, release_key)
         won = _apply_transition(conn, release_key, stage, new_rank, fields, payload, when)
         if won:
             logger.fdebug("[JOURNAL] advanced release_key=%s -> stage=%s (caller txn)" % (release_key, stage))
+            # Co-commit narrative; SSE publish is left to the transaction owner
+            # (or the next query-backed refetch — best-effort contract).
+            _emit_activity_for_won_transition(
+                stage,
+                release_key,
+                fields,
+                payload,
+                prior_rank=prior_rank,
+                prior_issueid=prior_issueid,
+                prior_provider=prior_provider,
+                conn=conn,
+            )
         return won
 
     # Own transaction with bounded retry-then-raise (mirrors db.upsert).
     attempt = 0
     while attempt < 5:
         try:
+            activity_payload = None
             with db.get_engine().begin() as own_conn:
+                prior_rank, prior_issueid, prior_provider = _prior_context(own_conn, release_key)
                 won = _apply_transition(own_conn, release_key, stage, new_rank, fields, payload, when)
+                if won:
+                    # Co-commit activity inside the same transaction so the
+                    # narrative row is durable with the stage advance.
+                    activity_payload = _emit_activity_for_won_transition(
+                        stage,
+                        release_key,
+                        fields,
+                        payload,
+                        prior_rank=prior_rank,
+                        prior_issueid=prior_issueid,
+                        prior_provider=prior_provider,
+                        conn=own_conn,
+                    )
             if won:
                 logger.fdebug("[JOURNAL] advanced release_key=%s -> stage=%s" % (release_key, stage))
+                if activity_payload:
+                    try:
+                        from comicarr.app.activity.events import publish_activity
+
+                        publish_activity(activity_payload)
+                    except Exception as e:
+                        logger.fdebug("[JOURNAL] activity publish skipped: %s" % e)
             return won
         except OperationalError as e:
             err_msg = str(e)

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -1215,12 +1215,12 @@ def reverse_the_pack_snatch(pack_id, comicid):
         db.upsert("issues", {"Status": "Skipped"}, {"IssueID": x})
     if reverselist:
         logger.info("[REVERSE UNO] Reversal completed for %s issues" % len(reverselist))
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "success",
-            "comicid": comicid,
-            "tables": "both",
-            "message": "Successfully changed status of %s issues to %s" % (len(reverselist), "Skipped"),
-        }
+        try:
+            from comicarr.app.activity.producers import emit_grab_cancelled_series
+
+            emit_grab_cancelled_series(comicid, count=len(reverselist))
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] grab.cancelled @series emit skipped: %s" % e)
 
 
 def _finalize_ddl_download(item, ddzstat, release_key):
@@ -1377,10 +1377,18 @@ def ddl_downloader(queue):
                     )
                     existing = journal.read_one(rkey)
                     if existing and not journal.is_terminal(existing.get("stage")):
+                        # fail_reason is token-only; exception text is not
+                        # concatenated (#430 A5). Sanitised detail rides the
+                        # payload for diagnostics / narrative reason_detail.
+                        from comicarr.app.common.redaction import redact_sensitive_text
+
+                        fail_detail = redact_sensitive_text(str(e))[:1000]
+                        journal_payload = dict(item) if isinstance(item, dict) else {}
+                        journal_payload["fail_detail"] = fail_detail
                         journal.mark_failed(
                             rkey,
-                            fail_reason="ddl-worker-rejected: %s" % e,
-                            payload=item if isinstance(item, dict) else None,
+                            fail_reason="ddl-worker-rejected",
+                            payload=journal_payload,
                             issueid=issueid,
                             provider="DDL",
                             downloader_type="ddl",

--- a/comicarr/app/metadata/service.py
+++ b/comicarr/app/metadata/service.py
@@ -249,14 +249,18 @@ def _do_manual_metatag(issueid, comicid=None, group=False):
                 [issueid],
             )
             if not issuedata:
-                comicarr.GLOBAL_MESSAGES = {
-                    "status": "failure",
-                    "comicname": None,
-                    "seriesyear": None,
-                    "comicid": comicid,
-                    "tables": "both",
-                    "message": "Unable to locate corresponding issueid: %s" % issueid,
-                }
+                try:
+                    from comicarr.app.activity.producers import emit_tag_activity
+
+                    emit_tag_activity(
+                        "failed",
+                        issueid=issueid,
+                        comicid=comicid,
+                        reason_code="issue_not_found",
+                        reason_detail="Unable to locate corresponding issueid: %s" % issueid,
+                    )
+                except Exception as e:
+                    logger.fdebug("[ACTIVITY] tag.failed emit skipped: %s" % e)
                 return
 
         comversion = issuedata["ComicVersion"]
@@ -290,14 +294,18 @@ def _do_manual_metatag(issueid, comicid=None, group=False):
                 "%s %s does not exist in the given location. Cannot metatag this filename due to this."
                 % (module, filename)
             )
-            comicarr.GLOBAL_MESSAGES = {
-                "status": "failure",
-                "comicname": None,
-                "seriesyear": None,
-                "comicid": comicid,
-                "tables": "both",
-                "message": "Unable to locate corresponding filename: %s" % filename,
-            }
+            try:
+                from comicarr.app.activity.producers import emit_tag_activity
+
+                emit_tag_activity(
+                    "failed",
+                    issueid=issueid,
+                    comicid=comicid,
+                    reason_code="file_not_found",
+                    reason_detail="Unable to locate corresponding filename: %s" % filename,
+                )
+            except Exception as e:
+                logger.fdebug("[ACTIVITY] tag.failed emit skipped: %s" % e)
             return
 
         comicid = issuedata["ComicID"]
@@ -348,28 +356,39 @@ def _do_manual_metatag(issueid, comicid=None, group=False):
     dst_filename = None
     if metaresponse == "fail":
         logger.fdebug(module + " Unable to write metadata successfully - check comicarr.log file.")
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "failure",
-            "comicname": comicname,
-            "seriesyear": seriesyear,
-            "comicid": comicid,
-            "tables": "both",
-            "message": "Unable to write metadata - there were errors. Check the log files",
-        }
+        try:
+            from comicarr.app.activity.producers import emit_tag_activity
+
+            emit_tag_activity(
+                "failed",
+                issueid=issueid,
+                comicid=comicid,
+                comicname=comicname,
+                seriesyear=seriesyear,
+                reason_code="metadata_write_failed",
+            )
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] tag.failed emit skipped: %s" % e)
         return
     elif metaresponse == "unrar error":
         logger.error(
             module
             + " This is a corrupt archive - whether CRC errors or it is incomplete. Marking as BAD, and retrying a different copy."
         )
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "failure",
-            "comicname": comicname,
-            "seriesyear": seriesyear,
-            "comicid": comicid,
-            "tables": "both",
-            "message": "%s is a corrupt archive." % filename,
-        }
+        try:
+            from comicarr.app.activity.producers import emit_tag_activity
+
+            emit_tag_activity(
+                "failed",
+                issueid=issueid,
+                comicid=comicid,
+                comicname=comicname,
+                seriesyear=seriesyear,
+                reason_code="bad_archive",
+                reason_detail="%s is a corrupt archive." % filename,
+            )
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] tag.failed emit skipped: %s" % e)
         return
     else:
         dst_filename = os.path.split(metaresponse)[1]
@@ -432,26 +451,37 @@ def _do_manual_metatag(issueid, comicid=None, group=False):
                     except OSError:
                         pass
 
-    if all([group is False, fail is False]):
-        updater.forceRescan(comicid)
+    # Always narrate per-issue tag outcomes (group batch rollups deleted; #430 §3.2).
+    if fail is False:
         if group is False:
-            comicarr.GLOBAL_MESSAGES = {
-                "status": "success",
-                "comicname": comicname,
-                "seriesyear": seriesyear,
-                "comicid": comicid,
-                "tables": "both",
-                "message": "Successfully meta-tagged %s" % dst_filename,
-            }
-    elif all([group is False, fail is True]):
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "failure",
-            "comicname": comicname,
-            "seriesyear": seriesyear,
-            "comicid": comicid,
-            "tables": "both",
-            "message": "Metatagging was not successful for %s" % dst_filename,
-        }
+            updater.forceRescan(comicid)
+        try:
+            from comicarr.app.activity.producers import emit_tag_activity
+
+            emit_tag_activity(
+                "succeeded",
+                issueid=issueid,
+                comicid=comicid,
+                comicname=comicname,
+                seriesyear=seriesyear,
+            )
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] tag.succeeded emit skipped: %s" % e)
+    else:
+        try:
+            from comicarr.app.activity.producers import emit_tag_activity
+
+            emit_tag_activity(
+                "failed",
+                issueid=issueid,
+                comicid=comicid,
+                comicname=comicname,
+                seriesyear=seriesyear,
+                reason_code="metatag_copy_failed",
+                reason_detail="Metatagging was not successful for %s" % dst_filename,
+            )
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] tag.failed emit skipped: %s" % e)
 
 
 def _thread_bulk_meta(comicinfo, issueinfo):
@@ -463,18 +493,11 @@ def _thread_bulk_meta(comicinfo, issueinfo):
         "[SERIES-METATAGGER][%s (%s)] Finished (re)tagging of metadata for selected issues."
         % (comicinfo["ComicName"], comicinfo["ComicYear"])
     )
-    issueline = "%s issues" % len(issueinfo)
-    if len(issueinfo) == 1:
-        issueline = "1 issue"
-    comicarr.GLOBAL_MESSAGES = {
-        "status": "success",
-        "comicname": comicinfo["ComicName"],
-        "seriesyear": comicinfo["ComicYear"],
-        "comicid": comicinfo["ComicID"],
-        "tables": "both",
-        "message": "Finished (re)tagging of %s of %s (%s)"
-        % (issueline, comicinfo["ComicName"], comicinfo["ComicYear"]),
-    }
+    # Batch rollup deleted (#430 §3.2 / #484): per-issue tag.* rows already emit.
+    logger.info(
+        "[SERIES-METATAGGER] bulk complete for %s (%s) — %s issues"
+        % (comicinfo["ComicName"], comicinfo["ComicYear"], len(issueinfo))
+    )
 
 
 def _do_bulk_metatag(ComicID, IssueIDs, threaded=False, registry=None):
@@ -521,14 +544,20 @@ def _do_bulk_metatag(ComicID, IssueIDs, threaded=False, registry=None):
         logger.warn(
             "[SERIES-METATAGGER][%s (%s)] %s" % (comicinfo["ComicName"], comicinfo["ComicYear"], warningMessage)
         )
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "failure",
-            "comicname": cinfo["ComicName"],
-            "seriesyear": cinfo["ComicYear"],
-            "comicid": ComicID,
-            "tables": "both",
-            "message": warningMessage,
-        }
+        try:
+            from comicarr.app.activity.producers import emit_tag_activity
+
+            emit_tag_activity(
+                "failed",
+                comicid=ComicID,
+                comicname=cinfo["ComicName"],
+                seriesyear=cinfo["ComicYear"],
+                reason_code="cv_batch_limit",
+                reason_detail=warningMessage,
+                subject_level="series",
+            )
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] tag.failed @series emit skipped: %s" % e)
         return
 
     issueinfo = []
@@ -557,18 +586,7 @@ def _thread_group_meta(comicinfo, issueinfo):
         "[SERIES-METATAGGER][%s (%s)] Finished complete series (re)tagging of metadata."
         % (comicinfo["ComicName"], comicinfo["ComicYear"])
     )
-    issueline = "%s issues" % len(issueinfo)
-    if len(issueinfo) == 1:
-        issueline = "1 issue"
-    comicarr.GLOBAL_MESSAGES = {
-        "status": "success",
-        "comicname": comicinfo["ComicName"],
-        "seriesyear": comicinfo["ComicYear"],
-        "comicid": comicinfo["ComicID"],
-        "tables": "both",
-        "message": "Finished complete series (re)tagging of %s of %s (%s)"
-        % (issueline, comicinfo["ComicName"], comicinfo["ComicYear"]),
-    }
+    # Batch rollup deleted (#430 §3.2 / #484): per-issue tag.* rows already emit.
 
 
 def _do_group_metatag(ComicID, threaded=False, registry=None):
@@ -606,14 +624,20 @@ def _do_group_metatag(ComicID, threaded=False, registry=None):
         logger.warn(
             "[SERIES-METATAGGER][%s (%s)] %s" % (comicinfo["ComicName"], comicinfo["ComicYear"], warningMessage)
         )
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "failure",
-            "comicname": cinfo["ComicName"],
-            "seriesyear": cinfo["ComicYear"],
-            "comicid": ComicID,
-            "tables": "both",
-            "message": warningMessage,
-        }
+        try:
+            from comicarr.app.activity.producers import emit_tag_activity
+
+            emit_tag_activity(
+                "failed",
+                comicid=ComicID,
+                comicname=cinfo["ComicName"],
+                seriesyear=cinfo["ComicYear"],
+                reason_code="cv_batch_limit",
+                reason_detail=warningMessage,
+                subject_level="series",
+            )
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] tag.failed @series emit skipped: %s" % e)
         return
 
     issueinfo = []

--- a/comicarr/app/search/commands.py
+++ b/comicarr/app/search/commands.py
@@ -354,7 +354,7 @@ def replay_search_obligations(*, work_queue=None, ledger=None, maintenance=None)
             ledger.record_outcome(run_id, item["entity_type"], entity_id, ItemOutcome.QUARANTINED, reason=str(e))
             continue
         if item["state"] == ItemOutcome.RUNNING.value:
-            ledger.record_requeue(run_id, item["entity_type"], entity_id, reason="worker restart")
+            ledger.record_requeue(run_id, item["entity_type"], entity_id, reason="worker restart", replay=True)
         _put_with_maintenance_lease(command, work_queue, maintenance)
         ledger.record_item_dispatch(run_id, item["entity_type"], entity_id, DispatchState.ACCEPTED)
         ledger.record_dispatch(run_id, DispatchState.ACCEPTED)

--- a/comicarr/app/storyarcs/service.py
+++ b/comicarr/app/storyarcs/service.py
@@ -616,22 +616,20 @@ def _add_story_arc(
     _arc_watchlist(storyarcid)
     if arcrefresh:
         logger.info("%s Successfully Refreshed %s" % (module, storyarcname))
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "success",
-            "event": "storyarc_added",
-            "storyarcname": storyarcname,
-            "storyarcid": storyarcid,
-            "message": "Successfully refreshed %s" % storyarcname,
-        }
+        try:
+            from comicarr.app.activity.producers import emit_arc_activity
+
+            emit_arc_activity("refresh", "succeeded", storyarcid, storyarcname)
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] refresh.succeeded @arc emit skipped: %s" % e)
     else:
         logger.info("%s Successfully Added %s" % (module, storyarcname))
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "success",
-            "event": "storyarc_added",
-            "storyarcname": storyarcname,
-            "storyarcid": storyarcid,
-            "message": "Successfully added %s" % storyarcname,
-        }
+        try:
+            from comicarr.app.activity.producers import emit_arc_activity
+
+            emit_arc_activity("add", "succeeded", storyarcid, storyarcname)
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] add.succeeded @arc emit skipped: %s" % e)
 
 
 # ---------------------------------------------------------------------------

--- a/comicarr/failed.py
+++ b/comicarr/failed.py
@@ -372,20 +372,9 @@ class FailedProcessor(object):
                 issueid=issueid,
                 nzbname=nzbname,
             )
-            failed_msg = "%s (%s) #%s failed to download. Retrying the search but ignoring the bad result." % (
-                issuenzb["ComicName"],
-                issuenzb["ComicYear"],
-                issuenzb["Issue_Number"],
-            )
             logger.info(module + " Sending back to search to see if we can find something that will not fail.")
-            comicarr.GLOBAL_MESSAGES = {
-                "status": "failure",
-                "comicname": issuenzb["ComicName"],
-                "seriesyear": issuenzb["ComicYear"],
-                "comicid": comicid,
-                "tables": "tables",
-                "message": failed_msg,
-            }
+            # Narrative download.failed is emitted from journal.mark_failed when
+            # the terminalize won (#484); reason_code = FAIL_REASON_RESEARCHING.
             self._log("Sending back to search to see if we can find something better that will not fail.")
             self.valreturn.append(
                 {
@@ -408,19 +397,8 @@ class FailedProcessor(object):
                 issueid=issueid,
                 nzbname=nzbname,
             )
-            failed_msg = "%s (%s) #%s failed to download." % (
-                issuenzb["ComicName"],
-                issuenzb["ComicYear"],
-                issuenzb["Issue_Number"],
-            )
-            comicarr.GLOBAL_MESSAGES = {
-                "status": "failure",
-                "comicname": issuenzb["ComicName"],
-                "seriesyear": issuenzb["ComicYear"],
-                "comicid": comicid,
-                "tables": "tables",
-                "message": failed_msg,
-            }
+            # Narrative download.failed is emitted from journal.mark_failed when
+            # the terminalize won (#484); reason_code = FAIL_REASON_NO_AUTO_HANDLING.
             logger.info(
                 module + " Stopping search here as automatic handling of failed downloads is not enabled *hint*"
             )

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -107,46 +107,21 @@ def addvialist(seriesQueue, issueWantQueue):
             if item == "exit":
                 break
             seriesyear = item.get("seriesyear")
+            # In-flight mass-add progress is log-only (#427 / #484): completion
+            # narrates as add.succeeded when addComictoDB finishes.
             if item["comicname"] is not None:
                 if seriesyear is not None:
                     logger.info(
                         "[MASS-ADD][1/%s] Now adding %s (%s) [%s] "
                         % (seriesQueue.qsize() + 1, item["comicname"], seriesyear, item["comicid"])
                     )
-                    comicarr.GLOBAL_MESSAGES = {
-                        "status": "success",
-                        "event": "addbyid",
-                        "comicname": item["comicname"],
-                        "seriesyear": seriesyear,
-                        "comicid": item["comicid"],
-                        "tables": "None",
-                        "message": "Now adding %s (%s)" % (urllib.parse.unquote_plus(item["comicname"]), seriesyear),
-                    }
                 else:
                     logger.info(
                         "[MASS-ADD][1/%s] Now adding %s [%s] "
                         % (seriesQueue.qsize() + 1, item["comicname"], item["comicid"])
                     )
-                    comicarr.GLOBAL_MESSAGES = {
-                        "status": "success",
-                        "event": "addbyid",
-                        "comicname": item["comicname"],
-                        "seriesyear": seriesyear,
-                        "comicid": item["comicid"],
-                        "tables": "None",
-                        "message": "Now adding %s" % (urllib.parse.unquote_plus(item["comicname"])),
-                    }
             else:
                 logger.info("[MASS-ADD][1/%s] Now adding ComicID: %s " % (seriesQueue.qsize() + 1, item["comicid"]))
-                comicarr.GLOBAL_MESSAGES = {
-                    "status": "success",
-                    "event": "addbyid",
-                    "comicname": item["comicname"],
-                    "seriesyear": seriesyear,
-                    "comicid": item["comicid"],
-                    "tables": "None",
-                    "message": "Now adding via ComicID %s" % (item["comicid"]),
-                }
 
             if "suppress_addall" in item.keys():
                 addComictoDB(item["comicid"], suppress_addall=item["suppress_addall"])
@@ -747,15 +722,7 @@ def addComictoDB(
 
     db.upsert("comics", newValueDict, controlValueDict)
 
-    comicarr.GLOBAL_MESSAGES = {
-        "status": "mid-message-event",
-        "event": "addbyid",
-        "comicname": comic["ComicName"],
-        "seriesyear": SeriesYear,
-        "comicid": comicid,
-        "tables": "None",
-        "message": "mid-message-event",
-    }
+    # mid-message-event progress ping deleted (#430 / #484) — not narrated.
 
     # comicsort here...
     # run the re-sortorder here in order to properly display the page
@@ -1039,14 +1006,18 @@ def addComictoDB(
         return
 
     if calledfrom == "addbyid":
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "success",
-            "comicname": comic["ComicName"],
-            "seriesyear": SeriesYear,
-            "comicid": comicid,
-            "tables": "both",
-            "message": "Successfully added %s (%s)!" % (comic["ComicName"], SeriesYear),
-        }
+        try:
+            from comicarr.app.activity.producers import emit_series_activity
+
+            emit_series_activity(
+                "add",
+                "succeeded",
+                comicid,
+                comicname=comic["ComicName"],
+                seriesyear=SeriesYear,
+            )
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] add.succeeded emit skipped: %s" % e)
         logger.info(
             "Sucessfully added %s (%s) to the watchlist by directly using the ComicVine ID"
             % (comic["ComicName"], SeriesYear)
@@ -1056,14 +1027,18 @@ def addComictoDB(
         logger.info("Sucessfully added %s (%s) to the watchlist" % (comic["ComicName"], SeriesYear))
         return {"status": "complete", "comicname": comic["ComicName"], "year": SeriesYear}
     else:
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "success",
-            "comicname": comic["ComicName"],
-            "seriesyear": SeriesYear,
-            "comicid": comicid,
-            "tables": "both",
-            "message": "Successfully added %s (%s)!" % (comic["ComicName"], SeriesYear),
-        }
+        try:
+            from comicarr.app.activity.producers import emit_series_activity
+
+            emit_series_activity(
+                "add",
+                "succeeded",
+                comicid,
+                comicname=comic["ComicName"],
+                seriesyear=SeriesYear,
+            )
+        except Exception as e:
+            logger.fdebug("[ACTIVITY] add.succeeded emit skipped: %s" % e)
         logger.info("Sucessfully added %s (%s) to the watchlist" % (comic["ComicName"], SeriesYear))
         return {"status": "complete"}
 
@@ -3232,7 +3207,7 @@ def replay_refresh_obligations(*, ledger=None, start_worker=True, maintenance=No
             ledger.record_outcome(run_id, "series", entity_id, ItemOutcome.QUARANTINED, reason=str(e))
             continue
         if item["state"] == ItemOutcome.RUNNING.value:
-            ledger.record_requeue(run_id, "series", entity_id, reason="worker restart")
+            ledger.record_requeue(run_id, "series", entity_id, reason="worker restart", replay=True)
         queue_items.append({**payload, "run_id": run_id})
         replayed_run_ids.add(run_id)
     _handoff_refresh_items(queue_items, start_worker=start_worker, maintenance=maintenance)

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -3520,7 +3520,6 @@ class PostProcessor(object):
                     self.Process_next(comicid, issueid, issuenumOG, ml, stat)
                     dupthis = None
 
-            m_event = None
             if self.failed_files == 0:
                 if all([self.comicid is not None, self.issueid is None]):
                     try:
@@ -3580,12 +3579,7 @@ class PostProcessor(object):
                     else:
                         logger.info("%s Manual post-processing completed for %s issues." % (module, i))
                         global_line = "Manual post-processing completed for %s issues" % (i)
-                    m_event = "scheduler_message"
-                    dspcname = None
-                    dspcyear = None
             else:
-                dspcname = None
-                dspcyear = None
                 if self.comicid is not None:
                     logger.info(
                         "%s post-processing of pack completed for %s issues [FAILED: %s]"
@@ -3602,19 +3596,9 @@ class PostProcessor(object):
                     )
                     global_line = "Successfully post-processed %s issues [FAILED: %s]" % (i, self.failed_files)
 
-            d_line = {
-                "status": "success",
-                "comicid": self.comicid,
-                "comicname": dspcname,
-                "seriesyear": dspcyear,
-                "tables": "both",
-                "message": global_line,
-            }
-
-            if m_event is not None:
-                d_line["event"] = m_event
-
-            comicarr.GLOBAL_MESSAGES = d_line
+            # Batch rollup deleted (#430 §3.2 / #484): per-item import.* rows
+            # already emit from journal post_processed / related stages.
+            logger.fdebug("%s %s" % (module, global_line))
 
             if comicarr.APILOCK.locked():
                 comicarr.APILOCK.release()

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -113,19 +113,13 @@ def addvialist(queue, ledger=None, maintenance=None):
             )
             with lease_context as lease:
                 time.sleep(3)
+                # In-flight mass-refresh progress is log-only (#427 / #484);
+                # completion narrates as refresh.succeeded from dbUpdate.
                 if r_mode == "updateissuedata":
                     logger.info(
                         "[MASS-REFRESH][WEEKLY-UPDATER] Now updating series data for %s (%s) [%s] "
                         % (comicname, display_year, comicid)
                     )
-                    comicarr.GLOBAL_MESSAGES = {
-                        "status": "success",
-                        "comicname": comicname,
-                        "seriesyear": seriesyear,
-                        "comicid": comicid,
-                        "tables": "both",
-                        "message": "Now refreshing %s (%s)" % (comicname, display_year),
-                    }
                     worker_maintenance.assert_lease_current(lease)
                     comicarr.importer.updateissuedata(
                         comicid,
@@ -138,14 +132,6 @@ def addvialist(queue, ledger=None, maintenance=None):
                         "[MASS-REFRESH][WEEKLY-UPDATER][AnnualID:%s] Now updating series data for %s (%s) [%s] "
                         % (values["manual_comicid"], comicname, display_year, comicid)
                     )
-                    comicarr.GLOBAL_MESSAGES = {
-                        "status": "success",
-                        "comicname": comicname,
-                        "seriesyear": seriesyear,
-                        "comicid": comicid,
-                        "tables": "both",
-                        "message": "Now refreshing %s (%s)" % (comicname, display_year),
-                    }
                     worker_maintenance.assert_lease_current(lease)
                     comicarr.importer.manualAnnual(
                         values["manual_comicid"],
@@ -160,14 +146,6 @@ def addvialist(queue, ledger=None, maintenance=None):
                         "[MASS-REFRESH][1/%s] Now refreshing %s (%s) [%s] "
                         % (queue.qsize() + 1, comicname, display_year, comicid)
                     )
-                    comicarr.GLOBAL_MESSAGES = {
-                        "status": "success",
-                        "comicname": comicname,
-                        "seriesyear": seriesyear,
-                        "comicid": comicid,
-                        "tables": "both",
-                        "message": "Now refreshing %s (%s)" % (comicname, display_year),
-                    }
                     worker_maintenance.assert_lease_current(lease)
                     dbUpdate([comicid], calledfrom="refresh")
             if command_ledger and run_id:
@@ -363,27 +341,39 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                 logger.warn(
                     "There was an error when refreshing this series - Make sure directories are writable/exist, and check the logs for any errors/problems."
                 )
-                comicarr.GLOBAL_MESSAGES = {
-                    "status": "failure",
-                    "comicname": ComicName,
-                    "seriesyear": dspyear,
-                    "comicid": ComicID,
-                    "tables": "both",
-                    "message": "Failure refreshing %s (%s)" % (ComicName, dspyear),
-                }
+                try:
+                    from comicarr.app.activity.producers import emit_series_activity
+
+                    emit_series_activity(
+                        "refresh",
+                        "failed",
+                        ComicID,
+                        comicname=ComicName,
+                        seriesyear=dspyear,
+                        reason_code="refresh_failed",
+                    )
+                except Exception as emit_err:
+                    logger.fdebug("[ACTIVITY] refresh.failed emit skipped: %s" % emit_err)
                 return
             try:
                 forceRescan(ComicID)
             except Exception as e:
                 logger.error("[MANGA-REFRESH] forceRescan failed for %s: %s" % (ComicID, e))
-                comicarr.GLOBAL_MESSAGES = {
-                    "status": "failure",
-                    "comicname": ComicName,
-                    "seriesyear": dspyear,
-                    "comicid": ComicID,
-                    "tables": "both",
-                    "message": "Failure rescanning %s (%s) after refresh" % (ComicName, dspyear),
-                }
+                try:
+                    from comicarr.app.activity.producers import emit_series_activity
+                    from comicarr.app.common.redaction import redact_sensitive_text
+
+                    emit_series_activity(
+                        "refresh",
+                        "failed",
+                        ComicID,
+                        comicname=ComicName,
+                        seriesyear=dspyear,
+                        reason_code="rescan_failed",
+                        reason_detail=redact_sensitive_text(str(e))[:1000],
+                    )
+                except Exception as emit_err:
+                    logger.fdebug("[ACTIVITY] refresh.failed emit skipped: %s" % emit_err)
                 return
         elif not comicarr.CONFIG.CV_ONLY or ComicID[:1] == "G":
             # "exceptions" table is not in tables.py -- use text()
@@ -488,14 +478,19 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                         logger.warn(
                             "There was an error when refreshing this series - Make sure directories are writable/exist, and check the logs for any errors/problems."
                         )
-                        comicarr.GLOBAL_MESSAGES = {
-                            "status": "failure",
-                            "comicname": ComicName,
-                            "seriesyear": dspyear,
-                            "comicid": ComicID,
-                            "tables": "both",
-                            "message": "Failure refreshing %s (%s)" % (ComicName, dspyear),
-                        }
+                        try:
+                            from comicarr.app.activity.producers import emit_series_activity
+
+                            emit_series_activity(
+                                "refresh",
+                                "failed",
+                                ComicID,
+                                comicname=ComicName,
+                                seriesyear=dspyear,
+                                reason_code="refresh_failed",
+                            )
+                        except Exception as emit_err:
+                            logger.fdebug("[ACTIVITY] refresh.failed emit skipped: %s" % emit_err)
                         return
 
                     issues_new = db.select_all(select(issues).where(issues.c.ComicID == ComicID))
@@ -809,14 +804,18 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
             time.sleep(15)  # pause for 15 secs so dont hammer CV and get 500 error
         else:
             if calledfrom == "refresh":
-                comicarr.GLOBAL_MESSAGES = {
-                    "status": "success",
-                    "comicname": ComicName,
-                    "seriesyear": dspyear,
-                    "comicid": ComicID,
-                    "tables": "both",
-                    "message": "Successfully refreshed %s (%s)" % (ComicName, dspyear),
-                }
+                try:
+                    from comicarr.app.activity.producers import emit_series_activity
+
+                    emit_series_activity(
+                        "refresh",
+                        "succeeded",
+                        ComicID,
+                        comicname=ComicName,
+                        seriesyear=dspyear,
+                    )
+                except Exception as emit_err:
+                    logger.fdebug("[ACTIVITY] refresh.succeeded emit skipped: %s" % emit_err)
             break
 
     # helpers.job_management(write=True, job='DB Updater', last_run_completed=helpers.utctimestamp(), status='Waiting')
@@ -1397,12 +1396,10 @@ def foundsearch(
 
     logger.fdebug(module + " comicid: " + str(ComicID))
     logger.fdebug(module + " issueid: " + str(IssueID))
-    seriesyear = None
     if mode != "pullwant":
         if mode != "story_arc":
             comic = db.select_one(select(comics).where(comics.c.ComicID == ComicID))
             ComicName = comic["ComicName"]
-            seriesyear = comic["ComicYear"]
             if mode == "want_ann":
                 issue = db.select_one(select(annuals).where(annuals.c.IssueID == IssueID))
                 if ComicName != issue["ReleaseComicName"] + " Annual":
@@ -1528,19 +1525,9 @@ def foundsearch(
 
             db.upsert("oneoffhistory", newValue, ctlVal)
 
-        global_line = "Successfully snatched %s #%s" % (ComicName, IssueNum)
-        if IssueNum is None:
-            global_line = "Successfully snatched %s" % (ComicName)
-
         logger.info("%s Updated the status (Snatched) complete for %s Issue: %s" % (module, ComicName, IssueNum))
-        comicarr.GLOBAL_MESSAGES = {
-            "status": "success",
-            "comicname": ComicName,
-            "seriesyear": seriesyear,
-            "comicid": ComicID,
-            "tables": "tables",
-            "message": global_line,
-        }
+        # grab.succeeded is owned by the journal snatched transition (#430 /
+        # #484) — do not double-write GLOBAL_MESSAGES here.
 
         # --- Durable pipeline journal: snatched (U2) ---------------------------
         # STRICTLY LAST on this seam: every db.upsert("snatched"/"nzblog"/...)

--- a/tests/unit/test_activity_producers.py
+++ b/tests/unit/test_activity_producers.py
@@ -1,0 +1,284 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Activity producers (#484) — journal stages, run brackets, ledger hygiene.
+
+Seams under test:
+
+* ``record_activity`` via journal ``record_transition`` (won-gated)
+* ``emit_run_completion`` via ``RunLedger.reconcile`` / ``complete_empty_run``
+* ``record_outcome`` / ``record_requeue`` redaction + ``replay`` flag
+* ``fail_reason`` token-only at the DDL worker concatenating site
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+
+import comicarr
+from comicarr import db
+from comicarr.app.acquisition.models import ItemOutcome
+from comicarr.app.acquisition.runs import RunLedger
+from comicarr.app.downloads import journal
+from comicarr.tables import activity_events, comics, issues, metadata
+
+
+@pytest.fixture
+def activity_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+@pytest.fixture
+def mock_event_bus(monkeypatch):
+    bus = MagicMock(name="event_bus")
+    bus.publish_sync.return_value = True
+    runtime = SimpleNamespace(event_bus=bus, disposed=False)
+    monkeypatch.setattr(
+        "comicarr.app.activity.events.get_runtime_if_initialized",
+        lambda: runtime,
+    )
+    return bus
+
+
+def _seed_issue(engine, *, issueid="1001", comicid="C1", name="Saga", number="1"):
+    with engine.begin() as conn:
+        conn.execute(
+            comics.insert(),
+            {
+                "ComicID": comicid,
+                "ComicName": name,
+                "ComicYear": "2012",
+                "Status": "Active",
+            },
+        )
+        conn.execute(
+            issues.insert(),
+            {
+                "IssueID": issueid,
+                "ComicID": comicid,
+                "ComicName": name,
+                "Issue_Number": number,
+                "Status": "Wanted",
+            },
+        )
+
+
+def _events(engine):
+    with engine.connect() as conn:
+        return [
+            dict(row._mapping) for row in conn.execute(select(activity_events).order_by(activity_events.c.event_id))
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Journal stage → activity (won-gated)
+# ---------------------------------------------------------------------------
+
+
+def test_journal_snatched_emits_grab_succeeded(activity_db, mock_event_bus):
+    _seed_issue(activity_db)
+    rkey = journal.release_key("1001", "NZBGeek", nzbname="Saga.001")
+    won = journal.record_transition(
+        rkey,
+        journal.SNATCHED,
+        issueid="1001",
+        provider="NZBGeek",
+        nzbname="Saga.001",
+    )
+    assert won is True
+    rows = _events(activity_db)
+    assert len(rows) == 1
+    assert rows[0]["activity"] == "grab"
+    assert rows[0]["status"] == "succeeded"
+    assert rows[0]["subject_type"] == "issue"
+    assert rows[0]["subject_id"] == "1001"
+    assert rows[0]["provider"] == "NZBGeek"
+    assert rows[0]["release_key"] == rkey
+    mock_event_bus.publish_sync.assert_called()
+
+
+def test_journal_duplicate_transition_does_not_emit(activity_db, mock_event_bus):
+    _seed_issue(activity_db)
+    rkey = journal.release_key("1001", "NZBGeek", nzbname="Saga.001")
+    assert journal.record_transition(rkey, journal.SNATCHED, issueid="1001", provider="NZBGeek") is True
+    assert journal.record_transition(rkey, journal.SNATCHED, issueid="1001", provider="NZBGeek") is False
+    assert len(_events(activity_db)) == 1
+
+
+def test_journal_downloaded_and_post_processed_chain(activity_db, mock_event_bus):
+    _seed_issue(activity_db)
+    rkey = journal.release_key("1001", "DDL", nzbname="file.cbz")
+    assert journal.record_transition(rkey, journal.SNATCHED, issueid="1001", provider="DDL") is True
+    assert journal.record_transition(rkey, journal.DOWNLOADED, issueid="1001", provider="DDL") is True
+    assert journal.record_transition(rkey, journal.POST_PROCESSING, issueid="1001", provider="DDL") is True
+    assert journal.record_transition(rkey, journal.POST_PROCESSED, issueid="1001", provider="DDL") is True
+    acts = [(r["activity"], r["status"]) for r in _events(activity_db)]
+    assert ("grab", "succeeded") in acts
+    assert ("download", "succeeded") in acts
+    assert ("import", "started") in acts
+    assert ("import", "succeeded") in acts
+
+
+def test_journal_failed_early_is_download_failed(activity_db, mock_event_bus):
+    _seed_issue(activity_db)
+    rkey = journal.release_key("1001", "NZBGeek", nzbname="bad")
+    journal.record_transition(rkey, journal.SNATCHED, issueid="1001", provider="NZBGeek")
+    won = journal.mark_failed(rkey, "download_failed_no_auto_handling", issueid="1001", provider="NZBGeek")
+    assert won is True
+    fails = [r for r in _events(activity_db) if r["status"] == "failed"]
+    assert len(fails) == 1
+    assert fails[0]["activity"] == "download"
+    assert fails[0]["reason_code"] == "download_failed_no_auto_handling"
+
+
+def test_journal_failed_after_pp_is_import_failed(activity_db, mock_event_bus):
+    _seed_issue(activity_db)
+    rkey = journal.release_key("1001", "NZBGeek", nzbname="pp-bad")
+    journal.record_transition(rkey, journal.SNATCHED, issueid="1001", provider="NZBGeek")
+    journal.record_transition(rkey, journal.DOWNLOADED, issueid="1001", provider="NZBGeek")
+    journal.record_transition(rkey, journal.POST_PROCESSING, issueid="1001", provider="NZBGeek")
+    won = journal.mark_failed(rkey, "import_failed", issueid="1001", provider="NZBGeek")
+    assert won is True
+    fails = [r for r in _events(activity_db) if r["status"] == "failed"]
+    assert len(fails) == 1
+    assert fails[0]["activity"] == "import"
+
+
+# ---------------------------------------------------------------------------
+# Run completion brackets (not in-flight)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_run_narrates_nothing_to_search(activity_db, mock_event_bus):
+    ledger = RunLedger(activity_db)
+    ledger.create_run("empty-1", command_kind="search", trigger="manual_wanted_scan")
+    ledger.complete_empty_run("empty-1")
+    rows = _events(activity_db)
+    assert len(rows) == 1
+    assert rows[0]["activity"] == "search"
+    assert rows[0]["status"] == "succeeded"
+    assert rows[0]["subject_type"] == "run"
+    assert rows[0]["reason_code"] == "nothing_to_search"
+    assert "accepted" in (rows[0]["reason_detail"] or "")
+
+
+def test_reconcile_completion_narrates_once_with_counts(activity_db, mock_event_bus):
+    ledger = RunLedger(activity_db)
+    ledger.create_run("run-1", command_kind="search", trigger="manual")
+    ledger.accept_item("run-1", "issue", "a")
+    ledger.accept_item("run-1", "issue", "b")
+    # Still open — no completion narrative.
+    assert _events(activity_db) == []
+    ledger.record_outcome("run-1", "issue", "a", ItemOutcome.SUCCEEDED)
+    assert _events(activity_db) == []  # still running
+    ledger.record_outcome("run-1", "issue", "b", ItemOutcome.NO_MATCH)
+    rows = _events(activity_db)
+    assert len(rows) == 1
+    assert rows[0]["activity"] == "search"
+    assert rows[0]["status"] == "succeeded"
+    assert rows[0]["subject_type"] == "run"
+    detail = rows[0]["reason_detail"] or ""
+    assert '"accepted":2' in detail
+    assert '"grabbed":1' in detail
+    assert '"no_match":1' in detail
+    # Re-reconcile must not double-emit.
+    ledger.reconcile("run-1")
+    assert len(_events(activity_db)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Ledger hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_record_outcome_redacts_sensitive_reason(activity_db):
+    ledger = RunLedger(activity_db)
+    ledger.create_run("r-redact", command_kind="refresh", trigger="t")
+    ledger.accept_item(
+        "r-redact",
+        "series",
+        "S1",
+        payload={"comicid": "S1", "comicname": "X", "seriesyear": "2020"},
+    )
+    ledger.claim_item("r-redact", "series", "S1")
+    ledger.record_outcome(
+        "r-redact",
+        "series",
+        "S1",
+        ItemOutcome.FAILED,
+        reason="boom apikey=supersecretvalue123 Authorization: Bearer tokensecret99",
+    )
+    item = ledger.get_item("r-redact", "series", "S1")
+    assert item["reason"] is not None
+    assert "supersecretvalue123" not in item["reason"]
+    assert "tokensecret99" not in item["reason"]
+    assert "[redacted]" in item["reason"]
+
+
+def test_record_requeue_accepts_replay_flag(activity_db):
+    from comicarr.app.acquisition.runs import is_retry_pending
+
+    ledger = RunLedger(activity_db)
+    ledger.create_run("r-replay", command_kind="search", trigger="t")
+    ledger.accept_item("r-replay", "issue", "i1")
+    assert ledger.claim_item("r-replay", "issue", "i1") is True
+    item = ledger.record_requeue("r-replay", "issue", "i1", reason="worker restart", replay=True)
+    assert item["state"] == ItemOutcome.ACCEPTED.value
+    assert item["attempt_count"] == 1  # discriminator: accepted + attempt_count > 0
+    assert item.get("replay") is True
+    assert is_retry_pending(item) is True
+
+
+def test_ddl_fail_detail_survives_payload_sanitizer(activity_db, mock_event_bus):
+    """fail_detail must remain available for narrative reason_detail (#430 A5)."""
+    _seed_issue(activity_db)
+    rkey = journal.release_key("1001", "DDL", nzbname="x.cbz", discriminant="d1")
+    journal.record_transition(rkey, journal.SNATCHED, issueid="1001", provider="DDL")
+    from comicarr.app.common.redaction import redact_sensitive_text
+
+    detail = redact_sensitive_text("boom apikey=supersecretvalue123")
+    won = journal.mark_failed(
+        rkey,
+        "ddl-worker-rejected",
+        payload={"issueid": "1001", "provider": "DDL", "fail_detail": detail},
+        issueid="1001",
+        provider="DDL",
+    )
+    assert won is True
+    fails = [r for r in _events(activity_db) if r["status"] == "failed"]
+    assert len(fails) == 1
+    assert fails[0]["reason_code"] == "ddl-worker-rejected"
+    assert fails[0]["reason_detail"] is not None
+    assert "supersecretvalue123" not in fails[0]["reason_detail"]
+    assert "[redacted]" in fails[0]["reason_detail"]
+
+
+# ---------------------------------------------------------------------------
+# fail_reason token-only
+# ---------------------------------------------------------------------------
+
+
+def test_ddl_worker_fail_reason_is_token_only():
+    """The concatenating site must not embed exception text in fail_reason."""
+    import inspect
+
+    from comicarr.app.downloads import service as downloads_service
+
+    src = inspect.getsource(downloads_service)
+    assert 'fail_reason="ddl-worker-rejected"' in src
+    assert 'fail_reason="ddl-worker-rejected: %s"' not in src

--- a/tests/unit/test_importer_addvialist.py
+++ b/tests/unit/test_importer_addvialist.py
@@ -25,15 +25,13 @@ def _run_single_item(series_queue, issue_queue, item):
     """Process one queue item then exit the addvialist loop."""
     series_queue.put(item)
     series_queue.put("exit")
-    captured_messages = None
 
     with patch("comicarr.importer.addComictoDB") as mock_add:
         with patch("comicarr.importer.time.sleep"):
             with patch.object(comicarr, "ADD_LIST", queue.Queue()):
                 addvialist(series_queue, issue_queue)
-                captured_messages = comicarr.GLOBAL_MESSAGES
 
-    return mock_add, captured_messages
+    return mock_add
 
 
 class TestAddvialistSeriesyear:
@@ -42,7 +40,7 @@ class TestAddvialistSeriesyear:
         issue_queue = queue.Queue()
         item = {"comicid": "12345", "comicname": None}
 
-        mock_add, _messages = _run_single_item(series_queue, issue_queue, item)
+        mock_add = _run_single_item(series_queue, issue_queue, item)
 
         mock_add.assert_called_once_with("12345")
 
@@ -51,19 +49,20 @@ class TestAddvialistSeriesyear:
         issue_queue = queue.Queue()
         item = {"comicid": "12345", "comicname": "Spider-Man"}
 
-        mock_add, _messages = _run_single_item(series_queue, issue_queue, item)
+        mock_add = _run_single_item(series_queue, issue_queue, item)
 
         mock_add.assert_called_once_with("12345")
 
     def test_comicname_with_seriesyear(self):
+        """In-flight mass-add no longer writes GLOBAL_MESSAGES (#484); seriesyear is passed through."""
         series_queue = queue.Queue()
         issue_queue = queue.Queue()
         item = {"comicid": "12345", "comicname": "Spider-Man", "seriesyear": "2020"}
 
-        mock_add, messages = _run_single_item(series_queue, issue_queue, item)
+        mock_add = _run_single_item(series_queue, issue_queue, item)
 
         mock_add.assert_called_once_with("12345")
-        assert messages["seriesyear"] == "2020"
+        assert item["seriesyear"] == "2020"
 
 
 class TestAddComicPayloads:

--- a/tests/unit/test_manga_refresh_regressions.py
+++ b/tests/unit/test_manga_refresh_regressions.py
@@ -70,12 +70,13 @@ class TestDbUpdateMangaShortCircuit:
         monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
         monkeypatch.setattr(comicarr, "IMPORTLOCK", False, raising=False)
         monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(CV_ONLY=True, CV_ONETIMER=1), raising=False)
-        monkeypatch.setattr(comicarr, "GLOBAL_MESSAGES", {}, raising=False)
 
         mock_add = MagicMock(return_value={"status": "complete", "comicid": "mal-161890", "content_type": "manga"})
         mock_rescan = MagicMock()
+        mock_emit = MagicMock(return_value={"event_id": 1})
         monkeypatch.setattr(comicarr.importer, "addComictoDB", mock_add)
         monkeypatch.setattr(updater, "forceRescan", mock_rescan)
+        monkeypatch.setattr("comicarr.app.activity.producers.emit_series_activity", mock_emit)
 
         updater.dbUpdate(["mal-161890"], calledfrom="refresh")
 
@@ -83,7 +84,8 @@ class TestDbUpdateMangaShortCircuit:
         # then re-matches files via forceRescan -- never the CV delete-and-reload path.
         mock_add.assert_called_once_with("mal-161890", "no")
         mock_rescan.assert_called_once_with("mal-161890")
-        assert comicarr.GLOBAL_MESSAGES["status"] == "success"
+        mock_emit.assert_called()
+        assert mock_emit.call_args[0][:2] == ("refresh", "succeeded")
 
 
 class TestForceRescanNullIssueDate:
@@ -444,15 +446,17 @@ class TestMangaRefreshForceRescanErrors:
         monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
         monkeypatch.setattr(comicarr, "IMPORTLOCK", False, raising=False)
         monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(CV_ONLY=True, CV_ONETIMER=1), raising=False)
-        monkeypatch.setattr(comicarr, "GLOBAL_MESSAGES", {}, raising=False)
         monkeypatch.setattr(
             comicarr.importer,
             "addComictoDB",
             MagicMock(return_value={"status": "complete", "comicid": "mal-161890"}),
         )
         monkeypatch.setattr(updater, "forceRescan", MagicMock(side_effect=RuntimeError("disk gone")))
+        mock_emit = MagicMock(return_value={"event_id": 1})
+        monkeypatch.setattr("comicarr.app.activity.producers.emit_series_activity", mock_emit)
 
         updater.dbUpdate(["mal-161890"], calledfrom="refresh")
 
-        assert comicarr.GLOBAL_MESSAGES["status"] == "failure"
-        assert "rescanning" in comicarr.GLOBAL_MESSAGES["message"].lower()
+        mock_emit.assert_called()
+        assert mock_emit.call_args[0][:2] == ("refresh", "failed")
+        assert mock_emit.call_args.kwargs.get("reason_code") == "rescan_failed"


### PR DESCRIPTION
## TLDR

Production seams now write Activity Center narrative events through the `record_activity` facade, and every production `GLOBAL_MESSAGES` write is converted or deleted in the same change so the timeline feed reflects real library work.

## Description

- Emit legal activity cells from won `pipeline_journal` stage advances and search run completion brackets (past tense with counts; in-flight progress stays derived)
- Convert or delete production `GLOBAL_MESSAGES` sites: add/refresh/tag/arc/grab.cancelled and download failures; drop rollups and mid-progress pings
- Ledger hygiene: redact `record_outcome`/`record_requeue` reasons, `record_requeue(replay=…)`, token-only `fail_reason` at the DDL concatenating site, no `retrying` rows

Closes #484

## Test plan

- [x] `uv run pytest tests/unit -q` (2040 passed)
- [x] Focused producer/journal/ledger tests
- [x] `ruff check` / format on touched files