### PR TITLE
fix: Pin update guidance to real GHCR image tags

### DIFF
--- a/.changeset/spotty-donkeys-shake.md
+++ b/.changeset/spotty-donkeys-shake.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fixed the `docker pull` command in the update-available popover, which pointed at an image tag that does not exist. Comicarr publishes bare-semver tags (`0.26.0`), but the popover copied a `v`-prefixed reference (`ghcr.io/frankieramirez/comicarr:v0.26.0`) that fails with a manifest-not-found error. The Compose note was also misleading: it implied a plain pull pins your install to a release, when a pull alone leaves a running container on `:latest`. It now tells you to set the pinned tag in your compose file.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,15 @@ curl -o docker-compose.yml https://raw.githubusercontent.com/frankieramirez/comi
 docker compose up -d
 ```
 
-Multi-architecture images (`amd64`, `arm64`) are published to `ghcr.io/frankieramirez/comicarr`.
+Multi-architecture images (`amd64`, `arm64`) are published to `ghcr.io/frankieramirez/comicarr` — GHCR is the only registry Comicarr publishes to.
+
+To pin a release instead of tracking `:latest`, note that **image tags are bare semver — they drop the `v` that GitHub releases and git tags carry**. Release `v0.26.0` is image tag `0.26.0`:
+
+```bash
+docker pull ghcr.io/frankieramirez/comicarr:0.26.0
+```
+
+Under Compose, change the `image:` line to the pinned tag and run `docker compose up -d` — pulling on its own does not move a running container off `:latest`.
 
 See the [installation guide](https://comicarr.com/docs/installation) for Docker Compose configuration, volume details, environment variables, and platform-specific notes.
 

--- a/frontend/src/lib/updateGuidance.ts
+++ b/frontend/src/lib/updateGuidance.ts
@@ -7,18 +7,28 @@ import type { InstallType } from "@/types/version";
 
 export const GHCR_IMAGE = "ghcr.io/frankieramirez/comicarr";
 
+/**
+ * The git/release line carries a `v` prefix: git tags, GitHub release pages.
+ */
+export function asGitTag(latestVersion: string): string {
+  return latestVersion.startsWith("v") ? latestVersion : `v${latestVersion}`;
+}
+
+/**
+ * The registry line does not: .github/workflows/release.yml pushes
+ * `${GHCR_IMAGE}:${version}` from package.json, bare semver. Carrying the `v`
+ * into a pull reference 404s (#545), so the two lines never share a helper.
+ */
+export function asRegistryTag(latestVersion: string): string {
+  return latestVersion.replace(/^v/, "");
+}
+
 export function releaseTagUrl(latestVersion: string): string {
-  const tag = latestVersion.startsWith("v")
-    ? latestVersion
-    : `v${latestVersion}`;
-  return `https://github.com/frankieramirez/comicarr/releases/tag/${tag}`;
+  return `https://github.com/frankieramirez/comicarr/releases/tag/${asGitTag(latestVersion)}`;
 }
 
 export function pinImageTag(latestVersion: string): string {
-  const tag = latestVersion.startsWith("v")
-    ? latestVersion
-    : `v${latestVersion}`;
-  return `${GHCR_IMAGE}:${tag}`;
+  return `${GHCR_IMAGE}:${asRegistryTag(latestVersion)}`;
 }
 
 export interface UpdateGuidance {
@@ -33,9 +43,7 @@ export function getUpdateGuidance(
   installType: InstallType | null | undefined,
   latestVersion: string,
 ): UpdateGuidance {
-  const tag = latestVersion.startsWith("v")
-    ? latestVersion
-    : `v${latestVersion}`;
+  const tag = asGitTag(latestVersion);
   const pinned = pinImageTag(latestVersion);
   const kind = (installType || "source").toLowerCase();
 
@@ -48,7 +56,7 @@ export function getUpdateGuidance(
         ["docker compose pull", "docker compose up -d"].join("\n"),
         `docker pull ${pinned}`,
       ],
-      note: "Prefer Compose when you use a compose file. The plain pull pins the image to this release — not floating :latest.",
+      note: `Prefer Compose when you use a compose file — it recreates the container, which a pull alone never does. To stay on this release rather than floating :latest, set image: ${pinned} in the compose file before pulling.`,
     };
   }
 

