### PR TITLE
fix: Only blocklist a provider when it is genuinely unreachable

### DIFF
--- a/.changeset/lazy-moons-shave.md
+++ b/.changeset/lazy-moons-shave.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fixed searches aborting and providers going dark for an hour whenever an indexer returned any error at all. A rate-limit response — Prowlarr's plain HTTP 429, the most common thing an indexer says when you search too often — was treated identically to the indexer being unreachable: Comicarr blocklisted the provider and abandoned the search. The check meant to distinguish the two cases had been written so that it always fired, so in practice every transient hiccup cost you the whole search cycle, and the next one 6 hours later. Comicarr now inspects the actual failure: if the provider answered at all, it is left enabled and only that one search is skipped, and only a genuine connection failure (refused, timed out, host or network unreachable) blocklists it. The same fix applies to the GetComics DDL provider. These failures also no longer dump a 130-entry table of system error codes into your logs on every occurrence.

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -15,6 +15,7 @@ rsscheck.py. Preserves ThreadPoolExecutor for parallel provider queries.
 """
 
 import datetime
+import errno
 import re
 import time
 import uuid
@@ -831,6 +832,58 @@ def block_provider_check(site, simple=True, force=False):
         return False
     else:
         return {"blocked": False, "remain": 0}
+
+
+# Socket errnos that mean the provider itself could not be reached. An HTTP
+# response of any status proves the opposite, so it is checked first.
+PROVIDER_DOWN_ERRNOS = frozenset(
+    {
+        errno.ETIMEDOUT,
+        errno.ECONNREFUSED,
+        errno.ECONNRESET,
+        errno.EHOSTDOWN,
+        errno.EHOSTUNREACH,
+        errno.ENETDOWN,
+        errno.ENETUNREACH,
+    }
+)
+
+
+def _nested_errno(exc, depth=0):
+    """Dig the OS-level errno out of a requests exception.
+
+    requests wraps urllib3 which wraps the original OSError, so the errno is
+    never on the exception we catch — it sits a few layers down in `args`,
+    `__cause__` or `__context__`.
+    """
+    if exc is None or depth > 6:
+        return None
+    code = getattr(exc, "errno", None)
+    if isinstance(code, int) and code:
+        return code
+    for nested in list(getattr(exc, "args", ()) or ()) + [exc.__cause__, exc.__context__]:
+        if isinstance(nested, BaseException):
+            code = _nested_errno(nested, depth + 1)
+            if code is not None:
+                return code
+    return None
+
+
+def provider_unreachable(exc):
+    """True when a requests exception means the provider is down, not just unhappy.
+
+    A rate-limit (429), an auth failure or any other HTTP error means the
+    provider answered — blocklisting it for an hour is the wrong response.
+    """
+    response = getattr(exc, "response", None)
+    if response is not None and getattr(response, "status_code", None):
+        return False
+    code = _nested_errno(exc)
+    if code is not None:
+        return code in PROVIDER_DOWN_ERRNOS
+    # No errno to inspect (DNS failure, SSL handshake, read timeout): trust the
+    # requests exception class instead.
+    return isinstance(exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout))
 
 
 def disable_provider(site, reason=None, delay=0):

--- a/comicarr/getcomics.py
+++ b/comicarr/getcomics.py
@@ -20,7 +20,6 @@
 
 
 import datetime
-import errno
 import json
 import os
 import re
@@ -254,14 +253,7 @@ class GC(object):
             return "no results"
         except requests.exceptions.ConnectionError as e:
             logger.warn("[WARNING] Connection refused to DDL site, stopped by a small tank. Error returned as : %s" % e)
-            if any(
-                [
-                    errno.ETIMEDOUT,
-                    errno.ECONNREFUSED,
-                    errno.EHOSTDOWN,
-                    errno.EHOSTUNREACH,
-                ]
-            ):
+            if helpers.provider_unreachable(e):
                 helpers.disable_provider("DDL", "Connection Refused.")
             return "no results"
         except Exception as err:

--- a/comicarr/helpers.py
+++ b/comicarr/helpers.py
@@ -113,6 +113,7 @@ from comicarr.app.search.service import (  # noqa: F401
     ignored_publisher_check,
     newznab_test,
     parse_32pfeed,
+    provider_unreachable,
     search_queue,
     torrent_create,
     torrentinfo,

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -19,7 +19,6 @@
 
 
 import datetime
-import errno
 import os
 import pathlib
 import re
@@ -1346,31 +1345,21 @@ def NZB_SEARCH(
                         break
                     except requests.exceptions.ConnectionError as e:
                         logger.warn("Connection error trying to retrieve data from %s: %s" % (nzbprov, e))
-                        logger.warn("[%s]Connection error trying to retrieve data from %s: %s" % (errno, nzbprov, e))
-                        if any(
-                            [
-                                errno.ETIMEDOUT,
-                                errno.ECONNREFUSED,
-                                errno.EHOSTDOWN,
-                                errno.EHOSTUNREACH,
-                            ]
-                        ):
+                        if helpers.provider_unreachable(e):
                             helpers.disable_provider(tmpprov, "Connection Refused.")
                         is_info["foundc"]["status"] = False
                         break
                     except requests.exceptions.RequestException as e:
-                        logger.warn("[%s]General Error fetching data from %s: %s" % (errno.errorcode, nzbprov, e))
-                        if any(
-                            [
-                                errno.ETIMEDOUT,
-                                errno.ECONNREFUSED,
-                                errno.EHOSTDOWN,
-                                errno.EHOSTUNREACH,
-                            ]
-                        ):
+                        logger.warn("General Error fetching data from %s: %s" % (nzbprov, e))
+                        if helpers.provider_unreachable(e):
                             helpers.disable_provider(tmpprov, "Connection Refused.")
                             logger.warn("Aborting search due to Provider unavailability")
-                            is_info["foundc"]["status"] = False
+                        else:
+                            logger.warn(
+                                "%s answered with an error - skipping this provider for this search, "
+                                "but leaving it enabled." % nzbprov
+                            )
+                        is_info["foundc"]["status"] = False
                         break
                     is_info["foundc"]["lastrun"] = time.time()
                     logger.info(

--- a/tests/unit/test_provider_unreachable.py
+++ b/tests/unit/test_provider_unreachable.py
@@ -1,0 +1,111 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Only a genuinely unreachable provider may be blocklisted.
+
+Guards the defect fixed in #560: `any([errno.ETIMEDOUT, ...])` is a list of
+nonzero constants and so was unconditionally true, meaning every request error
+— a plain 429 included — disabled the provider and aborted the search.
+"""
+
+import errno
+import socket
+from types import SimpleNamespace
+
+import pytest
+import requests
+from urllib3.exceptions import MaxRetryError, NewConnectionError, ProtocolError
+
+from comicarr.app.search.service import provider_unreachable
+
+
+def _http_error(status_code):
+    response = SimpleNamespace(status_code=status_code)
+    return requests.exceptions.HTTPError("%s error" % status_code, response=response)
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 429, 500, 503])
+def test_any_http_response_means_the_provider_is_alive(status_code):
+    assert provider_unreachable(_http_error(status_code)) is False
+
+
+def test_rate_limit_does_not_disable_the_provider():
+    # The exact production symptom: Prowlarr 429 was blocklisting the provider.
+    assert provider_unreachable(_http_error(429)) is False
+
+
+@pytest.mark.parametrize(
+    "code",
+    [errno.ETIMEDOUT, errno.ECONNREFUSED, errno.EHOSTDOWN, errno.EHOSTUNREACH, errno.ENETUNREACH],
+)
+def test_socket_errnos_buried_under_urllib3_are_found(code):
+    os_error = OSError(code, "boom")
+    wrapped = requests.exceptions.ConnectionError(ProtocolError("Connection aborted.", os_error))
+
+    assert provider_unreachable(wrapped) is True
+
+
+def test_errno_reached_through_exception_chaining():
+    try:
+        try:
+            raise OSError(errno.ECONNREFUSED, "refused")
+        except OSError as os_error:
+            raise requests.exceptions.ConnectionError("wrapped") from os_error
+    except requests.exceptions.ConnectionError as e:
+        assert provider_unreachable(e) is True
+
+
+def test_unrelated_errno_does_not_disable_the_provider():
+    os_error = OSError(errno.EACCES, "permission denied")
+    wrapped = requests.exceptions.ConnectionError(ProtocolError("Connection aborted.", os_error))
+
+    assert provider_unreachable(wrapped) is False
+
+
+def test_dns_failure_with_no_errno_still_counts_as_unreachable():
+    pool = SimpleNamespace(scheme="https", host="indexer.test", port=443)
+    reason = NewConnectionError(pool, "Failed to resolve 'indexer.test'")
+    wrapped = requests.exceptions.ConnectionError(MaxRetryError(pool, "https://indexer.test/api", reason=reason))
+
+    assert provider_unreachable(wrapped) is True
+
+
+def test_read_timeout_counts_as_unreachable():
+    assert provider_unreachable(requests.exceptions.ReadTimeout("timed out")) is True
+
+
+def test_socket_timeout_under_a_requests_timeout_is_unreachable():
+    assert provider_unreachable(requests.exceptions.ConnectTimeout(socket.timeout("timed out"))) is True
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        requests.exceptions.TooManyRedirects("too many redirects"),
+        requests.exceptions.InvalidURL("bad url"),
+        requests.exceptions.ContentDecodingError("bad gzip"),
+        requests.exceptions.ChunkedEncodingError("bad chunk"),
+    ],
+)
+def test_client_side_request_errors_leave_the_provider_enabled(exc):
+    assert provider_unreachable(exc) is False
+
+
+def test_http_error_without_a_response_is_not_treated_as_unreachable():
+    assert provider_unreachable(requests.exceptions.HTTPError("no response attached")) is False
+
+
+def test_self_referential_exception_chain_terminates():
+    # __context__ can point back at an ancestor; the depth cap must stop the walk.
+    outer = requests.exceptions.ConnectionError("outer")
+    inner = requests.exceptions.ConnectionError("inner")
+    outer.__context__ = inner
+    inner.__context__ = outer
+
+    assert provider_unreachable(outer) is True


