### PR TITLE
fix: Route torrent fetch failures to Failed Download Handling, not manual review

### DIFF
--- a/.changeset/olive-donkeys-fetch.md
+++ b/.changeset/olive-donkeys-fetch.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fixed a failed torrent download landing in manual review — and permanently blocking that issue from that provider — when the .torrent file simply could not be fetched. If the tracker was unreachable, timed out, or returned something unusable, Comicarr crashed inside the send step instead of reporting a clean failure. Because a crash there means "we do not know whether the download client got this", the attempt was filed for manual review, which is terminal: every later attempt on the same issue and provider was then refused before it even reached the client, so the 6-hourly search retried into the same wall forever while telling you nothing useful. A fetch that never reaches the download client is now reported as an ordinary failure and goes to Failed Download Handling, so the release can be retried normally. This affects all five torrent clients (rTorrent, Deluge, qBittorrent, Transmission, uTorrent).

--- a/comicarr/rsscheck.py
+++ b/comicarr/rsscheck.py
@@ -17,7 +17,6 @@
 #  You should have received a copy of the GNU General Public License
 #  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
 
-import gzip
 import os
 import random
 import re
@@ -25,7 +24,6 @@ import sys
 import time
 import urllib.parse
 from datetime import datetime
-from io import StringIO
 
 import feedparser
 import requests
@@ -1594,32 +1592,15 @@ def torsend2client(seriesname, issue, seriesyear, linkit, site, pubhash=None):
                         else:
                             r = scraper.get(redir_url, stream=True)
         except Exception as e:
+            # Must return, not fall through: every line below dereferences `r`,
+            # which this branch leaves unbound. Falling through raised NameError
+            # out of the sender, and perform_handoff routes a raising sender to
+            # manual review (submission_outcome_unknown) — the ambiguity lane for
+            # "it may have landed". Nothing was sent here, so this is a clean
+            # pre-submission failure and belongs on the "fail" path, which the
+            # caller hands to Failed Download Handling.
             logger.warn("Error fetching data from %s (%s): %s" % (site, url, e))
