### PR TITLE
fix: Unwedge the manual_review re-snatch that permanently blocked a provider

### DIFF
--- a/.changeset/quiet-pandas-unwedge.md
+++ b/.changeset/quiet-pandas-unwedge.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fixed Retry and Search again doing nothing for an issue that had landed in needs-attention. Once an attempt ended in manual review, that issue was permanently blocked from that provider: the retry re-wanted the issue and started a search, and the search then refused to hand anything to the download client — so the item quietly bounced back into needs-attention on the next cycle, forever, with nothing in the log to say why. Resolving a needs-attention item now genuinely releases it, so the next search can grab it again, however many times you need. An item you have *not* resolved yet still blocks — it may be something your download client already has, and clearing it automatically would both hide it from you and download it twice — but the log now names the item and its reason instead of reporting an unexplained handoff failure.

--- a/comicarr/app/downloads/handoff.py
+++ b/comicarr/app/downloads/handoff.py
@@ -101,8 +101,35 @@ def reserve(release_key, route, payload=None, **fields):
         **fields,
     )
     if not won:
-        raise HandoffReservationError("durable handoff reservation was not acquired")
+        raise HandoffReservationError(_reservation_refusal(release_key))
     return normalized
+
+
+def _reservation_refusal(release_key):
+    """Explain a lost reservation using the row that blocked it.
+
+    A refused reservation used to surface only as a bare
+    HandoffReservationError, so the most common cause — an unresolved
+    manual_review row holding the release_key terminal — read in the log as an
+    unexplained handoff failure repeating every search cycle (#562). The row is
+    the explanation, so read it once, here, where it is cheap.
+    """
+    from comicarr.app.downloads import journal
+
+    default = "durable handoff reservation was not acquired"
+    try:
+        current = journal.read_one(release_key) or {}
+    except Exception:
+        return default
+    stage = current.get("stage")
+    if stage != journal.MANUAL_REVIEW:
+        return default
+    detail = "%s awaiting operator review (%s)" % (release_key, current.get("fail_reason") or "no reason recorded")
+    logger.warn(
+        "[HANDOFF] reservation refused: %s. This release stays blocked for this "
+        "provider until the needs-attention band entry is resolved." % detail
+    )
+    return "handoff blocked: %s" % detail
 
 
 def _acceptance_identity(route, response):

--- a/comicarr/app/downloads/journal.py
+++ b/comicarr/app/downloads/journal.py
@@ -36,7 +36,7 @@ import json
 import re
 import time
 
-from sqlalchemy import or_, select, update
+from sqlalchemy import and_, or_, select, update
 from sqlalchemy.exc import IntegrityError, OperationalError
 
 from comicarr import db, logger