--- a/frontend/tests/unit/lib/updateGuidance.test.ts
+++ b/frontend/tests/unit/lib/updateGuidance.test.ts
@@ -16,13 +16,30 @@ describe("updateGuidance", () => {
   });
 
   it("pins docker image to notified release not :latest", () => {
-    expect(pinImageTag("0.21.0")).toBe(
-      "ghcr.io/frankieramirez/comicarr:v0.21.0",
-    );
+    expect(pinImageTag("0.21.0")).toBe("ghcr.io/frankieramirez/comicarr:0.21.0");
     const g = getUpdateGuidance("docker", "0.21.0");
-    expect(g.commands.some((c) => c.includes(":v0.21.0"))).toBe(true);
+    expect(g.commands.some((c) => c.includes(":0.21.0"))).toBe(true);
     expect(g.commands.some((c) => c.includes(":latest"))).toBe(false);
     expect(g.commands[0]).toContain("docker compose pull");
+  });
+
+  it("strips the v prefix the release line carries — registry tags are bare semver", () => {
+    // release.yml pushes ghcr.io/frankieramirez/comicarr:${version}, where
+    // version is package.json's bare semver. A :v-prefixed pull 404s.
+    expect(pinImageTag("v0.21.0")).toBe(
+      "ghcr.io/frankieramirez/comicarr:0.21.0",
+    );
+    const g = getUpdateGuidance("docker", "v0.21.0");
+    expect(g.commands.some((c) => c.includes(":v0.21.0"))).toBe(false);
+    expect(g.commands.some((c) => c.includes(":0.21.0"))).toBe(true);
+  });
+
+  it("does not claim a bare pull pins a compose stack", () => {
+    // docker-compose.yml ships `image: ...:latest`; a pinned `docker pull`
+    // only warms the local cache, so the recreate still resolves :latest.
+    const g = getUpdateGuidance("docker", "0.21.0");
+    expect(g.note).not.toMatch(/plain pull pins/i);
+    expect(g.note).toMatch(/image:/);
   });
 
   it("git guidance checks out tag not branch pull", () => {


### PR DESCRIPTION
## Summary

Closes part of #545. The in-app update popover offered a `docker pull` command for an image tag that does not exist.

`.github/workflows/release.yml` pushes **bare-semver** tags (`0.26.0`). Git tags and GitHub Release pages carry a **`v` prefix** (`v0.26.0`). `pinImageTag` added the prefix, producing `ghcr.io/frankieramirez/comicarr:v0.26.0` — which fails with a manifest-not-found error. This is exactly the 404 the issue reporter hit by guessing the tag from the release page.

Note the issue's headline premise no longer holds: GHCR anonymous pulls now return `200` for `latest` and `0.26.0`, so the package visibility was fixed out of band. The `v`-prefixed 404s are the real and permanent part.

## Changes

- `pinImageTag` strips the `v` prefix instead of adding it
- Split the normalization into `asGitTag` / `asRegistryTag`. The same inline `startsWith("v")` block existed at three call sites and the bug was fixing only one arm of the pair — the two tag lines now never share a helper
- Corrected the Compose note. It claimed *"The plain pull pins the image to this release"*, but `docker-compose.yml:3` pins `:latest`, so a pinned pull only warms the local cache and the recreate resolves `:latest` again. Both the popover and the README now say to set the pinned tag in the compose file
- README documents the tag scheme

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [ ] No app release impact; no changeset needed

## Testing

- [x] Tests pass locally (`pytest tests/unit -v`) — 2067 passed
- [x] Frontend builds (`cd frontend && npm run build`)
- [x] Backend lint/format
- [x] Frontend lint/format — 328 frontend tests pass, `tsc --noEmit` clean
- [x] Or one-shot: `npm run lint`

Built test-first: each behaviour change went red before green. Two new cases cover the `v`-prefix strip and the compose-note claim.

## Additional Notes

`npm run lint` at the repo root fails locally on `sh: python: command not found` — a pre-existing gap in my shell, not this branch. Every lane passes under `python3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XDQULnXaiV5TCrjGcQb2a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Docker update instructions in the update-available popover.
  - Docker image commands now use the correct bare semantic version tags.
  - Clarified that pinning a Compose deployment requires updating the Compose file and recreating the container.

- **Documentation**
  - Expanded Docker quick-start guidance with GHCR availability, multi-architecture images, version pinning, and Compose update steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->