### PR DESCRIPTION
Closes #560. Part of #550 — the map records this as shipping first, on its own, because nothing downstream in the fix thread is verifiable while it aborts every search.

## The bug

```python
if any([errno.ETIMEDOUT, errno.ECONNREFUSED, errno.EHOSTDOWN, errno.EHOSTUNREACH]):
    helpers.disable_provider(tmpprov, "Connection Refused.")
```

`any()` over a list of nonzero constants is unconditionally `True`. Every `RequestException` — including Prowlarr answering with a plain HTTP 429 — blocklisted the provider for `BLOCKLIST_TIMER` (1h default) and aborted the search. Confirmed doing exactly that on the NAS on 2026-08-03, 08-05 and 08-06, leaving 567 run-items stranded `accepted` (#551).

## The fix

`provider_unreachable(exc)` in `comicarr/app/search/service.py`, next to `disable_provider`:

1. **The provider answered?** Any `response.status_code` means it is alive — 429, 403, 503 all leave it enabled. This is the production symptom.
2. **Otherwise, what errno?** requests wraps urllib3 which wraps the original `OSError`, so the errno is never on the exception we catch. `_nested_errno` walks `args` / `__cause__` / `__context__` (depth-capped, so a self-referential chain terminates) and matches against `ETIMEDOUT`, `ECONNREFUSED`, `ECONNRESET`, `EHOSTDOWN`, `EHOSTUNREACH`, `ENETDOWN`, `ENETUNREACH`.
3. **No errno at all?** DNS failure, SSL handshake, read timeout — fall back to the requests exception class.

So `TooManyRedirects`, `InvalidURL` and `ContentDecodingError` no longer kill a provider either.

Three call sites, all the same defect: both branches in `search.py:1347/1361` and the DDL one in `getcomics.py:255`.

## Also

- The `RequestException` branch set `is_info["foundc"]["status"] = False` *inside* the guard. Now unconditional — which is what it already was in practice, since that path breaks out and `foundc["status"]` defaults to `False`.
- The warning interpolated `errno.errorcode`, the whole 130-entry dict, into every occurrence (~4KB a line), and the `ConnectionError` branch logged the same message twice. Both gone; `errno` is no longer imported in either module.

## Not in scope

Whether the provider cooldown should *escalate* once a provider fails honestly is deliberately left open on the map — this fixes the cooldown's trigger, not its semantics.

## Verification

24 new tests in `tests/unit/test_provider_unreachable.py` covering each branch, including a 429 explicitly. Full suite: 2091 passed. `npm run lint` clean (frontend eslint not installed in this worktree; no frontend files changed).

Still needs a NAS redeploy with Frankie driving to confirm live — per #552 that redeploy is bundled with the SAB handoff change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcWXYN2i1XvnKiZyxjESKp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider error handling during searches.
  * Rate limits and other provider responses no longer disable providers or stop entire searches.
  * Providers are disabled only when genuine connectivity failures occur.
  * Reduced unnecessary system error logging.
* **Tests**
  * Added coverage for network failures, timeouts, DNS errors, HTTP responses, and chained exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->