@@ -103,10 +103,30 @@ MANUAL_REVIEW_ACTIONS = (ACTION_IMPORT, ACTION_SEARCH_AGAIN, ACTION_STOP_WANTING
 STAGE_ACTIONS = {FAILED: FAILED_ACTIONS, MANUAL_REVIEW: MANUAL_REVIEW_ACTIONS}
 BAND_ACTIONS = frozenset(FAILED_ACTIONS) | frozenset(MANUAL_REVIEW_ACTIONS)
 
-# Fresh re-snatch stages that may supersede a terminal `failed` row under the
-# same release_key (same issue|provider). DDL handoff writes RESERVED first;
-# NZB/torrent snatch (updater.foundsearch) writes SNATCHED directly.
+# Fresh re-snatch stages that may supersede a supersedable terminal row under
+# the same release_key (same issue|provider). DDL handoff writes RESERVED
+# first; NZB/torrent snatch (updater.foundsearch) writes SNATCHED directly.
 _RESNATCH_STAGES = (RESERVED, SNATCHED)
+
+# Terminal stages a re-snatch may supersede. `failed` is always supersedable:
+# the attempt is closed and nothing is outstanding at the download client.
+#
+# `manual_review` is supersedable ONLY once an operator has resolved it (#562).
+# The asymmetry is deliberate. An unresolved manual_review row is an OPEN
+# obligation — it means "the client may already have this, go look" — and it is
+# on the needs-attention band precisely so a human does. Letting an automatic
+# re-snatch reset it would both hide the row and re-deliver a release the client
+# may already hold; on routes like watchdir, where every acceptance is manual
+# review by construction, every sweep would deliver another copy. Once the
+# operator has acted (retry / search again / import — the R9 stamp that takes
+# the row off the band), the obligation is discharged and the next grab must be
+# able to proceed. Before #562 it could not: the row stayed terminal, so the
+# operator's own retry wedged at reservation for that issue+provider forever.
+#
+# This widens the *stage gate* only. The reset is still reachable exclusively
+# from a fresh RESERVED/SNATCHED write, so it does not become an operator exit —
+# the boundary docs/architecture/activity-center.md draws is intact.
+_SUPERSEDABLE_TERMINALS = (FAILED, MANUAL_REVIEW)
 
 # Synthetic one-off IssueIDs are an unpersisted CONFIG.HIGHCOUNT counter that
 # starts at 900000 (see comicarr/updater.py:1214-1220). Such an IssueID is not
@@ -427,16 +447,20 @@ def _now():
     return now()
 
 
-def _try_reset_failed_attempt(conn, key, stage, new_rank, upd_values):
+def _try_reset_terminal_attempt(conn, key, stage, new_rank, upd_values):
     """RE-SNATCH special case: a fresh RESERVED or SNATCHED write observed
-    against a terminal `failed` row is a NEW in-flight obligation that
-    legitimately supersedes the closed failed attempt — reset the row.
+    against a supersedable terminal row is a NEW in-flight obligation that
+    legitimately supersedes the closed attempt — reset the row.
+
+    Supersedable means a terminal `failed` row, or a `manual_review` row an
+    operator has already resolved. See ``_SUPERSEDABLE_TERMINALS`` for why the
+    two differ; an unresolved manual_review row is left terminal on purpose.
 
     WHY this does NOT weaken the monotonic stale-replay guard: replay never
     issues a fresh RESERVED/SNATCHED transition (the snatch seam and DDL
     handoff do, only from a real new grab; replay re-enqueues still
     non-terminal items, never a first-stage write). So a re-snatch stage
-    seen against a `failed` row is always a genuine new obligation, never a
+    seen against a terminal row is always a genuine new obligation, never a
     stale replay — resetting is correct here and the monotonic guard is left
     fully intact for every other stage.
 
@@ -447,29 +471,52 @@ def _try_reset_failed_attempt(conn, key, stage, new_rank, upd_values):
     nothing (#483 / #437 amendment).
 
     This helper remains the re-snatch path only — operator band exits stamp
-    R9 status without calling it (#437 / #483).
+    R9 status without calling it (#437 / #483). Widening the stage gate does
+    not change that: nothing but a fresh RESERVED/SNATCHED write reaches here.
 
-    Returns True iff THIS call won the reset. The UPDATE is gated with
-    `WHERE stage = FAILED` so two concurrent re-snatch writers racing one
-    failed row yield exactly one True — the loser's gated UPDATE matches 0
-    rows and it falls back to the monotonic no-op.
+    Returns True iff THIS call won the reset. The UPDATE carries the same
+    stage/status predicate the caller matched on, so two concurrent re-snatch
+    writers racing one terminal row yield exactly one True — the loser's gated
+    UPDATE matches 0 rows and it falls back to the monotonic no-op.
     """
     if stage not in _RESNATCH_STAGES:
         return False
 
+    previous = conn.execute(select(pipeline_journal.c.stage).where(pipeline_journal.c.release_key == key)).scalar()
     reset = conn.execute(
         update(pipeline_journal)
         .where(pipeline_journal.c.release_key == key)
-        .where(pipeline_journal.c.stage == FAILED)
+        .where(_supersedable_terminal_predicate())
         .values(fail_reason=None, status=None, hash=None, **upd_values)
     )
     if reset.rowcount:
         logger.warn(
-            "[JOURNAL] release_key=%s reset from terminal failed -> %s "
-            "(new submission supersedes closed failed attempt)" % (key, stage)
+            "[JOURNAL] release_key=%s reset from terminal %s -> %s "
+            "(new submission supersedes closed attempt)" % (key, previous, stage)
         )
         return True
     return False
+
+
+def _supersedable_terminal_predicate():
+    """SQL for "this terminal row may be superseded by a fresh re-snatch"."""
+
+    return or_(
+        pipeline_journal.c.stage == FAILED,
+        and_(
+            pipeline_journal.c.stage == MANUAL_REVIEW,
+            pipeline_journal.c.status.in_(RESOLVED_STATUSES),
+        ),
+    )
+
+
+def _is_supersedable_terminal(mapping):
+    """Python mirror of :func:`_supersedable_terminal_predicate`."""
+
+    stage = mapping.get("stage")
+    if stage == FAILED:
+        return True
+    return stage == MANUAL_REVIEW and mapping.get("status") in RESOLVED_STATUSES
 
 
 def _apply_transition(conn, key, stage, new_rank, fields, payload, when):
@@ -486,7 +533,7 @@ def _apply_transition(conn, key, stage, new_rank, fields, payload, when):
         sanitize_payload(load_payload(existing_row._mapping.get("payload_json"))) if existing_row is not None else None
     )
     new_attempt = (
-        existing_row is not None and existing_row._mapping.get("stage") == FAILED and stage in _RESNATCH_STAGES
+        existing_row is not None and _is_supersedable_terminal(existing_row._mapping) and stage in _RESNATCH_STAGES
     )
     if new_attempt:
         # A new attempt must not inherit the previous client's acceptance id,