-        #    if site == '32P':
-        #        logger.info('[TOR2CLIENT-32P] Retrying with 32P')
-        #        if comicarr.CONFIG.MODE_32P == 1:
-
-        #            logger.info('[TOR2CLIENT-32P] Attempting to re-authenticate against 32P and poll new keys as required.')
-        #            feed32p = auth32p.info32p(reauthenticate=True)
-        #            feedinfo = feed32p.authenticate()
-
-        #            if feedinfo == "disable":
-        #                helpers.disable_provider('32P')
-        #                return "fail"
-
-        #            logger.debug('[TOR2CLIENT-32P] Creating CF Scraper')
-        #            scraper = cfscrape.create_scraper()
-
-        #            try:
-        #                r = scraper.get(url, params=payload, verify=verify, allow_redirects=True)
-        #            except Exception, e:
-        #                logger.warn('[TOR2CLIENT-32P] Unable to GET %s (%s): %s' % (site, url, e))
-        #                return "fail"
-        #        else:
-        #            logger.warn('[TOR2CLIENT-32P] Unable to authenticate using existing RSS Feed given. Make sure that you have provided a CURRENT feed from 32P')
-        #            return "fail"
-        #    else:
-        #        return "fail"
+            return "fail"
 
         if not filepath.startswith("magnet:"):
             if any([site == "DEM", site == "WWT"]) and any(
@@ -1646,11 +1627,12 @@ def torsend2client(seriesname, issue, seriesyear, linkit, site, pubhash=None):
                     except Exception:
                         return "fail"
 
-            if any([site == "DEM", site == "WWT"]):
-                if r.headers.get("Content-Encoding") == "gzip":
-                    buf = StringIO(r.content)
-                    f = gzip.GzipFile(fileobj=buf)
-
+            # A DEM/WWT gzip branch used to sit here. It built a GzipFile over
+            # StringIO(r.content) — a TypeError on bytes — and then discarded it,
+            # because `f` is immediately rebound by the open() below and the body
+            # is written straight from r.iter_content(). requests already decodes
+            # Content-Encoding: gzip transparently, so the branch was both broken
+            # and unnecessary.
             with open(filepath, "wb") as f:
                 for chunk in r.iter_content(chunk_size=1024):
                     if chunk:  # filter out keep-alive new chunks

--- a/tests/unit/test_torrent_fetch_failure.py
+++ b/tests/unit/test_torrent_fetch_failure.py
@@ -1,0 +1,177 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Torrent .torrent-fetch failures stay on the clean pre-submission path (#566).
+
+`torsend2client` catches any exception from the .torrent fetch, and used to
+fall through into code that dereferences the unbound response — a `NameError`
+raised out of the sender. `perform_handoff` treats a raising sender as
+*submission outcome unknown* (the "it may already have landed" lane) and files
+it for manual review, which is wrong for a failure that never touched the
+download client, and — because `manual_review` is terminal — wedges every later
+grab on that release_key.
+
+All five torrent routes share this sender, so the contract pinned here is:
+a fetch exception returns "fail", and "fail" lands in Failed Download Handling
+rather than manual review.
+"""
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from sqlalchemy import select
+
+import comicarr
+from comicarr import rsscheck
+from comicarr.app.acquisition.maintenance import ensure_acquisition_schema
+from comicarr.app.downloads import handoff, journal
+from comicarr.db import get_engine, shutdown_engine
+from comicarr.tables import metadata, pipeline_journal
+
+
+# ---------------------------------------------------------------------------
+# torsend2client — the sender itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def torrent_client_configured(tmp_path, monkeypatch):
+    """Minimal globals for torsend2client's generic (non-32P/DEM/WWT) path."""
+    monkeypatch.setattr(comicarr, "USE_QBITTORRENT", True, raising=False)
+    monkeypatch.setattr(comicarr, "USE_UTORRENT", False, raising=False)
+    monkeypatch.setattr(comicarr, "USE_RTORRENT", False, raising=False)
+    monkeypatch.setattr(comicarr, "USE_TRANSMISSION", False, raising=False)
+    monkeypatch.setattr(comicarr, "USE_DELUGE", False, raising=False)
+    monkeypatch.setattr(comicarr, "USE_WATCHDIR", False, raising=False)
+    config = MagicMock()
+    config.CACHE_DIR = str(tmp_path)
+    monkeypatch.setattr(comicarr, "CONFIG", config, raising=False)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        requests.exceptions.ConnectionError("connection refused"),
+        requests.exceptions.Timeout("read timed out"),
+        requests.exceptions.SSLError("certificate verify failed"),
+        ValueError("malformed response"),
+    ],
+)
+def test_fetch_exception_returns_fail(torrent_client_configured, error):
+    with patch.object(rsscheck.cfscrape, "create_scraper", side_effect=error):
+        result = rsscheck.torsend2client(
+            "Some Series",
+            "1",
+            "2020",
+            "https://tracker.example/download/abc.torrent",
+            "SomeTracker",
+        )
+
+    assert result == "fail"
+
+
+def test_fetch_exception_does_not_raise_nameerror(torrent_client_configured):
+    """The regression itself: falling through left `r` unbound."""
+    scraper = MagicMock()
+    scraper.get.side_effect = requests.exceptions.ConnectionError("connection refused")
+
+    with patch.object(rsscheck.cfscrape, "create_scraper", return_value=scraper):
+        result = rsscheck.torsend2client(
+            "Some Series",
+            "1",
+            "2020",
+            "https://tracker.example/download/abc.torrent",
+            "SomeTracker",
+        )
+
+    assert result == "fail"
+
+
+def test_fetch_exception_writes_no_torrent_file(torrent_client_configured):
+    cache_dir = torrent_client_configured
+    scraper = MagicMock()
+    scraper.get.side_effect = requests.exceptions.ConnectionError("connection refused")
+
+    with patch.object(rsscheck.cfscrape, "create_scraper", return_value=scraper):
+        rsscheck.torsend2client(
+            "Some Series",
+            "1",
+            "2020",
+            "https://tracker.example/download/abc.torrent",
+            "SomeTracker",
+        )
+
+    assert list(cache_dir.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# perform_handoff — where a "fail" lands versus where a raise lands
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    shutdown_engine()
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    if not hasattr(comicarr, "LOG_LEVEL") or comicarr.LOG_LEVEL is None:
+        monkeypatch.setattr(comicarr, "LOG_LEVEL", 0, raising=False)
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        types.SimpleNamespace(HIGHCOUNT=0, POST_PROCESSING=False),
+        raising=False,
+    )
+    engine = get_engine()
+    metadata.create_all(engine)
+    assert ensure_acquisition_schema(engine).ready
+    yield
+    shutdown_engine()
+
+
+def _journal_row(key):
+    with get_engine().connect() as conn:
+        row = conn.execute(select(pipeline_journal).where(pipeline_journal.c.release_key == key)).fetchone()
+        return dict(row._mapping) if row else None
+
+
+def test_fail_return_lands_on_the_failed_path_not_manual_review(isolated_db):
+    key = "I1|qbittorrent"
+
+    response, acceptance = handoff.perform_handoff(key, "qbittorrent", lambda: "fail")
+
+    row = _journal_row(key)
+    assert response == "fail"
+    assert acceptance.restart_safe is False
+    assert acceptance.manual_review is False
+    assert row["stage"] == journal.FAILED
+    assert row["stage"] != journal.MANUAL_REVIEW
+    assert not str(row["fail_reason"]).startswith("submission_outcome_unknown")
+
+
+def test_a_raising_sender_is_still_the_ambiguity_lane(isolated_db):
+    """The behaviour the fix routes *away* from — unchanged, and deliberately so.
+
+    A sender that raises genuinely may have reached the client, so manual review
+    remains correct there. #566 is about not reaching this lane by accident.
+    """
+    key = "I2|qbittorrent"
+
+    def raising_sender():
+        raise NameError("name 'r' is not defined")
+
+    with pytest.raises(NameError):
+        handoff.perform_handoff(key, "qbittorrent", raising_sender)
+
+    row = _journal_row(key)
+    assert row["stage"] == journal.MANUAL_REVIEW
+    assert row["fail_reason"] == "submission_outcome_unknown:NameError"


