### PR TITLE
fix: Correct case-mismatched db.upsert table names that break series refresh

### DIFF
--- a/.changeset/warm-pandas-refresh.md
+++ b/.changeset/warm-pandas-refresh.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fixed series refresh failing outright whenever it had issue or location changes to write. Refreshing a series looked up its database table under the wrong name, so the moment a refresh found something to update — a new issue, a changed status, a relocated series folder — the write raised `Unknown table for upsert` and the whole run was recorded as failed. Refreshes that happened to find nothing to change appeared to succeed, which is why this could go unnoticed while every real update was being dropped. The same defect affected annuals, the bulk series-location update after a config change, and the dynamic-name maintenance pass. All of them now write correctly, so a refresh actually persists what it finds.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Comicarr is built on the foundation of Mylar3 with a completely rebuilt React 19
 | Run app | `python3 Comicarr.py --nolaunch` |
 | Test backend | `pytest tests/unit -v` |
 | Lint modern backend | `npm run lint:modern` (`comicarr/app` + `Comicarr.py`) |
-| Check retired globals + fail_reason registry | `npm run lint:guards` (`scripts/check_retired_globals.py`, `scripts/check_fail_reason_registry.py`) |
+| Check retired globals + fail_reason registry + upsert tables | `npm run lint:guards` (`scripts/check_retired_globals.py`, `scripts/check_fail_reason_registry.py`, `scripts/check_upsert_tables.py`) |
 | Lint all (CI parity) | `npm run lint` |
 | Regenerate settings types | `npm run lint:fix:generated` (after editing the config registry) |
 
@@ -60,6 +60,7 @@ Conventional PR titles keep history readable, but they do not control releases. 
 - **Do NOT manually bump versions** - Changesets release automation handles this
 - **Do NOT call `useReactTable` directly** - `no-restricted-imports` allows it only in `frontend/src/components/data-table/useTableState.ts`. Call `useTableState`, which wraps it so `getRowId` is required and row identity can never fall back to TanStack's index default. Tables still awaiting migration are listed in an `overrides` allowlist in `eslint.config.js`; that list only ever shrinks — never add to it.
 - **Do NOT reintroduce `GLOBAL_MESSAGES`** - The pre-EventBus message bus is retired. Deleting the declaration cannot make its return fail (Python creates the attribute on first assignment), so `npm run lint:guards` scans source for it instead. Narrate through `comicarr.app.activity.events.record_activity`; that facade publishes the single `activity` SSE event after a durable commit. Add further retired names to `RETIRED_GLOBALS` in `scripts/check_retired_globals.py`. Contributor-only gate — no changeset.
