### PR TITLE
feat: Band actionability test and reconciliation (#541)

### DIFF
--- a/.changeset/band-actionability.md
+++ b/.changeset/band-actionability.md
@@ -1,0 +1,9 @@
+---
+"comicarr": minor
+---
+
+The needs-attention band no longer asks you to babysit failures Comicarr can handle itself. After a restart, downloads that vanished from the client, bad DDL links, and similar dead ends are returned to the acquisition cycle automatically — blocklisted when the release is gone, re-wanted so the next sweep can find a different source — instead of stacking up as hundreds of red cards you can only "retry" by hand.
+
+What still needs you stays on the band: files that downloaded but never made it into the library, downloads waiting on a decision only you can make, and failures where you turned auto-handling off. Those still group by series and cause, still open the Needs attention page, and still clear only when you act.
+
+Under the hood every failure reason is classified once, in code. New reasons have to declare whether they belong on the band before they can merge, so the next bulk failure can't recreate the old pile.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Comicarr is built on the foundation of Mylar3 with a completely rebuilt React 19
 | Run app | `python3 Comicarr.py --nolaunch` |
 | Test backend | `pytest tests/unit -v` |
 | Lint modern backend | `npm run lint:modern` (`comicarr/app` + `Comicarr.py`) |
-| Check retired globals | `npm run lint:guards` (`scripts/check_retired_globals.py`) |
+| Check retired globals + fail_reason registry | `npm run lint:guards` (`scripts/check_retired_globals.py`, `scripts/check_fail_reason_registry.py`) |
 | Lint all (CI parity) | `npm run lint` |
 | Regenerate settings types | `npm run lint:fix:generated` (after editing the config registry) |
 
@@ -60,6 +60,7 @@ Conventional PR titles keep history readable, but they do not control releases. 
 - **Do NOT manually bump versions** - Changesets release automation handles this
 - **Do NOT call `useReactTable` directly** - `no-restricted-imports` allows it only in `frontend/src/components/data-table/useTableState.ts`. Call `useTableState`, which wraps it so `getRowId` is required and row identity can never fall back to TanStack's index default. Tables still awaiting migration are listed in an `overrides` allowlist in `eslint.config.js`; that list only ever shrinks — never add to it.
 - **Do NOT reintroduce `GLOBAL_MESSAGES`** - The pre-EventBus message bus is retired. Deleting the declaration cannot make its return fail (Python creates the attribute on first assignment), so `npm run lint:guards` scans source for it instead. Narrate through `comicarr.app.activity.events.record_activity`; that facade publishes the single `activity` SSE event after a durable commit. Add further retired names to `RETIRED_GLOBALS` in `scripts/check_retired_globals.py`. Contributor-only gate — no changeset.
+- **Every `fail_reason` base token must be classified** in `comicarr/app/activity/reasons.py` before merge (`scripts/check_fail_reason_registry.py` under `lint:guards`). Runtime is fail-open; CI is the gate. Excluding a token requires a reconciliation obligation (never leave `Snatched`). See ADR-0001 / #523 / #541.
 - **Do NOT add per-feature SSE event types** - `activity` is the only narrative channel; `ai_activity`, `restart`, and `shutdown` are the only other listeners in `useServerEvents`. The client invalidates queries from a payload and never accumulates the stream into a list.
 - **Do NOT finish without linting** - Run `npm run lint` (or `npm run lint:fix` then re-check) before considering work done; do not bypass hooks with `--no-verify`
 

--- a/comicarr/app/activity/queries.py
+++ b/comicarr/app/activity/queries.py
@@ -19,6 +19,7 @@ from sqlalchemy import and_, func, or_, select, union
 from comicarr import db
 from comicarr.app.acquisition.models import ItemOutcome
 from comicarr.app.activity import grouping
+from comicarr.app.activity.reasons import actionable_reason_condition
 from comicarr.app.core.database import paginated_query
 from comicarr.app.downloads.journal import FAILED, MANUAL_REVIEW, OPEN_STAGES
 from comicarr.tables import acquisition_run_items, activity_events, annuals, issues, pipeline_journal
@@ -119,10 +120,12 @@ def list_timeline_events(limit=None, offset=None, scope_type=None, scope_id=None
 
 
 def unresolved_band_condition():
-    """R9 needs-attention predicate (Activity Center ADR §2).
+    """R9 needs-attention predicate (Activity Center ADR §2 / #541).
 
-    ``stage IN ('failed', 'manual_review')`` and status is null or not a
-    resolution status (``retried`` / ``ignored`` / ``imported``).
+    ``stage IN ('failed', 'manual_review')``, status is null or not a
+    resolution status (``retried`` / ``ignored`` / ``imported``), and the
+    ``fail_reason`` base token is actionable (#523). Non-actionable reasons
+    leave the band only because their writers reconcile the issue (clause 2).
     """
     return and_(
         pipeline_journal.c.stage.in_(BAND_TROUBLE_STAGES),
@@ -130,6 +133,7 @@ def unresolved_band_condition():
             pipeline_journal.c.status.is_(None),
             pipeline_journal.c.status.notin_(BAND_RESOLVED_STATUSES),
         ),
+        actionable_reason_condition(pipeline_journal.c.fail_reason),
     )
 
 

--- a/comicarr/app/activity/reasons.py
+++ b/comicarr/app/activity/reasons.py
@@ -7,7 +7,7 @@
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 
-"""Registry for ``fail_reason`` base tokens and their operator-facing phrases.
+"""Registry for ``fail_reason`` base tokens: phrases, verdicts, reconciliation.
 
 **The classifiable unit is the base token before the first ``:``** (#523).
 Many reasons are composite — ``postprocess_error:OperationalError`` — where the
@@ -15,16 +15,28 @@ suffix is a raw Python exception class, a route name, or a field name. The
 suffix space is open and not statically enumerable, so nothing may key on the
 whole ``fail_reason`` string.
 
-This module is the single home for wording. The band and the triage surface
-render ``reason_phrase`` computed here rather than mapping tokens client-side,
-so matching and wording cannot drift apart (#526). Unmapped tokens degrade to a
-generic phrase — never a snake_case token as an operator-facing line (#427).
+This module is the single home for wording and actionability. The band and the
+triage surface render ``reason_phrase`` computed here rather than mapping tokens
+client-side, so matching and wording cannot drift apart (#526).
 
-The actionability verdicts decided in #523 (which base tokens the band admits,
-and the reconciliation each excluded token owes) belong beside these phrases
-when that work lands; they are deliberately not asserted here yet, because
-excluding a reason without its reconciliation would strand the affected issues.
+**Actionability** (#523 / #541) is a two-clause test:
+
+1. **Admission.** The band admits a row only when resolving it requires
+   information, authority, or judgement the operator holds and the system does not.
+2. **Exclusion.** A reason may be excluded only if the system reconciles the
+   item — returning it to the acquisition cycle, or recording it as genuinely
+   terminal. Never left ``Status='Snatched'``.
+
+Unknown tokens are **admitted (fail-open)** at runtime. Fail-closed would strand
+new writers at ``Snatched`` with nothing watching. Completeness is enforced in CI
+(``scripts/check_fail_reason_registry.py``), not by the predicate.
 """
+
+from sqlalchemy import and_, not_, or_
+
+# ---------------------------------------------------------------------------
+# Operator-facing phrases (admitted base tokens)
+# ---------------------------------------------------------------------------
 
 #: Operator-facing phrase per admitted base token (#523 classification, #526 wording).
 REASON_PHRASES = {
@@ -50,6 +62,48 @@ REASON_PHRASES = {
 #: Shown when a base token has no phrase — the same degradation the timeline uses.
 UNMAPPED_REASON_PHRASE = "something went wrong"
 
+# ---------------------------------------------------------------------------
+# Actionability verdicts (#523 / #541)
+# ---------------------------------------------------------------------------
+
+#: Flat base tokens excluded from the band. Exact match only (no ``:`` suffix).
+NON_ACTIONABLE_FLAT = frozenset(
+    {
+        "download_gone",
+        "download_failed_researching",
+        "ddl_download_or_artifact_validation_failed",
+        "ddl-worker-rejected",  # hyphen spelling is live in the journal; do not rename
+        "torrent_hash_not_in_client",
+        "legacy_downloading_without_correlation",
+        "ambiguous_ddl_acceptance_after_restart",
+    }
+)
+
+#: Composite base tokens excluded from the band. Match ``base`` or ``base:%``.
+NON_ACTIONABLE_COMPOSITE = frozenset({"immutable_payload_conflict"})
+
+#: Reconciliation obligation per excluded base token.
+#:
+#: * ``none`` — already reconciled at the write site (do not double-act)
+#: * ``rewant`` — return the issue to Wanted (attempt dead; release may be fine)
+#: * ``blocklist_and_rewant`` — blocklist the release *and* re-want (release dead)
+#: * ``rewant_if_issue`` — re-want only when an issue id resolves (often none)
+#: * ``rewant_and_log`` — re-want and log loudly (internal invariant violation)
+RECONCILIATION = {
+    "download_gone": "blocklist_and_rewant",
+    "ddl_download_or_artifact_validation_failed": "blocklist_and_rewant",
+    "ddl-worker-rejected": "rewant",
+    "torrent_hash_not_in_client": "rewant",
+    "ambiguous_ddl_acceptance_after_restart": "rewant",
+    "immutable_payload_conflict": "rewant_and_log",
+    "legacy_downloading_without_correlation": "rewant_if_issue",
+    "download_failed_researching": "none",
+}
+
+#: Every known base token with an explicit verdict — admitted or excluded.
+#: Completeness gate equates this to the writable set from the AST scan.
+KNOWN_BASE_TOKENS = frozenset(REASON_PHRASES) | NON_ACTIONABLE_FLAT | NON_ACTIONABLE_COMPOSITE
+
 
 def base_reason(fail_reason):
     """Return the classifiable unit: everything before the first ``:``.
@@ -69,3 +123,42 @@ def base_reason(fail_reason):
 def reason_phrase(fail_reason):
     """Operator-facing phrase for a raw ``fail_reason``, matched on its base token."""
     return REASON_PHRASES.get(base_reason(fail_reason) or "", UNMAPPED_REASON_PHRASE)
+
+
+def is_actionable(fail_reason):
+    """Python-side actionability: True if the band should admit this reason.
+
+    Unknown / blank tokens are admitted (fail-open). Matches the SQL predicate.
+    """
+    token = base_reason(fail_reason)
+    if token is None:
+        return True
+    if token in NON_ACTIONABLE_FLAT:
+        return False
+    if token in NON_ACTIONABLE_COMPOSITE:
+        return False
+    return True
+
+
+def reconciliation_for(fail_reason):
+    """Return the reconciliation obligation string for a reason, or None if admitted."""
+    token = base_reason(fail_reason)
+    if token is None:
+        return None
+    return RECONCILIATION.get(token)
+
+
+def actionable_reason_condition(col):
+    """SQLAlchemy boolean expression: admit rows whose ``fail_reason`` is actionable.
+
+    NULL-safe and dialect-portable (sqlite / postgresql / mysql): no
+    ``instr``/``substr`` extraction. Composite exclusions use a bounded
+    ``LIKE 'base:%'`` set (one family today). Unknown tokens pass (fail-open).
+    """
+    non_actionable = or_(
+        col.in_(list(NON_ACTIONABLE_FLAT)),
+        *[col.like("%s:%%" % base) for base in sorted(NON_ACTIONABLE_COMPOSITE)],
+    )
+    # ``col.in_(...)`` / ``LIKE`` yield NULL when col is NULL; ``NOT NULL`` is
+    # still NULL and would drop the row. Explicitly admit NULL.
+    return or_(col.is_(None), and_(col.isnot(None), not_(non_actionable)))

--- a/comicarr/app/activity/reconcile.py
+++ b/comicarr/app/activity/reconcile.py
@@ -1,0 +1,269 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Clause-2 reconciliation for non-actionable ``fail_reason`` tokens (#541).
+
+Excluding a reason from the needs-attention band is not free. The band's retry
+button was previously the sole recovery path for issues left at
+``Status='Snatched'`` after a silent journal-only failure. When a reason is
+excluded, this module returns the issue to Wanted and — when the *release*
+is dead — blocklists it so the next sweep cannot re-snatch the same source.
+
+Call after (or with) the journal write that records the excluded reason.
+Safe no-op for admitted reasons and for ``download_failed_researching``
+(already reconciled by ``failed.py``).
+"""
+
+from __future__ import annotations
+
+from comicarr import logger
+from comicarr.app.activity.reasons import base_reason, reconciliation_for
+
+#: Audit identity for system-driven re-wants. Required by
+#: ``explicit_intent_values``; never invent explicit intent without one.
+RECONCILE_AUDIT_IDENTITY = "system:band-actionability"
+
+
+def _payload_dict(payload):
+    if isinstance(payload, dict):
+        return payload
+    if payload in (None, ""):
+        return {}
+    try:
+        from comicarr.app.downloads import journal
+
+        loaded = journal.load_payload(payload)
+        return loaded if isinstance(loaded, dict) else {}
+    except Exception:
+        return {}
+
+
+def _issue_id(*, issueid=None, payload=None):
+    if issueid not in (None, ""):
+        return str(issueid)
+    data = _payload_dict(payload)
+    for key in ("issueid", "IssueID"):
+        value = data.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+def _release_identity(*, provider=None, nzbname=None, release_id=None, payload=None, hash=None):
+    """Best-effort (ID, Provider, NZBName) for the failed-table blocklist key."""
+    data = _payload_dict(payload)
+    di = data.get("download_info") if isinstance(data.get("download_info"), dict) else {}
+
+    rid = release_id
+    if rid in (None, ""):
+        rid = data.get("ddl_id") or data.get("id") or di.get("id") or hash or data.get("hash") or None
+    prov = provider if provider not in (None, "") else (data.get("provider") or di.get("provider"))
+    name = (
+        nzbname if nzbname not in (None, "") else (data.get("nzbname") or data.get("filename") or data.get("nzb_name"))
+    )
+    return (
+        str(rid) if rid not in (None, "") else None,
+        str(prov) if prov not in (None, "") else None,
+        str(name) if name not in (None, "") else None,
+    )
+
+
+def _blocklist_release(
+    *,
+    release_id,
+    provider,
+    nzbname,
+    issueid=None,
+    comicid=None,
+    comicname=None,
+    issue_number=None,
+    payload=None,
+    conn=None,
+):
+    from comicarr import db, helpers
+
+    data = _payload_dict(payload)
+    comicid = comicid if comicid not in (None, "") else data.get("comicid")
+    comicname = comicname if comicname not in (None, "") else data.get("comicname") or data.get("series")
+    issue_number = (
+        issue_number if issue_number not in (None, "") else data.get("issuenumber") or data.get("Issue_Number")
+    )
+
+    values = {
+        "Status": "Failed",
+        "ComicName": comicname,
+        "Issue_Number": issue_number,
+        "IssueID": issueid,
+        "ComicID": comicid,
+        "DateFailed": helpers.now(),
+    }
+    ctrl = {"ID": release_id, "Provider": provider, "NZBName": nzbname}
+    if conn is not None:
+        db.upsert_conn(conn, "failed", values, ctrl)
+    else:
+        db.upsert("failed", values, ctrl)
+    logger.warn(
+        "[BAND-RECONCILE] blocklisted release ID=%s Provider=%s NZBName=%s issueid=%s"
+        % (release_id, provider, nzbname, issueid)
+    )
+
+
+def _rewant_issue(issueid):
+    from comicarr.app.series import queries as series_queries
+
+    series_queries.queue_issue(issueid, RECONCILE_AUDIT_IDENTITY)
+    logger.info("[BAND-RECONCILE] re-wanted issueid=%s (audit=%s)" % (issueid, RECONCILE_AUDIT_IDENTITY))
+
+
+def reconcile_excluded(
+    fail_reason,
+    *,
+    issueid=None,
+    provider=None,
+    nzbname=None,
+    release_id=None,
+    hash=None,
+    comicid=None,
+    comicname=None,
+    issue_number=None,
+    payload=None,
+    conn=None,
+):
+    """Discharge the clause-2 obligation for ``fail_reason``, if any.
+
+    Returns a short status string for tests/logging:
+    ``noop`` / ``none`` / ``rewanted`` / ``blocklisted_and_rewanted`` /
+    ``rewanted_no_issue`` / ``logged_and_rewanted`` / ``logged_no_issue``.
+    """
+    obligation = reconciliation_for(fail_reason)
+    if obligation is None:
+        return "noop"
+    if obligation == "none":
+        return "none"
+
+    token = base_reason(fail_reason)
+    resolved_issue = _issue_id(issueid=issueid, payload=payload)
+
+    if obligation == "rewant_and_log":
+        logger.error(
+            "[BAND-RECONCILE] immutable/internal exclusion token=%s issueid=%s — "
+            "re-wanting if possible; this belongs in logs, not the work queue" % (token, resolved_issue)
+        )
+
+    needs_blocklist = obligation == "blocklist_and_rewant"
+    needs_rewant = obligation in (
+        "rewant",
+        "blocklist_and_rewant",
+        "rewant_if_issue",
+        "rewant_and_log",
+    )
+
+    if needs_blocklist:
+        rid, prov, name = _release_identity(
+            provider=provider,
+            nzbname=nzbname,
+            release_id=release_id,
+            payload=payload,
+            hash=hash,
+        )
+        if rid and prov and name:
+            try:
+                _blocklist_release(
+                    release_id=rid,
+                    provider=prov,
+                    nzbname=name,
+                    issueid=resolved_issue,
+                    comicid=comicid,
+                    comicname=comicname,
+                    issue_number=issue_number,
+                    payload=payload,
+                    conn=conn,
+                )
+            except Exception as e:
+                logger.error("[BAND-RECONCILE] blocklist failed token=%s ID=%s: %s" % (token, rid, e))
+        else:
+            logger.warn(
+                "[BAND-RECONCILE] cannot blocklist token=%s — missing ID/Provider/NZBName "
+                "(id=%r provider=%r nzbname=%r); still re-wanting if possible" % (token, rid, prov, name)
+            )
+
+    if needs_rewant:
+        if not resolved_issue:
+            if obligation == "rewant_if_issue":
+                logger.fdebug("[BAND-RECONCILE] token=%s has no issue id — nothing to re-want (expected)" % token)
+            else:
+                logger.warn("[BAND-RECONCILE] token=%s owes re-want but no issue id resolved" % token)
+            if obligation == "rewant_and_log":
+                return "logged_no_issue"
+            return "rewanted_no_issue"
+        try:
+            _rewant_issue(resolved_issue)
+        except Exception as e:
+            logger.error("[BAND-RECONCILE] re-want failed token=%s issueid=%s: %s" % (token, resolved_issue, e))
+            return "rewant_failed"
+
+    if obligation == "rewant_and_log":
+        return "logged_and_rewanted"
+    if needs_blocklist:
+        return "blocklisted_and_rewanted"
+    return "rewanted"
+
+
+def reconcile_existing_excluded_rows():
+    """One-shot pass: re-want / blocklist issues stranded by pre-#541 exclusions.
+
+    The band is computed live, so changing admission drops excluded rows on
+    deploy with no journal migration. Those rows still leave issues at
+    ``Snatched`` unless clause 2 runs. Walk unresolved journal rows whose
+    reason is now non-actionable and discharge their obligations.
+
+    Idempotent: re-wanting an already-Wanted issue is a no-op upsert; blocklist
+    upserts the same failed-table key.
+    """
+    from sqlalchemy import and_, or_, select
+
+    from comicarr import db
+    from comicarr.app.activity.reasons import is_actionable
+    from comicarr.app.downloads.journal import FAILED, MANUAL_REVIEW, RESOLVED_STATUSES
+    from comicarr.tables import pipeline_journal
+
+    # Pre-actionability band: trouble stages + unresolved status, any reason.
+    # (Live ``unresolved_band_condition`` already drops non-actionable rows.)
+    pre_actionability = and_(
+        pipeline_journal.c.stage.in_((FAILED, MANUAL_REVIEW)),
+        or_(
+            pipeline_journal.c.status.is_(None),
+            pipeline_journal.c.status.notin_(RESOLVED_STATUSES),
+        ),
+    )
+
+    rows = db.select_all(select(pipeline_journal).where(pre_actionability))
+    summary = {"scanned": 0, "acted": 0, "skipped_actionable": 0, "results": {}}
+    for row in rows or []:
+        summary["scanned"] += 1
+        reason = row.get("fail_reason")
+        if is_actionable(reason):
+            summary["skipped_actionable"] += 1
+            continue
+        result = reconcile_excluded(
+            reason,
+            issueid=row.get("issueid"),
+            provider=row.get("provider"),
+            nzbname=row.get("nzbname"),
+            hash=row.get("hash"),
+            payload=row.get("payload_json"),
+        )
+        summary["acted"] += 1
+        summary["results"][result] = summary["results"].get(result, 0) + 1
+    if summary["acted"]:
+        logger.warn(
+            "[BAND-RECONCILE] one-shot stranded-row pass: scanned=%s acted=%s results=%s"
+            % (summary["scanned"], summary["acted"], summary["results"])
+        )
+    return summary

--- a/comicarr/app/downloads/journal.py
+++ b/comicarr/app/downloads/journal.py
@@ -543,6 +543,23 @@ def _apply_transition(conn, key, stage, new_rank, fields, payload, when):
         )
         if quarantined.rowcount:
             logger.error("[JOURNAL] quarantined release_key=%s: %s" % (key, reason))
+            # Clause 2 (#541): re-want + log loudly. Quarantine already logged;
+            # re-want returns the issue to the acquisition cycle.
+            try:
+                from comicarr.app.activity.reconcile import reconcile_excluded
+
+                mapping = existing_row._mapping
+                reconcile_excluded(
+                    reason,
+                    issueid=mapping.get("issueid") or fields.get("issueid"),
+                    provider=mapping.get("provider") or fields.get("provider"),
+                    nzbname=mapping.get("nzbname") or fields.get("nzbname"),
+                    hash=mapping.get("hash") or fields.get("hash"),
+                    payload=existing_payload,
+                    conn=conn,
+                )
+            except Exception as e:
+                logger.error("[JOURNAL] band reconciliation after immutable conflict %s: %s" % (key, e))
         return False
 
     # Same-stage calls are not a new side-effect claim, but may safely fill in

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -87,22 +87,38 @@ def _reconcile_legacy_ddl_downloading():
             nzbname=ddl_row.get("filename"),
             discriminant=ddl_id,
         )
+        legacy_payload = {
+            "issueid": ddl_row.get("issueid"),
+            "comicid": ddl_row.get("comicid"),
+            "provider": "DDL",
+            "ddl_id": ddl_id,
+            "filename": ddl_row.get("filename"),
+            "ddl": True,
+        }
         journal.mark_manual_review(
             rkey,
             "legacy_downloading_without_correlation",
-            payload={
-                "issueid": ddl_row.get("issueid"),
-                "comicid": ddl_row.get("comicid"),
-                "provider": "DDL",
-                "ddl_id": ddl_id,
-                "filename": ddl_row.get("filename"),
-                "ddl": True,
-            },
+            payload=legacy_payload,
             issueid=ddl_row.get("issueid"),
             provider="DDL",
             downloader_type="ddl",
             nzbname=ddl_row.get("filename"),
         )
+        # Clause 2 (#541): re-want only if an issue resolves (usually none).
+        try:
+            from comicarr.app.activity.reconcile import reconcile_excluded
+
+            reconcile_excluded(
+                "legacy_downloading_without_correlation",
+                issueid=ddl_row.get("issueid"),
+                provider="DDL",
+                nzbname=ddl_row.get("filename"),
+                release_id=ddl_id,
+                comicid=ddl_row.get("comicid"),
+                payload=legacy_payload,
+            )
+        except Exception as e:
+            logger.error("[RECOVERY] band reconciliation after legacy DDL review %s: %s" % (ddl_id, e))
         db.upsert("ddl_info", {"status": "Manual Review"}, {"ID": ddl_id})
         reviewed += 1
     return reviewed
@@ -859,9 +875,23 @@ def _resolve_row(snapshot_row, probes=None, pp_cap=None):
                 from comicarr.app.downloads import queries as dl_queries
 
                 dl_queries.update_ddl_status(ddl_id, "Manual Review")
+            # Clause 2 (#541): attempt ambiguous, no external client to inspect — re-want only.
+            try:
+                from comicarr.app.activity.reconcile import reconcile_excluded
+
+                reconcile_excluded(
+                    "ambiguous_ddl_acceptance_after_restart",
+                    issueid=row.get("issueid"),
+                    provider=row.get("provider"),
+                    nzbname=row.get("nzbname") or (payload or {}).get("filename") or (payload or {}).get("nzbname"),
+                    release_id=ddl_id,
+                    payload=payload,
+                )
+            except Exception as e:
+                logger.error("[RECOVERY] band reconciliation after ambiguous DDL %s: %s" % (rkey, e))
             logger.warn(
                 "[RECOVERY] %s -> MANUAL REVIEW (ambiguous DDL acceptance after restart); "
-                "no duplicate sender call." % rkey
+                "no duplicate sender call; issue re-wanted when resolvable (#541)." % rkey
             )
         else:
             comicarr.NZB_QUEUE.put(item)
@@ -891,7 +921,13 @@ def replay_pipeline(probes=None):
 
     Returns a small summary dict (counts) for logging/tests.
     """
-    summary = {"reconstructed": 0, "legacy_ddl_review": 0, "open": 0, "actions": {}}
+    summary = {
+        "reconstructed": 0,
+        "legacy_ddl_review": 0,
+        "band_reconcile": None,
+        "open": 0,
+        "actions": {},
+    }
 
     if getattr(comicarr, "ACQUISITION_WORKERS_BLOCKED", False):
         summary["actions"]["blocked"] = 1
@@ -904,6 +940,15 @@ def replay_pipeline(probes=None):
         summary["legacy_ddl_review"] = _reconcile_legacy_ddl_downloading()
     except Exception as e:
         logger.error("[RECOVERY] legacy DDL reconciliation failed; continuing: %s" % type(e).__name__)
+
+    # #541: re-want / blocklist issues stranded by excluded fail_reasons written
+    # before clause-2 reconciliation existed. Idempotent; safe every boot.
+    try:
+        from comicarr.app.activity.reconcile import reconcile_existing_excluded_rows
+
+        summary["band_reconcile"] = reconcile_existing_excluded_rows()
+    except Exception as e:
+        logger.error("[RECOVERY] band actionability one-shot failed; continuing: %s" % type(e).__name__)
 
     # 1. Anchor reconstruction FIRST (U2 residual window).
     try:

--- a/comicarr/app/downloads/recovery_classify.py
+++ b/comicarr/app/downloads/recovery_classify.py
@@ -577,8 +577,25 @@ def apply_verdict(row, verdict, conn=None):
         provider=row.get("provider"),
         downloader_type=row.get("downloader_type"),
     )
+    # Clause 2 (#541): download_gone is non-actionable — blocklist the release
+    # and re-want so the issue is not stranded at Snatched with nothing watching.
+    try:
+        from comicarr.app.activity.reconcile import reconcile_excluded
+
+        reconcile_excluded(
+            FAIL_REASON_GONE,
+            issueid=row.get("issueid"),
+            provider=row.get("provider"),
+            nzbname=row.get("nzbname") or (payload or {}).get("nzbname") or (payload or {}).get("filename"),
+            release_id=ddl_id,
+            hash=row.get("hash"),
+            payload=payload,
+            conn=conn,
+        )
+    except Exception as e:
+        logger.error("[RECOVERY-CLASSIFY] band reconciliation after GONE failed for %s: %s" % (rkey, e))
     logger.warn(
-        "[RECOVERY-CLASSIFY] %s marked failed (reason=%s) — payload retained "
-        "for future manual retry (R9); replay will NOT re-queue it." % (rkey, FAIL_REASON_GONE)
+        "[RECOVERY-CLASSIFY] %s marked failed (reason=%s) — release blocklisted and "
+        "issue re-wanted when resolvable (#541); replay will NOT re-queue it." % (rkey, FAIL_REASON_GONE)
     )
     return True

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -1342,22 +1342,38 @@ def _finalize_ddl_download(item, ddzstat, release_key):
             ddzstat["link_type_failure"] = item.get("link_type")
 
     if not ddzstat.get("success"):
+        fail_payload = {
+            "issueid": item.get("issueid"),
+            "comicid": item.get("comicid"),
+            "provider": "DDL",
+            "ddl_id": item.get("id"),
+            "filename": item.get("filename"),
+            "ddl": True,
+        }
         journal.mark_failed(
             release_key,
             "ddl_download_or_artifact_validation_failed",
-            payload={
-                "issueid": item.get("issueid"),
-                "comicid": item.get("comicid"),
-                "provider": "DDL",
-                "ddl_id": item.get("id"),
-                "filename": item.get("filename"),
-                "ddl": True,
-            },
+            payload=fail_payload,
             issueid=item.get("issueid"),
             provider="DDL",
             downloader_type="ddl",
             nzbname=item.get("filename"),
         )
+        # Clause 2 (#541): release is dead — blocklist + re-want.
+        try:
+            from comicarr.app.activity.reconcile import reconcile_excluded
+
+            reconcile_excluded(
+                "ddl_download_or_artifact_validation_failed",
+                issueid=item.get("issueid"),
+                provider="DDL",
+                nzbname=item.get("filename"),
+                release_id=item.get("id"),
+                comicid=item.get("comicid"),
+                payload=fail_payload,
+            )
+        except Exception as e:
+            logger.error("[DOWNLOADS-DDL] band reconciliation after validation failure: %s" % e)
         return False
 
     nzb_name = ddzstat.get("filename") or os.path.basename(ddzstat["path"])
@@ -1496,6 +1512,23 @@ def ddl_downloader(queue):
                             downloader_type="ddl",
                             nzbname=filename,
                         )
+                        # Clause 2 (#541): attempt dead, release may be fine — re-want only.
+                        try:
+                            from comicarr.app.activity.reconcile import reconcile_excluded
+
+                            reconcile_excluded(
+                                "ddl-worker-rejected",
+                                issueid=issueid,
+                                provider="DDL",
+                                nzbname=filename,
+                                release_id=item_id,
+                                payload=journal_payload,
+                            )
+                        except Exception as recon_error:
+                            logger.error(
+                                "[DOWNLOADS-DDL] band reconciliation after worker reject %s: %s"
+                                % (item_id, recon_error)
+                            )
                 except Exception as journal_error:
                     logger.error(
                         "[DOWNLOADS-DDL] Unable to close journal for rejected DDL item %s: %s"
@@ -2199,6 +2232,21 @@ def _handle_torrent_monitor_result(item, snstat):
             nzbname=item.get("nzbname"),
             hash=item.get("hash"),
         )
+        # Clause 2 (#541): attempt lost, release may be fine — re-want only.
+        try:
+            from comicarr.app.activity.reconcile import reconcile_excluded
+
+            reconcile_excluded(
+                "torrent_hash_not_in_client",
+                issueid=item.get("issueid"),
+                provider=item.get("provider"),
+                nzbname=item.get("nzbname"),
+                hash=item.get("hash"),
+                comicid=item.get("comicid"),
+                payload=payload,
+            )
+        except Exception as e:
+            logger.error("[DOWNLOADS-WORKER] band reconciliation after missing torrent hash: %s" % e)
         return
 
     if status not in {"MONITOR FAIL", "MONITOR COMPLETE"}:

--- a/docs/adr/0001-band-actionability.md
+++ b/docs/adr/0001-band-actionability.md
@@ -1,0 +1,77 @@
+# ADR-0001: Needs-attention band actionability
+
+**Status:** Accepted  
+**Date:** 2026-08-04  
+**Issues:** [#523](https://github.com/frankieramirez/comicarr/issues/523), [#541](https://github.com/frankieramirez/comicarr/issues/541)  
+**Map:** [Wayfinder: Needs-attention band contract](https://github.com/frankieramirez/comicarr/issues/520)
+
+## Context
+
+The needs-attention band is a work queue: rows clear only by operator action
+([activity-center.md](../architecture/activity-center.md)). That invariant
+prevents silent age-based eviction of genuine trouble.
+
+Admission, however, had no membership test. Every `failed` / `manual_review`
+row with an unresolved status entered the band — including bulk
+restart-replay artefacts (`download_gone`, …) where no operator action does
+anything the system cannot do itself. Production showed hundreds of such rows
+pushing the Activity timeline off the page.
+
+A denylist of one token would leave the real defect intact: the next bulk
+terminal reason would reproduce the leak.
+
+## Decision
+
+Band admission is governed by a **two-clause actionability test**:
+
+1. **Admission.** Admit a row only when resolving it requires information,
+   authority, or judgement the **operator** holds and the **system** does not.
+2. **Exclusion.** A reason may be excluded only if the system **reconciles the
+   item** — re-wanting it into the acquisition cycle, and blocklisting the
+   release when the release (not just the attempt) is dead. Never leave the
+   issue at `Status='Snatched'` with nothing watching.
+
+Classification is exhaustive over the 22 known `fail_reason` **base tokens**
+(substring before the first `:`), stored in
+`comicarr/app/activity/reasons.py` beside operator phrases:
+
+- 14 admitted (bytes stranded · external ambiguity · operator asked to be asked)
+- 8 excluded, each with a recorded reconciliation obligation
+
+Unknown tokens are **admitted (fail-open)** at runtime. Completeness is
+enforced in CI (`scripts/check_fail_reason_registry.py` under `lint:guards`),
+not by the predicate — fail-closed would strand the first unregistered writer.
+
+The live predicate is one portable clause on `unresolved_band_condition()`:
+
+```python
+actionable_reason_condition(pipeline_journal.c.fail_reason)
+```
+
+No schema column, no migration: the band is computed live; changing admission
+drops rows on deploy. A one-shot re-want/blocklist pass at recovery boot
+handles issues stranded before this ADR shipped.
+
+## Consequences
+
+- The work-queue invariant **survives**: rows still clear only by action. What
+  changes is *who is admitted* into the queue.
+- Excluded trouble remains visible on the muted timeline and Download History;
+  there is no second "quieter problems" tier.
+- Writers of excluded reasons must call
+  `comicarr.app.activity.reconcile.reconcile_excluded` (or already reconcile,
+  as `download_failed_researching` does in `failed.py`).
+- New `fail_reason` writers fail `npm run lint` until classified in `reasons.py`.
+- `activity-center.md` documents the widened predicate; this ADR is the
+  decision record for rewriting admission underneath the invariant.
+
+## Rejected alternatives
+
+| Alternative | Why rejected |
+|---|---|
+| `download_gone` denylist only | Leaves admission without a membership test |
+| `needs_operator` journal column | Migrates and backfills what the base token already declares |
+| Age-based eviction | Silently drops genuine `manual_review` trouble |
+| Fail-closed unknown tokens | Strands `Snatched` issues with no reconciliation path |
+| Conditional admit when artifact exists on disk | Per-row FS stats on every poll; band and status count can disagree |
+| Operator-configurable classification | Exclusion carries code-only reconciliation obligations |

--- a/docs/architecture/activity-center.md
+++ b/docs/architecture/activity-center.md
@@ -61,8 +61,24 @@ Pinned **above** the chronological feed. Population:
 SELECT * FROM pipeline_journal
  WHERE stage IN ('failed', 'manual_review')
    AND (status IS NULL OR status NOT IN ('retried', 'ignored', 'imported'))
+   AND (fail_reason IS NULL OR fail_reason NOT IN (
+         -- NON_ACTIONABLE_FLAT from comicarr/app/activity/reasons.py
+         'download_gone', 'download_failed_researching',
+         'ddl_download_or_artifact_validation_failed', 'ddl-worker-rejected',
+         'torrent_hash_not_in_client', 'legacy_downloading_without_correlation',
+         'ambiguous_ddl_acceptance_after_restart'
+       ))
+   AND (fail_reason IS NULL OR fail_reason NOT LIKE 'immutable_payload_conflict:%')
  ORDER BY updated_date DESC
 ```
+
+Admission is the **two-clause actionability test** ([#523](https://github.com/frankieramirez/comicarr/issues/523),
+[ADR-0001](../adr/0001-band-actionability.md)): the band admits trouble only when
+the operator holds something the system lacks, and exclusion always reconciles
+the issue (re-want / blocklist) so nothing is left at `Snatched` with the band
+as its only recovery path ([#541](https://github.com/frankieramirez/comicarr/issues/541)).
+The live predicate lives in `unresolved_band_condition()`; the SQL above is the
+shape, not a second source of truth.
 
 Those rows are then **grouped server-side** before anything renders them
 ([Decide the grouping key and group-row contract](https://github.com/frankieramirez/comicarr/issues/524)):

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare-github-release": "node scripts/release/prepare-github-release.mjs",
     "lint": "npm run lint:modern && npm run lint:guards && npm run lint:backend && npm run lint:generated && npm run lint:frontend",
     "lint:modern": "python scripts/run_ruff.py modern",
-    "lint:guards": "python scripts/check_retired_globals.py",
+    "lint:guards": "python scripts/check_retired_globals.py && python scripts/check_fail_reason_registry.py",
     "lint:backend": "python scripts/run_ruff.py check comicarr/ && python scripts/run_ruff.py format --check comicarr/",
     "lint:generated": "python scripts/generate_config_types.py --check",
     "lint:frontend": "npm --prefix frontend run lint && npm --prefix frontend run format:check",

--- a/scripts/check_fail_reason_registry.py
+++ b/scripts/check_fail_reason_registry.py
@@ -1,0 +1,401 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""CI completeness gate: every writable fail_reason base token is classified.
+
+Hybrid AST scan (#527): equate base tokens declared in
+``comicarr/app/activity/reasons.py`` with every base token the codebase can
+write onto ``pipeline_journal.fail_reason`` via:
+
+* ``journal.mark_failed(...)``
+* ``journal.mark_manual_review(...)``
+* the inline quarantine write at ``journal.py`` (immutable payload conflict)
+
+Runtime stays fail-open (#523). Contributor-facing only — no changeset.
+
+Wire-in: ``npm run lint:guards``.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REASONS_PATH = ROOT / "comicarr" / "app" / "activity" / "reasons.py"
+
+# Trees that can write pipeline_journal.fail_reason. Vendor and test fixtures
+# are out of scope for the gate.
+SCAN_GLOBS = (
+    "comicarr/app/**/*.py",
+    "comicarr/failed.py",
+    "comicarr/process.py",
+)
+
+SKIP_DIR_NAMES = {"_vendor", "__pycache__", ".venv", "node_modules"}
+
+# Functions that accept a variable reason and forward it. Callers must be
+# scanned so concrete bases still surface. Adding a new dynamic writer without
+# allowlisting fails with the unresolvable-site message.
+PASS_THROUGH_WRITERS = frozenset(
+    {
+        "terminalize_failed_download",
+        "_quarantine_postprocess_item",
+    }
+)
+
+MARK_ATTRS = frozenset({"mark_failed", "mark_manual_review"})
+
+# Parameter names that indicate a pass-through body (the enclosing function
+# is the allowlisted writer; callers supply the literal).
+PASS_THROUGH_PARAM_NAMES = frozenset({"fail_reason", "reason"})
+
+
+def _base_token(value: str) -> str:
+    token = value.strip()
+    if not token:
+        return token
+    return token.split(":", 1)[0]
+
+
+def _literal_set_from_assign(node: ast.Assign) -> set[str] | None:
+    """Extract string members from NAME = frozenset({...}) / set / dict keys."""
+    value = node.value
+    # frozenset({...}) / set({...})
+    if isinstance(value, ast.Call) and isinstance(value.func, ast.Name):
+        if value.func.id in ("frozenset", "set") and value.args:
+            value = value.args[0]
+    if isinstance(value, (ast.Set, ast.List, ast.Tuple)):
+        out = set()
+        for elt in value.elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                out.add(elt.value)
+            else:
+                return None
+        return out
+    if isinstance(value, ast.Dict):
+        out = set()
+        for key in value.keys:
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                out.add(key.value)
+            else:
+                return None
+        return out
+    return None
+
+
+def _load_registry() -> set[str]:
+    """Parse reasons.py via AST — no package import, no sqlalchemy needed."""
+    tree = ast.parse(REASONS_PATH.read_text(encoding="utf-8"), filename=str(REASONS_PATH))
+    buckets: dict[str, set[str]] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        members = _literal_set_from_assign(node)
+        if members is None:
+            continue
+        for name in names:
+            buckets[name] = members
+
+    phrases = buckets.get("REASON_PHRASES", set())
+    flat = buckets.get("NON_ACTIONABLE_FLAT", set())
+    composite = buckets.get("NON_ACTIONABLE_COMPOSITE", set())
+    recon = buckets.get("RECONCILIATION", set())
+    known = buckets.get("KNOWN_BASE_TOKENS")
+    if known is None:
+        known = phrases | flat | composite
+
+    for token in flat | composite:
+        if token not in recon:
+            raise SystemExit("Excluded base token %r has no RECONCILIATION entry in reasons.py" % token)
+    for token in phrases:
+        if token in flat or token in composite:
+            raise SystemExit("Base token %r is both admitted (REASON_PHRASES) and excluded" % token)
+    return set(known)
+
+
+def _collect_module_string_constants(path: Path) -> dict[str, str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return {}
+    out: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Constant):
+            continue
+        if not isinstance(node.value.value, str):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                out[target.id] = node.value.value
+    return out
+
+
+def _build_const_maps(files: list[Path]) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for path in files:
+        for name, value in _collect_module_string_constants(path).items():
+            if "REASON" in name or name.startswith("FAIL_"):
+                mapping[name] = _base_token(value)
+    return mapping
+
+
+def _const_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _string_from(node: ast.AST, const_map: dict[str, str]) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mod):
+        if isinstance(node.left, ast.Constant) and isinstance(node.left.value, str):
+            left = node.left.value
+            if "%s" in left or "%(" in left:
+                return left.split("%", 1)[0].rstrip(":")
+            return left
+    if isinstance(node, ast.JoinedStr):
+        parts = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            else:
+                break
+        if parts:
+            joined = "".join(parts)
+            if joined.endswith(":"):
+                return joined.rstrip(":")
+            return joined.split(":", 1)[0] if ":" in joined else joined
+    name = _const_name(node)
+    if name and name in const_map:
+        return const_map[name]
+    return None
+
+
+def _strings_from(node: ast.AST, const_map: dict[str, str], assigns: dict[str, ast.AST] | None = None) -> set[str]:
+    """Resolve one or more base tokens from an expression (including ternaries / names)."""
+    assigns = assigns or {}
+    direct = _string_from(node, const_map)
+    if direct is not None:
+        return {_base_token(direct)}
+    # Ternary: both branches are reason literals.
+    if isinstance(node, ast.IfExp):
+        return _strings_from(node.body, const_map, assigns) | _strings_from(node.orelse, const_map, assigns)
+    # Local Name bound to a prior assignment in the same function (e.g. `reason = ...`).
+    if isinstance(node, ast.Name) and node.id in assigns:
+        return _strings_from(assigns[node.id], const_map, assigns)
+    return set()
+
+
+def _call_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _reason_arg(node: ast.Call, attr: str) -> ast.AST | None:
+    if attr == "mark_failed":
+        if len(node.args) >= 2:
+            return node.args[1]
+        for kw in node.keywords:
+            if kw.arg in ("fail_reason", "reason"):
+                return kw.value
+    if attr == "mark_manual_review":
+        if len(node.args) >= 2:
+            return node.args[1]
+        for kw in node.keywords:
+            if kw.arg in ("reason", "fail_reason"):
+                return kw.value
+    return None
+
+
+def _enclosing_function_names(tree: ast.AST) -> dict[int, str]:
+    """Map lineno → innermost function name for pass-through detection."""
+    mapping: dict[int, str] = {}
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self):
+            self.stack: list[str] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef):
+            self.stack.append(node.name)
+            for child in ast.walk(node):
+                if child is not node and hasattr(child, "lineno"):
+                    mapping[child.lineno] = node.name
+            self.generic_visit(node)
+            self.stack.pop()
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+    Visitor().visit(tree)
+    return mapping
+
+
+def _local_assigns(tree: ast.AST) -> dict[int, dict[str, ast.AST]]:
+    """Per-function map of simple ``name = expr`` assignments, keyed by any
+    lineno belonging to that function (so a call site can resolve locals)."""
+    by_func: dict[str, dict[str, ast.AST]] = {}
+    lineno_to_func: dict[int, str] = {}
+
+    class Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef):
+            assigns: dict[str, ast.AST] = {}
+            for child in ast.walk(node):
+                if isinstance(child, ast.Assign):
+                    for target in child.targets:
+                        if isinstance(target, ast.Name):
+                            assigns[target.id] = child.value
+                if child is not node and hasattr(child, "lineno"):
+                    lineno_to_func[child.lineno] = node.name
+            by_func[node.name] = assigns
+            self.generic_visit(node)
+
+        visit_AsyncFunctionDef = visit_FunctionDef
+
+    Visitor().visit(tree)
+    # lineno → that function's assign map
+    return {lineno: by_func[name] for lineno, name in lineno_to_func.items()}
+
+
+def _scan_file(path: Path, const_map: dict[str, str]) -> tuple[set[str], list[str]]:
+    rel = path.relative_to(ROOT).as_posix()
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError) as e:
+        return set(), ["%s: cannot parse: %s" % (rel, e)]
+
+    found: set[str] = set()
+    errors: list[str] = []
+    enclosing = _enclosing_function_names(tree)
+    local_assigns = _local_assigns(tree)
+
+    if rel.endswith("app/downloads/journal.py"):
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                if node.value.startswith("immutable_payload_conflict"):
+                    found.add(_base_token(node.value))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        attr = _call_name(node)
+        if attr is None:
+            continue
+        if attr in PASS_THROUGH_WRITERS:
+            continue
+        if attr not in MARK_ATTRS:
+            continue
+
+        reason_node = _reason_arg(node, attr)
+        lineno = getattr(node, "lineno", "?")
+        if reason_node is None:
+            errors.append(_unresolvable_msg(rel, lineno))
+            continue
+
+        # Inside an allowlisted pass-through function body, a bare Name is OK.
+        if isinstance(reason_node, ast.Name) and reason_node.id in PASS_THROUGH_PARAM_NAMES:
+            parent = enclosing.get(lineno)
+            if parent in PASS_THROUGH_WRITERS:
+                continue
+
+        assigns = local_assigns.get(lineno, {}) if isinstance(lineno, int) else {}
+        tokens = _strings_from(reason_node, const_map, assigns)
+        if not tokens:
+            errors.append(_unresolvable_msg(rel, lineno))
+            continue
+        found |= tokens
+
+    return found, errors
+
+
+def _unresolvable_msg(rel: str, lineno) -> str:
+    return (
+        "Cannot statically resolve fail_reason at %s:%s.\n"
+        "Either pass a reasons.py constant / string literal, or add this site to\n"
+        "PASS_THROUGH_WRITERS in scripts/check_fail_reason_registry.py and ensure\n"
+        "every caller is scanned." % (rel, lineno)
+    )
+
+
+def _iter_scan_files() -> list[Path]:
+    files: list[Path] = []
+    for pattern in SCAN_GLOBS:
+        for path in ROOT.glob(pattern):
+            if not path.is_file():
+                continue
+            if SKIP_DIR_NAMES.intersection(path.parts):
+                continue
+            files.append(path)
+    return sorted(set(files))
+
+
+def main() -> int:
+    registry = _load_registry()
+    files = _iter_scan_files()
+    const_map = _build_const_maps(files)
+
+    writable: set[str] = set()
+    errors: list[str] = []
+
+    for path in files:
+        found, file_errors = _scan_file(path, const_map)
+        writable |= found
+        errors.extend(file_errors)
+
+    missing = sorted(writable - registry)
+
+    if errors:
+        for err in errors:
+            print(err, file=sys.stderr)
+            print("", file=sys.stderr)
+
+    if missing:
+        for token in missing:
+            print(
+                "fail_reason base token not in the actionability registry:\n"
+                "\n"
+                "  token:  %s\n"
+                "\n"
+                "Every base token written to pipeline_journal must be classified in\n"
+                "comicarr/app/activity/reasons.py before merge.\n"
+                "\n"
+                "You owe a verdict against the actionability test:\n"
+                "  (1) ADMIT  — resolving needs info/authority/judgement the operator has\n"
+                "               and the system does not\n"
+                "  (2) EXCLUDE — only if the system reconciles the item (never leave\n"
+                "               Status='Snatched'); record blocklist+re-want vs re-want only\n"
+                "\n"
+                "Also add the operator-facing phrase next to the verdict (band display).\n"
+                "\n"
+                "Unknown tokens are admitted at runtime (fail-open) so production does not\n"
+                "strand issues — CI is the gate. See Wayfinder map #520 / issue #523." % token,
+                file=sys.stderr,
+            )
+            print("", file=sys.stderr)
+
+    if errors or missing:
+        return 1
+
+    print(
+        "fail_reason registry OK: %d known, %d writable bases matched" % (len(registry), len(writable))
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_band_actionability.py
+++ b/tests/unit/test_band_actionability.py
@@ -1,0 +1,226 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""#541 — band actionability predicate and clause-2 reconciliation."""
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import insert, select
+
+import comicarr
+from comicarr import db
+from comicarr.app.activity import queries, reasons
+from comicarr.app.activity import reconcile as band_reconcile
+from comicarr.tables import failed, issues, metadata, pipeline_journal
+
+
+@pytest.fixture
+def activity_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+def _journal(**overrides):
+    base = {
+        "release_key": "rk-1",
+        "issueid": "iss-1",
+        "provider": "DDL",
+        "stage": "failed",
+        "stage_rank": 60,
+        "updated_date": "2026-07-10 12:00:00",
+        "status": None,
+        "fail_reason": "postprocess_error:OperationalError",
+        "nzbname": "Saga.cbz",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_registry_covers_exactly_twenty_two_bases():
+    assert len(reasons.KNOWN_BASE_TOKENS) == 22
+    assert len(reasons.REASON_PHRASES) == 14
+    assert len(reasons.NON_ACTIONABLE_FLAT) == 7
+    assert len(reasons.NON_ACTIONABLE_COMPOSITE) == 1
+    # Every exclusion has a reconciliation obligation; no admitted token is excluded.
+    for token in reasons.NON_ACTIONABLE_FLAT | reasons.NON_ACTIONABLE_COMPOSITE:
+        assert token in reasons.RECONCILIATION
+        assert token not in reasons.REASON_PHRASES
+    for token in reasons.REASON_PHRASES:
+        assert token not in reasons.RECONCILIATION
+
+
+def test_is_actionable_fail_open_and_exclusions():
+    assert reasons.is_actionable(None) is True
+    assert reasons.is_actionable("") is True
+    assert reasons.is_actionable("brand_new_writer_token") is True
+    assert reasons.is_actionable("postprocess_error:ValueError") is True
+    assert reasons.is_actionable("download_gone") is False
+    assert reasons.is_actionable("ddl-worker-rejected") is False
+    assert reasons.is_actionable("immutable_payload_conflict:issueid") is False
+    assert reasons.is_actionable("immutable_payload_conflict") is False
+
+
+def test_band_excludes_non_actionable_and_admits_null(activity_db):
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(pipeline_journal),
+            [
+                _journal(release_key="in-actionable", fail_reason="postprocess_error:X"),
+                _journal(release_key="out-gone", fail_reason="download_gone"),
+                _journal(release_key="out-hyphen", fail_reason="ddl-worker-rejected"),
+                _journal(
+                    release_key="out-composite",
+                    fail_reason="immutable_payload_conflict:provider",
+                    stage="manual_review",
+                ),
+                _journal(release_key="in-null", fail_reason=None),
+                _journal(release_key="in-unknown", fail_reason="never_seen_before"),
+                _journal(release_key="resolved-gone", fail_reason="download_gone", status="retried"),
+            ],
+        )
+
+    keys = {row["release_key"] for row in queries.list_attention_band()}
+    assert keys == {"in-actionable", "in-null", "in-unknown"}
+    assert queries.count_attention_band() == 3
+
+
+def test_band_and_count_stay_consistent(activity_db):
+    """list and count share unresolved_band_condition — including actionability."""
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(pipeline_journal),
+            [
+                _journal(release_key="a", fail_reason="download_gone"),
+                _journal(
+                    release_key="b",
+                    stage="manual_review",
+                    stage_rank=55,
+                    fail_reason="downloaded_invalid_artifact_command:PostProcessCommandError",
+                ),
+                _journal(
+                    release_key="c",
+                    stage="manual_review",
+                    stage_rank=55,
+                    fail_reason="postprocess_error:ValueError",
+                ),
+            ],
+        )
+    rows = queries.list_attention_band()
+    assert queries.count_attention_band() == len(rows)
+    assert {r["release_key"] for r in rows} == {"b", "c"}
+    # Status open-work counts use the same predicate via attention_members.
+    counts = queries.get_open_work_counts()
+    assert counts["attention_members"] == 2
+
+
+def test_reconcile_blocklist_and_rewant(activity_db):
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(issues),
+            [{"IssueID": "iss-9", "ComicID": "c1", "ComicName": "Saga", "Status": "Snatched"}],
+        )
+
+    result = band_reconcile.reconcile_excluded(
+        "download_gone",
+        issueid="iss-9",
+        provider="DDL",
+        nzbname="Saga.cbz",
+        release_id="ddl-42",
+        comicid="c1",
+        comicname="Saga",
+        issue_number="1",
+    )
+    assert result == "blocklisted_and_rewanted"
+
+    issue = db.select_one(select(issues).where(issues.c.IssueID == "iss-9"))
+    assert issue["Status"] == "Wanted"
+    assert issue["AcquisitionIntent"] == "wanted"
+
+    block = db.select_one(
+        select(failed).where(
+            failed.c.ID == "ddl-42",
+            failed.c.Provider == "DDL",
+            failed.c.NZBName == "Saga.cbz",
+        )
+    )
+    assert block is not None
+    assert block["Status"] == "Failed"
+    assert block["IssueID"] == "iss-9"
+
+
+def test_reconcile_rewant_only(activity_db):
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(issues),
+            [{"IssueID": "iss-7", "ComicID": "c1", "ComicName": "Saga", "Status": "Snatched"}],
+        )
+
+    result = band_reconcile.reconcile_excluded(
+        "ddl-worker-rejected",
+        issueid="iss-7",
+        provider="DDL",
+        nzbname="x.cbz",
+        release_id="ddl-1",
+    )
+    assert result == "rewanted"
+    issue = db.select_one(select(issues).where(issues.c.IssueID == "iss-7"))
+    assert issue["Status"] == "Wanted"
+    # No blocklist for attempt-dead tokens.
+    assert db.select_one(select(failed)) is None
+
+
+def test_reconcile_noop_for_admitted_and_already_done():
+    assert band_reconcile.reconcile_excluded("postprocess_error:X") == "noop"
+    assert band_reconcile.reconcile_excluded("download_failed_researching") == "none"
+
+
+def test_reconcile_existing_excluded_rows(activity_db):
+    with activity_db.begin() as conn:
+        conn.execute(
+            insert(issues),
+            [
+                {"IssueID": "iss-a", "ComicID": "c1", "ComicName": "A", "Status": "Snatched"},
+                {"IssueID": "iss-b", "ComicID": "c1", "ComicName": "B", "Status": "Snatched"},
+            ],
+        )
+        conn.execute(
+            insert(pipeline_journal),
+            [
+                _journal(
+                    release_key="gone-1",
+                    issueid="iss-a",
+                    fail_reason="download_gone",
+                    nzbname="a.cbz",
+                    provider="DDL",
+                    payload_json='{"ddl_id":"d1","filename":"a.cbz","provider":"DDL"}',
+                ),
+                _journal(
+                    release_key="keep",
+                    issueid="iss-b",
+                    fail_reason="postprocess_error:X",
+                    payload_json=None,
+                ),
+            ],
+        )
+
+    summary = band_reconcile.reconcile_existing_excluded_rows()
+    assert summary["acted"] == 1
+    assert summary["skipped_actionable"] == 1
+    issue = db.select_one(select(issues).where(issues.c.IssueID == "iss-a"))
+    assert issue["Status"] == "Wanted"
+    # Actionable row's issue stays Snatched (operator still needs to act).
+    other = db.select_one(select(issues).where(issues.c.IssueID == "iss-b"))
+    assert other["Status"] == "Snatched"

--- a/tests/unit/test_needs_attention_resolution.py
+++ b/tests/unit/test_needs_attention_resolution.py
@@ -643,7 +643,7 @@ def test_reason_to_stage_is_a_function():
     assert sorted(unresolved) == [
         "comicarr/app/downloads/handoff.py:156",
         "comicarr/app/downloads/recovery_classify.py:571",
-        "comicarr/app/downloads/service.py:2120",
+        "comicarr/app/downloads/service.py:2153",
         "comicarr/failed.py:114",
     ], "a mark_* call site with a non-literal reason changed: %s" % sorted(unresolved)
 


### PR DESCRIPTION
## Summary

Implements [#541](https://github.com/frankieramirez/comicarr/issues/541) — the only remaining piece of the needs-attention band work after [#539](https://github.com/frankieramirez/comicarr/pull/539).

- **Registry** (`activity/reasons.py`): all 22 base tokens have verdicts; 14 admitted with phrases, 8 excluded with reconciliation obligations.
- **Predicate**: `unresolved_band_condition()` gains a NULL-safe, dialect-portable `actionable_reason_condition` clause. Unknown tokens fail-open.
- **Clause 2 reconciliation**: excluded writers re-want (and blocklist dead releases) so issues are never left at `Snatched` with nothing watching. Boot one-shot covers pre-existing stranded rows.
- **ADR-0001** + operator changeset + CI completeness guard (`lint:guards` → `check_fail_reason_registry.py`).

## Why this is not just a denylist

Excluding without reconciliation strands ~195 production issues permanently — the band's retry button was their only recovery path. Reconciliation ships with the admission change.

## Test plan

- [x] `uv run pytest tests/unit/test_band_actionability.py tests/unit/test_activity_read_apis.py tests/unit/test_needs_attention_resolution.py tests/unit/test_recovery_classify.py tests/unit/test_recovery_replay.py` (113 passed)
- [x] `npm run lint:guards` / `lint:backend` / `lint:modern`
- [ ] CI green on PR
- [ ] After deploy: band count drops (~399 → ~204), excluded issues return to Wanted, no new Snatched orphans for OUT tokens

Closes #541