### PR TITLE
fix: Reap stale in-flight residue with a restart bound instead of replaying forever

### DIFF
--- a/.changeset/lucky-otters-reap.md
+++ b/.changeset/lucky-otters-reap.md
@@ -1,0 +1,7 @@
+---
+"comicarr": patch
+---
+
+Fixed the "in flight" count reporting work that stopped happening long ago. When Comicarr restarted, it restored every unfinished search and refresh — correct for something a restart interrupted, but it also restored obligations that could never make progress, over and over, with nothing ever giving up on them. On a long-running install those accumulated into hundreds of entries the health count reported as active work, so the number told you nothing. Comicarr now gives up on an item that has come back from three restarts without ever finishing, records it as quarantined, and stops counting it. The bound is restarts rather than elapsed time, so an item that is simply queued behind a long backlog is never abandoned. Entries stranded before this shipped are cleared once on the first start after upgrading; nothing is lost, because whether an issue is wanted lives on the issue itself and anything still wanted is picked up by the next search.
+
+The status endpoint also reports `recovery_pending` alongside `in_flight`, so a surface can say "N in flight (K recovered from a restart)" instead of one number that hides the difference.

--- a/comicarr/app/acquisition/maintenance.py
+++ b/comicarr/app/acquisition/maintenance.py
@@ -19,6 +19,7 @@ from sqlalchemy import func, insert, inspect, literal, select, text, update
 from sqlalchemy.exc import IntegrityError
 
 import comicarr
+from comicarr import logger
 from comicarr.db import get_engine
 from comicarr.tables import (
     acquisition_canary_permits,
@@ -41,7 +42,7 @@ from comicarr.tables import (
 )
 
 SCHEMA_COMPONENT = "acquisition"
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 CONTROL_ID = "acquisition"
 RECONCILIATION_CONTROL_ID = "migration-reconciliation"
 
@@ -248,6 +249,54 @@ def _add_item_queue_priority_column(engine):
         )
 
 
+def _add_item_recovery_count_column(engine):
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("acquisition_run_items")}
+    if "recovery_count" in columns:
+        return
+    quoted_table = engine.dialect.identifier_preparer.quote("acquisition_run_items")
+    quoted_column = engine.dialect.identifier_preparer.quote("recovery_count")
+    with engine.begin() as conn:
+        conn.execute(text("ALTER TABLE %s ADD COLUMN %s INTEGER NOT NULL DEFAULT 0" % (quoted_table, quoted_column)))
+
+
+def _cancel_prebound_residue(engine):
+    """One-time reap of non-terminal items that predate the recovery bound.
+
+    Before #555, replay re-drove every ``accepted``/``running`` item forever
+    and nothing ever terminalised one that could not make progress, so a
+    deployment accumulated hundreds of rows that the in-flight counter reported
+    as live work. Those rows carry no recovery_count history, so the new bound
+    would take three more restarts to clear them; reaping them once here makes
+    the health number honest on the first start after upgrade instead.
+
+    This is safe because the run ledger records **attempts, not intent**.
+    Wanting lives on ``issues.Status``, so cancelling a dead attempt row cannot
+    lose a want — anything still Wanted is picked up by the next search sweep.
+    Migrations run before workers start, so nothing legitimately in flight can
+    be cancelled here.
+    """
+    now = _utcnow()
+    with engine.begin() as conn:
+        result = conn.execute(
+            update(acquisition_run_items)
+            .where(acquisition_run_items.c.state.in_(["accepted", "running"]))
+            .values(
+                state="cancelled",
+                reason="stale_before_recovery_bound",
+                next_attempt_at=None,
+                updated_at=now,
+                completed_at=now,
+            )
+        )
+    if result.rowcount:
+        logger.warn(
+            "[ACQUISITION] Cancelled %s in-flight run items stranded before the "
+            "recovery bound existed (#555). Anything still Wanted is re-searched "
+            "by the next sweep." % result.rowcount
+        )
+
+
 def _ensure_control_row(engine):
     with engine.begin() as conn:
         existing = conn.execute(
@@ -388,6 +437,11 @@ def _apply_schema_v6(engine):
     _add_item_queue_priority_column(engine)
 
 
+def _apply_schema_v7(engine):
+    _add_item_recovery_count_column(engine)
+    _cancel_prebound_residue(engine)
+
+
 def _version_tables(target_version):
     tables = list(_BASE_SCHEMA_TABLES)
     if target_version >= 2:
@@ -428,6 +482,8 @@ def _verify_schema(engine, target_version=SCHEMA_VERSION):
         required_columns["acquisition_run_items"].discard("dispatch_state")
     if target_version < 6:
         required_columns["acquisition_run_items"].discard("queue_priority")
+    if target_version < 7:
+        required_columns["acquisition_run_items"].discard("recovery_count")
     missing_columns = []
     for table_name, expected in required_columns.items():
         actual = {column["name"] for column in inspector.get_columns(table_name)}
@@ -546,6 +602,16 @@ def ensure_acquisition_schema(engine=None):
                     )
                 )
             version = 6
