### PR TITLE
fix: restore frontend CI after attention prototype

### DIFF
--- a/frontend/src/components/activity/prototype-attention/PrototypeSwitcher.tsx
+++ b/frontend/src/components/activity/prototype-attention/PrototypeSwitcher.tsx
@@ -26,6 +26,10 @@ export function parseVariant(raw: string | null): VariantKey | null {
 export function PrototypeSwitcher() {
   if (import.meta.env.PROD) return null;
 
+  return <DevelopmentPrototypeSwitcher />;
+}
+
+function DevelopmentPrototypeSwitcher() {
   const [params, setParams] = useSearchParams();
   const current = parseVariant(params.get("variant")) ?? "A";
 
@@ -111,7 +115,10 @@ export function PrototypeSwitcher() {
       </button>
       <div className="min-w-[220px] text-center font-mono text-[11px]">
         <span className="font-semibold">{current}</span>
-        <span className="text-muted-foreground"> — {VARIANT_META[current]}</span>
+        <span className="text-muted-foreground">
+          {" "}
+          — {VARIANT_META[current]}
+        </span>
       </div>
       <button
         type="button"

--- a/frontend/src/components/activity/prototype-attention/VariantA.tsx
+++ b/frontend/src/components/activity/prototype-attention/VariantA.tsx
@@ -155,7 +155,8 @@ function TriageTable({ groups }: { groups: MockGroup[] }) {
 
   const filtered = groups.filter((g) => {
     if (reasonFilter && g.base_reason !== reasonFilter) return false;
-    if (q && !g.series_label.toLowerCase().includes(q.toLowerCase())) return false;
+    if (q && !g.series_label.toLowerCase().includes(q.toLowerCase()))
+      return false;
     return true;
   });
 
@@ -189,7 +190,10 @@ function TriageTable({ groups }: { groups: MockGroup[] }) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b px-5 py-2.5" style={{ borderColor: "var(--border)" }}>
+      <div
+        className="flex shrink-0 flex-wrap items-center gap-2 border-b px-5 py-2.5"
+        style={{ borderColor: "var(--border)" }}
+      >
         <input
           className="max-w-xs flex-1 rounded border bg-transparent px-2 py-1 font-mono text-[11px]"
           style={{ borderColor: "var(--border)" }}
@@ -211,7 +215,8 @@ function TriageTable({ groups }: { groups: MockGroup[] }) {
           ))}
         </select>
         <span className="font-mono text-[10px] text-muted-foreground">
-          {filtered.length} groups · not Download History (only unresolved + actions)
+          {filtered.length} groups · not Download History (only unresolved +
+          actions)
         </span>
       </div>
 
@@ -304,17 +309,18 @@ function TriageTable({ groups }: { groups: MockGroup[] }) {
             />
             <div className="min-w-0 flex-1">
               <div className="flex flex-wrap items-baseline gap-x-2">
-                <span className="text-[13px] font-medium">{g.series_label}</span>
+                <span className="text-[13px] font-medium">
+                  {g.series_label}
+                </span>
                 <span className="font-mono text-[11px] text-muted-foreground">
                   ×{g.member_count}
                 </span>
                 <span
                   className="font-mono text-[10px] uppercase"
                   style={{
-                    color:
-                      g.available_actions.includes("retry")
-                        ? "var(--status-error)"
-                        : "var(--status-paused)",
+                    color: g.available_actions.includes("retry")
+                      ? "var(--status-error)"
+                      : "var(--status-paused)",
                   }}
                 >
                   {g.available_actions.includes("retry")

--- a/frontend/src/components/activity/prototype-attention/VariantB.tsx
+++ b/frontend/src/components/activity/prototype-attention/VariantB.tsx
@@ -62,8 +62,16 @@ export function VariantB() {
       />
       <TabRow>
         <Tab active label="Timeline" onClick={() => undefined} />
-        <Tab active={false} label="Direct Downloads" onClick={() => undefined} />
-        <Tab active={false} label="Download History" onClick={() => undefined} />
+        <Tab
+          active={false}
+          label="Direct Downloads"
+          onClick={() => undefined}
+        />
+        <Tab
+          active={false}
+          label="Download History"
+          onClick={() => undefined}
+        />
       </TabRow>
 
       {/* One-line band — height ceiling is this strip only */}
@@ -284,7 +292,9 @@ function BulkBar({
       style={{ borderColor: "var(--border)" }}
     >
       {toast && (
-        <p className="mb-2 font-mono text-[11px] text-muted-foreground">{toast}</p>
+        <p className="mb-2 font-mono text-[11px] text-muted-foreground">
+          {toast}
+        </p>
       )}
       {confirmStop ? (
         <div>

--- a/frontend/src/components/activity/prototype-attention/VariantC.tsx
+++ b/frontend/src/components/activity/prototype-attention/VariantC.tsx
@@ -27,7 +27,9 @@ export function VariantC() {
   const ranked = useMemo(() => rankByNewest(MOCK_GROUPS), []);
 
   if (route === "attention") {
-    return <AttentionRoute groups={ranked} onBack={() => setRoute("activity")} />;
+    return (
+      <AttentionRoute groups={ranked} onBack={() => setRoute("activity")} />
+    );
   }
 
   const preview = ranked.slice(0, PREVIEW_CAP);
@@ -41,8 +43,16 @@ export function VariantC() {
       />
       <TabRow>
         <Tab active label="Timeline" onClick={() => undefined} />
-        <Tab active={false} label="Direct Downloads" onClick={() => undefined} />
-        <Tab active={false} label="Download History" onClick={() => undefined} />
+        <Tab
+          active={false}
+          label="Direct Downloads"
+          onClick={() => undefined}
+        />
+        <Tab
+          active={false}
+          label="Download History"
+          onClick={() => undefined}
+        />
       </TabRow>
 
       <section
@@ -80,7 +90,11 @@ export function VariantC() {
         </div>
         <div className="flex gap-2 overflow-x-auto px-5 pb-3">
           {preview.map((g) => (
-            <Card key={g.group_key} group={g} onOpen={() => setRoute("attention")} />
+            <Card
+              key={g.group_key}
+              group={g}
+              onOpen={() => setRoute("attention")}
+            />
           ))}
           {more > 0 && (
             <button
@@ -161,9 +175,9 @@ function AttentionRoute({
   groups: MockGroup[];
   onBack: () => void;
 }) {
-  const [stageFilter, setStageFilter] = useState<"all" | "failed" | "manual_review">(
-    "all",
-  );
+  const [stageFilter, setStageFilter] = useState<
+    "all" | "failed" | "manual_review"
+  >("all");
   const [age, setAge] = useState<"all" | "7d" | "30d">("all");
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [toast, setToast] = useState<string | null>(null);
@@ -235,7 +249,8 @@ function AttentionRoute({
           <option value="30d">Last 30 days</option>
         </select>
         <span className="font-mono text-[10px] text-muted-foreground">
-          vs Download History: only unresolved · group actions · no import ledger
+          vs Download History: only unresolved · group actions · no import
+          ledger
         </span>
       </div>
 
@@ -256,9 +271,7 @@ function AttentionRoute({
             className="rounded border px-2 py-1 font-mono text-[10px]"
             style={{ borderColor: "var(--border)" }}
             onClick={() => {
-              setToast(
-                `Search again · ${Math.min(25, memberN)} of ${memberN}`,
-              );
+              setToast(`Search again · ${Math.min(25, memberN)} of ${memberN}`);
               setSelected(new Set());
             }}
           >

--- a/frontend/src/components/activity/prototype-attention/mockData.ts
+++ b/frontend/src/components/activity/prototype-attention/mockData.ts
@@ -28,17 +28,22 @@ export type MockGroup = {
 
 /** Operator-facing phrases for admitted base tokens (draft for #526). */
 export const REASON_PHRASES: Record<string, string> = {
-  downloaded_invalid_artifact_command: "downloaded file failed post-process checks",
-  invalid_recovered_postprocess_command: "recovered download has a bad post-process command",
+  downloaded_invalid_artifact_command:
+    "downloaded file failed post-process checks",
+  invalid_recovered_postprocess_command:
+    "recovered download has a bad post-process command",
   postprocess_error: "post-processing failed",
   invalid_postprocess_command: "post-process command is invalid",
   recovered_postprocess_error: "recovered download failed post-processing",
   ddl_artifact_state_persistence_error: "could not save download state (DDL)",
-  torrent_artifact_state_persistence_error: "could not save download state (torrent)",
+  torrent_artifact_state_persistence_error:
+    "could not save download state (torrent)",
   nzb_artifact_state_persistence_error: "could not save download state (NZB)",
-  reserved_without_persisted_acceptance: "download reserved but not fully accepted",
+  reserved_without_persisted_acceptance:
+    "download reserved but not fully accepted",
   route_acceptance_missing_identity: "acceptance missing identity fields",
-  submission_outcome_unknown: "submission result unknown — check the downloader",
+  submission_outcome_unknown:
+    "submission result unknown — check the downloader",
   route_not_restart_safe: "route is not safe to resume after restart",
   download_failed_no_auto_handling: "download failed — auto-handling is off",
   submission_rejected: "submission was rejected",
@@ -82,7 +87,13 @@ function group(
     newest_updated_at: newest,
     oldest_updated_at: oldest,
     available_actions: actions,
-    members: members(series, Math.min(n, 8), stage, `${comicid}-${base_reason}`, newest),
+    members: members(
+      series,
+      Math.min(n, 8),
+      stage,
+      `${comicid}-${base_reason}`,
+      newest,
+    ),
   };
 }
 
@@ -271,17 +282,23 @@ export const MOCK_GROUPS: MockGroup[] = [
 ];
 
 export const TOTAL_GROUPS = MOCK_GROUPS.length;
-export const TOTAL_MEMBERS = MOCK_GROUPS.reduce((s, g) => s + g.member_count, 0);
+export const TOTAL_MEMBERS = MOCK_GROUPS.reduce(
+  (s, g) => s + g.member_count,
+  0,
+);
 
 export function rankByVolumeThenNewest(groups: MockGroup[]): MockGroup[] {
   return [...groups].sort((a, b) => {
-    if (b.member_count !== a.member_count) return b.member_count - a.member_count;
+    if (b.member_count !== a.member_count)
+      return b.member_count - a.member_count;
     return b.newest_updated_at.localeCompare(a.newest_updated_at);
   });
 }
 
 export function rankByNewest(groups: MockGroup[]): MockGroup[] {
-  return [...groups].sort((a, b) => b.newest_updated_at.localeCompare(a.newest_updated_at));
+  return [...groups].sort((a, b) =>
+    b.newest_updated_at.localeCompare(a.newest_updated_at),
+  );
 }
 
 export function actionLabel(id: string): string {

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -16,9 +16,7 @@ import {
 import { useDebounce } from "@/hooks/use-debounce";
 import { TimelineView } from "@/components/activity/timeline";
 import { AttentionPrototypeHost } from "@/components/activity/prototype-attention/AttentionPrototypeHost";
-import {
-  parseVariant,
-} from "@/components/activity/prototype-attention/PrototypeSwitcher";
+import { parseVariant } from "@/components/activity/prototype-attention/PrototypeSwitcher";
 import { DataTable } from "@/components/data-table/DataTable";
 import { useTableState } from "@/components/data-table/useTableState";
 import { useServerPage } from "@/components/data-table/useServerPage";


### PR DESCRIPTION
## What changed

- move the development-only prototype switcher hooks into a dedicated child component so hooks are always called unconditionally
- apply the repository's Prettier formatting to the six prototype files that failed the frontend format gate

## Root cause

PR #529 placed `useSearchParams` and `useEffect` after a production-only early return. ESLint correctly reported both as conditional hook calls. Once that lint error was removed, the prototype files also failed the next CI step, `format:check`.

Because all open Dependabot PRs are based on this broken `main`, they inherited the same frontend failures despite unrelated diffs.

## Impact

Production behavior is unchanged: the prototype switcher remains absent from production builds. This restores the frontend CI path so the Dependabot PRs can be rebased and evaluated on their own changes.

## Validation

- `PATH="$PWD/.venv/bin:$PATH" npm run lint`
- `npm run typecheck`
- `npm run build`
- `npx --yes -p node@22 -c 'node --version && npm run test:run'` — 46 files, 316 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for development-only prototype switching.
  * Reformatted prototype views and download-related interface elements for consistency.
  * Updated sample activity data and exposed a total member count for development use.

* **Bug Fixes**
  * Updated sample reason descriptions displayed in prototype activity data.

* **Style**
  * Applied consistent formatting across prototype components without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->