### PR DESCRIPTION
Closes #566.

## What was broken

`torsend2client` wraps the `.torrent` fetch in a `try` (`comicarr/rsscheck.py:1563`) that caught any exception, logged it, and **fell through** — every recovery and `return` beneath it was commented out. Execution continued into the block that dereferences `r` (`r.status_code`, `r.headers`, `r.iter_content`) while it is still unbound → `NameError` out of the sender.

`perform_handoff` catches that and journals `submission_outcome_unknown:NameError` → **manual review** (`comicarr/app/downloads/handoff.py:216-227`). That lane exists for "the client may already have it", which is exactly wrong here: nothing was ever sent. And `manual_review` is terminal (rank 55), so — compounding #562 — every later grab on the same `release_key` raises `HandoffReservationError` before the sender. One transient tracker hiccup wedged that issue+provider permanently while the `SEARCH_INTERVAL` sweep retried into the same wall, narrating nothing useful.

All five torrent routes share this sender via `_configured_torrent_handoff_route()`, and qBittorrent is on the NAS deployment's live route.

## The fix

The `except` branch returns `"fail"`, which `search.py:3504-3530` already hands to Failed Download Handling. The commented-out 32P recovery block that made the fall-through invisible is deleted; a comment in its place records why the return is load-bearing.

This is #554's contract being violated by accident rather than by design — a sender must never raise for a known failure — so it lands independently of the vocabulary work.

## Also fixed (latent, same block)

The DEM/WWT gzip branch built `gzip.GzipFile(fileobj=StringIO(r.content))` — a `TypeError` on bytes if ever reached — and then discarded the result, because `f` is immediately rebound by the `open()` below and the body is written straight from `r.iter_content()`. `requests` decodes `Content-Encoding: gzip` transparently, so the branch was both broken and unnecessary. Removed, along with the now-unused `gzip` and `StringIO` imports.

## Tests

`tests/unit/test_torrent_fetch_failure.py` — 8 tests:

- a fetch exception returns `"fail"` (connection error, timeout, SSL error, and a non-`requests` `ValueError`)
- the regression itself: no `NameError` escapes, and no partial file is left in the cache dir
- at the handoff level: a `"fail"` return journals `stage=failed` with a reason that is not `submission_outcome_unknown:*` — **not** manual review
- the contrast case is pinned too: a genuinely raising sender still lands in manual review, since it may have reached the client. The fix is about not arriving there by accident.

`pytest tests/unit/test_torrent_fetch_failure.py tests/unit/test_manga_rss.py tests/unit/test_journal_snatch_seam.py tests/unit/test_failed_journal_terminals.py` — 51 passed. `npm run lint:modern` and `lint:backend` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1WDZ6KSy4VDxYHg7PDozn