+        if version < 7:
+            _apply_schema_v7(engine)
+            _verify_schema(engine, target_version=7)
+            with engine.begin() as conn:
+                conn.execute(
+                    insert(acquisition_schema_versions).values(
+                        component=SCHEMA_COMPONENT, version=7, applied_at=_utcnow()
+                    )
+                )
+            version = 7
         _verify_schema(engine, target_version=SCHEMA_VERSION)
         status = SchemaStatus(True, version, None)
     except Exception as e:

--- a/comicarr/app/acquisition/runs.py
+++ b/comicarr/app/acquisition/runs.py
@@ -15,12 +15,18 @@ import json
 from sqlalchemy import func, insert, select, update
 from sqlalchemy.exc import IntegrityError
 
+from comicarr import logger
 from comicarr.app.acquisition.models import DispatchState, ItemOutcome, RunState
 from comicarr.app.common.redaction import redact_sensitive_text
 from comicarr.db import get_engine
 from comicarr.tables import acquisition_run_items, acquisition_runs
 
 MAX_PAYLOAD_BYTES = 16 * 1024
+
+# How many times crash recovery may re-drive one non-terminal item before it is
+# quarantined instead. Three restarts is generous for a genuinely interrupted
+# obligation and decisive for a stuck one (#555).
+MAX_RECOVERY_ATTEMPTS = 3
 PAYLOAD_FIELDS = {
     "search": frozenset(
         {
@@ -189,6 +195,7 @@ class RunLedger:
             "queue_priority": str(queue_priority),
             "payload_json": encoded,
             "attempt_count": 0,
+            "recovery_count": 0,
             "next_attempt_at": None,
             "reason": None,
             "created_at": now,
@@ -443,6 +450,73 @@ class RunLedger:
         for row in rows:
             row["payload"] = _decode_payload(row["payload_json"])
         return rows
+
+    def claim_recovery(self, item):
+        """Count one crash-recovery re-drive, or reap the item if it is spent.
+
+        Replay is a re-driver, not a reaper: it faithfully re-queues every
+        non-terminal item, which is correct for an obligation interrupted by a
+        restart and useless for one that cannot make progress at all. Without a
+        bound the second kind is replayed forever and reported as in-flight
+        work — the residue behind the "940 in flight" number (#555).
+
+        The bound counts **restarts, not time**. A clock cannot tell a stuck
+        item from one queued behind a long backlog; surviving
+        ``MAX_RECOVERY_ATTEMPTS`` restarts without ever reaching a terminal
+        outcome can only mean stuck.
+
+        Returns True when the caller should re-drive the item, False when this
+        call terminalised it as ``quarantined``.
+        """
+        run_id = item["run_id"]
+        entity_type = item["entity_type"]
+        entity_id = item["entity_id"]
+        try:
+            recovered = int(item.get("recovery_count") or 0)
+        except (TypeError, ValueError):
+            recovered = 0
+
+        if recovered >= MAX_RECOVERY_ATTEMPTS:
+            self.record_outcome(
+                run_id,
+                entity_type,
+                entity_id,
+                ItemOutcome.QUARANTINED,
+                reason="recovery_attempts_exhausted",
+            )
+            logger.warn(
+                "[ACQUISITION] %s %s/%s quarantined after %s crash recoveries without "
+                "reaching a terminal outcome (#555)." % (item["command_kind"], entity_type, entity_id, recovered)
+            )
+            return False
+
+        now = _utcnow()
+        with self.engine.begin() as conn:
+            conn.execute(
+                update(acquisition_run_items)
+                .where(acquisition_run_items.c.item_id == item["item_id"])
+                .values(
+                    recovery_count=acquisition_run_items.c.recovery_count + 1,
+                    updated_at=now,
+                )
+            )
+        return True
+
+    def count_recovery_pending(self):
+        """Non-terminal items that have already survived at least one restart.
+
+        Separating these from the raw in-flight total is what makes the health
+        number readable: "N in flight (K recovered from a restart)" says
+        something an operator can act on, where one opaque number did not.
+        """
+        stmt = (
+            select(func.count().label("item_count"))
+            .select_from(acquisition_run_items)
+            .where(acquisition_run_items.c.state.in_([ItemOutcome.ACCEPTED.value, ItemOutcome.RUNNING.value]))
+            .where(acquisition_run_items.c.recovery_count > 0)
+        )
+        with self.engine.connect() as conn:
+            return int(conn.execute(stmt).scalar() or 0)
 
     def list_pending_dispatch_items(self, run_id):
         """Return accepted items that have not reached the worker queue."""

--- a/comicarr/app/activity/queries.py
+++ b/comicarr/app/activity/queries.py
@@ -204,6 +204,24 @@ def count_in_flight_run_items():
     return int((row or {}).get("item_count", 0) or 0)
 
 
+def count_recovery_pending_run_items():
+    """Non-terminal run items that have already survived at least one restart.
+
+    Reported alongside ``in_flight`` rather than folded into it so the health
+    number can read "N in flight (K recovered from a restart)". One opaque
+    number could not distinguish live work from obligations that keep coming
+    back, which is what made the old count untrustworthy (#555).
+    """
+    stmt = (
+        select(func.count().label("item_count"))
+        .select_from(acquisition_run_items)
+        .where(acquisition_run_items.c.state.in_(IN_FLIGHT_ITEM_STATES))
+        .where(acquisition_run_items.c.recovery_count > 0)
+    )
+    row = db.select_one(stmt)
+    return int((row or {}).get("item_count", 0) or 0)
+
+
 def count_open_journal_stages():
     """Count pipeline_journal rows still in OPEN_STAGES."""
     stmt = (
@@ -219,6 +237,8 @@ def get_open_work_counts():
     """Quiet-count DTO inputs from derived ledgers only.
 
     ``in_flight`` = accepted|running run items + OPEN_STAGES journal rows.
+    ``recovery_pending`` = the subset of those run items that has already
+    survived a restart — a qualifier on ``in_flight``, not an addition to it.
     ``attention`` = unresolved band **group** count — the number of distinct
     problems, which is what the band shows and what the operator has to act on.
     ``attention_members`` keeps the underlying row count available for copy that
@@ -227,6 +247,7 @@ def get_open_work_counts():
     """
     return {
         "in_flight": count_in_flight_run_items() + count_open_journal_stages(),
+        "recovery_pending": count_recovery_pending_run_items(),
         "attention": count_attention_groups(),
         "attention_members": count_attention_band(),
     }

--- a/comicarr/app/activity/router.py
+++ b/comicarr/app/activity/router.py
@@ -82,6 +82,8 @@ def get_status():
     """Return derived open-work counts for the quiet-counts status indicator.
 
     ``in_flight`` = accepted|running run items + OPEN_STAGES journal.
+    ``recovery_pending`` = the subset of those run items that has survived a
+    restart — a qualifier on ``in_flight``, not an addition to it (#555).
     ``attention`` = unresolved band count. Never aggregates activity_events.
     """
     return service.get_status()

--- a/comicarr/app/search/commands.py
+++ b/comicarr/app/search/commands.py
@@ -344,6 +344,11 @@ def replay_search_obligations(*, work_queue=None, ledger=None, maintenance=None)
     for item in ledger.list_recoverable_items("search"):
         run_id = item["run_id"]
         entity_id = item["entity_id"]
+        # Bound the re-drive before doing any work: an item that has survived
+        # MAX_RECOVERY_ATTEMPTS restarts without terminalising is stuck, not
+        # interrupted, and claim_recovery quarantines it instead (#555).
+        if not ledger.claim_recovery(item):
+            continue
         try:
             command = SearchCommand.from_mapping(
                 {**(item["payload"] or {}), "run_id": run_id, "entity_type": item["entity_type"]}

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -3201,6 +3201,11 @@ def replay_refresh_obligations(*, ledger=None, start_worker=True, maintenance=No
     for item in ledger.list_recoverable_items("refresh"):
         run_id = item["run_id"]
         entity_id = item["entity_id"]
+        # Bound the re-drive before doing any work: an item that has survived
+        # MAX_RECOVERY_ATTEMPTS restarts without terminalising is stuck, not
+        # interrupted, and claim_recovery quarantines it instead (#555).
+        if not ledger.claim_recovery(item):
+            continue
         try:
             payload = _refresh_payload(item["payload"] or {})
         except ValueError as e:

--- a/comicarr/tables.py
+++ b/comicarr/tables.py
@@ -827,6 +827,11 @@ acquisition_run_items = Table(
     # must never contain provider credentials or downloader secrets.
     Column("payload_json", Text),
     Column("attempt_count", Integer, nullable=False, server_default="0"),
+    # How many times crash recovery has re-driven this item. Distinct from
+    # attempt_count, which counts worker claims: an item can be re-driven
+    # without ever being claimed. This is the bound that stops a permanently
+    # stuck obligation from being replayed forever (#555).
+    Column("recovery_count", Integer, nullable=False, server_default="0"),
     Column("next_attempt_at", String(40)),
     Column("reason", Text),
     Column("created_at", String(40), nullable=False),

--- a/docs/architecture/activity-center.md
+++ b/docs/architecture/activity-center.md
@@ -489,8 +489,29 @@ library: unavailable · api: offline · unreachable
 | Number | Query |
 |---|---|
 | `M in flight` | `COUNT(acquisition_run_items WHERE state IN ('accepted','running'))` **+** `COUNT(pipeline_journal WHERE stage IN OPEN_STAGES)` |
+| `recovery_pending` | The subset of those run items with `recovery_count > 0` — a **qualifier** on `M`, never added to it |
 | `K need attention` | Same unresolved band predicate as the Timeline band |
 | `idle` | both open-work counts zero and attention zero |
+
+**Why `M` is now trustworthy (#555).** Crash replay is a *re-driver*, not a
+reaper: it re-queues every non-terminal run item at startup. That is right for
+an obligation a restart interrupted and wrong for one that cannot make progress
+— which was then replayed forever and counted here, producing a number
+(famously "940 in flight") that mixed live work with residue.
+
+`RunLedger.claim_recovery` bounds the re-drive: an item that has survived
+`MAX_RECOVERY_ATTEMPTS` (3) restarts without reaching a terminal outcome is
+quarantined with reason `recovery_attempts_exhausted` instead of re-queued. The
+bound counts **restarts, not time** — a clock cannot tell a stuck item from one
+queued behind a long backlog, while surviving three restarts without
+terminalising can only mean stuck, so there is no TTL and no tuning knob.
+
+Residue predating the bound is cancelled once by acquisition schema v7 with
+reason `stale_before_recovery_bound`, so the number is honest on the first start
+after upgrade rather than after three. That is safe because **the run ledger
+records attempts, not intent**: wanting lives on `issues.Status`, so cancelling
+a dead attempt row cannot lose a want — anything still Wanted is picked up by
+the next sweep.
 
 - Shared app SSE invalidates status React Query; **30s poll** remains; **no** second EventSource.
 - Single click on activity/attention text → `/activity`.

--- a/frontend/src/hooks/useActivityStatus.ts
+++ b/frontend/src/hooks/useActivityStatus.ts
@@ -7,6 +7,12 @@ const STATUS_POLL_MS = 30 * 1000;
 /** Derived open-work counts from GET /api/activity/status (never narrative). */
 export interface ActivityStatusResponse {
   in_flight: number;
+  /**
+   * Subset of in_flight that has already survived a restart — a qualifier on
+   * in_flight, never added to it. Lets a surface say "N in flight (K recovered
+   * from a restart)" instead of one opaque number (#555).
+   */
+  recovery_pending?: number;
   attention: number;
 }
 

--- a/tests/unit/test_activity_read_apis.py
+++ b/tests/unit/test_activity_read_apis.py
@@ -661,7 +661,12 @@ def test_open_work_idle_when_ledgers_empty(activity_db):
     from comicarr.app.activity import queries
 
     counts = queries.get_open_work_counts()
-    assert counts == {"in_flight": 0, "attention": 0, "attention_members": 0}
+    assert counts == {
+        "in_flight": 0,
+        "recovery_pending": 0,
+        "attention": 0,
+        "attention_members": 0,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_inflight_residue_reaping.py
+++ b/tests/unit/test_inflight_residue_reaping.py
@@ -1,0 +1,197 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Stale in-flight residue is reaped by a restart bound, not a clock (#555).
+
+Crash replay is a re-driver, not a reaper: it faithfully re-queues every
+non-terminal item. Correct for an obligation a restart interrupted; useless
+for one that cannot make progress, which is then replayed forever and counted
+as live work — the residue behind the "940 in flight" number.
+
+The bound counts restarts because a clock cannot tell a stuck item from one
+queued behind a long backlog, while surviving MAX_RECOVERY_ATTEMPTS restarts
+without terminalising can only mean stuck.
+"""
+
+import pytest
+from sqlalchemy import select, update
+
+import comicarr
+from comicarr.app.acquisition.maintenance import ensure_acquisition_schema
+from comicarr.app.acquisition.models import ItemOutcome
+from comicarr.app.acquisition.runs import MAX_RECOVERY_ATTEMPTS, RunLedger
+from comicarr.db import get_engine, shutdown_engine
+from comicarr.tables import acquisition_run_items, metadata
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", None, raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    shutdown_engine()
+    engine = get_engine()
+    metadata.create_all(engine)
+    assert ensure_acquisition_schema(engine).ready
+    yield
+    shutdown_engine()
+
+
+def _ledger():
+    return RunLedger(get_engine())
+
+
+def _seed_item(ledger, run_id="run-1", entity_id="issue-1"):
+    ledger.create_run(run_id, command_kind="search", trigger="manual")
+    return ledger.accept_item(run_id, entity_type="issue", entity_id=entity_id)
+
+
+def _item(ledger, run_id="run-1", entity_id="issue-1"):
+    return ledger.get_item(run_id, "issue", entity_id)
+
+
+# ---------------------------------------------------------------------------
+# The bound
+# ---------------------------------------------------------------------------
+
+
+def test_a_fresh_item_is_redriven_and_counted():
+    ledger = _ledger()
+    _seed_item(ledger)
+
+    assert ledger.claim_recovery(_item(ledger)) is True
+
+    item = _item(ledger)
+    assert item["recovery_count"] == 1
+    assert item["state"] == ItemOutcome.ACCEPTED.value
+
+
+def test_recovery_is_bounded_and_then_quarantines():
+    ledger = _ledger()
+    _seed_item(ledger)
+
+    for expected in range(1, MAX_RECOVERY_ATTEMPTS + 1):
+        assert ledger.claim_recovery(_item(ledger)) is True
+        assert _item(ledger)["recovery_count"] == expected
+
+    # The item has now survived MAX_RECOVERY_ATTEMPTS restarts without ever
+    # reaching a terminal outcome. It is stuck, not interrupted.
+    assert ledger.claim_recovery(_item(ledger)) is False
+
+    item = _item(ledger)
+    assert item["state"] == ItemOutcome.QUARANTINED.value
+    assert item["reason"] == "recovery_attempts_exhausted"
+    assert item["completed_at"] is not None
+
+
+def test_a_reaped_item_is_no_longer_recoverable_or_in_flight():
+    ledger = _ledger()
+    _seed_item(ledger)
+    with get_engine().begin() as conn:
+        conn.execute(update(acquisition_run_items).values(recovery_count=MAX_RECOVERY_ATTEMPTS))
+
+    ledger.claim_recovery(_item(ledger))
+
+    assert ledger.list_recoverable_items("search") == []
+    assert ledger.count_recovery_pending() == 0
+
+
+def test_an_item_that_terminalises_normally_is_never_reaped():
+    """Recovery counting must not leak into the ordinary success path."""
+    ledger = _ledger()
+    _seed_item(ledger)
+    ledger.claim_recovery(_item(ledger))
+
+    ledger.record_outcome("run-1", "issue", "issue-1", ItemOutcome.SUCCEEDED)
+
+    item = _item(ledger)
+    assert item["state"] == ItemOutcome.SUCCEEDED.value
+    assert item["reason"] is None
+    assert ledger.list_recoverable_items("search") == []
+
+
+def test_recovery_count_is_independent_of_attempt_count():
+    """attempt_count counts worker claims; an item can be re-driven without one."""
+    ledger = _ledger()
+    _seed_item(ledger)
+
+    ledger.claim_recovery(_item(ledger))
+    ledger.claim_recovery(_item(ledger))
+
+    item = _item(ledger)
+    assert item["recovery_count"] == 2
+    assert item["attempt_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# The counter
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_pending_qualifies_in_flight_without_inflating_it():
+    from comicarr.app.activity import queries
+
+    ledger = _ledger()
+    ledger.create_run("run-1", command_kind="search", trigger="manual")
+    ledger.accept_item("run-1", entity_type="issue", entity_id="fresh")
+    ledger.accept_item("run-1", entity_type="issue", entity_id="recovered")
+    ledger.claim_recovery(ledger.get_item("run-1", "issue", "recovered"))
+
+    counts = queries.get_open_work_counts()
+
+    assert counts["in_flight"] == 2
+    assert counts["recovery_pending"] == 1
+
+
+# ---------------------------------------------------------------------------
+# The one-time migration for residue that predates the bound
+# ---------------------------------------------------------------------------
+
+
+def test_schema_v7_cancels_residue_that_predates_the_bound(tmp_path, monkeypatch):
+    """Frankie's 940 stranded rows, cleared on the first start after upgrade.
+
+    Safe because the run ledger records attempts, not intent: wanting lives on
+    issues.Status, so cancelling a dead attempt row cannot lose a want.
+    """
+    from comicarr.app.acquisition import maintenance
+
+    ledger = _ledger()
+    ledger.create_run("old-run", command_kind="search", trigger="scheduled")
+    ledger.accept_item("old-run", entity_type="issue", entity_id="stranded-1")
+    ledger.accept_item("old-run", entity_type="issue", entity_id="stranded-2")
+    ledger.accept_item("old-run", entity_type="issue", entity_id="done")
+    ledger.record_outcome("old-run", "issue", "done", ItemOutcome.SUCCEEDED)
+
+    maintenance._cancel_prebound_residue(get_engine())
+
+    with get_engine().connect() as conn:
+        rows = {
+            row["entity_id"]: dict(row)
+            for row in (r._mapping for r in conn.execute(select(acquisition_run_items)))
+        }
+
+    assert rows["stranded-1"]["state"] == ItemOutcome.CANCELLED.value
+    assert rows["stranded-1"]["reason"] == "stale_before_recovery_bound"
+    assert rows["stranded-2"]["state"] == ItemOutcome.CANCELLED.value
+    # An already-terminal item is untouched.
+    assert rows["done"]["state"] == ItemOutcome.SUCCEEDED.value
+    assert rows["done"]["reason"] is None
+
+    assert ledger.list_recoverable_items() == []
+
+
+def test_schema_v7_is_applied_and_verified():
+    from comicarr.app.acquisition import maintenance
+
+    status = ensure_acquisition_schema(get_engine())
+
+    assert status.ready is True
+    assert maintenance.SCHEMA_VERSION >= 7
+    assert status.version == maintenance.SCHEMA_VERSION

--- a/tests/unit/test_search_queue.py
+++ b/tests/unit/test_search_queue.py
@@ -20,7 +20,7 @@ from sqlalchemy import insert
 import comicarr
 from comicarr.app.acquisition.maintenance import MaintenanceBlocked, MaintenanceController, ensure_acquisition_schema
 from comicarr.app.acquisition.models import ItemOutcome
-from comicarr.app.acquisition.runs import RunLedger
+from comicarr.app.acquisition.runs import MAX_RECOVERY_ATTEMPTS, RunLedger
 from comicarr.app.search import service
 from comicarr.app.search.commands import (
     enqueue_failed_download_retry,
@@ -134,6 +134,49 @@ def test_replayed_search_commands_are_marked_lower_priority(acquisition_ledger):
     assert replay_search_obligations(work_queue=work, ledger=acquisition_ledger) == 1
     assert work.get_nowait()["queue_priority"] == "recovery"
     assert acquisition_ledger.get_item("replay-priority", "issue", "issue-1")["queue_priority"] == "recovery"
+
+
+def test_replay_counts_each_redrive(acquisition_ledger):
+    acquisition_ledger.create_run("replay-count", "search", "wanted_scan")
+    acquisition_ledger.accept_item(
+        "replay-count",
+        "issue",
+        "issue-1",
+        payload={"comicid": "comic-1", "issueid": "issue-1", "manual": False},
+    )
+
+    for expected in (1, 2, 3):
+        assert replay_search_obligations(work_queue=FairSearchQueue(), ledger=acquisition_ledger) == 1
+        item = acquisition_ledger.get_item("replay-count", "issue", "issue-1")
+        assert item["recovery_count"] == expected
+
+
+def test_replay_quarantines_an_item_that_survives_the_bound(acquisition_ledger):
+    """The residue reaper, end to end (#555).
+
+    An item that keeps coming back through replay without ever terminalising
+    is stuck, not interrupted. It stops being re-queued and stops counting as
+    in-flight work.
+    """
+    acquisition_ledger.create_run("replay-bound", "search", "wanted_scan")
+    acquisition_ledger.accept_item(
+        "replay-bound",
+        "issue",
+        "issue-1",
+        payload={"comicid": "comic-1", "issueid": "issue-1", "manual": False},
+    )
+
+    for _ in range(MAX_RECOVERY_ATTEMPTS):
+        assert replay_search_obligations(work_queue=FairSearchQueue(), ledger=acquisition_ledger) == 1
+
+    work = FairSearchQueue()
+    assert replay_search_obligations(work_queue=work, ledger=acquisition_ledger) == 0
+    assert work.empty()
+
+    item = acquisition_ledger.get_item("replay-bound", "issue", "issue-1")
+    assert item["state"] == ItemOutcome.QUARANTINED.value
+    assert item["reason"] == "recovery_attempts_exhausted"
+    assert acquisition_ledger.list_recoverable_items("search") == []
 
 
 def test_unlocked_command_reaches_provider_search_once(monkeypatch):


### PR DESCRIPTION
Closes #555. This is the decision **and** its implementation, since the decision turned out to be small enough not to need a separate task ticket.

## Ticket premise, corrected

The ticket says crash recovery is "wired only to `acquisition_repair.py`". It is not — `comicarr/__init__.py:replay_acquisition_obligations` calls `replay_search_obligations` and `replay_refresh_obligations` on every start. **That is precisely why the residue survived:** replay is a *re-driver*, not a reaper. It faithfully re-queued every `accepted`/`running` item, so an obligation that could never make progress came back every restart and was counted as live work forever. Wiring recovery in more places would have made it worse.

## The decision

**Reap at startup replay, bounded by restarts — not by a clock.**

`RunLedger.claim_recovery(item)` is called before each re-drive. It increments a new `recovery_count`; at `MAX_RECOVERY_ATTEMPTS` (3) it terminalises the item as `QUARANTINED / recovery_attempts_exhausted` instead of re-queueing.

**Why restarts and not a TTL.** Time cannot distinguish a stuck item from one queued behind a long backlog — a clock would reap legitimate work and would need a tuning knob nobody can set correctly. Surviving three restarts without ever reaching a terminal outcome can only mean stuck. No TTL, no knob.

**Why a new column.** `attempt_count` counts *worker claims*; an item can be re-driven without ever being claimed (process died before dispatch), so it is the wrong bound. `recovery_count` counts re-drives. A test pins that they move independently.

**Frankie's existing 940 rows** are handled by a one-time pass in acquisition schema **v7**, cancelling every pre-existing non-terminal item with reason `stale_before_recovery_bound` — so the number is honest on the first start after upgrade rather than after three.

That one-time cancel is safe for a reason worth stating plainly, because the whole decision rests on it: **the run ledger records attempts, not intent.** Wanting lives on `issues.Status`. Cancelling a dead attempt row cannot lose a want — anything still Wanted is picked up by the next sweep. And migrations run before workers start, so nothing legitimately in flight can be caught.

**Redefining the counter.** `in_flight` keeps its meaning, and `/api/activity/status` gains `recovery_pending` — the subset that has survived a restart. It is a **qualifier, never added to the total**, so a surface can say "12 in flight (3 recovered from a restart)" instead of one number that hides the difference. The TS type gains the optional field; no UI is changed here, since what the dashboard shows is #557/#559's call.

## Changes

- `acquisition_run_items.recovery_count` (`tables.py`), acquisition schema **v7** (`_add_item_recovery_count_column`, `_cancel_prebound_residue`), added to the version chain and `_verify_schema`'s per-version column set
- `RunLedger.claim_recovery` / `count_recovery_pending`, `MAX_RECOVERY_ATTEMPTS = 3`
- both replay paths gated on `claim_recovery` (`app/search/commands.py`, `importer.py`)
- `count_recovery_pending_run_items` in `activity/queries.py`, surfaced through `get_open_work_counts`
- `docs/architecture/activity-center.md` documents why `M in flight` is now trustworthy

## Tests

`tests/unit/test_inflight_residue_reaping.py` (new, 8): the bound counts and then quarantines; a reaped item leaves both `list_recoverable_items` and the in-flight count; an item that terminalises normally is never reaped; `recovery_count` is independent of `attempt_count`; `recovery_pending` qualifies `in_flight` without inflating it; schema v7 cancels pre-bound residue while leaving already-terminal items alone; v7 applies and verifies.

`tests/unit/test_search_queue.py` (+2): end-to-end through real `replay_search_obligations` — each replay counts, and the fourth stops re-queueing and quarantines instead.

Full backend suite: **2130 passed**. `lint:modern`, `lint:backend`, `lint:guards` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1WDZ6KSy4VDxYHg7PDozn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bounded recovery for unfinished searches and refreshes after restarts.
  * Items that remain unfinished after three recovery attempts are quarantined instead of repeatedly requeued.
  * Activity status now reports `recovery_pending` as the subset of in-flight work that survived a restart.

* **Bug Fixes**
  * Cleans up stale pre-existing acquisition items during the upgrade, preventing them from being retried indefinitely.
  * Improved recovery handling to avoid duplicate or excessive replay attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->