+- **`db.upsert` / `db.upsert_conn` table names must be lowercase `TABLE_MAP` keys** - The table is resolved by dict lookup, so `"Issues"` for `"issues"` lints clean and raises `ValueError: Unknown table for upsert` only when that write branch runs — it broke series refresh in production (#561). `scripts/check_upsert_tables.py` (under `lint:guards`) AST-scans every literal table argument. Runtime-built names are skipped; if you must build one, lowercase it at the source. Contributor-only gate — no changeset.
 - **Every `fail_reason` base token must be classified** in `comicarr/app/activity/reasons.py` before merge (`scripts/check_fail_reason_registry.py` under `lint:guards`). Runtime is fail-open; CI is the gate. Excluding a token requires a reconciliation obligation (never leave `Snatched`). See ADR-0001 / #523 / #541.
 - **Do NOT add per-feature SSE event types** - `activity` is the only narrative channel; `ai_activity`, `restart`, and `shutdown` are the only other listeners in `useServerEvents`. The client invalidates queries from a payload and never accumulates the stream into a list.
 - **Do NOT finish without linting** - Run `npm run lint` (or `npm run lint:fix` then re-check) before considering work done; do not bypass hooks with `--no-verify`

--- a/comicarr.egg-info/PKG-INFO
+++ b/comicarr.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: comicarr
-Version: 0.19.13
+Version: 0.26.1
 Summary: Automated Comic Book Manager
 Requires-Python: >=3.10
 Description-Content-Type: text/markdown
@@ -120,7 +120,29 @@ curl -o docker-compose.yml https://raw.githubusercontent.com/frankieramirez/comi
 docker compose up -d
 ```
 
-Multi-architecture images (`amd64`, `arm64`) are published to `ghcr.io/frankieramirez/comicarr`.
+### Registries
+
+Multi-architecture images (`amd64`, `arm64`) are published to two registries with identical tags, from the same build:
+
+| Registry | Image reference | |
+| -------- | --------------- | - |
+| GitHub Container Registry | `ghcr.io/frankieramirez/comicarr` | canonical |
+| Docker Hub | `comicarr/comicarr` | mirror |
+
+Either works. GHCR does not rate-limit anonymous pulls; Docker Hub does.
+
+To pin a release instead of tracking `:latest`, note that **image tags are bare semver — they drop the `v` that GitHub releases and git tags carry**. Release `v0.26.0` is image tag `0.26.0`:
+
+```bash
+docker pull ghcr.io/frankieramirez/comicarr:0.26.0
+```
+
+Pulling on its own never moves a running container to the new image — you have to recreate it:
+
+- **Compose:** change the `image:` line to the pinned tag, then `docker compose up -d`.
+- **Standalone:** `docker stop comicarr && docker rm comicarr`, then re-run the `docker run` command above with the pinned tag.
+
+Your config and library are mounted volumes, so both paths leave them untouched.
 
 See the [installation guide](https://comicarr.com/docs/installation) for Docker Compose configuration, volume details, environment variables, and platform-specific notes.
 
@@ -239,7 +261,7 @@ cd frontend && npm ci && cd ..
 python3 Comicarr.py --nolaunch   # backend on :8090
 
 # separate terminal — frontend HMR (proxies API to :8090)
-cd frontend && npm run dev
+cd frontend && npm run dev   # https://comicarr.localhost:1355 (portless)
 ```
 
 ## Attribution

--- a/comicarr.egg-info/SOURCES.txt
+++ b/comicarr.egg-info/SOURCES.txt
@@ -6,6 +6,7 @@ comicarr/auth32p.py
 comicarr/carepackage.py
 comicarr/cdh_mapping.py
 comicarr/cfscrape_compat.py
+comicarr/changelog_notes.py
 comicarr/cmtag.py
 comicarr/comicsync.py
 comicarr/config.py
@@ -52,6 +53,7 @@ comicarr/scanutil.py
 comicarr/search.py
 comicarr/search_filer.py
 comicarr/searchit.py
+comicarr/series_kind.py
 comicarr/series_metadata.py
 comicarr/tables.py
 comicarr/updater.py
@@ -155,7 +157,18 @@ comicarr/app/acquisition/evidence.py
 comicarr/app/acquisition/maintenance.py
 comicarr/app/acquisition/models.py
 comicarr/app/acquisition/policy.py
+comicarr/app/acquisition/retention.py
 comicarr/app/acquisition/runs.py
+comicarr/app/activity/__init__.py
+comicarr/app/activity/events.py
+comicarr/app/activity/grouping.py
+comicarr/app/activity/producers.py
+comicarr/app/activity/queries.py
+comicarr/app/activity/reasons.py
+comicarr/app/activity/reconcile.py
+comicarr/app/activity/retention.py
+comicarr/app/activity/router.py
+comicarr/app/activity/service.py
 comicarr/app/ai/__init__.py
 comicarr/app/ai/chat.py
 comicarr/app/ai/chat_images.py
@@ -182,10 +195,13 @@ comicarr/app/common/__init__.py
 comicarr/app/common/dates.py
 comicarr/app/common/filesystem.py
 comicarr/app/common/numbers.py
+comicarr/app/common/placement.py
 comicarr/app/common/redaction.py
 comicarr/app/common/remote_artifacts.py
 comicarr/app/common/strings.py
 comicarr/app/common/utilities.py
+comicarr/app/config/__init__.py
+comicarr/app/config/registry.py
 comicarr/app/core/__init__.py
 comicarr/app/core/context.py
 comicarr/app/core/database.py
@@ -244,6 +260,7 @@ comicarr/app/system/__init__.py
 comicarr/app/system/acquisition_repair.py
 comicarr/app/system/router.py
 comicarr/app/system/service.py
+comicarr/app/system/whats_new.py
 comicarr/app/weekly/__init__.py
 comicarr/app/weekly/queries.py
 comicarr/app/weekly/router.py

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -1225,7 +1225,7 @@ def updateComicLocation():
                 for cl in comloc:
                     ctrlVal = {"ComicID": cl["comicid"]}
                     newVal = {"ComicLocation": cl["comlocation"]}
-                    db.upsert("Comics", newVal, ctrlVal)
+                    db.upsert("comics", newVal, ctrlVal)
                     logger.fdebug("Updated : " + cl["origlocation"] + " .: TO :. " + cl["comlocation"])
                 logger.info(
                     "Updated " + str(len(comloc)) + " series to a new Comic Location as specified in the config.ini"

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -1345,7 +1345,7 @@ def upgrade_dynamic():
         for dl in dynamic_comiclist:
             CtrlVal = {"ComicID": dl["ComicID"]}
             newVal = {"DynamicComicName": dl["DynamicComicName"]}
-            db.upsert("Comics", newVal, CtrlVal)
+            db.upsert("comics", newVal, CtrlVal)
 
     # update the storyarcsdb to include the Dynamic Names (and any futher changes as required)
     dynamic_storylist = []

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -633,10 +633,10 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                                                 + " #: "
                                                 + str(issue["Issue_Number"])
                                             )
-                                            db.upsert("Annuals", newVAL, ctrlVAL)
+                                            db.upsert("annuals", newVAL, ctrlVAL)
                                         else:
                                             # logger.fdebug('#' + str(issue['Issue_Number']) + ' writing issuedata: ' + str(newVAL))
-                                            db.upsert("Issues", newVAL, ctrlVAL)
+                                            db.upsert("issues", newVAL, ctrlVAL)
                                         fndissue.append({"IssueID": issue["IssueID"]})
                                         icount += 1
                                         break
@@ -770,9 +770,9 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                             newVAL = {"Status": newi["Status"]}
                             # logger.fdebug('writing issuedata: ' + str(newVAL))
                             if newi["Annual"]:
-                                db.upsert("Annuals", newVAL, ctrlVAL)
+                                db.upsert("annuals", newVAL, ctrlVAL)
                             else:
-                                db.upsert("Issues", newVAL, ctrlVAL)
+                                db.upsert("issues", newVAL, ctrlVAL)
 
                     logger.info(
                         "I have added " + str(len(newiss)) + " new issues for this series that were not present before."

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare-github-release": "node scripts/release/prepare-github-release.mjs",
     "lint": "npm run lint:modern && npm run lint:guards && npm run lint:backend && npm run lint:generated && npm run lint:frontend",
     "lint:modern": "python scripts/run_ruff.py modern",
-    "lint:guards": "python scripts/check_retired_globals.py && python scripts/check_fail_reason_registry.py",
+    "lint:guards": "python scripts/check_retired_globals.py && python scripts/check_fail_reason_registry.py && python scripts/check_upsert_tables.py",
     "lint:backend": "python scripts/run_ruff.py check comicarr/ && python scripts/run_ruff.py format --check comicarr/",
     "lint:generated": "python scripts/generate_config_types.py --check",
     "lint:frontend": "npm --prefix frontend run lint && npm --prefix frontend run format:check",

--- a/scripts/check_upsert_tables.py
+++ b/scripts/check_upsert_tables.py
@@ -1,0 +1,137 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""CI gate: every literal ``upsert`` table name is a key of ``TABLE_MAP``.
+
+``db.upsert()`` resolves its table by dict lookup (``comicarr/db.py``), so a
+name that is merely mis-cased — ``"Issues"`` for ``"issues"`` — type-checks,
+imports, and lints clean, then raises ``ValueError: Unknown table for upsert``
+the first time that branch runs. Six such literals silently broke series
+refresh on a live deployment (#561): the failure only surfaces on the write
+path, which is exactly the path unit tests tend not to reach.
+
+The lookup key is a plain string, so no type can carry the constraint. An AST
+scan at author time is the cheapest gate that closes the class.
+
+Table names built at runtime (``db.upsert(updatetable, ...)``) cannot be
+checked statically and are skipped — the literals are where the typo lives.
+
+Contributor-facing only — no changeset (CLAUDE.md).
+
+Wire-in: ``npm run lint:guards``.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TABLES_PATH = ROOT / "comicarr" / "tables.py"
+
+# Trees that can call upsert. Tests are scanned too: a mis-cased literal in a
+# fixture pins the wrong contract just as convincingly as one in source.
+SCAN_GLOBS = (
+    "comicarr/**/*.py",
+    "tests/**/*.py",
+    "Comicarr.py",
+)
+
+SKIP_DIR_NAMES = {"_vendor", "__pycache__", ".venv", "node_modules"}
+
+# upsert(table, values, controls) — table is arg 0.
+# upsert_conn(conn, table, values, controls) — table is arg 1.
+TABLE_ARG_INDEX = {"upsert": 0, "upsert_conn": 1}
+
+
+def _table_map_keys() -> set[str]:
+    """Extract the TABLE_MAP keys from tables.py without importing SQLAlchemy."""
+    tree = ast.parse(TABLES_PATH.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if "TABLE_MAP" not in targets or not isinstance(node.value, ast.Dict):
+            continue
+        return {k.value for k in node.value.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)}
+    raise SystemExit("check_upsert_tables: TABLE_MAP literal not found in %s" % TABLES_PATH)
+
+
+def _iter_source_files():
+    seen = set()
+    for glob in SCAN_GLOBS:
+        for path in sorted(ROOT.glob(glob)):
+            if not path.is_file() or path.suffix != ".py":
+                continue
+            if SKIP_DIR_NAMES.intersection(path.parts):
+                continue
+            if path in seen:
+                continue
+            seen.add(path)
+            yield path
+
+
+def _called_name(func: ast.expr) -> str | None:
+    """Return the bare function name for ``upsert(...)`` and ``db.upsert(...)``."""
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def main() -> int:
+    valid = _table_map_keys()
+    violations: list[tuple[str, int, str]] = []
+
+    for path in _iter_source_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, SyntaxError):
+            continue
+        rel = path.relative_to(ROOT).as_posix()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            index = TABLE_ARG_INDEX.get(_called_name(node.func) or "")
+            if index is None or len(node.args) <= index:
+                continue
+            arg = node.args[index]
+            if not (isinstance(arg, ast.Constant) and isinstance(arg.value, str)):
+                continue  # runtime-built name; not statically checkable
+            if arg.value not in valid:
+                violations.append((rel, node.lineno, arg.value))
+
+    if not violations:
+        return 0
+
+    print("Unknown upsert table name (not a key of tables.TABLE_MAP):", file=sys.stderr)
+    for rel, lineno, name in violations:
+        suggestion = ""
+        lowered = name.lower()
+        if lowered in valid:
+            suggestion = ' — did you mean "%s"?' % lowered
+        print('  %s:%d: "%s"%s' % (rel, lineno, name, suggestion), file=sys.stderr)
+    print("", file=sys.stderr)
+    print("TABLE_MAP keys are lowercase; db.upsert() raises ValueError at runtime", file=sys.stderr)
+    print("for anything else. See comicarr/tables.py and comicarr/db.py.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_upsert_table_guard.py
+++ b/tests/unit/test_upsert_table_guard.py
@@ -1,0 +1,77 @@
+#  Tests for scripts/check_upsert_tables.py — the literal-table-name gate (#561).
+#
+#  db.upsert() resolves its table by dict lookup, so "Issues" for "issues" fails
+#  only at runtime, on the write path. These tests pin both halves of the gate:
+#  the tree is clean today, and a mis-cased literal is actually caught.
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "check_upsert_tables.py"
+
+
+@pytest.fixture(scope="module")
+def guard():
+    spec = importlib.util.spec_from_file_location("check_upsert_tables", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def test_every_literal_upsert_table_in_tree_is_known(guard):
+    """The repository is clean — this is the regression gate for #561 itself."""
+    assert guard.main() == 0
+
+
+def test_table_map_keys_are_all_lowercase(guard):
+    """The convention the guard's suggestion text leans on."""
+    keys = guard._table_map_keys()
+    assert keys, "TABLE_MAP parsed empty — the AST extraction has drifted"
+    assert all(key == key.lower() for key in keys)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        'db.upsert("Issues", values, controls)',
+        'upsert("Comics", values, controls)',
+        'db.upsert_conn(conn, "Annuals", values, controls)',
+    ],
+)
+def test_miscased_literal_is_rejected(guard, tmp_path, monkeypatch, source):
+    module = tmp_path / "comicarr" / "leaf.py"
+    module.parent.mkdir(parents=True)
+    module.write_text(source + "\n")
+
+    monkeypatch.setattr(guard, "ROOT", tmp_path)
+    monkeypatch.setattr(guard, "SCAN_GLOBS", ("comicarr/**/*.py",))
+
+    assert guard.main() == 1
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        'db.upsert("issues", values, controls)',
+        'db.upsert_conn(conn, "provider_searches", values, controls)',
+        # Runtime-built names cannot be checked statically and must not trip it.
+        "db.upsert(updatetable, values, controls)",
+        # Unrelated calls that merely share an argument shape.
+        'mock_db.upsert.assert_any_call("Issues", values, controls)',
+    ],
+)
+def test_valid_or_unresolvable_literal_is_accepted(guard, tmp_path, monkeypatch, source):
+    module = tmp_path / "comicarr" / "leaf.py"
+    module.parent.mkdir(parents=True)
+    module.write_text(source + "\n")
+
+    monkeypatch.setattr(guard, "ROOT", tmp_path)
+    monkeypatch.setattr(guard, "SCAN_GLOBS", ("comicarr/**/*.py",))
+
+    assert guard.main() == 0


