### PR TITLE
chore: Portless frontend dev and attention-band prototype

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ Agent-oriented project guide for Comicarr. Prefer retrieval-led reasoning: consu
 | Install with pip (unlocked) | `pip install .` |
 | Install (frontend) | `cd frontend && npm ci` |
 | Run app | `python3 Comicarr.py --nolaunch` |
-| Dev frontend | `cd frontend && npm run dev` |
+| Dev frontend | `cd frontend && npm run dev` → **https://comicarr.localhost:1355** (portless) |
+| Dev frontend (raw Vite) | `cd frontend && npm run dev:vite` → localhost:5173 |
 | Build frontend | `cd frontend && npm run build` |
 | Test backend | `pytest tests/unit -v` |
 | Test frontend | `cd frontend && npm run test:run` |
@@ -39,7 +40,9 @@ Agent-oriented project guide for Comicarr. Prefer retrieval-led reasoning: consu
 | Add dependency | `uv add <package>` |
 | Add dev dep | `uv add --optional dev <package>` |
 
-When using Vite (`npm run dev`) with a separate backend process, the proxy targets `http://localhost:8090`. Override with `VITE_API_PROXY_TARGET` if needed.
+When using Vite with a separate backend process, the proxy targets `http://localhost:8090`. Override with `VITE_API_PROXY_TARGET` if needed.
+
+**Local frontend URL:** `npm run dev` runs through [portless](https://github.com/vercel-labs/portless) at **https://comicarr.localhost:1355** (proxy on unprivileged port 1355 — no sudo). Other projects can use their own names without stealing 5173. First HTTPS session may need `npx portless trust` once. Optional clean URL without `:1355`: `sudo npx portless proxy start --https` then set `PORTLESS_PORT=443` (or stop the 1355 proxy and re-run). Escape hatch: `npm run dev:vite` for bare `localhost:PORT` (feval uses this).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Comicarr is built on the foundation of Mylar3 with a completely rebuilt React 19
 
 `frontend/src/types/config.generated.ts` is generated from `comicarr/app/config/registry.py` and committed. `npm run lint` fails if it is stale; a pre-commit hook regenerates it when the registry or `system/service.py` changes.
 
-Default HTTP port is **8090**. Vite dev proxy targets `http://localhost:8090` (override with `VITE_API_PROXY_TARGET`).
+Default HTTP port is **8090**. Vite dev proxy targets `http://localhost:8090` (override with `VITE_API_PROXY_TARGET`). Frontend `npm run dev` uses **portless** → **https://comicarr.localhost:1355** (raw Vite: `npm run dev:vite`).
 
 ## Releases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,15 +70,20 @@ If a hook rewrites files, stage the changes and commit again. Avoid `git commit 
 
 ```bash
 cd frontend
-npm run dev     # Start dev server with HMR
-npm run lint    # Run ESLint
+npm run dev        # https://comicarr.localhost:1355 (portless + HMR)
+npm run dev:vite   # raw Vite on localhost:5173 if needed
+npm run lint       # Run ESLint
 npm run typecheck  # Run TypeScript checks
-npm run build   # Production build
+npm run build      # Production build
 ```
 
-When using `npm run dev` with a separately running backend, Comicarr defaults
-to port **8090**. The Vite proxy targets `http://localhost:8090` (override with
-`VITE_API_PROXY_TARGET` if needed).
+The default `dev` script goes through [portless](https://github.com/vercel-labs/portless)
+(`https://comicarr.localhost:1355`) so other local apps can keep their own named
+URLs without stealing port 5173. First HTTPS session may need `npx portless trust`.
+
+When using the Vite dev server with a separately running backend, Comicarr
+defaults to port **8090**. The Vite proxy targets `http://localhost:8090`
+(override with `VITE_API_PROXY_TARGET` if needed).
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ cd frontend && npm ci && cd ..
 python3 Comicarr.py --nolaunch   # backend on :8090
 
 # separate terminal — frontend HMR (proxies API to :8090)
-cd frontend && npm run dev
+cd frontend && npm run dev   # https://comicarr.localhost:1355 (portless)
 ```
 
 ## Attribution

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,53 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+**Layout: single-context.** Comicarr uses one root `CONTEXT.md` (present) plus `docs/adr/` for architectural decisions (created lazily by `/domain-modeling` when a decision is actually resolved). There is no `CONTEXT-MAP.md`.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,7 +6,8 @@ the FastAPI application from `frontend/dist`.
 ## Common Commands
 
 ```bash
-npm run dev
+npm run dev        # https://comicarr.localhost:1355 (portless — preferred)
+npm run dev:vite   # raw Vite on localhost:5173 (escape hatch)
 npm run lint
 npm run format:check
 npm run typecheck
@@ -14,11 +15,18 @@ npm run test:run
 npm run build
 ```
 
+`npm run dev` uses [portless](https://github.com/vercel-labs/portless) so the
+frontend keeps a stable name (`https://comicarr.localhost:1355`) instead of
+competing for port 5173 with other local projects. The proxy listens on
+unprivileged port **1355** (no sudo). First HTTPS session may need
+`npx portless trust`. Use `dev:vite` only when something needs a bare host:port.
+
 ## Backend during dev
 
-When using `npm run dev` with a separately running backend, Comicarr defaults
-to port 8090. The Vite proxy targets `http://localhost:8090` (override with
-`VITE_API_PROXY_TARGET` if needed).
+When using the Vite dev server with a separately running backend, Comicarr
+defaults to port 8090. The Vite proxy targets `http://localhost:8090`
+(override with `VITE_API_PROXY_TARGET` if needed). API traffic still goes
+through the Vite origin, so the browser only talks to `comicarr.localhost`.
 
 ## E2E Tests
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,6 +62,7 @@
         "globals": "^17.7.0",
         "happy-dom": "^20.11.0",
         "msw": "^2.13.4",
+        "portless": "^0.15.5",
         "postcss": "^8.5.23",
         "prettier": "^3.8.4",
         "tailwindcss": "^4.1.18",
@@ -5505,6 +5506,24 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/portless": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/portless/-/portless-0.15.5.tgz",
+      "integrity": "sha512-zmJu4Q8/fY54oVUT/5NnmF4Ih8wTdCvCf6JCN783dRYl9mXkJBzXSckX2lztGCLIbM70varDjCudAbGKT73XPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "portless": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,12 @@
   "private": true,
   "version": "0.24.1",
   "type": "module",
+  "portless": {
+    "name": "comicarr"
+  },
   "scripts": {
-    "dev": "vite",
+    "dev": "PORTLESS_PORT=1355 portless run vite",
+    "dev:vite": "vite",
     "build": "vite build",
     "lint": "eslint .",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,css,json}\" \"tests/e2e/**/*.{ts,tsx,js,jsx,mjs}\" \"playwright.config.ts\"",
@@ -75,6 +79,7 @@
     "globals": "^17.7.0",
     "happy-dom": "^20.11.0",
     "msw": "^2.13.4",
+    "portless": "^0.15.5",
     "postcss": "^8.5.23",
     "prettier": "^3.8.4",
     "tailwindcss": "^4.1.18",

--- a/frontend/src/components/activity/prototype-attention/AttentionPrototypeHost.tsx
+++ b/frontend/src/components/activity/prototype-attention/AttentionPrototypeHost.tsx
@@ -1,0 +1,31 @@
+/**
+ * PROTOTYPE host for #526 — bounded band preview + triage surface.
+ *
+ * Question: What do the bounded band preview and dedicated triage surface look like?
+ * Three structural variants on /activity?variant=A|B|C (dev only entry from ActivityPage).
+ */
+
+import { VariantA } from "./VariantA";
+import { VariantB } from "./VariantB";
+import { VariantC } from "./VariantC";
+import { PrototypeSwitcher, type VariantKey } from "./PrototypeSwitcher";
+
+export function AttentionPrototypeHost({ variant }: { variant: VariantKey }) {
+  return (
+    <>
+      {variant === "A" && <VariantA />}
+      {variant === "B" && <VariantB />}
+      {variant === "C" && <VariantC />}
+      <PrototypeSwitcher />
+      <div
+        className="pointer-events-none fixed bottom-16 left-1/2 z-[99] -translate-x-1/2 rounded-full border px-3 py-1 font-mono text-[10px] text-muted-foreground"
+        style={{
+          borderColor: "var(--border)",
+          background: "var(--background)",
+        }}
+      >
+        PROTOTYPE · mock data · ← → switch · not production
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/activity/prototype-attention/PrototypeSwitcher.tsx
+++ b/frontend/src/components/activity/prototype-attention/PrototypeSwitcher.tsx
@@ -1,0 +1,126 @@
+/**
+ * PROTOTYPE — floating variant switcher (#526). Hidden in production builds.
+ */
+
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export type VariantKey = "A" | "B" | "C";
+
+export const VARIANT_META: Record<VariantKey, string> = {
+  A: "Sentry strip + Attention tab",
+  B: "One-line bar + master-detail sheet",
+  C: "Issue cards + dedicated route",
+};
+
+const ORDER: VariantKey[] = ["A", "B", "C"];
+
+export function parseVariant(raw: string | null): VariantKey | null {
+  if (!raw) return null;
+  const u = raw.toUpperCase();
+  if (u === "A" || u === "B" || u === "C") return u;
+  return null;
+}
+
+export function PrototypeSwitcher() {
+  if (import.meta.env.PROD) return null;
+
+  const [params, setParams] = useSearchParams();
+  const current = parseVariant(params.get("variant")) ?? "A";
+
+  const setVariant = (v: VariantKey) => {
+    setParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("variant", v);
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  const cycle = (dir: -1 | 1) => {
+    const i = ORDER.indexOf(current);
+    const next = ORDER[(i + dir + ORDER.length) % ORDER.length];
+    setVariant(next);
+  };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (
+        t &&
+        (t.tagName === "INPUT" ||
+          t.tagName === "TEXTAREA" ||
+          t.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        setParams(
+          (prev) => {
+            const cur = parseVariant(prev.get("variant")) ?? "A";
+            const i = ORDER.indexOf(cur);
+            const nextV = ORDER[(i - 1 + ORDER.length) % ORDER.length];
+            const next = new URLSearchParams(prev);
+            next.set("variant", nextV);
+            return next;
+          },
+          { replace: true },
+        );
+      }
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        setParams(
+          (prev) => {
+            const cur = parseVariant(prev.get("variant")) ?? "A";
+            const i = ORDER.indexOf(cur);
+            const nextV = ORDER[(i + 1) % ORDER.length];
+            const next = new URLSearchParams(prev);
+            next.set("variant", nextV);
+            return next;
+          },
+          { replace: true },
+        );
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [setParams]);
+
+  return (
+    <div
+      className="fixed bottom-4 left-1/2 z-[100] flex -translate-x-1/2 items-center gap-2 rounded-full border px-2 py-1.5 shadow-lg"
+      style={{
+        background: "var(--background)",
+        borderColor: "var(--border)",
+        boxShadow: "0 8px 30px color-mix(in oklab, black 25%, transparent)",
+      }}
+      role="group"
+      aria-label="Prototype variant switcher"
+    >
+      <button
+        type="button"
+        className="rounded-full p-1.5 hover:bg-muted"
+        onClick={() => cycle(-1)}
+        aria-label="Previous variant"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+      <div className="min-w-[220px] text-center font-mono text-[11px]">
+        <span className="font-semibold">{current}</span>
+        <span className="text-muted-foreground"> — {VARIANT_META[current]}</span>
+      </div>
+      <button
+        type="button"
+        className="rounded-full p-1.5 hover:bg-muted"
+        onClick={() => cycle(1)}
+        aria-label="Next variant"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/activity/prototype-attention/VariantA.tsx
+++ b/frontend/src/components/activity/prototype-attention/VariantA.tsx
@@ -1,0 +1,372 @@
+/**
+ * PROTOTYPE Variant A — Sentry strip + fourth "Attention" tab.
+ *
+ * Band: max 3 groups, volume×newest rank, hard height ~3 rows.
+ * Fold: "and K more · open Attention" → fourth tab.
+ * Triage: full list + reason/series filters + selection + bulk (cap 25).
+ */
+
+import { useMemo, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import PageHeader, { Tab, TabRow } from "@/components/layout/PageHeader";
+import {
+  MOCK_GROUPS,
+  TOTAL_GROUPS,
+  TOTAL_MEMBERS,
+  actionLabel,
+  rankByVolumeThenNewest,
+  type MockGroup,
+} from "./mockData";
+
+const PREVIEW_CAP = 3;
+
+type View = "timeline" | "queue" | "history" | "attention";
+
+export const VARIANT_A_NAME = "Sentry strip + Attention tab";
+
+export function VariantA() {
+  const [view, setView] = useState<View>("timeline");
+  const ranked = useMemo(() => rankByVolumeThenNewest(MOCK_GROUPS), []);
+  const preview = ranked.slice(0, PREVIEW_CAP);
+  const more = ranked.length - preview.length;
+
+  return (
+    <div className="page-transition flex h-full min-h-0 flex-col">
+      <PageHeader
+        title="Activity"
+        meta="PROTOTYPE A — fourth tab owns the workspace"
+      />
+      <TabRow>
+        {(
+          [
+            ["timeline", "Timeline"],
+            ["queue", "Direct Downloads"],
+            ["history", "Download History"],
+            ["attention", `Attention · ${TOTAL_GROUPS}`],
+          ] as const
+        ).map(([id, label]) => (
+          <Tab
+            key={id}
+            active={view === id}
+            label={label}
+            onClick={() => setView(id)}
+          />
+        ))}
+      </TabRow>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        {view === "timeline" && (
+          <>
+            <BandPreview
+              preview={preview}
+              more={more}
+              onOpenAttention={() => setView("attention")}
+            />
+            <FakeTimeline />
+          </>
+        )}
+        {view === "attention" && <TriageTable groups={ranked} />}
+        {view === "queue" && <Stub label="Direct Downloads (unchanged)" />}
+        {view === "history" && (
+          <Stub label="Download History — full ledger, no band actions" />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BandPreview({
+  preview,
+  more,
+  onOpenAttention,
+}: {
+  preview: MockGroup[];
+  more: number;
+  onOpenAttention: () => void;
+}) {
+  return (
+    <section
+      aria-label="Needs attention preview"
+      className="shrink-0 border-b"
+      style={{
+        borderColor: "var(--border)",
+        background:
+          "var(--status-error-bg, color-mix(in oklab, var(--status-error) 12%, transparent))",
+        maxHeight: 148,
+      }}
+    >
+      <div className="flex items-center gap-2 px-5 pt-3 pb-1.5">
+        <AlertTriangle
+          className="h-3.5 w-3.5"
+          style={{ color: "var(--status-error)" }}
+        />
+        <span
+          className="font-mono text-[11px] uppercase tracking-[0.1em]"
+          style={{ color: "var(--status-error)" }}
+        >
+          {TOTAL_GROUPS} need attention
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {TOTAL_MEMBERS} issues · groups, not rows
+        </span>
+      </div>
+      <ul className="px-5 pb-2">
+        {preview.map((g) => (
+          <li
+            key={g.group_key}
+            className="flex items-baseline justify-between gap-3 py-1"
+          >
+            <div className="min-w-0 truncate text-[13px]">
+              <span className="font-medium">{g.series_label}</span>
+              <span className="text-muted-foreground">
+                {" "}
+                · {g.reason_phrase}
+              </span>
+            </div>
+            <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
+              ×{g.member_count}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {more > 0 && (
+        <button
+          type="button"
+          onClick={onOpenAttention}
+          className="w-full border-t px-5 py-2 text-left font-mono text-[11px] hover:bg-black/5"
+          style={{
+            borderColor: "var(--border)",
+            color: "var(--status-error)",
+          }}
+        >
+          and {more} more · open Attention →
+        </button>
+      )}
+    </section>
+  );
+}
+
+function TriageTable({ groups }: { groups: MockGroup[] }) {
+  const [reasonFilter, setReasonFilter] = useState("");
+  const [q, setQ] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [confirmStop, setConfirmStop] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const filtered = groups.filter((g) => {
+    if (reasonFilter && g.base_reason !== reasonFilter) return false;
+    if (q && !g.series_label.toLowerCase().includes(q.toLowerCase())) return false;
+    return true;
+  });
+
+  const reasons = useMemo(
+    () => [...new Set(groups.map((g) => g.base_reason))].sort(),
+    [groups],
+  );
+
+  const selectedMembers = filtered
+    .filter((g) => selected.has(g.group_key))
+    .reduce((n, g) => n + g.member_count, 0);
+
+  const toggle = (key: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const runBulk = (action: string) => {
+    const n = Math.min(25, selectedMembers);
+    setToast(
+      `${actionLabel(action)}: processed ${n} of ${selectedMembers}` +
+        (selectedMembers > 25 ? " (cap 25)" : ""),
+    );
+    setConfirmStop(false);
+    setSelected(new Set());
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b px-5 py-2.5" style={{ borderColor: "var(--border)" }}>
+        <input
+          className="max-w-xs flex-1 rounded border bg-transparent px-2 py-1 font-mono text-[11px]"
+          style={{ borderColor: "var(--border)" }}
+          placeholder="Filter series…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <select
+          className="rounded border bg-transparent px-2 py-1 font-mono text-[11px]"
+          style={{ borderColor: "var(--border)" }}
+          value={reasonFilter}
+          onChange={(e) => setReasonFilter(e.target.value)}
+        >
+          <option value="">All reasons</option>
+          {reasons.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {filtered.length} groups · not Download History (only unresolved + actions)
+        </span>
+      </div>
+
+      {selected.size > 0 && (
+        <div
+          className="flex shrink-0 flex-wrap items-center gap-2 border-b px-5 py-2"
+          style={{
+            borderColor: "var(--border)",
+            background: "color-mix(in oklab, var(--primary) 8%, transparent)",
+          }}
+        >
+          <span className="font-mono text-[11px]">
+            {selected.size} groups · ~{selectedMembers} issues
+            {selectedMembers > 25 ? " · cap 25/click" : ""}
+          </span>
+          <button
+            type="button"
+            className="rounded border px-2 py-1 font-mono text-[10px]"
+            style={{ borderColor: "var(--border)" }}
+            onClick={() => runBulk("search_again")}
+          >
+            Search again
+          </button>
+          <button
+            type="button"
+            className="rounded border px-2 py-1 font-mono text-[10px]"
+            style={{ borderColor: "var(--border)" }}
+            onClick={() => setConfirmStop(true)}
+          >
+            Stop wanting…
+          </button>
+        </div>
+      )}
+
+      {confirmStop && (
+        <div
+          className="shrink-0 border-b px-5 py-3"
+          style={{
+            borderColor: "var(--border)",
+            background:
+              "color-mix(in oklab, var(--status-error) 10%, transparent)",
+          }}
+        >
+          <p className="text-[13px] font-medium">
+            Stop acquiring ~{Math.min(25, selectedMembers)} issues?
+          </p>
+          <p className="mt-1 text-[12px] text-muted-foreground">
+            They will be marked ignored in your library and leave Needs
+            attention. They won’t be searched until you re-want them.
+          </p>
+          <div className="mt-2 flex gap-2">
+            <button
+              type="button"
+              className="rounded border px-2 py-1 font-mono text-[10px]"
+              style={{ borderColor: "var(--border)" }}
+              onClick={() => runBulk("stop_wanting")}
+            >
+              Stop wanting
+            </button>
+            <button
+              type="button"
+              className="rounded border px-2 py-1 font-mono text-[10px]"
+              style={{ borderColor: "var(--border)" }}
+              onClick={() => setConfirmStop(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {toast && (
+        <div className="shrink-0 px-5 py-1.5 font-mono text-[11px] text-muted-foreground">
+          {toast}
+        </div>
+      )}
+
+      <ul className="min-h-0 flex-1 overflow-auto px-5 py-2">
+        {filtered.map((g) => (
+          <li
+            key={g.group_key}
+            className="flex items-start gap-3 border-b py-2.5"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <input
+              type="checkbox"
+              checked={selected.has(g.group_key)}
+              onChange={() => toggle(g.group_key)}
+              className="mt-1"
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-baseline gap-x-2">
+                <span className="text-[13px] font-medium">{g.series_label}</span>
+                <span className="font-mono text-[11px] text-muted-foreground">
+                  ×{g.member_count}
+                </span>
+                <span
+                  className="font-mono text-[10px] uppercase"
+                  style={{
+                    color:
+                      g.available_actions.includes("retry")
+                        ? "var(--status-error)"
+                        : "var(--status-paused)",
+                  }}
+                >
+                  {g.available_actions.includes("retry")
+                    ? "failed"
+                    : "manual review"}
+                </span>
+              </div>
+              <div className="text-[12px] text-muted-foreground">
+                {g.reason_phrase}
+              </div>
+              <div className="mt-1 flex flex-wrap gap-1.5">
+                {g.available_actions.map((a) => (
+                  <span
+                    key={a}
+                    className="rounded border px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                    style={{ borderColor: "var(--border)" }}
+                  >
+                    {actionLabel(a)}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function FakeTimeline() {
+  return (
+    <div className="min-h-0 flex-1 overflow-auto px-5 py-4">
+      <p className="mb-3 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+        Timeline stays below the fold — position stable (~3 group rows max)
+      </p>
+      {Array.from({ length: 8 }, (_, i) => (
+        <div
+          key={i}
+          className="border-b py-2 text-[13px] text-muted-foreground"
+          style={{ borderColor: "var(--border)" }}
+        >
+          story row {i + 1} · muted history · no actions
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Stub({ label }: { label: string }) {
+  return (
+    <div className="flex flex-1 items-center justify-center p-8 text-center text-[13px] text-muted-foreground">
+      {label}
+    </div>
+  );
+}

--- a/frontend/src/components/activity/prototype-attention/VariantB.tsx
+++ b/frontend/src/components/activity/prototype-attention/VariantB.tsx
@@ -1,0 +1,345 @@
+/**
+ * PROTOTYPE Variant B — one-line band + master-detail sheet (no new tab).
+ *
+ * Band never grows: single status strip. Timeline always near the top.
+ * Triage is a full-height overlay sheet (not Download History).
+ * Left: groups. Right: members + selection + bulk.
+ */
+
+import { useMemo, useState } from "react";
+import { AlertTriangle, X } from "lucide-react";
+import PageHeader, { Tab, TabRow } from "@/components/layout/PageHeader";
+import {
+  MOCK_GROUPS,
+  TOTAL_GROUPS,
+  TOTAL_MEMBERS,
+  actionLabel,
+  rankByNewest,
+  type MockGroup,
+} from "./mockData";
+
+export const VARIANT_B_NAME = "One-line bar + master-detail sheet";
+
+export function VariantB() {
+  const [open, setOpen] = useState(false);
+  const [activeKey, setActiveKey] = useState(MOCK_GROUPS[0]?.group_key ?? "");
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [confirmStop, setConfirmStop] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const ranked = useMemo(() => rankByNewest(MOCK_GROUPS), []);
+  const largest = useMemo(
+    () => [...MOCK_GROUPS].sort((a, b) => b.member_count - a.member_count)[0],
+    [],
+  );
+  const active = ranked.find((g) => g.group_key === activeKey) ?? ranked[0];
+
+  const selectedMemberCount = ranked
+    .filter((g) => selectedKeys.has(g.group_key))
+    .reduce((n, g) => n + g.member_count, 0);
+
+  const toggleSelect = (key: string) => {
+    setSelectedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const run = (action: string) => {
+    const n = Math.min(25, selectedMemberCount || active?.member_count || 0);
+    setToast(`${actionLabel(action)} · processed up to ${n} (cap 25)`);
+    setConfirmStop(false);
+    setSelectedKeys(new Set());
+  };
+
+  return (
+    <div className="page-transition relative flex h-full min-h-0 flex-col">
+      <PageHeader
+        title="Activity"
+        meta="PROTOTYPE B — no fourth tab; sheet is the workspace"
+      />
+      <TabRow>
+        <Tab active label="Timeline" onClick={() => undefined} />
+        <Tab active={false} label="Direct Downloads" onClick={() => undefined} />
+        <Tab active={false} label="Download History" onClick={() => undefined} />
+      </TabRow>
+
+      {/* One-line band — height ceiling is this strip only */}
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex shrink-0 items-center gap-2 border-b px-5 py-2.5 text-left"
+        style={{
+          borderColor: "var(--border)",
+          background:
+            "var(--status-error-bg, color-mix(in oklab, var(--status-error) 12%, transparent))",
+        }}
+      >
+        <AlertTriangle
+          className="h-3.5 w-3.5 shrink-0"
+          style={{ color: "var(--status-error)" }}
+        />
+        <span
+          className="font-mono text-[11px] uppercase tracking-[0.1em]"
+          style={{ color: "var(--status-error)" }}
+        >
+          {TOTAL_GROUPS} need attention
+        </span>
+        <span className="truncate font-mono text-[11px] text-muted-foreground">
+          {TOTAL_MEMBERS} issues · largest {largest?.series_label} ×
+          {largest?.member_count}
+        </span>
+        <span
+          className="ml-auto shrink-0 font-mono text-[11px]"
+          style={{ color: "var(--status-error)" }}
+        >
+          Open triage →
+        </span>
+      </button>
+
+      <div className="min-h-0 flex-1 overflow-auto px-5 py-4">
+        <p className="mb-3 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+          Timeline starts immediately under the one-line band
+        </p>
+        {Array.from({ length: 12 }, (_, i) => (
+          <div
+            key={i}
+            className="border-b py-2 text-[13px] text-muted-foreground"
+            style={{ borderColor: "var(--border)" }}
+          >
+            story row {i + 1}
+          </div>
+        ))}
+      </div>
+
+      {open && (
+        <div
+          className="absolute inset-0 z-40 flex flex-col"
+          style={{ background: "var(--background)" }}
+        >
+          <div
+            className="flex shrink-0 items-center gap-3 border-b px-5 py-3"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <div>
+              <div className="text-[16px] font-semibold">Needs attention</div>
+              <div className="font-mono text-[11px] text-muted-foreground">
+                Unresolved groups only · actions live here · not Download
+                History
+              </div>
+            </div>
+            <button
+              type="button"
+              className="ml-auto rounded border p-1.5"
+              style={{ borderColor: "var(--border)" }}
+              onClick={() => setOpen(false)}
+              aria-label="Close triage"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="flex min-h-0 flex-1">
+            {/* Master list */}
+            <ul
+              className="w-[42%] min-w-[240px] overflow-auto border-r"
+              style={{ borderColor: "var(--border)" }}
+            >
+              {ranked.map((g) => (
+                <li key={g.group_key}>
+                  <button
+                    type="button"
+                    onClick={() => setActiveKey(g.group_key)}
+                    className="flex w-full items-start gap-2 px-4 py-2.5 text-left hover:bg-muted/40"
+                    style={{
+                      background:
+                        g.group_key === active?.group_key
+                          ? "color-mix(in oklab, var(--primary) 8%, transparent)"
+                          : undefined,
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedKeys.has(g.group_key)}
+                      onChange={(e) => {
+                        e.stopPropagation();
+                        toggleSelect(g.group_key);
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      className="mt-1"
+                    />
+                    <div className="min-w-0">
+                      <div className="truncate text-[13px] font-medium">
+                        {g.series_label}{" "}
+                        <span className="font-mono text-[11px] text-muted-foreground">
+                          ×{g.member_count}
+                        </span>
+                      </div>
+                      <div className="truncate text-[11px] text-muted-foreground">
+                        {g.reason_phrase}
+                      </div>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+
+            {/* Detail */}
+            <div className="flex min-w-0 flex-1 flex-col">
+              {active && <Detail group={active} />}
+              <BulkBar
+                selectedGroups={selectedKeys.size}
+                selectedMembers={selectedMemberCount}
+                confirmStop={confirmStop}
+                setConfirmStop={setConfirmStop}
+                onRun={run}
+                toast={toast}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Detail({ group }: { group: MockGroup }) {
+  return (
+    <div className="min-h-0 flex-1 overflow-auto px-5 py-4">
+      <h2 className="text-[15px] font-semibold">{group.series_label}</h2>
+      <p className="mt-1 text-[13px] text-muted-foreground">
+        {group.reason_phrase}
+      </p>
+      <p className="mt-1 font-mono text-[10px] text-muted-foreground">
+        {group.member_count} issues · newest {group.newest_updated_at} · oldest{" "}
+        {group.oldest_updated_at}
+      </p>
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {group.available_actions.map((a) => (
+          <span
+            key={a}
+            className="rounded border px-2 py-1 font-mono text-[10px]"
+            style={{ borderColor: "var(--border)" }}
+          >
+            {actionLabel(a)} (group)
+          </span>
+        ))}
+      </div>
+      <h3 className="mt-5 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+        Members (sample)
+      </h3>
+      <ul className="mt-2">
+        {group.members.map((m) => (
+          <li
+            key={m.release_key}
+            className="border-b py-1.5 text-[13px]"
+            style={{ borderColor: "var(--border)" }}
+          >
+            {m.issue_label}
+            <span className="ml-2 font-mono text-[10px] text-muted-foreground">
+              {m.release_key}
+            </span>
+          </li>
+        ))}
+        {group.member_count > group.members.length && (
+          <li className="py-1.5 text-[12px] text-muted-foreground">
+            …and {group.member_count - group.members.length} more
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
+function BulkBar({
+  selectedGroups,
+  selectedMembers,
+  confirmStop,
+  setConfirmStop,
+  onRun,
+  toast,
+}: {
+  selectedGroups: number;
+  selectedMembers: number;
+  confirmStop: boolean;
+  setConfirmStop: (v: boolean) => void;
+  onRun: (action: string) => void;
+  toast: string | null;
+}) {
+  if (selectedGroups === 0 && !toast && !confirmStop) {
+    return (
+      <div
+        className="shrink-0 border-t px-5 py-2 font-mono text-[10px] text-muted-foreground"
+        style={{ borderColor: "var(--border)" }}
+      >
+        Select groups on the left for bulk · cap 25 issues/click
+      </div>
+    );
+  }
+  return (
+    <div
+      className="shrink-0 border-t px-5 py-3"
+      style={{ borderColor: "var(--border)" }}
+    >
+      {toast && (
+        <p className="mb-2 font-mono text-[11px] text-muted-foreground">{toast}</p>
+      )}
+      {confirmStop ? (
+        <div>
+          <p className="text-[13px] font-medium">
+            Stop acquiring ~{Math.min(25, selectedMembers)} issues across{" "}
+            {selectedGroups} groups?
+          </p>
+          <p className="mt-1 text-[12px] text-muted-foreground">
+            Library intent → ignored. Not an alert dismiss.
+          </p>
+          <div className="mt-2 flex gap-2">
+            <button
+              type="button"
+              className="rounded border px-2 py-1 font-mono text-[10px]"
+              style={{ borderColor: "var(--border)" }}
+              onClick={() => onRun("stop_wanting")}
+            >
+              Stop wanting
+            </button>
+            <button
+              type="button"
+              className="rounded border px-2 py-1 font-mono text-[10px]"
+              style={{ borderColor: "var(--border)" }}
+              onClick={() => setConfirmStop(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        selectedGroups > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-[11px]">
+              {selectedGroups} groups · ~{selectedMembers} issues
+              {selectedMembers > 25 ? " · will process 25" : ""}
+            </span>
+            <button
+              type="button"
+              className="rounded border px-2 py-1 font-mono text-[10px]"
+              style={{ borderColor: "var(--border)" }}
+              onClick={() => onRun("search_again")}
+            >
+              Search again
+            </button>
+            <button
+              type="button"
+              className="rounded border px-2 py-1 font-mono text-[10px]"
+              style={{ borderColor: "var(--border)" }}
+              onClick={() => setConfirmStop(true)}
+            >
+              Stop wanting…
+            </button>
+          </div>
+        )
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/activity/prototype-attention/VariantC.tsx
+++ b/frontend/src/components/activity/prototype-attention/VariantC.tsx
@@ -1,0 +1,359 @@
+/**
+ * PROTOTYPE Variant C — issue cards on the band + dedicated /attention route.
+ *
+ * Band: top 5 cards ranked by newest, stage-coloured (failed vs manual_review).
+ * Height ceiling: fixed card row (~168px). Fold: "See all N →" deep-links.
+ * Triage: own "route" (mock) with age facet + stage split — answers "do stages
+ * read differently" and "not Download History".
+ */
+
+import { useMemo, useState } from "react";
+import { AlertTriangle, ArrowLeft } from "lucide-react";
+import PageHeader, { Tab, TabRow } from "@/components/layout/PageHeader";
+import {
+  MOCK_GROUPS,
+  TOTAL_GROUPS,
+  actionLabel,
+  rankByNewest,
+  type MockGroup,
+} from "./mockData";
+
+const PREVIEW_CAP = 5;
+
+export const VARIANT_C_NAME = "Issue cards + dedicated route";
+
+export function VariantC() {
+  const [route, setRoute] = useState<"activity" | "attention">("activity");
+  const ranked = useMemo(() => rankByNewest(MOCK_GROUPS), []);
+
+  if (route === "attention") {
+    return <AttentionRoute groups={ranked} onBack={() => setRoute("activity")} />;
+  }
+
+  const preview = ranked.slice(0, PREVIEW_CAP);
+  const more = ranked.length - preview.length;
+
+  return (
+    <div className="page-transition flex h-full min-h-0 flex-col">
+      <PageHeader
+        title="Activity"
+        meta="PROTOTYPE C — dedicated attention route, cards on band"
+      />
+      <TabRow>
+        <Tab active label="Timeline" onClick={() => undefined} />
+        <Tab active={false} label="Direct Downloads" onClick={() => undefined} />
+        <Tab active={false} label="Download History" onClick={() => undefined} />
+      </TabRow>
+
+      <section
+        className="shrink-0 border-b"
+        style={{
+          borderColor: "var(--border)",
+          maxHeight: 176,
+          overflow: "hidden",
+          background:
+            "var(--status-error-bg, color-mix(in oklab, var(--status-error) 8%, transparent))",
+        }}
+      >
+        <div className="flex items-center gap-2 px-5 pt-3 pb-2">
+          <AlertTriangle
+            className="h-3.5 w-3.5"
+            style={{ color: "var(--status-error)" }}
+          />
+          <span
+            className="font-mono text-[11px] uppercase tracking-[0.1em]"
+            style={{ color: "var(--status-error)" }}
+          >
+            {TOTAL_GROUPS} problems
+          </span>
+          <span className="font-mono text-[10px] text-muted-foreground">
+            ranked newest · stage colour
+          </span>
+          <button
+            type="button"
+            onClick={() => setRoute("attention")}
+            className="ml-auto font-mono text-[11px]"
+            style={{ color: "var(--status-error)" }}
+          >
+            See all {TOTAL_GROUPS} →
+          </button>
+        </div>
+        <div className="flex gap-2 overflow-x-auto px-5 pb-3">
+          {preview.map((g) => (
+            <Card key={g.group_key} group={g} onOpen={() => setRoute("attention")} />
+          ))}
+          {more > 0 && (
+            <button
+              type="button"
+              onClick={() => setRoute("attention")}
+              className="flex h-[104px] w-[120px] shrink-0 flex-col items-center justify-center rounded border border-dashed font-mono text-[11px] text-muted-foreground"
+              style={{ borderColor: "var(--border)" }}
+            >
+              +{more}
+              <span className="mt-1">more</span>
+            </button>
+          )}
+        </div>
+      </section>
+
+      <div className="min-h-0 flex-1 overflow-auto px-5 py-4">
+        <p className="mb-3 font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+          Timeline — band height capped at one card row
+        </p>
+        {Array.from({ length: 10 }, (_, i) => (
+          <div
+            key={i}
+            className="border-b py-2 text-[13px] text-muted-foreground"
+            style={{ borderColor: "var(--border)" }}
+          >
+            story row {i + 1}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function stageOf(g: MockGroup): "failed" | "manual_review" {
+  return g.available_actions.includes("retry") ? "failed" : "manual_review";
+}
+
+function Card({ group, onOpen }: { group: MockGroup; onOpen: () => void }) {
+  const stage = stageOf(group);
+  const color =
+    stage === "failed" ? "var(--status-error)" : "var(--status-paused)";
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex h-[104px] w-[200px] shrink-0 flex-col rounded border bg-background p-2.5 text-left"
+      style={{ borderColor: "var(--border)" }}
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          className="h-1.5 w-1.5 rounded-full"
+          style={{ background: color }}
+        />
+        <span
+          className="font-mono text-[9px] uppercase tracking-wider"
+          style={{ color }}
+        >
+          {stage === "failed" ? "failed" : "review"}
+        </span>
+        <span className="ml-auto font-mono text-[11px] font-semibold">
+          ×{group.member_count}
+        </span>
+      </div>
+      <div className="mt-1.5 line-clamp-2 text-[12px] font-medium leading-snug">
+        {group.series_label}
+      </div>
+      <div className="mt-auto line-clamp-2 text-[10px] text-muted-foreground">
+        {group.reason_phrase}
+      </div>
+    </button>
+  );
+}
+
+function AttentionRoute({
+  groups,
+  onBack,
+}: {
+  groups: MockGroup[];
+  onBack: () => void;
+}) {
+  const [stageFilter, setStageFilter] = useState<"all" | "failed" | "manual_review">(
+    "all",
+  );
+  const [age, setAge] = useState<"all" | "7d" | "30d">("all");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [toast, setToast] = useState<string | null>(null);
+
+  const filtered = groups.filter((g) => {
+    const st = stageOf(g);
+    if (stageFilter !== "all" && st !== stageFilter) return false;
+    if (age === "7d" && g.newest_updated_at < "2026-07-04") return false;
+    if (age === "30d" && g.newest_updated_at < "2026-06-11") return false;
+    return true;
+  });
+
+  const memberN = filtered
+    .filter((g) => selected.has(g.group_key))
+    .reduce((n, g) => n + g.member_count, 0);
+
+  return (
+    <div className="page-transition flex h-full min-h-0 flex-col">
+      <PageHeader
+        title="Needs attention"
+        meta="PROTOTYPE C route · /activity/attention · actionable only"
+        actions={
+          <button
+            type="button"
+            onClick={onBack}
+            className="inline-flex items-center gap-1 rounded border px-2 py-1 font-mono text-[11px]"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <ArrowLeft className="h-3 w-3" /> Activity
+          </button>
+        }
+      />
+
+      <div
+        className="flex shrink-0 flex-wrap items-center gap-2 border-b px-5 py-2.5"
+        style={{ borderColor: "var(--border)" }}
+      >
+        {(
+          [
+            ["all", "All stages"],
+            ["failed", "Failed"],
+            ["manual_review", "Manual review"],
+          ] as const
+        ).map(([id, label]) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => setStageFilter(id)}
+            className="rounded border px-2 py-1 font-mono text-[10px]"
+            style={{
+              borderColor: "var(--border)",
+              background:
+                stageFilter === id
+                  ? "color-mix(in oklab, var(--primary) 12%, transparent)"
+                  : undefined,
+            }}
+          >
+            {label}
+          </button>
+        ))}
+        <select
+          className="rounded border bg-transparent px-2 py-1 font-mono text-[11px]"
+          style={{ borderColor: "var(--border)" }}
+          value={age}
+          onChange={(e) => setAge(e.target.value as typeof age)}
+        >
+          <option value="all">Any age</option>
+          <option value="7d">Last 7 days</option>
+          <option value="30d">Last 30 days</option>
+        </select>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          vs Download History: only unresolved · group actions · no import ledger
+        </span>
+      </div>
+
+      {selected.size > 0 && (
+        <div
+          className="flex shrink-0 items-center gap-2 border-b px-5 py-2"
+          style={{
+            borderColor: "var(--border)",
+            background: "color-mix(in oklab, var(--primary) 8%, transparent)",
+          }}
+        >
+          <span className="font-mono text-[11px]">
+            {selected.size} groups · ~{memberN} issues
+            {memberN > 25 ? " · cap 25" : ""}
+          </span>
+          <button
+            type="button"
+            className="rounded border px-2 py-1 font-mono text-[10px]"
+            style={{ borderColor: "var(--border)" }}
+            onClick={() => {
+              setToast(
+                `Search again · ${Math.min(25, memberN)} of ${memberN}`,
+              );
+              setSelected(new Set());
+            }}
+          >
+            Search again
+          </button>
+          <button
+            type="button"
+            className="rounded border px-2 py-1 font-mono text-[10px]"
+            style={{ borderColor: "var(--border)" }}
+            onClick={() => {
+              setToast(
+                `Stop wanting confirm would open · ${Math.min(25, memberN)} issues`,
+              );
+            }}
+          >
+            Stop wanting…
+          </button>
+        </div>
+      )}
+
+      {toast && (
+        <div className="px-5 py-1.5 font-mono text-[11px] text-muted-foreground">
+          {toast}
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-auto p-5">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((g) => {
+            const stage = stageOf(g);
+            const color =
+              stage === "failed"
+                ? "var(--status-error)"
+                : "var(--status-paused)";
+            return (
+              <div
+                key={g.group_key}
+                className="rounded border p-3"
+                style={{ borderColor: "var(--border)" }}
+              >
+                <div className="flex items-start gap-2">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(g.group_key)}
+                    onChange={() => {
+                      setSelected((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(g.group_key)) next.delete(g.group_key);
+                        else next.add(g.group_key);
+                        return next;
+                      });
+                    }}
+                    className="mt-1"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="font-mono text-[9px] uppercase"
+                        style={{ color }}
+                      >
+                        {stage === "failed" ? "failed" : "manual review"}
+                      </span>
+                      <span className="ml-auto font-mono text-[12px]">
+                        ×{g.member_count}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-[13px] font-medium">
+                      {g.series_label}
+                    </div>
+                    <div className="mt-1 text-[12px] text-muted-foreground">
+                      {g.reason_phrase}
+                    </div>
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {g.available_actions.map((a) => (
+                        <span
+                          key={a}
+                          className="rounded border px-1.5 py-0.5 font-mono text-[10px]"
+                          style={{ borderColor: "var(--border)" }}
+                        >
+                          {actionLabel(a)}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        {filtered.length === 0 && (
+          <p className="text-center text-[13px] text-muted-foreground">
+            No groups match these filters — band would hide when empty.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/activity/prototype-attention/mockData.ts
+++ b/frontend/src/components/activity/prototype-attention/mockData.ts
@@ -1,0 +1,300 @@
+/**
+ * PROTOTYPE — throwaway mock for needs-attention band / triage (#526).
+ * Shaped like production after actionability + grouping decisions.
+ * Do not import from production paths.
+ */
+
+export type Stage = "failed" | "manual_review";
+
+export type MockMember = {
+  release_key: string;
+  issue_label: string;
+  updated_at: string;
+  stage: Stage;
+};
+
+export type MockGroup = {
+  group_key: string;
+  comicid: string;
+  series_label: string;
+  base_reason: string;
+  reason_phrase: string;
+  member_count: number;
+  newest_updated_at: string;
+  oldest_updated_at: string;
+  available_actions: string[];
+  members: MockMember[];
+};
+
+/** Operator-facing phrases for admitted base tokens (draft for #526). */
+export const REASON_PHRASES: Record<string, string> = {
+  downloaded_invalid_artifact_command: "downloaded file failed post-process checks",
+  invalid_recovered_postprocess_command: "recovered download has a bad post-process command",
+  postprocess_error: "post-processing failed",
+  invalid_postprocess_command: "post-process command is invalid",
+  recovered_postprocess_error: "recovered download failed post-processing",
+  ddl_artifact_state_persistence_error: "could not save download state (DDL)",
+  torrent_artifact_state_persistence_error: "could not save download state (torrent)",
+  nzb_artifact_state_persistence_error: "could not save download state (NZB)",
+  reserved_without_persisted_acceptance: "download reserved but not fully accepted",
+  route_acceptance_missing_identity: "acceptance missing identity fields",
+  submission_outcome_unknown: "submission result unknown — check the downloader",
+  route_not_restart_safe: "route is not safe to resume after restart",
+  download_failed_no_auto_handling: "download failed — auto-handling is off",
+  submission_rejected: "submission was rejected",
+};
+
+function members(
+  series: string,
+  n: number,
+  stage: Stage,
+  prefix: string,
+  newest: string,
+): MockMember[] {
+  return Array.from({ length: n }, (_, i) => ({
+    release_key: `${prefix}|${i + 1}`,
+    issue_label: `${series} #${i + 1}`,
+    updated_at: newest,
+    stage,
+  }));
+}
+
+function group(
+  comicid: string,
+  series: string,
+  base_reason: string,
+  n: number,
+  stage: Stage,
+  newest: string,
+  oldest: string,
+): MockGroup {
+  const actions =
+    stage === "failed"
+      ? ["retry", "stop_wanting"]
+      : ["import", "search_again", "stop_wanting"];
+  return {
+    group_key: `${comicid}|${base_reason}`,
+    comicid,
+    series_label: series,
+    base_reason,
+    reason_phrase: REASON_PHRASES[base_reason] ?? "something went wrong",
+    member_count: n,
+    newest_updated_at: newest,
+    oldest_updated_at: oldest,
+    available_actions: actions,
+    members: members(series, Math.min(n, 8), stage, `${comicid}-${base_reason}`, newest),
+  };
+}
+
+/** ~20 groups, production-ish weights after admission. */
+export const MOCK_GROUPS: MockGroup[] = [
+  group(
+    "18839",
+    "Looney Tunes",
+    "downloaded_invalid_artifact_command",
+    47,
+    "manual_review",
+    "2026-07-11T11:30:04Z",
+    "2026-07-11T11:30:00Z",
+  ),
+  group(
+    "158418",
+    "X-Men: From the Ashes Infinity Comic",
+    "downloaded_invalid_artifact_command",
+    19,
+    "manual_review",
+    "2026-07-11T11:30:03Z",
+    "2026-07-11T11:30:00Z",
+  ),
+  group(
+    "91078",
+    "Action Comics",
+    "downloaded_invalid_artifact_command",
+    15,
+    "manual_review",
+    "2026-07-11T11:30:02Z",
+    "2026-07-11T11:30:00Z",
+  ),
+  group(
+    "142577",
+    "The Amazing Spider-Man",
+    "postprocess_error",
+    12,
+    "manual_review",
+    "2026-07-11T11:30:01Z",
+    "2026-07-11T11:30:00Z",
+  ),
+  group(
+    "148476",
+    "Superman",
+    "downloaded_invalid_artifact_command",
+    11,
+    "manual_review",
+    "2026-07-11T11:30:01Z",
+    "2026-07-11T11:30:00Z",
+  ),
+  group(
+    "58231",
+    "Swamp Thing",
+    "invalid_recovered_postprocess_command",
+    11,
+    "manual_review",
+    "2026-07-11T11:30:00Z",
+    "2026-07-11T11:30:00Z",
+  ),
+  group(
+    "145912",
+    "Fantastic Four",
+    "downloaded_invalid_artifact_command",
+    10,
+    "manual_review",
+    "2026-07-11T11:30:00Z",
+    "2026-07-11T11:30:00Z",
+  ),
+  group(
+    "153968",
+    "Transformers",
+    "submission_outcome_unknown",
+    10,
+    "manual_review",
+    "2026-07-10T08:00:00Z",
+    "2026-07-09T12:00:00Z",
+  ),
+  group(
+    "141907",
+    "Batman/Superman: World's Finest",
+    "download_failed_no_auto_handling",
+    7,
+    "failed",
+    "2026-07-08T16:00:00Z",
+    "2026-07-01T10:00:00Z",
+  ),
+  group(
+    "120001",
+    "Detective Comics",
+    "submission_rejected",
+    6,
+    "failed",
+    "2026-07-07T14:00:00Z",
+    "2026-07-07T14:00:00Z",
+  ),
+  group(
+    "120002",
+    "Green Lantern",
+    "downloaded_invalid_artifact_command",
+    5,
+    "manual_review",
+    "2026-07-06T09:00:00Z",
+    "2026-07-06T09:00:00Z",
+  ),
+  group(
+    "120003",
+    "Wonder Woman",
+    "route_not_restart_safe",
+    4,
+    "manual_review",
+    "2026-07-05T11:00:00Z",
+    "2026-07-05T11:00:00Z",
+  ),
+  group(
+    "120004",
+    "Aquaman",
+    "postprocess_error",
+    4,
+    "manual_review",
+    "2026-07-04T11:00:00Z",
+    "2026-07-04T11:00:00Z",
+  ),
+  group(
+    "120005",
+    "Flash",
+    "downloaded_invalid_artifact_command",
+    3,
+    "manual_review",
+    "2026-07-03T11:00:00Z",
+    "2026-07-03T11:00:00Z",
+  ),
+  group(
+    "120006",
+    "Hawkman",
+    "reserved_without_persisted_acceptance",
+    3,
+    "manual_review",
+    "2026-07-02T11:00:00Z",
+    "2026-07-02T11:00:00Z",
+  ),
+  group(
+    "120007",
+    "Martian Manhunter",
+    "downloaded_invalid_artifact_command",
+    2,
+    "manual_review",
+    "2026-07-01T11:00:00Z",
+    "2026-07-01T11:00:00Z",
+  ),
+  group(
+    "120008",
+    "Shazam!",
+    "ddl_artifact_state_persistence_error",
+    2,
+    "manual_review",
+    "2026-06-30T11:00:00Z",
+    "2026-06-30T11:00:00Z",
+  ),
+  group(
+    "orphan-rk-1",
+    "Series (unlabelled)",
+    "downloaded_invalid_artifact_command",
+    1,
+    "manual_review",
+    "2026-06-29T11:00:00Z",
+    "2026-06-29T11:00:00Z",
+  ),
+  group(
+    "120009",
+    "Booster Gold",
+    "route_acceptance_missing_identity",
+    1,
+    "manual_review",
+    "2026-06-28T11:00:00Z",
+    "2026-06-28T11:00:00Z",
+  ),
+  group(
+    "120010",
+    "Blue Beetle",
+    "submission_rejected",
+    1,
+    "failed",
+    "2026-06-27T11:00:00Z",
+    "2026-06-27T11:00:00Z",
+  ),
+];
+
+export const TOTAL_GROUPS = MOCK_GROUPS.length;
+export const TOTAL_MEMBERS = MOCK_GROUPS.reduce((s, g) => s + g.member_count, 0);
+
+export function rankByVolumeThenNewest(groups: MockGroup[]): MockGroup[] {
+  return [...groups].sort((a, b) => {
+    if (b.member_count !== a.member_count) return b.member_count - a.member_count;
+    return b.newest_updated_at.localeCompare(a.newest_updated_at);
+  });
+}
+
+export function rankByNewest(groups: MockGroup[]): MockGroup[] {
+  return [...groups].sort((a, b) => b.newest_updated_at.localeCompare(a.newest_updated_at));
+}
+
+export function actionLabel(id: string): string {
+  switch (id) {
+    case "retry":
+      return "Retry";
+    case "search_again":
+      return "Search again";
+    case "import":
+      return "Import";
+    case "stop_wanting":
+      return "Stop wanting";
+    default:
+      return id;
+  }
+}

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -15,6 +15,10 @@ import {
 } from "@/hooks/useActivity";
 import { useDebounce } from "@/hooks/use-debounce";
 import { TimelineView } from "@/components/activity/timeline";
+import { AttentionPrototypeHost } from "@/components/activity/prototype-attention/AttentionPrototypeHost";
+import {
+  parseVariant,
+} from "@/components/activity/prototype-attention/PrototypeSwitcher";
 import { DataTable } from "@/components/data-table/DataTable";
 import { useTableState } from "@/components/data-table/useTableState";
 import { useServerPage } from "@/components/data-table/useServerPage";
@@ -117,6 +121,14 @@ export default function ActivityPage() {
 
   const scope_type = searchParams.get("scope_type");
   const scope_id = searchParams.get("scope_id");
+
+  // PROTOTYPE #526 — gated by ?variant=A|B|C; never shown without the param.
+  const protoVariant = !import.meta.env.PROD
+    ? parseVariant(searchParams.get("variant"))
+    : null;
+  if (protoVariant) {
+    return <AttentionPrototypeHost variant={protoVariant} />;
+  }
 
   const setView = (view: ActivityView) => {
     setSearchParams((current) => {


### PR DESCRIPTION
## TLDR

Frontend `npm run dev` now uses portless (`https://comicarr.localhost:1355`) so other local apps no longer steal port 5173. Also lands the throwaway needs-attention band UI prototype from wayfinder #520 (Variant C chosen).

## Description

- Wire [portless](https://github.com/vercel-labs/portless) as the default frontend dev entry (`portless run vite` on proxy port 1355); keep `npm run dev:vite` for raw Vite / feval.
- Document the new URL in AGENTS/CLAUDE/CONTRIBUTING/READMEs; add `docs/agents/` tracker notes used by wayfinding skills.
- Add `frontend/src/components/activity/prototype-attention/` (variants A–C, switcher) gated by `?variant=` on Activity in non-production builds — primary source for [Prototype the bounded band preview and triage surface](https://github.com/frankieramirez/comicarr/issues/526) (winner: **C**).

## Notes

- No operator-facing product change when `?variant=` is absent; no changeset.
- Prototype is throwaway reference for implementation of the band contract map (#520); fold C in later, then drop the switcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added three development-only Activity prototypes for reviewing and managing items needing attention.
  - Added variant switching with URL controls, previous/next navigation, and keyboard shortcuts.
  - Prototypes include filtering, grouping, details, bulk actions, confirmations, and feedback messages.
  - Added a preferred local HTTPS development URL with a raw Vite fallback.

- **Documentation**
  - Expanded frontend setup, proxy, HTTPS trust, and development workflow guidance.
  - Added guidance for domain concepts, issue tracking, and triage labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->