@@ -639,12 +686,12 @@ def _apply_transition(conn, key, stage, new_rank, fields, payload, when):
             )
             if retry.rowcount:
                 return True
-            # The now-present row may be a terminal `failed` row (a concurrent
-            # writer inserted-then-failed it): the monotonic re-run matched 0,
-            # so this is the absent-of-monotonic-match branch for the
-            # failed-row case — apply the same gated re-snatch reset here so
-            # the P1-2 race path composes with the failed->snatched rule.
-            if _try_reset_failed_attempt(conn, key, stage, new_rank, upd_values):
+            # The now-present row may be a supersedable terminal row (a
+            # concurrent writer inserted-then-terminalised it): the monotonic
+            # re-run matched 0, so this is the absent-of-monotonic-match branch
+            # for that case — apply the same gated re-snatch reset here so the
+            # P1-2 race path composes with the terminal->snatched rule.
+            if _try_reset_terminal_attempt(conn, key, stage, new_rank, upd_values):
                 return True
             logger.fdebug(
                 "[JOURNAL] first-writer race resolved: release_key=%s stage=%s "
@@ -654,9 +701,11 @@ def _apply_transition(conn, key, stage, new_rank, fields, payload, when):
             return False
 
     # Row exists and is at/ahead of new_rank. The ONE legal exception to the
-    # monotonic no-op: a fresh RESERVED/SNATCHED write against a terminal
-    # `failed` row is a RE-SNATCH that supersedes the closed failed attempt.
-    if existing[0] == FAILED and _try_reset_failed_attempt(conn, key, stage, new_rank, upd_values):
+    # monotonic no-op: a fresh RESERVED/SNATCHED write against a supersedable
+    # terminal row is a RE-SNATCH that supersedes the closed attempt. The
+    # status half of "supersedable" is enforced by the helper's own gated
+    # UPDATE, so this stage check only avoids a pointless statement.
+    if existing[0] in _SUPERSEDABLE_TERMINALS and _try_reset_terminal_attempt(conn, key, stage, new_rank, upd_values):
         return True
 
     # Row exists and is at/ahead of new_rank — a regressing or post-terminal

--- a/docs/architecture/activity-center.md
+++ b/docs/architecture/activity-center.md
@@ -171,8 +171,26 @@ remainder comes back as `skipped_for_cap`. A mixed outcome is `success: true` wi
   ships ([Decide how an item exits manual_review and failed](https://github.com/frankieramirez/comicarr/issues/437)
   amendment from grouping).
 
-`_try_reset_failed_attempt` stays as-is for genuine re-snatch; it is not the operator
-path and is not extended to `manual_review`.
+`_try_reset_terminal_attempt` is the genuine-re-snatch path only; it is not the
+operator path. It supersedes a terminal `failed` row unconditionally, and a
+`manual_review` row **only once that row carries an R9 resolution stamp**
+([#562](https://github.com/frankieramirez/comicarr/issues/562)).
+
+The asymmetry is the point. An *unresolved* `manual_review` row is an open
+obligation — "the client may already have this, go look" — and it is on the band
+so a human does. Letting an automatic re-snatch reset it would hide the row and
+re-deliver a release the client may already hold; on a route like `watchdir`,
+where every acceptance is manual review by construction, every sweep would
+deliver another copy. So it still blocks — but `handoff.reserve` now names the
+row and its reason in the refusal instead of raising a bare reservation error.
+
+Once the operator has acted, the obligation is discharged and the next grab must
+proceed. Before #562 it could not: the stamp takes the row off the band without
+rewriting `stage`, so the operator's own `[retry]` / `[search again]` — which
+re-wants the issue and queues a search — then wedged at reservation for that
+issue+provider, forever. This widens the *stage gate* only; nothing but a fresh
+`RESERVED`/`SNATCHED` write reaches the helper, so it still cannot become an
+operator exit.
 
 ---
 

--- a/tests/unit/test_manual_review_resnatch.py
+++ b/tests/unit/test_manual_review_resnatch.py
@@ -1,0 +1,154 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""The manual_review re-snatch wedge, at the handoff seam (#562).
+
+`manual_review` is terminal (rank 55), so a release_key that ends there used to
+refuse every later grab at `handoff.reserve` — including the operator's own
+`retry` / `search again`, which re-wants the issue and queues a search but
+leaves the journal row terminal. That made the operator exit unreachable for
+that issue+provider: the sweep retried into the same wall every SEARCH_INTERVAL
+and narrated nothing.
+
+The boundary that stays: an *unresolved* manual_review row is an open
+obligation on the needs-attention band and still blocks — but it now says why.
+"""
+
+import types
+
+import pytest
+from sqlalchemy import select
+
+import comicarr
+from comicarr.app.acquisition.maintenance import ensure_acquisition_schema
+from comicarr.app.downloads import handoff, journal
+from comicarr.db import get_engine, shutdown_engine
+from comicarr.tables import metadata, pipeline_journal
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    shutdown_engine()
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    if not hasattr(comicarr, "LOG_LEVEL") or comicarr.LOG_LEVEL is None:
+        monkeypatch.setattr(comicarr, "LOG_LEVEL", 0, raising=False)
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        types.SimpleNamespace(HIGHCOUNT=0, POST_PROCESSING=False),
+        raising=False,
+    )
+    engine = get_engine()
+    metadata.create_all(engine)
+    assert ensure_acquisition_schema(engine).ready
+    yield
+    shutdown_engine()
+
+
+def _row(key):
+    with get_engine().connect() as conn:
+        row = conn.execute(select(pipeline_journal).where(pipeline_journal.c.release_key == key)).fetchone()
+        return dict(row._mapping) if row else None
+
+
+def _accepting_sender():
+    return lambda: {"hash": "abc123"}
+
+
+def _strand_in_manual_review(key, reason="submission_outcome_unknown:NameError"):
+    """Drive a real handoff into manual review, the way a broken sender does."""
+
+    def raising_sender():
+        raise NameError("name 'r' is not defined")
+
+    with pytest.raises(NameError):
+        handoff.perform_handoff(key, "qbittorrent", raising_sender)
+    assert _row(key)["stage"] == journal.MANUAL_REVIEW
+    assert _row(key)["fail_reason"] == reason
+
+
+def test_regrab_after_operator_resolution_no_longer_wedges():
+    """The wedge itself: the operator's retry must be able to reach the sender."""
+    key = "I1|qbittorrent"
+    _strand_in_manual_review(key)
+
+    # What the band's retry / search_again action does to the row.
+    assert journal.stamp_resolution(key, journal.STATUS_RETRIED, increment_retry=True) is True
+
+    response, acceptance = handoff.perform_handoff(key, "qbittorrent", _accepting_sender())
+
+    assert response == {"hash": "abc123"}
+    assert acceptance.restart_safe is True
+    assert _row(key)["stage"] == journal.SNATCHED
+
+
+def test_repeated_operator_retries_keep_working():
+    """Not a one-shot unwedge — a later attempt that strands again resolves the
+    same way, rather than the row becoming permanently stuck on round two."""
+    key = "I2|qbittorrent"
+    _strand_in_manual_review(key)
+
+    for _ in range(2):
+        assert journal.stamp_resolution(key, journal.STATUS_RETRIED, increment_retry=True) is True
+        handoff.perform_handoff(key, "qbittorrent", _accepting_sender())
+        assert _row(key)["stage"] == journal.SNATCHED
+        # The re-grabbed attempt strands again, the way a route with no pollable
+        # identity does on every single acceptance.
+        assert journal.mark_manual_review(key, "route_not_restart_safe:watchdir") is True
+
+
+def test_unresolved_manual_review_still_blocks_and_says_why(capture_logs):
+    """The operator-exit boundary the activity-center doc draws, intact.
+
+    An unresolved row means the client may already hold this release, so an
+    automatic sweep must not reset it out from under the band. What changes is
+    that the refusal is legible instead of a bare reservation error.
+    """
+    key = "I3|qbittorrent"
+    _strand_in_manual_review(key)
+
+    with pytest.raises(handoff.HandoffReservationError) as excinfo:
+        handoff.perform_handoff(key, "qbittorrent", _accepting_sender())
+
+    assert "awaiting operator review" in str(excinfo.value)
+    assert "submission_outcome_unknown:NameError" in str(excinfo.value)
+    assert "reservation refused" in capture_logs.text
+    # And the band row is untouched.
+    row = _row(key)
+    assert row["stage"] == journal.MANUAL_REVIEW
+    assert row["fail_reason"] == "submission_outcome_unknown:NameError"
+
+
+def test_blocked_regrab_never_reaches_the_sender():
+    """A refused reservation must not produce a second delivery."""
+    key = "I4|qbittorrent"
+    _strand_in_manual_review(key)
+
+    calls = []
+
+    def counting_sender():
+        calls.append(1)
+        return {"hash": "abc123"}
+
+    with pytest.raises(handoff.HandoffReservationError):
+        handoff.perform_handoff(key, "qbittorrent", counting_sender)
+
+    assert calls == []
+
+
+def test_failed_terminal_still_supersedes_without_operator_action():
+    """The pre-existing failed -> re-snatch rule is unchanged."""
+    key = "I5|qbittorrent"
+    handoff.perform_handoff(key, "qbittorrent", lambda: "fail")
+    assert _row(key)["stage"] == journal.FAILED
+
+    handoff.perform_handoff(key, "qbittorrent", _accepting_sender())
+
+    assert _row(key)["stage"] == journal.SNATCHED

--- a/tests/unit/test_needs_attention_resolution.py
+++ b/tests/unit/test_needs_attention_resolution.py
@@ -641,7 +641,7 @@ def test_reason_to_stage_is_a_function():
     # Each parameterized writer must keep feeding exactly one stage. Update this
     # list only alongside a check that its callers do not cross stages.
     assert sorted(unresolved) == [
-        "comicarr/app/downloads/handoff.py:156",
+        "comicarr/app/downloads/handoff.py:183",
         "comicarr/app/downloads/recovery_classify.py:571",
         "comicarr/app/downloads/service.py:2153",
         "comicarr/failed.py:114",

--- a/tests/unit/test_pipeline_journal.py
+++ b/tests/unit/test_pipeline_journal.py
@@ -280,6 +280,115 @@ def test_two_concurrent_resnatch_writers_vs_one_failed_row_exactly_one_winner():
     assert _row(key)["fail_reason"] is None
 
 
+# ---------------------------------------------------------------------------
+# RE-SNATCH after terminal manual_review (#562 — the operator-exit wedge)
+# ---------------------------------------------------------------------------
+
+
+def test_unresolved_manual_review_still_blocks_a_resnatch(capture_logs):
+    """An unresolved manual_review row is an OPEN obligation on the band.
+
+    It means "the client may already have this, go look", so an automatic
+    re-snatch must not reset it — that would both hide the band row and
+    re-deliver a release the client may already hold.
+    """
+    key = journal.release_key("410", "prov")
+    journal.record_transition(key, journal.SNATCHED)
+    assert journal.mark_manual_review(key, "route_acceptance_missing_identity:qbittorrent") is True
+
+    won = journal.record_transition(key, journal.RESERVED, payload={"issueid": "410"})
+
+    assert won is False
+    row = _row(key)
+    assert row["stage"] == "manual_review"
+    assert row["fail_reason"] == "route_acceptance_missing_identity:qbittorrent"
+    assert "no-op" in capture_logs.text
+
+
+@pytest.mark.parametrize("resolution", journal.RESOLVED_STATUSES)
+def test_resolved_manual_review_no_longer_wedges_a_resnatch(resolution):
+    """Once the operator has acted, the obligation is discharged and the next
+    grab on the same issue+provider must proceed (#562).
+
+    Before this, the row stayed terminal at manual_review forever, so the
+    operator's own retry — which re-wants the issue and queues a search —
+    raised HandoffReservationError at reservation for that issue+provider.
+    """
+    key = journal.release_key("411", "prov")
+    journal.record_transition(key, journal.SNATCHED, payload={"issueid": "411", "hash": "oldgrab"})
+    journal.mark_manual_review(key, "submission_outcome_unknown:NameError")
+    assert journal.stamp_resolution(key, resolution) is True
+
+    payload = {"issueid": "411", "hash": "newgrab"}
+    won = journal.record_transition(key, journal.RESERVED, payload=payload)
+
+    assert won is True
+    row = _row(key)
+    assert row["stage"] == "reserved"
+    assert row["fail_reason"] is None
+    assert row["status"] is None
+    assert row["hash"] is None
+    # The new attempt carries its own identity and inherits none of the old one.
+    assert journal.load_payload(row["payload_json"]) == payload
+    assert len(_all_rows()) == 1
+
+
+def test_resolved_manual_review_resnatch_can_advance_normally():
+    """The reset row is an ordinary in-flight obligation afterwards."""
+    key = journal.release_key("412", "prov")
+    journal.record_transition(key, journal.SNATCHED)
+    journal.mark_manual_review(key, "route_not_restart_safe:watchdir")
+    journal.stamp_resolution(key, journal.STATUS_RETRIED)
+
+    assert journal.record_transition(key, journal.RESERVED) is True
+    assert journal.record_transition(key, journal.SNATCHED, payload={"nzo_id": "new-client-id"}) is True
+    assert journal.record_transition(key, journal.DOWNLOADED) is True
+    assert _row(key)["stage"] == "downloaded"
+
+
+def test_downloaded_against_resolved_manual_review_still_noop(capture_logs):
+    """Widening the gate is re-snatch-only: non-re-snatch stages stay no-ops."""
+    key = journal.release_key("413", "prov")
+    journal.record_transition(key, journal.SNATCHED)
+    journal.mark_manual_review(key, "submission_outcome_unknown:NameError")
+    journal.stamp_resolution(key, journal.STATUS_RETRIED)
+
+    assert journal.record_transition(key, journal.DOWNLOADED) is False
+    assert _row(key)["stage"] == "manual_review"
+    assert "no-op" in capture_logs.text
+
+
+def test_two_concurrent_resnatch_writers_vs_one_resolved_manual_review_row():
+    """Exactly-one-winner holds for the widened gate too."""
+    key = journal.release_key("414", "prov")
+    journal.record_transition(key, journal.SNATCHED)
+    journal.mark_manual_review(key, "submission_outcome_unknown:NameError")
+    journal.stamp_resolution(key, journal.STATUS_RETRIED)
+
+    results = []
+    errors = []
+    barrier = threading.Barrier(2)
+
+    def writer():
+        try:
+            barrier.wait()
+            results.append(journal.record_transition(key, journal.RESERVED))
+        except Exception as e:  # noqa: BLE001 - test must observe any leak
+            errors.append(e)
+
+    t1 = threading.Thread(target=writer)
+    t2 = threading.Thread(target=writer)
+    t1.start()
+    t2.start()
+    t1.join(timeout=20)
+    t2.join(timeout=20)
+
+    assert errors == [], "error leaked from concurrent re-snatch: %s" % errors
+    assert sorted(results) == [False, True], "exactly-one-winner broken: %s" % results
+    assert len(_all_rows()) == 1
+    assert _row(key)["stage"] == "reserved"
+
+
 def test_failed_retry_clears_old_acceptance_identity_before_new_acceptance():
     key = journal.release_key("retry-id", "nzb.su")
     journal.record_transition(


### PR DESCRIPTION
Closes #562.

## What was broken

`manual_review` is terminal (rank 55, `journal.py:74`), and `_try_reset_failed_attempt`'s UPDATE was gated `WHERE stage = FAILED`. So once an attempt ended in manual review — `route_not_restart_safe:*` / `route_acceptance_missing_identity:*` (`handoff.py:156`) or `submission_outcome_unknown:*` (`handoff.py:218`) — every later grab on the same `release_key` went `reserve` → `record_transition(RESERVED)` → `won=False` → `HandoffReservationError`, aborting **before the sender**, permanently, for that issue+provider.

The part that makes this a wedge rather than a policy: it defeated the operator exit. `retry` / `search_again` re-want the issue and queue a search, then stamp an R9 status — which takes the row off the band **without rewriting `stage`** (`service.py:280-300`). The queued search then hit the same wall. So the item bounced straight back into needs-attention every `SEARCH_INTERVAL`, forever, and the only log line was `SABnzbd/Torrent handoff could not be durably completed: HandoffReservationError`.

## The decision

`docs/architecture/activity-center.md:174` said `_try_reset_failed_attempt` "is not extended to `manual_review`". That line exists to stop the operator exit from laundering itself through the reset — not to make a provider-driven re-snatch wedge. So the gate is widened along the axis that distinguishes the two cases:

| row | supersedable by a fresh re-snatch? | why |
|---|---|---|
| `failed` | yes (unchanged) | attempt closed, nothing outstanding at the client |
| `manual_review`, **unresolved** | **no** | open obligation: the client may already hold this release. Auto-resetting would hide the band row *and* re-deliver — on `watchdir`, where every acceptance is manual review by construction, every sweep would deliver another copy |
| `manual_review`, **operator-resolved** | **yes** | the obligation is discharged; the operator explicitly asked for another attempt |

This widens the **stage gate** only. Nothing but a fresh `RESERVED`/`SNATCHED` write reaches the helper — replay never issues one — so it still cannot become an operator exit. The activity-center doc is updated to state the refined rule rather than the one it replaces.

For the case that still blocks, `handoff.reserve` now reads the blocking row once and reports it: `handoff blocked: I3|qbittorrent awaiting operator review (submission_outcome_unknown:NameError)`, plus a warn naming what the operator has to do. Previously the most common cause of a refused reservation surfaced as an unexplained handoff failure repeating every cycle.

`_try_reset_failed_attempt` → `_try_reset_terminal_attempt`, since `failed` is no longer the only stage it resets. The `new_attempt` payload scrub (which stops a new `nzo_id` colliding with the old attempt's identity and being quarantined) follows the same widened predicate.

## Tests

`tests/unit/test_manual_review_resnatch.py` (new, 5) — at the handoff seam, driving real `perform_handoff` calls:
- the wedge itself: a re-grab after the operator's resolution now reaches the sender and reaches `snatched`
- repeated round-trips keep working — not a one-shot unwedge
- an unresolved row still blocks, the message names the release and its reason, and the band row is untouched
- a blocked re-grab never calls the sender (no second delivery)
- the pre-existing `failed` → re-snatch rule is unchanged

`tests/unit/test_pipeline_journal.py` (+6) — at the journal level: unresolved manual_review stays a no-op; each of the three resolution stamps unwedges; the reset row advances normally afterwards; a non-re-snatch stage (`downloaded`) against a resolved row is still a no-op; and exactly-one-winner holds for two concurrent re-snatch writers against the widened gate.

`test_needs_attention_resolution.py`'s line pin for `handoff.py` is updated for the shifted line.

Full backend suite: **2103 passed**. `npm run lint:modern`, `lint:backend`, `lint:guards` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1WDZ6KSy4VDxYHg7PDozn