### PR TITLE
fix: Pin data table pagination to the bottom of the viewport

### DIFF
--- a/.changeset/table-footer-pinned-to-viewport.md
+++ b/.changeset/table-footer-pinned-to-viewport.md
@@ -1,0 +1,7 @@
+---
+"comicarr": patch
+---
+
+Pagination controls on Library, Search, Wanted, and Activity now stay on the bottom edge of the window. The rows scroll inside the table while the page header, filters, and the pager stay in place, so moving to the next page no longer means scrolling to the end of the list first.
+
+Every table now shares one footer: it reads `21–40 of 143` so you can see where you are in the results rather than just how many there are, and single-page tables drop the pager instead of showing prev and next greyed out.

--- a/frontend/src/components/activity/timeline/TimelineView.tsx
+++ b/frontend/src/components/activity/timeline/TimelineView.tsx
@@ -239,11 +239,14 @@ export function TimelineView({
   }
 
   return (
-    <>
+    // The page column is viewport-bounded, so the band and the filters stay
+    // put and only the feed scrolls — the pager below it stays reachable
+    // without scrolling to the end of the timeline.
+    <div className="flex h-full min-h-0 flex-col">
       <AttentionBand items={bandItems} />
 
       {scoped && (
-        <div className="flex items-center gap-2 border-b border-border px-5 py-2 font-mono text-[11px] text-muted-foreground">
+        <div className="flex shrink-0 items-center gap-2 border-b border-border px-5 py-2 font-mono text-[11px] text-muted-foreground">
           <span>
             Scoped to {scope_type}:{scope_id}
           </span>
@@ -253,7 +256,7 @@ export function TimelineView({
         </div>
       )}
 
-      <div className="flex items-center gap-3 border-b border-border px-5 py-2.5">
+      <div className="flex shrink-0 items-center gap-3 border-b border-border px-5 py-2.5">
         <div className="max-w-sm flex-1">
           <FilterField
             placeholder="Filter timeline…"
@@ -284,7 +287,11 @@ export function TimelineView({
         </select>
       </div>
 
-      <div role="feed" aria-label="Activity timeline">
+      <div
+        role="feed"
+        aria-label="Activity timeline"
+        className="flex-1 min-h-0 overflow-auto"
+      >
         {pageNodes.map((story, index) => {
           const prev = pageNodes[index - 1];
           const showDay =
@@ -362,7 +369,7 @@ export function TimelineView({
       </div>
 
       {(filtered.length > 0 || hasMoreEvents) && (
-        <div className="flex items-center gap-3 px-5 py-2.5">
+        <div className="flex shrink-0 items-center gap-3 border-t border-border px-5 py-2.5">
           <span className="font-mono text-[10px] text-muted-foreground">
             {filtered.length === 0
               ? "0 stories"
@@ -407,9 +414,9 @@ export function TimelineView({
           </div>
         </div>
       )}
-      <p className="px-5 pb-4 font-mono text-[10px] text-muted-foreground">
+      <p className="shrink-0 px-5 pb-4 font-mono text-[10px] text-muted-foreground">
         older than 90 days is deleted · see download history for the full ledger
       </p>
-    </>
+    </div>
   );
 }

--- a/frontend/src/components/data-table/DataTable.tsx
+++ b/frontend/src/components/data-table/DataTable.tsx
@@ -39,7 +39,10 @@ export function DataTable<TData>({
               {headerGroup.headers.map((header) => (
                 <TableHead
                   key={header.id}
-                  className="px-5 py-2 font-mono text-[10px] font-normal text-muted-foreground/70 uppercase tracking-wider"
+                  // Sticky per-cell rather than on <thead>: the page scrolls
+                  // the table body now, and an opaque background is needed so
+                  // rows do not show through the header as they pass under it.
+                  className="sticky top-0 z-10 bg-background px-5 py-2 font-mono text-[10px] font-normal text-muted-foreground/70 uppercase tracking-wider"
                   style={
                     header.column.getSize() !== 150
                       ? { width: header.column.getSize() }

--- a/frontend/src/components/data-table/DataTableFooter.tsx
+++ b/frontend/src/components/data-table/DataTableFooter.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+/**
+ * The one pagination rail for every table in the app.
+ *
+ * It reads as the bottom counterpart of the omni status bar: same card
+ * surface, same hairline, same lowercase mono voice. Position on the left,
+ * movement on the right. Client-paginated tables pass the numbers directly;
+ * server-paginated ones go through `DataTableServerPagination`, which is a
+ * thin adapter over this.
+ */
+interface DataTableFooterProps {
+  /** 1-based index of the first row on this page. */
+  start: number;
+  /** 1-based index of the last row on this page. */
+  end: number;
+  /** Rows in the whole (filtered) set, not just this page. */
+  total: number;
+  /** 1-based page number. */
+  page: number;
+  /** Total pages. The pager is hidden when there is only one. */
+  pageCount: number;
+  onPrevPage: () => void;
+  onNextPage: () => void;
+  /** Extra state for the left rail, e.g. `3 selected`. */
+  notes?: ReactNode;
+}
+
+const PAGE_BUTTON =
+  "inline-flex items-center gap-1 rounded-[5px] border border-border px-2 py-1 transition-colors hover:text-foreground hover:border-muted-foreground/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-40";
+
+export function DataTableFooter({
+  start,
+  end,
+  total,
+  page,
+  pageCount,
+  onPrevPage,
+  onNextPage,
+  notes,
+}: DataTableFooterProps) {
+  return (
+    <div className="shrink-0 flex items-center gap-2 border-t border-border bg-card px-5 py-1.5 font-mono text-[11px] text-muted-foreground">
+      <span className="tabular-nums">
+        {total === 0 ? "no rows" : `${start}–${end} of ${total}`}
+      </span>
+      {notes != null && (
+        <>
+          <span aria-hidden="true" className="text-muted-foreground/40">
+            ·
+          </span>
+          <span>{notes}</span>
+        </>
+      )}
+      {pageCount > 1 && (
+        <nav
+          aria-label="Pagination"
+          className="ml-auto flex items-center gap-2"
+        >
+          <button
+            type="button"
+            aria-label="Previous page"
+            className={PAGE_BUTTON}
+            onClick={onPrevPage}
+            disabled={page <= 1}
+          >
+            <ChevronLeft className="w-3 h-3" aria-hidden="true" />
+            prev
+          </button>
+          <span className="px-1 tabular-nums">
+            page {page} of {pageCount}
+          </span>
+          <button
+            type="button"
+            aria-label="Next page"
+            className={PAGE_BUTTON}
+            onClick={onNextPage}
+            disabled={page >= pageCount}
+          >
+            next
+            <ChevronRight className="w-3 h-3" aria-hidden="true" />
+          </button>
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/data-table/DataTableServerPagination.tsx
+++ b/frontend/src/components/data-table/DataTableServerPagination.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/components/ui/button";
+import { DataTableFooter } from "@/components/data-table/DataTableFooter";
 import type { PaginationMeta } from "@/types";
 
 interface DataTableServerPaginationProps {
@@ -7,37 +7,30 @@ interface DataTableServerPaginationProps {
   onPrevPage: () => void;
 }
 
+/**
+ * Adapter: turns an API `pagination` block into the shared table footer, so a
+ * server-paginated table reads exactly like a client-paginated one.
+ */
 export function DataTableServerPagination({
   pagination,
   onNextPage,
   onPrevPage,
 }: DataTableServerPaginationProps) {
-  const start = pagination.offset + 1;
-  const end = Math.min(pagination.offset + pagination.limit, pagination.total);
+  const { total, offset } = pagination;
+  // A zero limit would only come from a malformed response, but it must not
+  // divide the page maths by zero.
+  const limit = pagination.limit || 1;
+  const returned = pagination.returned ?? Math.min(limit, total - offset);
 
   return (
-    <div className="border-t border-card-border px-6 py-3 flex items-center justify-between bg-muted/50">
-      <div className="text-sm text-muted-foreground">
-        Showing {start} to {end} of {pagination.total}
-      </div>
-      <div className="flex items-center space-x-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onPrevPage}
-          disabled={pagination.offset === 0}
-        >
-          Previous
-        </Button>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onNextPage}
-          disabled={!pagination.has_more}
-        >
-          Next
-        </Button>
-      </div>
-    </div>
+    <DataTableFooter
+      start={total === 0 ? 0 : offset + 1}
+      end={offset + Math.max(0, returned)}
+      total={total}
+      page={Math.floor(offset / limit) + 1}
+      pageCount={Math.max(1, Math.ceil(total / limit))}
+      onPrevPage={onPrevPage}
+      onNextPage={onNextPage}
+    />
   );
 }

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -38,11 +38,19 @@ export default function Layout({ children }: LayoutProps) {
   const mock = isMockEnabled();
 
   return (
-    <SidebarProvider>
+    // The shell is exactly one viewport tall and never scrolls itself: the
+    // status bar stays put and each page owns its own scroll region, so a
+    // table's pagination footer can sit on the bottom edge of the viewport
+    // without fixed/absolute positioning. Full-bleed pages must therefore be
+    // `h-full flex flex-col` with a `flex-1 min-h-0 overflow-auto` body —
+    // anything they render outside that body is clipped, not scrolled.
+    <SidebarProvider className="h-svh overflow-hidden">
       <AppSidebar />
-      <main className="flex-1 min-w-0">
+      {/* No height of its own: as a flex item it stretches to the shell's
+          height, so the column below is bounded by the viewport. */}
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col">
         {/* Mobile header with trigger - only visible on mobile */}
-        <header className="sticky top-0 z-10 flex h-16 items-center gap-4 border-b bg-background px-4 md:hidden">
+        <header className="z-10 flex h-16 shrink-0 items-center gap-4 border-b bg-background px-4 md:hidden">
           <SidebarTrigger />
           <span className="text-lg font-bold gradient-brand">Comicarr</span>
           {showAiBell && (
@@ -59,7 +67,7 @@ export default function Layout({ children }: LayoutProps) {
         </header>
 
         {/* Desktop omni status bar */}
-        <div className="hidden md:flex h-12 items-center gap-3 border-b-[0.5px] border-border bg-card px-4 font-mono text-[11px] text-muted-foreground">
+        <div className="hidden md:flex h-12 shrink-0 items-center gap-3 border-b-[0.5px] border-border bg-card px-4 font-mono text-[11px] text-muted-foreground">
           <SidebarTrigger />
           <AppStatusBar />
           <div className="ml-auto flex items-center gap-3">
@@ -89,8 +97,11 @@ export default function Layout({ children }: LayoutProps) {
           </div>
         </div>
 
-        {/* Main content area */}
-        <div className="flex-1 overflow-auto min-w-0">
+        {/* Main content area. Full-bleed pages scroll internally so their
+            footers can stay on the viewport edge; centred pages scroll here. */}
+        <div
+          className={`flex-1 min-h-0 min-w-0 ${fullBleed ? "overflow-hidden" : "overflow-auto"}`}
+        >
           {fullBleed ? (
             children
           ) : (

--- a/frontend/src/components/layout/PageHeader.tsx
+++ b/frontend/src/components/layout/PageHeader.tsx
@@ -19,7 +19,7 @@ export default function PageHeader({
 }: PageHeaderProps) {
   return (
     <div
-      className={`px-5 py-3.5 border-b border-border flex items-center gap-3 ${className}`}
+      className={`shrink-0 px-5 py-3.5 border-b border-border flex items-center gap-3 ${className}`}
     >
       <div className="min-w-0">
         <div className="text-[18px] font-semibold tracking-tight leading-none">
@@ -54,7 +54,7 @@ export function TabRow({ children, ariaLabel }: TabRowProps) {
     <div
       role="group"
       aria-label={ariaLabel ?? "View toggles"}
-      className="px-5 pt-3 border-b border-border flex items-end gap-6"
+      className="shrink-0 px-5 pt-3 border-b border-border flex items-end gap-6"
     >
       {children}
     </div>

--- a/frontend/src/components/queue/WantedTable.tsx
+++ b/frontend/src/components/queue/WantedTable.tsx
@@ -30,11 +30,14 @@ export default function WantedTable({
   }
 
   return (
-    <div>
-      <DataTable
-        table={table}
-        onRowClick={(row) => navigate(`/library/${row.ComicID}`)}
-      />
+    // Fills the page column: rows scroll, the pager stays on the bottom edge.
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex-1 min-h-0 overflow-auto">
+        <DataTable
+          table={table}
+          onRowClick={(row) => navigate(`/library/${row.ComicID}`)}
+        />
+      </div>
       {pagination && onNextPage && onPrevPage && (
         <DataTableServerPagination
           pagination={pagination}

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -316,12 +316,13 @@ export default function SearchResultsTable({
 
   return (
     <div>
-      {/* Header */}
+      {/* Header — sticky inside the page's results scroll region. */}
       <div
-        className="grid items-center gap-3 px-5 py-2 font-mono text-[10px] tracking-[0.08em] uppercase border-b"
+        className="sticky top-0 z-10 grid items-center gap-3 px-5 py-2 font-mono text-[10px] tracking-[0.08em] uppercase border-b"
         style={{
           gridTemplateColumns: GRID,
           borderColor: "var(--border)",
+          background: "var(--background)",
           color: "var(--text-muted)",
         }}
       >

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -36,6 +36,7 @@ import {
   useTableState,
   type TableStore,
 } from "@/components/data-table/useTableState";
+import { DataTableFooter } from "@/components/data-table/DataTableFooter";
 import { useTableUrlStore } from "@/components/data-table/tableUrlStore";
 import { getProgressPercentage, getProgressCategory } from "@/lib/series-utils";
 import {
@@ -307,7 +308,7 @@ export default function SeriesTable({
   return (
     <div className="flex flex-col h-full min-h-0">
       {/* Unified action bar: view · search · filters · results */}
-      <div className="px-5 py-2 border-b border-border flex flex-wrap items-center gap-2 min-h-[44px]">
+      <div className="shrink-0 px-5 py-2 border-b border-border flex flex-wrap items-center gap-2 min-h-[44px]">
         <div className="inline-flex shrink-0 rounded-md border border-border overflow-hidden">
           <button
             type="button"
@@ -377,7 +378,7 @@ export default function SeriesTable({
 
       {/* Bulk action bar */}
       {!isGridView && selectedSeriesIds.length > 0 && (
-        <div className="px-5 py-2 border-b border-border flex items-center gap-3 bg-primary/5">
+        <div className="shrink-0 px-5 py-2 border-b border-border flex items-center gap-3 bg-primary/5">
           <span className="text-xs font-medium">
             {selectedSeriesIds.length} selected
           </span>
@@ -498,46 +499,27 @@ export default function SeriesTable({
                 ))
               )}
             </div>
-
-            {/* Footer */}
-            <div className="sticky bottom-0 z-10 px-5 py-1.5 border-t border-border bg-muted/30 flex items-center gap-3 font-mono text-[10px] text-muted-foreground">
-              <span>
-                {pageRows.length} of {totalFiltered} shown
-              </span>
-              {selectedSeriesIds.length > 0 && (
-                <>
-                  <span className="text-muted-foreground/50">·</span>
-                  <span>{selectedSeriesIds.length} selected</span>
-                </>
-              )}
-              {pageCount > 1 && (
-                <>
-                  <span className="text-muted-foreground/50">·</span>
-                  <span>
-                    page {effectivePage + 1} of {pageCount}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => table.previousPage()}
-                    disabled={!table.getCanPreviousPage()}
-                    className="px-1 hover:text-foreground disabled:opacity-40"
-                  >
-                    prev
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => table.nextPage()}
-                    disabled={!table.getCanNextPage()}
-                    className="px-1 hover:text-foreground disabled:opacity-40"
-                  >
-                    next
-                  </button>
-                </>
-              )}
-            </div>
           </div>
         </div>
       )}
+
+      {/* Footer — a sibling of the scroll region rather than a sticky child, so
+          it sits on the bottom edge of the viewport for both views and does not
+          ride the list's horizontal scroll. */}
+      <DataTableFooter
+        start={pageRows.length === 0 ? 0 : effectivePage * pageSize + 1}
+        end={effectivePage * pageSize + pageRows.length}
+        total={totalFiltered}
+        page={effectivePage + 1}
+        pageCount={pageCount}
+        onPrevPage={() => table.previousPage()}
+        onNextPage={() => table.nextPage()}
+        notes={
+          selectedSeriesIds.length > 0
+            ? `${selectedSeriesIds.length} selected`
+            : undefined
+        }
+      />
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -378,7 +378,7 @@ export async function apiRequest<T = unknown>(
   body?: object | null,
 ): Promise<T> {
   if (isMockEnabled()) {
-    const mocked = mockApiResponse(method, path);
+    const mocked = mockApiResponse(method, path, body);
     if (mocked !== undefined) {
       return mocked as T;
     }

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -272,7 +272,32 @@ function coverToComic(c: MockCover): Comic {
   };
 }
 
-const SERIES: Comic[] = COVERS.map(coverToComic);
+/**
+ * Twelve hand-written covers are not enough rows to page through, and the
+ * paginated views (Library, Search, Activity) are exactly what needs eyeballing
+ * when their footers change. Each cover is repeated as numbered volumes with an
+ * id of `${coverId}--v${n}`, which `resolveCoverId` maps back so detail pages
+ * still resolve.
+ */
+const VOLUMES_PER_COVER = 8;
+
+const LIBRARY: Comic[] = COVERS.flatMap((c) =>
+  Array.from({ length: VOLUMES_PER_COVER }, (_, i) => {
+    const base = coverToComic(c);
+    if (i === 0) return base;
+    return {
+      ...base,
+      ComicID: `${c.id}--v${i + 1}`,
+      ComicName: `${c.title} Vol. ${i + 1}`,
+      ComicYear: String(c.year + i),
+    };
+  }),
+).sort((a, b) => a.ComicName.localeCompare(b.ComicName));
+
+/** Strip the synthetic volume suffix so padded rows share a cover's detail. */
+function resolveCoverId(id: string): string {
+  return id.replace(/--v\d+$/, "");
+}
 
 function buildIssues(c: MockCover): Issue[] {
   const arcs =
@@ -441,9 +466,9 @@ function wantedIssues(): WantedIssue[] {
 }
 
 function dashboardPayload() {
-  const totalSeries = SERIES.length;
-  const totalIssues = SERIES.reduce((sum, s) => sum + (s.Have || 0), 0);
-  const totalExpected = SERIES.reduce((sum, s) => sum + (s.Total || 0), 0);
+  const totalSeries = LIBRARY.length;
+  const totalIssues = LIBRARY.reduce((sum, s) => sum + (s.Have || 0), 0);
+  const totalExpected = LIBRARY.reduce((sum, s) => sum + (s.Total || 0), 0);
   return {
     recently_downloaded: recentDownloads(),
     active_queue: [],
@@ -462,9 +487,10 @@ function dashboardPayload() {
 }
 
 function seriesDetail(id: string) {
-  const cover = COVERS.find((c) => c.id === id);
+  const coverId = resolveCoverId(id);
+  const cover = COVERS.find((c) => c.id === coverId);
   if (!cover) return null;
-  const issues = ISSUES_BY_COMIC.get(id) || [];
+  const issues = ISSUES_BY_COMIC.get(coverId) || [];
   return {
     comic: coverToComic(cover),
     issues,
@@ -512,13 +538,103 @@ export function isMockEnabled(): boolean {
 // there's no real backend to keep it.
 let mockAuthenticated = true;
 
+/** Provider search results. Enough of them to page through. */
+function searchResults(query: string, kind: "comic" | "manga") {
+  const pool = COVERS.filter((c) => c.kind === kind);
+  const source = kind === "manga" ? "mangadex" : "comicvine";
+  const q = query.trim().toLowerCase();
+  const all = Array.from({ length: 143 }, (_, i) => {
+    const c = pool[i % pool.length];
+    const volume = Math.floor(i / pool.length) + 1;
+    return {
+      id: `${c.id}-search-${i}`,
+      comicid: `${c.id}-search-${i}`,
+      name: volume === 1 ? c.title : `${c.title} Vol. ${volume}`,
+      publisher: c.publisher,
+      start_year: String(c.year + volume - 1),
+      comicyear: String(c.year + volume - 1),
+      count_of_issues: c.total + volume,
+      deck: c.description,
+      comicimage: coverSvgDataUri(c, 80, 120),
+      metadata_source: source,
+      url: `https://example.invalid/${c.id}`,
+      in_library: i % 7 === 0,
+    };
+  }).filter((r) => !q || r.name.toLowerCase().includes(q));
+  return all;
+}
+
+/** Queue and history rows for Activity, derived from the mock library. */
+function queueItems() {
+  return COVERS.flatMap((c, index) =>
+    Array.from({ length: 4 }, (_, n) => {
+      const issue = c.have + n + 1;
+      return {
+        ID: `${c.id}-q${n}`,
+        series: c.title,
+        year: String(c.year),
+        filename: `${c.title.replace(/\s+/g, ".")}.${String(issue).padStart(3, "0")}.cbz`,
+        size: `${28 + ((index * 7 + n * 3) % 40)} MB`,
+        issueid: `${c.id}-${issue}`,
+        comicid: c.id,
+        link: `https://example.invalid/${c.id}/${issue}`,
+        status: ["Snatched", "Downloading", "Post-Processing", "Failed"][n],
+        remote_filesize: `${28 + ((index * 7 + n * 3) % 40)} MB`,
+        updated_date: new Date(2026, 6, 20 - n, 12 - n).toISOString(),
+        site: n % 2 === 0 ? "NZBgeek" : "Torznab",
+        submit_date: new Date(2026, 6, 20 - n, 10 - n).toISOString(),
+      };
+    }),
+  );
+}
+
+function historyItems() {
+  return COVERS.flatMap((c, index) =>
+    Array.from({ length: 6 }, (_, n) => {
+      const issue = Math.max(1, c.have - n);
+      return {
+        IssueID: `${c.id}-${issue}`,
+        ComicName: c.title,
+        Issue_Number: String(issue),
+        Size: (30 + ((index + n) % 25)) * 1024 * 1024,
+        DateAdded: new Date(2026, 6, 28 - n, 9 + (index % 8)).toISOString(),
+        Status: n % 5 === 0 ? "Failed" : "Post-Processed",
+        FolderName: `/comics/${c.title}`,
+        ComicID: c.id,
+        Provider: n % 2 === 0 ? "NZBgeek (Prowlarr)" : "Torznab",
+      };
+    }),
+  );
+}
+
+/** Slice a mock collection the way the paginated endpoints do. */
+function paginate<T>(all: T[], parsed: URL) {
+  const limit = Number(parsed.searchParams.get("limit") ?? 50);
+  const offset = Number(parsed.searchParams.get("offset") ?? 0);
+  const rows = all.slice(offset, offset + limit);
+  return {
+    rows,
+    pagination: {
+      total: all.length,
+      limit,
+      offset,
+      returned: rows.length,
+      has_more: offset + rows.length < all.length,
+    },
+  };
+}
+
 /**
  * Match an incoming request to a mock payload. Returns `undefined` to signal
  * "no mock for this endpoint — fall through to the real backend".
+ *
+ * `body` is the request body of a write — the search endpoints take their
+ * query and page window there rather than in the URL.
  */
 export function mockApiResponse(
   method: string,
   path: string,
+  body?: object | null,
 ): unknown | undefined {
   const parsed = new URL(path, "http://mock.local");
   const url = parsed.pathname;
@@ -560,7 +676,7 @@ export function mockApiResponse(
     return dashboardPayload();
   }
   if (m === "GET" && url === "/api/series") {
-    return SERIES;
+    return LIBRARY;
   }
   if (m === "GET" && url === "/api/wanted") {
     const q = (parsed.searchParams.get("q") ?? "").trim().toLowerCase();
@@ -610,9 +726,46 @@ export function mockApiResponse(
     return [];
   }
   if (m === "GET" && url === "/api/downloads/queue") {
+    const q = (parsed.searchParams.get("q") ?? "").trim().toLowerCase();
+    const all = queueItems().filter(
+      (item) => !q || item.series.toLowerCase().includes(q),
+    );
+    const { rows, pagination } = paginate(all, parsed);
+    return { queue: rows, pagination };
+  }
+  if (m === "GET" && url === "/api/downloads/history") {
+    const q = (parsed.searchParams.get("q") ?? "").trim().toLowerCase();
+    const all = historyItems().filter(
+      (item) => !q || item.ComicName.toLowerCase().includes(q),
+    );
+    const { rows, pagination } = paginate(all, parsed);
+    return { history: rows, pagination };
+  }
+  if (
+    m === "POST" &&
+    (url === "/api/search/comics" || url === "/api/search/manga")
+  ) {
+    const search = (body ?? {}) as {
+      name?: string;
+      limit?: number;
+      offset?: number;
+    };
+    const all = searchResults(
+      search.name ?? "",
+      url.endsWith("manga") ? "manga" : "comic",
+    );
+    const limit = search.limit ?? 20;
+    const offset = search.offset ?? 0;
+    const results = all.slice(offset, offset + limit);
     return {
-      queue: [],
-      pagination: { total: 0, limit: 1, offset: 0, has_more: false },
+      results,
+      pagination: {
+        total: all.length,
+        limit,
+        offset,
+        returned: results.length,
+        has_more: offset + results.length < all.length,
+      },
     };
   }
   if (m === "GET" && url === "/api/config") {
@@ -628,14 +781,14 @@ export function mockApiResponse(
 
   const issuesMatch = url.match(/^\/api\/series\/([^/]+)\/issues$/);
   if (m === "GET" && issuesMatch) {
-    return ISSUES_BY_COMIC.get(issuesMatch[1]) || [];
+    return ISSUES_BY_COMIC.get(resolveCoverId(issuesMatch[1])) || [];
   }
 
   // Cover art — return a tiny transparent gif; frontend already falls back
   // gracefully, and the list views synthesize their own SVG covers.
   const artMatch = url.match(/^\/api\/metadata\/art\/([^/]+)$/);
   if (m === "GET" && artMatch) {
-    const cover = COVERS.find((c) => c.id === artMatch[1]);
+    const cover = COVERS.find((c) => c.id === resolveCoverId(artMatch[1]));
     if (cover) return { image: coverSvgDataUri(cover) };
   }
 

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -135,7 +135,7 @@ export default function ActivityPage() {
         : "download history";
 
   return (
-    <div className="page-transition">
+    <div className="page-transition flex h-full min-h-0 flex-col">
       <PageHeader title="Activity" meta={meta} />
 
       <TabRow>
@@ -156,11 +156,13 @@ export default function ActivityPage() {
         />
       </TabRow>
 
-      {currentView === "timeline" && (
-        <TimelineView scope_type={scope_type} scope_id={scope_id} />
-      )}
-      {currentView === "queue" && <QueueView />}
-      {currentView === "history" && <HistoryView />}
+      <div className="flex-1 min-h-0 flex flex-col">
+        {currentView === "timeline" && (
+          <TimelineView scope_type={scope_type} scope_id={scope_id} />
+        )}
+        {currentView === "queue" && <QueueView />}
+        {currentView === "history" && <HistoryView />}
+      </div>
     </div>
   );
 }
@@ -181,7 +183,7 @@ function ActivityToolbar({
   onRefresh: () => void;
 }) {
   return (
-    <div className="px-5 py-2.5 border-b border-border flex items-center gap-3">
+    <div className="shrink-0 px-5 py-2.5 border-b border-border flex items-center gap-3">
       <div className="flex-1 max-w-lg">
         <FilterField
           placeholder={placeholder}
@@ -350,8 +352,10 @@ function ActivityTableView<TData>({
         </div>
       )}
       {!isLoading && !error && pagination && rows.length > 0 && (
-        <div className="overflow-hidden border-b border-border">
-          <DataTable table={table} />
+        <div className="flex-1 min-h-0 flex flex-col border-b border-border">
+          <div className="flex-1 min-h-0 overflow-auto">
+            <DataTable table={table} />
+          </div>
           <DataTableServerPagination
             pagination={pagination}
             onNextPage={onNextPage}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -225,274 +225,279 @@ export default function DashboardPage() {
         </div>
       </div>
 
-      {/* KPI strip */}
-      <div className="grid grid-cols-2 lg:grid-cols-4 border-b border-border">
-        <Kpi
-          label="Active series"
-          value={isLoading ? "—" : String(activeSeries)}
-        />
-        <Kpi
-          label="Issues"
-          value={isLoading ? "—" : String(totalIssues)}
-          borderLeft
-        />
-        <Kpi
-          label="Completion"
-          value={isLoading ? "—" : `${completion.toFixed(1)}%`}
-          borderLeft
-        />
-        <Kpi label="Queue" value={String(queueCount)} borderLeft />
-      </div>
+      {/* Everything below the ask bar scrolls inside the page column. */}
+      <div className="flex-1 min-h-0 overflow-auto">
+        {/* KPI strip */}
+        <div className="grid grid-cols-2 lg:grid-cols-4 border-b border-border">
+          <Kpi
+            label="Active series"
+            value={isLoading ? "—" : String(activeSeries)}
+          />
+          <Kpi
+            label="Issues"
+            value={isLoading ? "—" : String(totalIssues)}
+            borderLeft
+          />
+          <Kpi
+            label="Completion"
+            value={isLoading ? "—" : `${completion.toFixed(1)}%`}
+            borderLeft
+          />
+          <Kpi label="Queue" value={String(queueCount)} borderLeft />
+        </div>
 
-      {/* Operational summaries */}
-      <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] border-b border-border min-h-[320px]">
-        {/* Active queue and recent history */}
-        <section className="px-5 py-4 lg:border-r lg:border-border">
-          <div className="flex items-center justify-between gap-3 mb-3">
-            <div className="flex items-center gap-2.5">
-              <div className="text-[13px] font-semibold">Active queue</div>
-              <div className="font-mono text-[10px] text-muted-foreground tracking-wider uppercase">
-                {queueCount} item{queueCount === 1 ? "" : "s"}
-              </div>
-            </div>
-            <Link
-              to="/activity"
-              className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
-            >
-              open queue →
-            </Link>
-          </div>
-
-          {isLoading && (
-            <div className="font-mono text-[11px] text-muted-foreground py-3">
-              loading queue…
-            </div>
-          )}
-
-          {!isLoading && activeQueue.length === 0 && (
-            <div className="font-mono text-[11px] text-muted-foreground py-3">
-              queue is clear
-            </div>
-          )}
-
-          <div className="font-mono text-[11px]">
-            {activeQueue.map((item, index) => (
-              <div
-                key={item.ID}
-                className="grid items-center gap-2 py-1.5"
-                style={{
-                  gridTemplateColumns: "minmax(140px, 1fr) 100px 120px",
-                  borderTop:
-                    index > 0
-                      ? "1px solid var(--border-soft, var(--border))"
-                      : "none",
-                }}
-              >
-                <div className="min-w-0">
-                  <div className="font-sans text-foreground truncate">
-                    {item.series || item.filename || "Unnamed download"}
-                  </div>
-                  {item.filename && item.filename !== item.series && (
-                    <div className="text-muted-foreground truncate">
-                      {item.filename}
-                    </div>
-                  )}
-                </div>
-                <QueueStatus status={item.status} />
-                <span className="text-muted-foreground truncate text-right">
-                  {item.updated_date ? (
-                    <RelativeTime value={item.updated_date} />
-                  ) : (
-                    "—"
-                  )}
-                </span>
-              </div>
-            ))}
-          </div>
-
-          <div className="mt-5 pt-4 border-t border-border">
+        {/* Operational summaries */}
+        <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] border-b border-border min-h-[320px]">
+          {/* Active queue and recent history */}
+          <section className="px-5 py-4 lg:border-r lg:border-border">
             <div className="flex items-center justify-between gap-3 mb-3">
               <div className="flex items-center gap-2.5">
-                <div className="text-[13px] font-semibold">Recent activity</div>
+                <div className="text-[13px] font-semibold">Active queue</div>
                 <div className="font-mono text-[10px] text-muted-foreground tracking-wider uppercase">
-                  {downloads.length} event{downloads.length === 1 ? "" : "s"} ·
-                  30 days
+                  {queueCount} item{queueCount === 1 ? "" : "s"}
                 </div>
               </div>
               <Link
-                to="/activity?view=history"
+                to="/activity"
                 className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
               >
-                open history →
+                open queue →
+              </Link>
+            </div>
+
+            {isLoading && (
+              <div className="font-mono text-[11px] text-muted-foreground py-3">
+                loading queue…
+              </div>
+            )}
+
+            {!isLoading && activeQueue.length === 0 && (
+              <div className="font-mono text-[11px] text-muted-foreground py-3">
+                queue is clear
+              </div>
+            )}
+
+            <div className="font-mono text-[11px]">
+              {activeQueue.map((item, index) => (
+                <div
+                  key={item.ID}
+                  className="grid items-center gap-2 py-1.5"
+                  style={{
+                    gridTemplateColumns: "minmax(140px, 1fr) 100px 120px",
+                    borderTop:
+                      index > 0
+                        ? "1px solid var(--border-soft, var(--border))"
+                        : "none",
+                  }}
+                >
+                  <div className="min-w-0">
+                    <div className="font-sans text-foreground truncate">
+                      {item.series || item.filename || "Unnamed download"}
+                    </div>
+                    {item.filename && item.filename !== item.series && (
+                      <div className="text-muted-foreground truncate">
+                        {item.filename}
+                      </div>
+                    )}
+                  </div>
+                  <QueueStatus status={item.status} />
+                  <span className="text-muted-foreground truncate text-right">
+                    {item.updated_date ? (
+                      <RelativeTime value={item.updated_date} />
+                    ) : (
+                      "—"
+                    )}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-5 pt-4 border-t border-border">
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <div className="flex items-center gap-2.5">
+                  <div className="text-[13px] font-semibold">
+                    Recent activity
+                  </div>
+                  <div className="font-mono text-[10px] text-muted-foreground tracking-wider uppercase">
+                    {downloads.length} event{downloads.length === 1 ? "" : "s"}{" "}
+                    · 30 days
+                  </div>
+                </div>
+                <Link
+                  to="/activity?view=history"
+                  className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
+                >
+                  open history →
+                </Link>
+              </div>
+
+              {isLoading && (
+                <div className="font-mono text-[11px] text-muted-foreground py-4">
+                  loading recent activity…
+                </div>
+              )}
+
+              {!isLoading && downloads.length === 0 && (
+                <div className="font-mono text-[11px] text-muted-foreground py-4">
+                  no activity in the last 30 days —{" "}
+                  <Link
+                    to="/activity?view=history"
+                    className="hover:text-foreground"
+                  >
+                    open full history
+                  </Link>
+                </div>
+              )}
+
+              <div className="font-mono text-[11px]">
+                {downloads.slice(0, 5).map((d, i) => {
+                  const action = d.Status?.toLowerCase() || "—";
+                  const color = action.includes("down")
+                    ? "var(--chart-4)"
+                    : action.includes("post") || action.includes("import")
+                      ? "var(--status-active)"
+                      : action.includes("snatch") || action.includes("queue")
+                        ? "var(--status-paused)"
+                        : "var(--muted-foreground)";
+                  return (
+                    <div
+                      key={`${d.ComicID}-${d.IssueID}-${i}`}
+                      className="grid items-center gap-2 py-1.5"
+                      style={{
+                        gridTemplateColumns:
+                          "120px 90px minmax(180px, 1fr) 140px",
+                        borderTop:
+                          i > 0
+                            ? "1px solid var(--border-soft, var(--border))"
+                            : "none",
+                      }}
+                    >
+                      <RelativeTime value={d.DateAdded} />
+                      <span className="uppercase truncate" style={{ color }}>
+                        {action}
+                      </span>
+                      <div className="flex items-center gap-2 min-w-0">
+                        {d.ComicID && (
+                          <img
+                            src={`/api/metadata/art/${d.ComicID}`}
+                            alt=""
+                            className="w-4 h-6 object-cover rounded-[1px] shrink-0"
+                            onError={(e) => {
+                              e.currentTarget.style.visibility = "hidden";
+                            }}
+                          />
+                        )}
+                        <Link
+                          to={`/library/${d.ComicID}`}
+                          className="font-sans text-foreground truncate hover:text-[var(--primary)]"
+                        >
+                          {d.ComicName} #{d.Issue_Number}
+                        </Link>
+                      </div>
+                      <span className="text-muted-foreground truncate">
+                        {d.Provider || "—"}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </section>
+
+          {/* This week */}
+          <section className="px-5 py-4">
+            <div className="flex items-center justify-between gap-3 mb-3">
+              <div className="flex items-center gap-2.5">
+                <div className="text-[13px] font-semibold">This week</div>
+                <div className="font-mono text-[10px] text-muted-foreground tracking-wider uppercase">
+                  {upcoming.length} releases
+                </div>
+              </div>
+              <Link
+                to="/releases?view=mine"
+                className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
+              >
+                view mine →
               </Link>
             </div>
 
             {isLoading && (
               <div className="font-mono text-[11px] text-muted-foreground py-4">
-                loading recent activity…
+                loading releases…
               </div>
             )}
 
-            {!isLoading && downloads.length === 0 && (
+            {!isLoading && upcoming.length === 0 && (
               <div className="font-mono text-[11px] text-muted-foreground py-4">
-                no activity in the last 30 days —{" "}
-                <Link
-                  to="/activity?view=history"
-                  className="hover:text-foreground"
-                >
-                  open full history
-                </Link>
+                nothing upcoming this week
               </div>
             )}
 
-            <div className="font-mono text-[11px]">
-              {downloads.slice(0, 5).map((d, i) => {
-                const action = d.Status?.toLowerCase() || "—";
-                const color = action.includes("down")
-                  ? "var(--chart-4)"
-                  : action.includes("post") || action.includes("import")
-                    ? "var(--status-active)"
-                    : action.includes("snatch") || action.includes("queue")
-                      ? "var(--status-paused)"
-                      : "var(--muted-foreground)";
-                return (
-                  <div
-                    key={`${d.ComicID}-${d.IssueID}-${i}`}
-                    className="grid items-center gap-2 py-1.5"
-                    style={{
-                      gridTemplateColumns:
-                        "120px 90px minmax(180px, 1fr) 140px",
-                      borderTop:
-                        i > 0
-                          ? "1px solid var(--border-soft, var(--border))"
-                          : "none",
-                    }}
+            {upcoming.slice(0, 6).map((u, i) => (
+              <div
+                key={`${u.ComicID}-${u.IssueNumber}-${i}`}
+                className="flex items-center gap-2.5 py-2.5"
+                style={{
+                  borderTop:
+                    i > 0
+                      ? "1px solid var(--border-soft, var(--border))"
+                      : "none",
+                }}
+              >
+                <div className="font-mono text-[10px] text-muted-foreground w-12 shrink-0">
+                  {u.IssueDate?.slice(5) || "—"}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <Link
+                    to={`/library/${u.ComicID}`}
+                    className="text-[12px] truncate block hover:text-[var(--primary)]"
                   >
-                    <RelativeTime value={d.DateAdded} />
-                    <span className="uppercase truncate" style={{ color }}>
-                      {action}
-                    </span>
-                    <div className="flex items-center gap-2 min-w-0">
-                      {d.ComicID && (
-                        <img
-                          src={`/api/metadata/art/${d.ComicID}`}
-                          alt=""
-                          className="w-4 h-6 object-cover rounded-[1px] shrink-0"
-                          onError={(e) => {
-                            e.currentTarget.style.visibility = "hidden";
-                          }}
-                        />
-                      )}
-                      <Link
-                        to={`/library/${d.ComicID}`}
-                        className="font-sans text-foreground truncate hover:text-[var(--primary)]"
-                      >
-                        {d.ComicName} #{d.Issue_Number}
-                      </Link>
-                    </div>
-                    <span className="text-muted-foreground truncate">
-                      {d.Provider || "—"}
-                    </span>
+                    {u.ComicName}
+                  </Link>
+                  <div className="font-mono text-[10px] text-muted-foreground">
+                    #{u.IssueNumber}
                   </div>
-                );
-              })}
-            </div>
-          </div>
-        </section>
-
-        {/* This week */}
-        <section className="px-5 py-4">
-          <div className="flex items-center justify-between gap-3 mb-3">
-            <div className="flex items-center gap-2.5">
-              <div className="text-[13px] font-semibold">This week</div>
-              <div className="font-mono text-[10px] text-muted-foreground tracking-wider uppercase">
-                {upcoming.length} releases
-              </div>
-            </div>
-            <Link
-              to="/releases?view=mine"
-              className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
-            >
-              view mine →
-            </Link>
-          </div>
-
-          {isLoading && (
-            <div className="font-mono text-[11px] text-muted-foreground py-4">
-              loading releases…
-            </div>
-          )}
-
-          {!isLoading && upcoming.length === 0 && (
-            <div className="font-mono text-[11px] text-muted-foreground py-4">
-              nothing upcoming this week
-            </div>
-          )}
-
-          {upcoming.slice(0, 6).map((u, i) => (
-            <div
-              key={`${u.ComicID}-${u.IssueNumber}-${i}`}
-              className="flex items-center gap-2.5 py-2.5"
-              style={{
-                borderTop:
-                  i > 0
-                    ? "1px solid var(--border-soft, var(--border))"
-                    : "none",
-              }}
-            >
-              <div className="font-mono text-[10px] text-muted-foreground w-12 shrink-0">
-                {u.IssueDate?.slice(5) || "—"}
-              </div>
-              <div className="flex-1 min-w-0">
-                <Link
-                  to={`/library/${u.ComicID}`}
-                  className="text-[12px] truncate block hover:text-[var(--primary)]"
-                >
-                  {u.ComicName}
-                </Link>
+                </div>
                 <div className="font-mono text-[10px] text-muted-foreground">
-                  #{u.IssueNumber}
+                  {u.Status || "auto"}
                 </div>
               </div>
-              <div className="font-mono text-[10px] text-muted-foreground">
-                {u.Status || "auto"}
-              </div>
-            </div>
-          ))}
+            ))}
 
-          <div className="mt-4 p-3 rounded-[6px] border border-border bg-card">
-            <div className="flex items-center justify-between gap-2 mb-1.5">
-              <div className="mono-label">Recent chats</div>
-              <Link
-                to="/chat"
-                className="font-mono text-[10px] text-primary hover:underline"
-              >
-                all →
-              </Link>
-            </div>
-            {recentChats.length === 0 ? (
-              <div className="font-mono text-[11px] text-muted-foreground py-1">
-                no saved chats yet
-              </div>
-            ) : (
-              recentChats.map((thread) => (
+            <div className="mt-4 p-3 rounded-[6px] border border-border bg-card">
+              <div className="flex items-center justify-between gap-2 mb-1.5">
+                <div className="mono-label">Recent chats</div>
                 <Link
-                  key={thread.id}
-                  to={`/chat/${thread.id}`}
-                  className="block px-2 py-1.5 -mx-1 rounded-[6px] hover:bg-accent"
+                  to="/chat"
+                  className="font-mono text-[10px] text-primary hover:underline"
                 >
-                  <div className="text-[12px] font-medium truncate">
-                    {thread.title}
-                  </div>
-                  <div className="mono-meta text-[10px]">
-                    {thread.message_count} msgs ·{" "}
-                    <RelativeTime value={thread.updated_at} />
-                  </div>
+                  all →
                 </Link>
-              ))
-            )}
-          </div>
-        </section>
+              </div>
+              {recentChats.length === 0 ? (
+                <div className="font-mono text-[11px] text-muted-foreground py-1">
+                  no saved chats yet
+                </div>
+              ) : (
+                recentChats.map((thread) => (
+                  <Link
+                    key={thread.id}
+                    to={`/chat/${thread.id}`}
+                    className="block px-2 py-1.5 -mx-1 rounded-[6px] hover:bg-accent"
+                  >
+                    <div className="text-[12px] font-medium truncate">
+                      {thread.title}
+                    </div>
+                    <div className="mono-meta text-[10px]">
+                      {thread.message_count} msgs ·{" "}
+                      <RelativeTime value={thread.updated_at} />
+                    </div>
+                  </Link>
+                ))
+              )}
+            </div>
+          </section>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/ImportPage.tsx
+++ b/frontend/src/pages/ImportPage.tsx
@@ -283,13 +283,14 @@ export default function ImportPage() {
   const importDirectoryConfigured = Boolean(appConfig?.import_dir);
 
   return (
-    <div className="page-transition">
+    <div className="page-transition flex h-full min-h-0 flex-col">
       <PageHeader
         title="Import"
         meta={isLoading ? "loading…" : pendingReviewMeta}
       />
 
-      <div className="px-5 py-5 space-y-8">
+      {/* Import stacks several sections, so the whole body scrolls as one. */}
+      <div className="flex-1 min-h-0 overflow-auto px-5 py-5 space-y-8">
         {/* Pending */}
         <section>
           <SectionHeader

--- a/frontend/src/pages/IssueDetailPage.tsx
+++ b/frontend/src/pages/IssueDetailPage.tsx
@@ -116,119 +116,122 @@ export default function IssueDetailPage() {
         </span>
       </nav>
 
-      <div className="grid gap-7 border-b px-5 py-6 md:grid-cols-[140px_minmax(0,1fr)]">
-        <div
-          className="aspect-[2/3] w-[112px] overflow-hidden rounded-[5px] border md:w-[140px]"
-          style={{
-            borderColor: "var(--border)",
-            background:
-              "color-mix(in oklab, var(--muted-foreground) 8%, transparent)",
-          }}
-        >
-          {imageUrl ? (
-            <img
-              src={imageUrl}
-              alt={title}
-              className="h-full w-full object-cover"
-              onError={(event) => {
-                event.currentTarget.style.display = "none";
-              }}
-            />
-          ) : null}
-        </div>
-
-        <div className="min-w-0 space-y-3">
-          <div className="flex flex-wrap items-center gap-2 font-mono text-[10px] uppercase tracking-[0.08em]">
-            {number ? (
-              <span style={{ color: "var(--muted-foreground)" }}>
-                Issue {number}
-              </span>
-            ) : null}
-            <StatusBadge status={status} />
-          </div>
-
-          <h1
-            className="text-[28px] font-bold leading-tight tracking-[-0.02em]"
-            data-testid="issue-detail-title"
+      {/* The breadcrumb stays; the issue body scrolls under it. */}
+      <div className="flex-1 min-h-0 overflow-auto">
+        <div className="grid gap-7 border-b px-5 py-6 md:grid-cols-[140px_minmax(0,1fr)]">
+          <div
+            className="aspect-[2/3] w-[112px] overflow-hidden rounded-[5px] border md:w-[140px]"
+            style={{
+              borderColor: "var(--border)",
+              background:
+                "color-mix(in oklab, var(--muted-foreground) 8%, transparent)",
+            }}
           >
-            {title}
-          </h1>
-
-          <p
-            className="font-mono text-[11px]"
-            style={{ color: "var(--muted-foreground)" }}
-            data-testid="issue-detail-ids"
-          >
-            series:{comicId} · issue:{issueId}
-          </p>
-
-          {issueId ? (
-            <div className="pt-1">
-              <Link
-                to={`/activity?scope_type=issue&scope_id=${encodeURIComponent(issueId)}`}
-                className="inline-flex items-center gap-1.5 rounded-[5px] border px-3 py-1.5 text-[12px] font-semibold transition-colors hover:text-foreground"
-                style={{
-                  borderColor: "var(--border)",
-                  color: "var(--muted-foreground)",
+            {imageUrl ? (
+              <img
+                src={imageUrl}
+                alt={title}
+                className="h-full w-full object-cover"
+                onError={(event) => {
+                  event.currentTarget.style.display = "none";
                 }}
-                aria-label="View activity for this issue"
-              >
-                <Activity className="h-3.5 w-3.5" />
-                Activity
-              </Link>
-            </div>
-          ) : null}
-        </div>
-      </div>
+              />
+            ) : null}
+          </div>
 
-      <div className="px-5 py-6">
-        <dl className="grid max-w-2xl gap-4 sm:grid-cols-2">
-          <div>
-            <dt
-              className="font-mono text-[10px] uppercase tracking-[0.08em]"
-              style={{ color: "var(--muted-foreground)" }}
+          <div className="min-w-0 space-y-3">
+            <div className="flex flex-wrap items-center gap-2 font-mono text-[10px] uppercase tracking-[0.08em]">
+              {number ? (
+                <span style={{ color: "var(--muted-foreground)" }}>
+                  Issue {number}
+                </span>
+              ) : null}
+              <StatusBadge status={status} />
+            </div>
+
+            <h1
+              className="text-[28px] font-bold leading-tight tracking-[-0.02em]"
+              data-testid="issue-detail-title"
             >
-              Series
-            </dt>
-            <dd className="mt-1 text-sm">
-              <Link
-                to={`/library/${comicId}`}
-                className="text-primary hover:underline"
+              {title}
+            </h1>
+
+            <p
+              className="font-mono text-[11px]"
+              style={{ color: "var(--muted-foreground)" }}
+              data-testid="issue-detail-ids"
+            >
+              series:{comicId} · issue:{issueId}
+            </p>
+
+            {issueId ? (
+              <div className="pt-1">
+                <Link
+                  to={`/activity?scope_type=issue&scope_id=${encodeURIComponent(issueId)}`}
+                  className="inline-flex items-center gap-1.5 rounded-[5px] border px-3 py-1.5 text-[12px] font-semibold transition-colors hover:text-foreground"
+                  style={{
+                    borderColor: "var(--border)",
+                    color: "var(--muted-foreground)",
+                  }}
+                  aria-label="View activity for this issue"
+                >
+                  <Activity className="h-3.5 w-3.5" />
+                  Activity
+                </Link>
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="px-5 py-6">
+          <dl className="grid max-w-2xl gap-4 sm:grid-cols-2">
+            <div>
+              <dt
+                className="font-mono text-[10px] uppercase tracking-[0.08em]"
+                style={{ color: "var(--muted-foreground)" }}
               >
-                {seriesName}
-              </Link>
-            </dd>
-          </div>
-          <div>
-            <dt
-              className="font-mono text-[10px] uppercase tracking-[0.08em]"
-              style={{ color: "var(--muted-foreground)" }}
-            >
-              Status
-            </dt>
-            <dd className="mt-1 text-sm">{field(status)}</dd>
-          </div>
-          <div>
-            <dt
-              className="font-mono text-[10px] uppercase tracking-[0.08em]"
-              style={{ color: "var(--muted-foreground)" }}
-            >
-              Release date
-            </dt>
-            <dd className="mt-1 font-mono text-sm">{field(releaseDate)}</dd>
-          </div>
-          <div>
-            <dt
-              className="font-mono text-[10px] uppercase tracking-[0.08em]"
-              style={{ color: "var(--muted-foreground)" }}
-            >
-              Location
-            </dt>
-            <dd className="mt-1 break-all font-mono text-sm">
-              {field(location)}
-            </dd>
-          </div>
-        </dl>
+                Series
+              </dt>
+              <dd className="mt-1 text-sm">
+                <Link
+                  to={`/library/${comicId}`}
+                  className="text-primary hover:underline"
+                >
+                  {seriesName}
+                </Link>
+              </dd>
+            </div>
+            <div>
+              <dt
+                className="font-mono text-[10px] uppercase tracking-[0.08em]"
+                style={{ color: "var(--muted-foreground)" }}
+              >
+                Status
+              </dt>
+              <dd className="mt-1 text-sm">{field(status)}</dd>
+            </div>
+            <div>
+              <dt
+                className="font-mono text-[10px] uppercase tracking-[0.08em]"
+                style={{ color: "var(--muted-foreground)" }}
+              >
+                Release date
+              </dt>
+              <dd className="mt-1 font-mono text-sm">{field(releaseDate)}</dd>
+            </div>
+            <div>
+              <dt
+                className="font-mono text-[10px] uppercase tracking-[0.08em]"
+                style={{ color: "var(--muted-foreground)" }}
+              >
+                Location
+              </dt>
+              <dd className="mt-1 break-all font-mono text-sm">
+                {field(location)}
+              </dd>
+            </div>
+          </dl>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -188,9 +188,9 @@ export default function ReleasesPage() {
   };
 
   return (
-    <div className="page-transition">
+    <div className="page-transition flex h-full min-h-0 flex-col">
       {/* Header */}
-      <div className="px-5 py-3.5 border-b border-border flex items-center justify-between gap-3">
+      <div className="shrink-0 px-5 py-3.5 border-b border-border flex items-center justify-between gap-3">
         <div>
           <div className="text-[18px] font-semibold tracking-tight leading-none">
             Releases
@@ -227,7 +227,7 @@ export default function ReleasesPage() {
         <div
           role={weeklyStatus === "error" ? "alert" : "status"}
           aria-live={weeklyStatus === "error" ? "assertive" : "polite"}
-          className="px-5 py-2 border-b border-border font-mono text-[11px]"
+          className="shrink-0 px-5 py-2 border-b border-border font-mono text-[11px]"
           style={{
             color:
               weeklyStatus === "error"
@@ -244,7 +244,7 @@ export default function ReleasesPage() {
       )}
 
       {/* Tab row */}
-      <div className="px-5 pt-3 border-b border-border flex items-end gap-6">
+      <div className="shrink-0 px-5 pt-3 border-b border-border flex items-end gap-6">
         <Tab
           active={currentView === "mine"}
           label="Mine"
@@ -257,7 +257,7 @@ export default function ReleasesPage() {
         />
       </div>
 
-      <div>
+      <div className="flex-1 min-h-0 flex flex-col">
         {currentView === "mine" ? <MyReleasesView /> : <AllReleasesView />}
       </div>
     </div>
@@ -358,9 +358,9 @@ function MyReleasesView() {
   };
 
   return (
-    <div>
+    <div className="flex h-full min-h-0 flex-col">
       {/* Full-width filter bar */}
-      <div className="px-5 py-2.5 border-b border-border flex items-center gap-2 flex-wrap">
+      <div className="shrink-0 px-5 py-2.5 border-b border-border flex items-center gap-2 flex-wrap">
         <div className="font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground/70 pr-1">
           Filter
         </div>
@@ -442,31 +442,35 @@ function MyReleasesView() {
         </div>
       </div>
 
-      {isLoading && (
-        <div className="px-5 py-4 space-y-2">
-          <Skeleton className="h-14" />
-          <Skeleton className="h-14" />
-          <Skeleton className="h-14" />
-        </div>
-      )}
+      {/* Only the release rows scroll; the filter bar above and the bulk bar
+          below stay put. */}
+      <div className="flex-1 min-h-0 overflow-auto">
+        {isLoading && (
+          <div className="px-5 py-4 space-y-2">
+            <Skeleton className="h-14" />
+            <Skeleton className="h-14" />
+            <Skeleton className="h-14" />
+          </div>
+        )}
 
-      {error && (
-        <div className="px-5 py-4">
-          <ErrorDisplay
-            error={error}
-            title="Unable to load your releases"
-            onRetry={() => refetch()}
-          />
-        </div>
-      )}
+        {error && (
+          <div className="px-5 py-4">
+            <ErrorDisplay
+              error={error}
+              title="Unable to load your releases"
+              onRetry={() => refetch()}
+            />
+          </div>
+        )}
 
-      {!isLoading && !error && issues.length === 0 && (
-        <EmptyState variant="upcoming" />
-      )}
+        {!isLoading && !error && issues.length === 0 && (
+          <EmptyState variant="upcoming" />
+        )}
 
-      {!isLoading && !error && issues.length > 0 && (
-        <UpcomingTable table={table} />
-      )}
+        {!isLoading && !error && issues.length > 0 && (
+          <UpcomingTable table={table} />
+        )}
+      </div>
 
       <BulkActionBar
         selectedCount={selectedIds.length}
@@ -494,7 +498,7 @@ function AllReleasesView() {
   }
 
   return (
-    <>
+    <div className="flex-1 min-h-0 overflow-auto">
       {aiStatus?.configured && (
         <div className="px-5 py-4">
           <AiSuggestions />
@@ -517,7 +521,7 @@ function AllReleasesView() {
       ) : (
         <div>
           <div
-            className="grid font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground/70 px-5 py-2 border-b bg-muted/30"
+            className="sticky top-0 z-10 grid font-mono text-[10px] tracking-[0.1em] uppercase text-muted-foreground/70 px-5 py-2 border-b bg-background"
             style={{
               borderColor: "var(--border)",
               gridTemplateColumns: "1fr 80px 160px 100px",
@@ -563,6 +567,6 @@ function AllReleasesView() {
           })}
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,11 +1,6 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
-import {
-  Search as SearchIcon,
-  ChevronLeft,
-  ChevronRight,
-  Settings,
-} from "lucide-react";
+import { Search as SearchIcon, Settings } from "lucide-react";
 import FilterField from "@/components/ui/FilterField";
 import {
   Select,
@@ -20,6 +15,7 @@ import SearchResultsTable from "@/components/search/SearchResultsTable";
 import { Skeleton } from "@/components/ui/skeleton";
 import EmptyState from "@/components/ui/EmptyState";
 import PageHeader, { Tab, TabRow } from "@/components/layout/PageHeader";
+import { DataTableFooter } from "@/components/data-table/DataTableFooter";
 import type { ContentType } from "@/types/entities";
 
 interface SortOption {
@@ -94,6 +90,7 @@ export default function SearchPage() {
       : "manga";
 
   const [searchQuery, setSearchQuery] = useState(urlQuery);
+  const resultsRef = useRef<HTMLDivElement>(null);
   const [columnToggleEl, setColumnToggleEl] = useState<HTMLDivElement | null>(
     null,
   );
@@ -149,7 +146,9 @@ export default function SearchPage() {
     const params: Record<string, string> = Object.fromEntries(searchParams);
     params.page = newPage.toString();
     setSearchParams(params);
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    // The results list is its own scroll container now (the page fills the
+    // viewport), so the window never scrolled here in the first place.
+    resultsRef.current?.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   const handleSortChange = (value: string) => {
@@ -170,7 +169,7 @@ export default function SearchPage() {
   const showBothTabs = comicsEnabled && mangaEnabled;
 
   return (
-    <div className="page-transition min-w-0 overflow-hidden">
+    <div className="page-transition flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
       <PageHeader
         title="Search"
         meta={
@@ -199,7 +198,7 @@ export default function SearchPage() {
 
       {/* Compact search form + sort controls */}
       <div
-        className="px-5 py-2.5 border-b flex items-center gap-3 flex-wrap"
+        className="shrink-0 px-5 py-2.5 border-b flex items-center gap-3 flex-wrap"
         style={{ borderColor: "var(--border)" }}
       >
         <form
@@ -251,49 +250,49 @@ export default function SearchPage() {
         </div>
       </div>
 
-      {/* Results area — full-bleed */}
-      {isLoading && (
-        <div className="p-5 space-y-2">
-          {[0, 1, 2, 3, 4].map((i) => (
-            <Skeleton key={i} className="h-14" />
-          ))}
-        </div>
-      )}
+      {/* Results area — full-bleed, and the only thing that scrolls. */}
+      <div ref={resultsRef} className="flex-1 min-h-0 overflow-auto">
+        {isLoading && (
+          <div className="p-5 space-y-2">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <Skeleton key={i} className="h-14" />
+            ))}
+          </div>
+        )}
 
-      {error && (
-        <div className="p-5">
-          {searchMode === "comic" && !comicsConfigured ? (
+        {error && (
+          <div className="p-5">
+            {searchMode === "comic" && !comicsConfigured ? (
+              <EmptyState
+                variant="custom"
+                icon={Settings}
+                eyebrow="PROVIDER · NOT CONFIGURED"
+                title="Comic Vine API key required"
+                description="Add a Comic Vine API key in Settings → API to search comics."
+                action={{ label: "Open settings", to: "/settings" }}
+              />
+            ) : (
+              <EmptyState
+                variant="custom"
+                eyebrow="SEARCH · ERROR"
+                title="Search failed"
+                description={error.message}
+              />
+            )}
+          </div>
+        )}
+
+        {!isLoading && !error && urlQuery && searchResults.length === 0 && (
+          <div className="p-5">
             <EmptyState
-              variant="custom"
-              icon={Settings}
-              eyebrow="PROVIDER · NOT CONFIGURED"
-              title="Comic Vine API key required"
-              description="Add a Comic Vine API key in Settings → API to search comics."
-              action={{ label: "Open settings", to: "/settings" }}
+              variant="search"
+              eyebrow="SEARCH · NO MATCH"
+              description={`No results for "${urlQuery}". Try a different query or check spelling.`}
             />
-          ) : (
-            <EmptyState
-              variant="custom"
-              eyebrow="SEARCH · ERROR"
-              title="Search failed"
-              description={error.message}
-            />
-          )}
-        </div>
-      )}
+          </div>
+        )}
 
-      {!isLoading && !error && urlQuery && searchResults.length === 0 && (
-        <div className="p-5">
-          <EmptyState
-            variant="search"
-            eyebrow="SEARCH · NO MATCH"
-            description={`No results for "${urlQuery}". Try a different query or check spelling.`}
-          />
-        </div>
-      )}
-
-      {!isLoading && !error && searchResults.length > 0 && (
-        <>
+        {!isLoading && !error && searchResults.length > 0 && (
           <SearchResultsTable
             results={searchResults}
             currentSort={urlSort}
@@ -301,49 +300,32 @@ export default function SearchPage() {
             contentType={searchMode}
             columnToggleContainer={columnToggleEl}
           />
-          {totalPages > 1 && (
-            <div
-              className="flex items-center justify-between px-5 py-3 border-t font-mono text-[11px] text-muted-foreground"
-              style={{ borderColor: "var(--border)" }}
-            >
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 px-2.5 py-1 rounded border disabled:opacity-50"
-                style={{ borderColor: "var(--border)" }}
-                onClick={() => handlePageChange(urlPage - 1)}
-                disabled={urlPage === 1}
-              >
-                <ChevronLeft className="w-3 h-3" />
-                prev
-              </button>
-              <span>
-                page {urlPage} / {totalPages}
-              </span>
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 px-2.5 py-1 rounded border disabled:opacity-50"
-                style={{ borderColor: "var(--border)" }}
-                onClick={() => handlePageChange(urlPage + 1)}
-                disabled={urlPage >= totalPages}
-              >
-                next
-                <ChevronRight className="w-3 h-3" />
-              </button>
-            </div>
-          )}
-        </>
-      )}
+        )}
 
-      {!urlQuery && (
-        <div className="p-5">
-          <EmptyState
-            variant="custom"
-            icon={SearchIcon}
-            eyebrow="SEARCH · READY"
-            title={`Find ${searchMode === "manga" ? "manga" : "comics"} to add`}
-            description="Type at least 3 characters to search across your configured providers."
-          />
-        </div>
+        {!urlQuery && (
+          <div className="p-5">
+            <EmptyState
+              variant="custom"
+              icon={SearchIcon}
+              eyebrow="SEARCH · READY"
+              title={`Find ${searchMode === "manga" ? "manga" : "comics"} to add`}
+              description="Type at least 3 characters to search across your configured providers."
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Pager — sibling of the scroll region, so it rides the viewport edge. */}
+      {!isLoading && !error && searchResults.length > 0 && pagination && (
+        <DataTableFooter
+          start={startIndex}
+          end={endIndex}
+          total={pagination.total}
+          page={urlPage}
+          pageCount={totalPages}
+          onPrevPage={() => handlePageChange(urlPage - 1)}
+          onNextPage={() => handlePageChange(urlPage + 1)}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -633,7 +633,7 @@ export default function SeriesDetailPage() {
       <div className="flex-1 min-h-0 overflow-auto">
         <div className="min-w-[720px]">
           <div
-            className="grid grid-cols-[54px_42px_minmax(220px,1fr)_130px_110px_190px] gap-3 border-b px-5 py-2 font-mono text-[10px] uppercase tracking-[0.1em]"
+            className="sticky top-0 z-10 grid grid-cols-[54px_42px_minmax(220px,1fr)_130px_110px_190px] gap-3 border-b px-5 py-2 font-mono text-[10px] uppercase tracking-[0.1em]"
             style={{
               borderColor: "var(--border)",
               color: "var(--text-muted)",

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -630,7 +630,7 @@ export default function SeriesDetailPage() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 min-h-0 overflow-auto">
         <div className="min-w-[720px]">
           <div
             className="grid grid-cols-[54px_42px_minmax(220px,1fr)_130px_110px_190px] gap-3 border-b px-5 py-2 font-mono text-[10px] uppercase tracking-[0.1em]"

--- a/frontend/src/pages/StoryArcDetailPage.tsx
+++ b/frontend/src/pages/StoryArcDetailPage.tsx
@@ -37,7 +37,7 @@ export default function StoryArcDetailPage() {
   }
 
   return (
-    <div className="space-y-6 page-transition">
+    <div className="h-full min-h-0 overflow-auto space-y-6 page-transition">
       {/* Breadcrumb */}
       <nav className="flex items-center gap-1 text-sm text-muted-foreground">
         <Link

--- a/frontend/src/pages/StoryArcsPage.tsx
+++ b/frontend/src/pages/StoryArcsPage.tsx
@@ -22,7 +22,7 @@ export default function StoryArcsPage() {
   const count = arcs?.length ?? 0;
 
   return (
-    <div className="page-transition">
+    <div className="page-transition flex h-full min-h-0 flex-col">
       <PageHeader
         title="Story Arcs"
         meta={
@@ -32,7 +32,7 @@ export default function StoryArcsPage() {
         }
       />
 
-      <div className="px-5 py-4 space-y-6">
+      <div className="flex-1 min-h-0 overflow-auto px-5 py-4 space-y-6">
         {aiStatus?.configured && <ArcGenerator />}
 
         <ArcSearch searchInputRef={searchInputRef} formRef={searchFormRef} />

--- a/frontend/src/pages/WantedPage.tsx
+++ b/frontend/src/pages/WantedPage.tsx
@@ -169,7 +169,7 @@ export default function WantedPage() {
   const matchCount = isFiltering ? total : null;
 
   return (
-    <div className="page-transition">
+    <div className="page-transition flex h-full min-h-0 flex-col">
       <PageHeader
         title="Wanted"
         meta={
@@ -208,7 +208,7 @@ export default function WantedPage() {
         }
       />
 
-      <div className="px-5 py-2.5 border-b border-border flex items-center gap-3">
+      <div className="shrink-0 px-5 py-2.5 border-b border-border flex items-center gap-3">
         <div className="flex-1 max-w-md">
           <FilterField
             placeholder="Filter wanted issues…"
@@ -226,38 +226,41 @@ export default function WantedPage() {
         )}
       </div>
 
-      {isLoading && (
-        <div className="px-5 py-4 space-y-2">
-          <Skeleton className="h-14" />
-          <Skeleton className="h-14" />
-          <Skeleton className="h-14" />
-        </div>
-      )}
+      {/* Body column — the table owns the scrolling inside it. */}
+      <div className="flex-1 min-h-0 flex flex-col">
+        {isLoading && (
+          <div className="px-5 py-4 space-y-2">
+            <Skeleton className="h-14" />
+            <Skeleton className="h-14" />
+            <Skeleton className="h-14" />
+          </div>
+        )}
 
-      {error && (
-        <div className="px-5 py-4">
-          <ErrorDisplay
-            error={error}
-            title="Unable to load wanted issues"
-            onRetry={() => refetch()}
+        {error && (
+          <div className="px-5 py-4">
+            <ErrorDisplay
+              error={error}
+              title="Unable to load wanted issues"
+              onRetry={() => refetch()}
+            />
+          </div>
+        )}
+
+        {!isLoading && !error && (
+          <WantedTable
+            table={table}
+            pagination={pagination}
+            onNextPage={() => {
+              nextPage();
+              clearSelection();
+            }}
+            onPrevPage={() => {
+              prevPage();
+              clearSelection();
+            }}
           />
-        </div>
-      )}
-
-      {!isLoading && !error && (
-        <WantedTable
-          table={table}
-          pagination={pagination}
-          onNextPage={() => {
-            nextPage();
-            clearSelection();
-          }}
-          onPrevPage={() => {
-            prevPage();
-            clearSelection();
-          }}
-        />
-      )}
+        )}
+      </div>
 
       <BulkActionBar
         selectedCount={selectedIds.length}

--- a/frontend/tests/components/SeriesTable.test.tsx
+++ b/frontend/tests/components/SeriesTable.test.tsx
@@ -58,7 +58,7 @@ describe("SeriesTable", () => {
       </NuqsAdapter>,
     );
 
-    await user.click(screen.getByRole("button", { name: "next" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
 
     expect(screen.getByText("Series 21")).toBeTruthy();
     expect(screen.queryByText("Series 1")).toBeNull();
@@ -212,7 +212,7 @@ describe("SeriesTable", () => {
     );
 
     await user.click(screen.getByRole("checkbox", { name: "Select Series 1" }));
-    await user.click(screen.getByRole("button", { name: "next" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
     await settle();
 
     // Series 1 is on the previous page — out of sight but not out of the
@@ -220,7 +220,7 @@ describe("SeriesTable", () => {
     expect(screen.queryByText("Series 1")).toBeNull();
     expect(screen.queryAllByText("1 selected")).not.toHaveLength(0);
 
-    await user.click(screen.getByRole("button", { name: "prev" }));
+    await user.click(screen.getByRole("button", { name: "Previous page" }));
     await settle();
 
     expect(

--- a/frontend/tests/pages/ActivityPage.test.tsx
+++ b/frontend/tests/pages/ActivityPage.test.tsx
@@ -276,7 +276,7 @@ describe("ActivityPage", () => {
     });
     await screen.findByText("Absolute Flash");
 
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
     await waitFor(() => {
       expect(requests.at(-1)?.searchParams.get("offset")).toBe("25");
     });
@@ -288,7 +288,7 @@ describe("ActivityPage", () => {
       expect(last?.searchParams.get("offset")).toBe("0");
     });
 
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
     await waitFor(() => {
       expect(requests.at(-1)?.searchParams.get("offset")).toBe("25");
     });
@@ -351,14 +351,14 @@ describe("ActivityPage", () => {
       ).toBe(true);
     });
 
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
     await waitFor(() => {
       expect(
         requests.some((url) => url.searchParams.get("offset") === "25"),
       ).toBe(true);
     });
     expect(await screen.findByText("No matching queue items")).toBeTruthy();
-    expect(screen.queryByText(/Showing \d+ to \d+ of/)).toBeNull();
+    expect(screen.queryByText(/\d+–\d+ of \d+/)).toBeNull();
     expect(
       screen.getByRole("button", { name: "Previous" }).hasAttribute("disabled"),
     ).toBe(false);

--- a/frontend/tests/pages/WantedPage.test.tsx
+++ b/frontend/tests/pages/WantedPage.test.tsx
@@ -252,7 +252,7 @@ describe("WantedPage", () => {
     render(<WantedPage />);
 
     expect(await screen.findByText("53 issues in queue")).toBeTruthy();
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
     await waitFor(() => {
       expect(requests.at(-1)?.searchParams.get("offset")).toBe("50");
     });
@@ -270,10 +270,10 @@ describe("WantedPage", () => {
 
     expect(await screen.findByText("12 matches")).toBeTruthy();
     expect(screen.getByText("12 issues in queue")).toBeTruthy();
-    expect(await screen.findByText("Showing 1 to 12 of 12")).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Next" }).hasAttribute("disabled"),
-    ).toBe(true);
+    expect(await screen.findByText("1–12 of 12")).toBeTruthy();
+    // One page of matches: the footer keeps the range and drops the pager
+    // rather than showing two dead buttons.
+    expect(screen.queryByRole("navigation", { name: "Pagination" })).toBeNull();
     // Matches that lived past the first unfiltered page are still listed.
     expect(screen.getByText("10")).toBeTruthy();
     expect(screen.getByText("12")).toBeTruthy();
@@ -302,7 +302,7 @@ describe("WantedPage", () => {
     render(<WantedPage />);
     await screen.findByText("90 issues in queue");
 
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
     await waitFor(() => {
       expect(requests.at(-1)?.searchParams.get("offset")).toBe("50");
     });


### PR DESCRIPTION
Table pagination now sits on the bottom edge of the window instead of at the end of a long scrolling page, and every table shares one footer component.

## What's changing

- **The app shell is viewport-bounded.** `Layout` was `min-h-svh` wrapping a `flex-1 overflow-auto` div whose parent was not a flex container, so both utilities were inert and the whole document scrolled. The shell is now exactly one viewport tall and never scrolls itself; each full-bleed page owns a `flex-1 min-h-0 overflow-auto` body with its header and footer as `shrink-0` siblings. No fixed or absolute positioning. Pages that were already declaring `h-full flex flex-col` (Dashboard, Settings, Series detail) finally get the height they were asking for, and pages without an internal scroll region got one so nothing is clipped.
- **One footer for every table.** Library, Search, and `DataTableServerPagination` each had their own style — the last one being the only sentence-case sans UI in the app. All three are replaced by `DataTableFooter`: the lowercase mono rail that mirrors the omni status bar, position on the left, movement on the right. It reads `21–40 of 143` so you can see where you are rather than just how many rows exist, and single-page tables drop the pager instead of showing prev and next greyed out. `DataTableServerPagination` is now a thin adapter over it.
- **Mock mode has enough rows to page through.** `?mock=1` now serves 96 library series, paginated search results, and Activity queue/history, so these surfaces can be eyeballed without a populated backend.

## Notes

- Table headers are sticky now that the body scrolls under them.
- Test queries were updated for the new accessible names; two assertions changed meaning rather than wording (single-page tables render no pager at all).
- `TimelineView` (merged to main after this branch started) got the same layout treatment so the new default Activity tab is not clipped. Its pager still has its own styling — it models an unknown total and an "older" fetch-more action that `DataTableFooter` does not, so folding it in is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uwUFXWLA13CamN5SPtuQh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent table footers showing visible row ranges, totals, notes, and pagination controls.
  - Pagination is hidden when results fit on a single page.
  - Table headers remain visible while scrolling through results.
- **Bug Fixes**
  - Improved page layouts so filters, headers, and pagination stay anchored while content scrolls independently.
  - Enhanced scrolling behavior across Activity, Search, Wanted, Releases, Dashboard, and detail pages.
  - Search results smoothly return to the top when changing pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->