### PR TITLE
fix: Give standalone Docker installs a recreate step

### DIFF
--- a/.changeset/spotty-donkeys-shake.md
+++ b/.changeset/spotty-donkeys-shake.md
@@ -2,4 +2,4 @@
 "comicarr": patch
 ---
 
-Fixed the `docker pull` command in the update-available popover, which pointed at an image tag that does not exist. Comicarr publishes bare-semver tags (`0.26.0`), but the popover copied a `v`-prefixed reference (`ghcr.io/frankieramirez/comicarr:v0.26.0`) that fails with a manifest-not-found error. The Compose note was also misleading: it implied a plain pull pins your install to a release, when a pull alone leaves a running container on `:latest`. It now tells you to set the pinned tag in your compose file.
+Fixed the `docker pull` command in the update-available popover, which pointed at an image tag that does not exist. Comicarr publishes bare-semver tags (`0.26.0`), but the popover copied a `v`-prefixed reference (`ghcr.io/frankieramirez/comicarr:v0.26.0`) that fails with a manifest-not-found error. The surrounding advice was also incomplete: pulling an image never moves a running container onto it, but the popover implied a plain pull was enough. Both paths are now spelled out — set the pinned tag in your compose file and `up -d`, or stop and remove the container and re-run it. The README says the same.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,12 @@ To pin a release instead of tracking `:latest`, note that **image tags are bare 
 docker pull ghcr.io/frankieramirez/comicarr:0.26.0
 ```
 
-Under Compose, change the `image:` line to the pinned tag and run `docker compose up -d` — pulling on its own does not move a running container off `:latest`.
+Pulling on its own never moves a running container to the new image — you have to recreate it:
+
+- **Compose:** change the `image:` line to the pinned tag, then `docker compose up -d`.
+- **Standalone:** `docker stop comicarr && docker rm comicarr`, then re-run the `docker run` command above with the pinned tag.
+
+Your config and library are mounted volumes, so both paths leave them untouched.
 
 See the [installation guide](https://comicarr.com/docs/installation) for Docker Compose configuration, volume details, environment variables, and platform-specific notes.
 

--- a/frontend/src/lib/updateGuidance.ts
+++ b/frontend/src/lib/updateGuidance.ts
@@ -54,9 +54,16 @@ export function getUpdateGuidance(
         "Pull the notified release and recreate the container on the host. Comicarr cannot replace its own container.",
       commands: [
         ["docker compose pull", "docker compose up -d"].join("\n"),
-        `docker pull ${pinned}`,
+        // Stop and rm because a pull replaces the image, never the running
+        // container. The recreate itself belongs to the operator: their
+        // original volume, port, and env flags are not knowable from here.
+        [
+          `docker pull ${pinned}`,
+          "docker stop comicarr",
+          "docker rm comicarr",
+        ].join("\n"),
       ],
-      note: `Prefer Compose when you use a compose file — it recreates the container, which a pull alone never does. To stay on this release rather than floating :latest, set image: ${pinned} in the compose file before pulling.`,
+      note: `Compose: set image: ${pinned} in the compose file before pulling — a pull alone never moves a running container off :latest. Standalone: after the stop and rm, re-run your original docker run with ${pinned}. Your config and library are mounted volumes and survive either path.`,
     };
   }
 

--- a/frontend/tests/unit/lib/updateGuidance.test.ts
+++ b/frontend/tests/unit/lib/updateGuidance.test.ts
@@ -39,7 +39,24 @@ describe("updateGuidance", () => {
     // only warms the local cache, so the recreate still resolves :latest.
     const g = getUpdateGuidance("docker", "0.21.0");
     expect(g.note).not.toMatch(/plain pull pins/i);
-    expect(g.note).toMatch(/image:/);
+    // Naming the field is not enough — the note has to carry the value the
+    // operator is meant to paste into it, and the recreate that applies it.
+    expect(g.note).toContain("image: ghcr.io/frankieramirez/comicarr:0.21.0");
+    expect(g.commands[0]).toContain("docker compose up -d");
+  });
+
+  it("gives standalone installs a recreate, not just a pull", () => {
+    // A pull leaves the running container on its old image whether or not
+    // Compose is involved. The non-Compose block must replace the container.
+    const g = getUpdateGuidance("docker", "0.21.0");
+    const standalone = g.commands.find((c) => !c.includes("docker compose"));
+    expect(standalone).toBeDefined();
+    expect(standalone).toContain("docker pull ghcr.io/frankieramirez/comicarr:0.21.0");
+    expect(standalone).toContain("docker stop");
+    expect(standalone).toContain("docker rm");
+    // Original run flags (volumes, ports) are unknowable here, so the note
+    // must hand the recreate back to the operator rather than invent them.
+    expect(g.note).toMatch(/docker run/i);
   });
 
   it("git guidance checks out tag not branch pull", () => {


### PR DESCRIPTION
## Summary

Follow-up to #546, from CodeRabbit's review on that PR. It was raised before merge but landed after, so it needs its own PR.

A `docker pull` replaces the image, never the running container. #546 corrected that claim for the Compose path but left the standalone path offering a bare `docker pull` — the same failure, one branch over. A non-Compose operator could follow the popover exactly and keep running the old image.

## Changes

- The non-Compose command block now stops and removes the container alongside the pull
- The recreate itself stays with the operator. Their original volume, port, and env flags cannot be reconstructed from the popover, and emitting a synthesized `docker run` would silently drop their mounts — so the note hands that step back explicitly
- README documents both recreation paths under the pinning section
- Changeset updated to describe the completed behaviour rather than only the Compose half

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [ ] No app release impact; no changeset needed

This amends `.changeset/spotty-donkeys-shake.md`, which is still unconsumed on `main` — Version Packages #548 will pick up the revised text.

## Testing

- [x] Tests pass locally (`pytest tests/unit -v`)
- [x] Frontend builds (`cd frontend && npm run build`)
- [x] Backend lint/format
- [x] Frontend lint/format — 329 frontend tests pass, `tsc --noEmit` clean
- [x] Or one-shot: `npm run lint`

Test-first: the standalone case went red before the fix. Also strengthened the existing Compose assertion, which checked only that the note mentioned `image:` without verifying it carried the pinned value or the `up -d` that applies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XDQULnXaiV5TCrjGcQb2a