### PR DESCRIPTION
Closes #561.

## What was broken

`db.upsert()` resolves its table by dict lookup against `TABLE_MAP` (`comicarr/tables.py:1177`), whose keys are lowercase. Six call sites passed capitalised literals, so `_build_upsert_stmt` raised `ValueError: Unknown table for upsert: Issues` (`comicarr/db.py:252`) the moment a refresh actually had something to persist:

- `comicarr/updater.py:636,639` — `"Annuals"` / `"Issues"`
- `comicarr/updater.py:773,775` — `"Annuals"` / `"Issues"`
- `comicarr/app/series/service.py:1228` — `"Comics"`
- `comicarr/app/system/service.py:1348` — `"Comics"`

On the NAS deployment eight `refresh` runs failed with `reason = "Unknown table for upsert: Issues"` (2026-07-31, 2026-08-05), leaving `acquisition_run_items` rows in `state=failed`. A refresh that happened to find nothing to change still looked successful — which is how this stayed invisible while every real update was dropped.

## The fix

The six literals are corrected to their `TABLE_MAP` keys.

## The guard

A mis-cased string type-checks, imports, and lints clean; the failure only appears on the write path. `scripts/check_upsert_tables.py` AST-scans every literal `upsert` / `upsert_conn` table argument across `comicarr/`, `tests/`, and `Comicarr.py` and fails if it is not a `TABLE_MAP` key — reading the valid keys straight out of `tables.py` by AST, so it needs no app import. Runtime-built names (`db.upsert(updatetable, ...)`) are skipped: the literals are where the typo lives. Wired into `npm run lint:guards`, which CI already runs via `npm run lint`.

Verified negative: reintroducing `"Issues"` makes the guard fail with `comicarr/updater.py:639: "Issues" — did you mean "issues"?`.

Per `CLAUDE.md` the guard is contributor-only and is documented there rather than in the changeset; the refresh fix is operator-visible and carries one.

## Tests

`tests/unit/test_upsert_table_guard.py` — 9 tests pinning both halves: the tree is clean today, and mis-cased literals in all three call shapes (`upsert`, `db.upsert`, `db.upsert_conn`) are rejected while valid names, runtime-built names, and unrelated calls that merely share the argument shape are accepted.

`pytest tests/unit/test_upsert_table_guard.py tests/unit/test_db.py tests/unit/test_updater_watchlist.py tests/unit/test_system_domain.py` — 181 passed. `npm run lint` clean (frontend eslint not run locally — no frontend deps in this worktree, and no frontend files are touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1WDZ6KSy4VDxYHg7PDozn