### PR TITLE
feat: Add select-all bulk selection to Needs attention

### DIFF
--- a/.changeset/attention-select-all.md
+++ b/.changeset/attention-select-all.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Needs attention now has a "select all" checkbox in the filter bar, so every visible issue can be selected at once instead of checking cards one by one. It follows the active filters — narrow to Failed or the last 7 days first and only those issues are grabbed — and it shows a dash when only some are picked.

--- a/frontend/src/pages/AttentionPage.tsx
+++ b/frontend/src/pages/AttentionPage.tsx
@@ -124,6 +124,18 @@ export default function AttentionPage() {
     selectedMembers.map(({ group }) => group.group_key),
   ).size;
 
+  // Every issue the current filters admit — what "select all" means here, so
+  // narrowing the filters first narrows what the checkbox grabs.
+  const filteredKeys = useMemo(
+    () =>
+      filtered.flatMap((group) =>
+        group.members.map((member) => member.release_key),
+      ),
+    [filtered],
+  );
+  const allSelected =
+    filteredKeys.length > 0 && selectedIssues === filteredKeys.length;
+
   const scoped = Boolean(scope_type?.trim() && scope_id?.trim());
 
   const clearGroupFocus = () => {
@@ -299,6 +311,22 @@ export default function AttentionPage() {
           <option value="7d">last 7 days</option>
           <option value="30d">last 30 days</option>
         </select>
+        {filteredKeys.length > 0 && (
+          <label className="flex cursor-pointer items-center gap-1.5 font-mono text-[10px] text-muted-foreground hover:text-foreground">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              ref={(node) => {
+                // Partial selection must not read as "none picked".
+                if (node)
+                  node.indeterminate = selectedIssues > 0 && !allSelected;
+              }}
+              onChange={() => setKeysSelected(filteredKeys, !allSelected)}
+              aria-label={`Select all ${filteredKeys.length} issues`}
+            />
+            select all {filteredKeys.length}
+          </label>
+        )}
         <span className="ml-auto font-mono text-[10px] text-muted-foreground">
           unresolved only · Download History keeps the full ledger
         </span>


### PR DESCRIPTION
Needs attention gets a "select all" checkbox in the filter bar, so every visible issue can be selected in one click instead of checking cards one at a time.

- Adds a tri-state **select all N** checkbox to the filter row that selects every issue admitted by the current filters (stage, age, text query) — narrowing filters first narrows what it grabs
- Shows the indeterminate dash when only some issues are picked; plugs into the existing selection bar, shared bulk actions, and 25-at-a-time batch cap unchanged
- Adds a minor changeset for the operator-visible feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aCEmgQAyokpGGRuqZQXLU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Select all” checkbox to the filter bar for selecting or clearing all visible issues.
  * The checkbox reflects partial selections with an indeterminate state.
  * Displays the number of issues matching the active filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->