### PR TITLE
refactor: Give each dashboard panel its own query and a shared panel shell

### DIFF
--- a/.changeset/silver-moons-report.md
+++ b/.changeset/silver-moons-report.md
@@ -6,4 +6,4 @@ The dashboard no longer goes blank when one thing behind it breaks. Every panel 
 
 That distinction is the point: an empty panel now means the answer really was nothing, and a broken one says so out loud. The panels also reserve their space while loading, so a slow one no longer shifts the page around as it arrives.
 
-The dashboard reads the same information in the same order as before.
+The dashboard reads the same information in the same order as before, with one correction: the count above each panel now matches the rows beneath it. "Recent activity" could previously say ten events above a list of five.

--- a/.changeset/silver-moons-report.md
+++ b/.changeset/silver-moons-report.md
@@ -1,0 +1,9 @@
+---
+"comicarr": patch
+---
+
+The dashboard no longer goes blank when one thing behind it breaks. Every panel — the library figures, the queue, recent activity, this week's releases, recent chats — now loads on its own. If one of them cannot be answered, that panel alone says "unavailable" and offers a retry next to it, and everything else on the page still works. Previously the whole page was built from a single request, so one failure took the page down entirely, and a failure that was quietly swallowed showed up as an empty panel — indistinguishable from a genuinely quiet week.
+
+That distinction is the point: an empty panel now means the answer really was nothing, and a broken one says so out loud. The panels also reserve their space while loading, so a slow one no longer shifts the page around as it arrives.
+
+The dashboard reads the same information in the same order as before.

--- a/comicarr/app/dashboard/queries.py
+++ b/comicarr/app/dashboard/queries.py
@@ -12,7 +12,6 @@
 from sqlalchemy import func, or_, select
 
 from comicarr import db
-from comicarr.tables import ai_activity_log as t_ai_activity_log
 from comicarr.tables import comics as t_comics
 from comicarr.tables import snatched as t_snatched
 
@@ -66,20 +65,3 @@ def get_library_stats(content_type=None):
         conditions = (t_comics.c.Status != "Paused",)
 
     return db.select_one(select(*columns).select_from(t_comics).where(*conditions))
-
-
-def get_recent_ai_activity(limit=5):
-    """Return the dashboard's compact newest-first AI activity preview."""
-    stmt = (
-        select(
-            t_ai_activity_log.c.timestamp,
-            t_ai_activity_log.c.feature_type,
-            t_ai_activity_log.c.action_description,
-            t_ai_activity_log.c.prompt_tokens,
-            t_ai_activity_log.c.completion_tokens,
-            t_ai_activity_log.c.success,
-        )
-        .order_by(t_ai_activity_log.c.timestamp.desc())
-        .limit(int(limit))
-    )
-    return db.select_all(stmt)

--- a/comicarr/app/dashboard/router.py
+++ b/comicarr/app/dashboard/router.py
@@ -8,21 +8,55 @@
 #  (at your option) any later version.
 
 """
-Dashboard domain router — home dashboard data aggregation endpoint.
+Dashboard domain router — one route per dashboard panel.
+
+There is deliberately no aggregate payload: a single fan-in read makes one
+slow or broken source blank the whole page, which is the failure mode
+``docs/architecture/dashboard-spec.md`` §5 exists to prevent.
 """
 
 from fastapi import APIRouter, Depends
 
-from comicarr.app.core.context import AppContext, get_context
 from comicarr.app.core.security import require_session
 
 router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
 
 
-@router.get("", dependencies=[Depends(require_session)])
-@router.get("/", dependencies=[Depends(require_session)])
-def get_dashboard(ctx: AppContext = Depends(get_context)):
-    """Return aggregated dashboard data for the home page."""
+@router.get("/library", dependencies=[Depends(require_session)])
+def get_library():
+    """Return the library aggregates behind the KPI strip."""
     from comicarr.app.dashboard import service
 
-    return service.get_dashboard_data(ctx)
+    return service.get_library_panel()
+
+
+@router.get("/queue", dependencies=[Depends(require_session)])
+def get_queue():
+    """Return the active-download count and preview."""
+    from comicarr.app.dashboard import service
+
+    return service.get_queue_panel()
+
+
+@router.get("/activity", dependencies=[Depends(require_session)])
+def get_activity():
+    """Return the bounded recent-activity preview."""
+    from comicarr.app.dashboard import service
+
+    return service.get_activity_panel()
+
+
+@router.get("/upcoming", dependencies=[Depends(require_session)])
+def get_upcoming():
+    """Return this week's releases for series in the library."""
+    from comicarr.app.dashboard import service
+
+    return service.get_upcoming_panel()
+
+
+@router.get("/scan-targets", dependencies=[Depends(require_session)])
+def get_scan_targets():
+    """Return which libraries the dashboard's scan action can start."""
+    from comicarr.app.dashboard import service
+
+    return service.get_scan_targets()

--- a/comicarr/app/dashboard/service.py
+++ b/comicarr/app/dashboard/service.py
@@ -25,7 +25,14 @@ from comicarr.app.downloads import queries as dl_queries
 from comicarr.app.storyarcs import service as storyarcs_service
 
 RECENT_ACTIVITY_DAYS = 30
+
+# Every panel's preview is bounded here rather than in the client. A panel that
+# renders fewer rows than it counts is claiming a number it is not showing, so
+# the count and the list share one bound — the rule ``get_queue_panel`` already
+# followed by sharing the active DDL predicate.
 ACTIVE_QUEUE_PREVIEW_LIMIT = 5
+RECENT_ACTIVITY_PREVIEW_LIMIT = 5
+UPCOMING_PREVIEW_LIMIT = 6
 
 
 def recent_activity_cutoff(now=None):
@@ -84,22 +91,25 @@ def get_activity_panel():
     """Return the bounded recent-activity preview and the window it covers."""
     cutoff = recent_activity_cutoff().strftime("%Y-%m-%d %H:%M:%S")
     return {
-        "events": dashboard_queries.get_recent_activity(cutoff) or [],
+        "events": dashboard_queries.get_recent_activity(cutoff, limit=RECENT_ACTIVITY_PREVIEW_LIMIT) or [],
         "days": RECENT_ACTIVITY_DAYS,
     }
 
 
 def get_upcoming_panel():
     """Return this week's releases for series already in the library."""
-    return {"releases": storyarcs_service.get_upcoming(include_downloaded=True) or []}
+    releases = storyarcs_service.get_upcoming(include_downloaded=True) or []
+    return {"releases": releases[:UPCOMING_PREVIEW_LIMIT]}
 
 
-def _has_directory(name):
-    """Return whether a library directory is configured to a non-empty path."""
-    value = getattr(comicarr.CONFIG, name, None)
-    return isinstance(value, str) and bool(value)
+def _is_configured_path(value):
+    """Return whether a configured library directory is a usable, non-empty path."""
+    return isinstance(value, str) and bool(value.strip())
 
 
 def get_scan_targets():
     """Return which libraries the dashboard's scan action can start."""
-    return {"comic": _has_directory("COMIC_DIR"), "manga": _has_directory("MANGA_DIR")}
+    return {
+        "comic": _is_configured_path(comicarr.CONFIG.COMIC_DIR),
+        "manga": _is_configured_path(comicarr.CONFIG.MANGA_DIR),
+    }

--- a/comicarr/app/dashboard/service.py
+++ b/comicarr/app/dashboard/service.py
@@ -8,19 +8,24 @@
 #  (at your option) any later version.
 
 """
-Dashboard domain service — aggregates data from existing tables for
-the home dashboard view.
+Dashboard domain service — panel-scoped reads for the home dashboard.
+
+Each panel owns its own read. A read that cannot be answered **raises**
+rather than returning a default: the client renders that one panel as
+unavailable with its own retry, and its neighbours still render. An empty
+panel and a broken panel must never look alike — see §5 of
+``docs/architecture/dashboard-spec.md``.
 """
 
 from datetime import datetime, timedelta
 
 import comicarr
-from comicarr import logger
 from comicarr.app.dashboard import queries as dashboard_queries
 from comicarr.app.downloads import queries as dl_queries
 from comicarr.app.storyarcs import service as storyarcs_service
 
 RECENT_ACTIVITY_DAYS = 30
+ACTIVE_QUEUE_PREVIEW_LIMIT = 5
 
 
 def recent_activity_cutoff(now=None):
@@ -28,93 +33,73 @@ def recent_activity_cutoff(now=None):
     return (now or datetime.now()) - timedelta(days=RECENT_ACTIVITY_DAYS)
 
 
-def get_dashboard_data(ctx):
-    """Aggregate dashboard data from existing tables.
+def _percentage(part, whole):
+    """Return ``part`` of ``whole`` as a one-decimal percentage, or 0 when unknowable."""
+    return round(part / whole * 100, 1) if whole > 0 else 0
 
-    Returns a dict with recently_downloaded, upcoming_releases, stats,
-    ai_activity, and ai_configured flag.
-    """
+
+def get_library_panel():
+    """Return the library aggregates behind the dashboard's KPI strip."""
+    stats = dashboard_queries.get_library_stats() or {}
+    total_issues = stats.get("total_issues", 0) or 0
+    total_expected = stats.get("total_expected", 0) or 0
     result = {
-        "recently_downloaded": [],
-        "active_queue": [],
-        "upcoming_releases": [],
-        "stats": {"queue_count": 0},
-        "ai_activity": [],
-        "ai_configured": False,
-        "scan_targets": {
-            "comic": isinstance(getattr(comicarr.CONFIG, "COMIC_DIR", None), str) and bool(comicarr.CONFIG.COMIC_DIR),
-            "manga": isinstance(getattr(comicarr.CONFIG, "MANGA_DIR", None), str) and bool(comicarr.CONFIG.MANGA_DIR),
-        },
+        "total_series": stats.get("total_series", 0) or 0,
+        "total_issues": total_issues,
+        "total_expected": total_expected,
+        "completion_pct": _percentage(total_issues, total_expected),
     }
 
-    # Recent activity is a bounded preview. Full history retains all rows.
-    try:
-        cutoff = recent_activity_cutoff().strftime("%Y-%m-%d %H:%M:%S")
-        recent = dashboard_queries.get_recent_activity(cutoff)
-        result["recently_downloaded"] = recent or []
-    except Exception as e:
-        logger.error("[DASHBOARD] Error fetching recent downloads: %s" % e)
+    manga_stats = dashboard_queries.get_library_stats("manga")
+    if manga_stats:
+        manga_have = manga_stats.get("manga_have", 0) or 0
+        manga_total = manga_stats.get("manga_total", 0) or 0
+        result["manga_series"] = manga_stats.get("manga_series", 0)
+        result["manga_have"] = manga_have
+        result["manga_total"] = manga_total
+        result["manga_completion_pct"] = _percentage(manga_have, manga_total)
 
-    # Library releases: matching titles from this application current week.
-    try:
-        result["upcoming_releases"] = storyarcs_service.get_upcoming(include_downloaded=True) or []
-    except Exception as e:
-        logger.error("[DASHBOARD] Error fetching upcoming: %s" % e)
+    comic_stats = dashboard_queries.get_library_stats("comic")
+    if comic_stats:
+        result["comic_series"] = comic_stats.get("comic_series", 0)
+        result["comic_have"] = comic_stats.get("comic_have", 0) or 0
+        result["comic_total"] = comic_stats.get("comic_total", 0) or 0
 
-    # Stats: aggregate from comics (combined + per content type)
-    try:
-        stats = dashboard_queries.get_library_stats()
-        if stats:
-            total_expected = stats.get("total_expected", 0) or 0
-            total_issues = stats.get("total_issues", 0) or 0
-            result["stats"] = {
-                "total_series": stats.get("total_series", 0),
-                "total_issues": total_issues,
-                "total_expected": total_expected,
-                "completion_pct": round(total_issues / total_expected * 100, 1) if total_expected > 0 else 0,
-            }
-            result["stats"].setdefault("queue_count", 0)
+    return {"stats": result}
 
-        # Manga-specific stats
-        manga_stats = dashboard_queries.get_library_stats("manga")
-        if manga_stats:
-            manga_total = manga_stats.get("manga_total", 0) or 0
-            manga_have = manga_stats.get("manga_have", 0) or 0
-            result["stats"]["manga_series"] = manga_stats.get("manga_series", 0)
-            result["stats"]["manga_have"] = manga_have
-            result["stats"]["manga_total"] = manga_total
-            result["stats"]["manga_completion_pct"] = round(manga_have / manga_total * 100, 1) if manga_total > 0 else 0
 
-        # Comic-specific stats (non-manga)
-        comic_stats = dashboard_queries.get_library_stats("comic")
-        if comic_stats:
-            result["stats"]["comic_series"] = comic_stats.get("comic_series", 0)
-            result["stats"]["comic_have"] = comic_stats.get("comic_have", 0) or 0
-            result["stats"]["comic_total"] = comic_stats.get("comic_total", 0) or 0
-    except Exception as e:
-        logger.error("[DASHBOARD] Error fetching stats: %s" % e)
+def get_queue_panel():
+    """Return the active-download count and its bounded preview.
 
-    # Queue KPI and preview deliberately share the active DDL predicate.
-    try:
-        result["stats"]["queue_count"] = dl_queries.count_active_ddl_items()
-    except Exception as e:
-        logger.error("[DASHBOARD] Error fetching active queue count: %s" % e)
-        result["stats"].setdefault("queue_count", 0)
+    Count and preview share the active DDL predicate deliberately, so the
+    tile and the list below it can never disagree.
+    """
+    return {
+        "count": dl_queries.count_active_ddl_items(),
+        "items": dl_queries.get_active_ddl_preview(limit=ACTIVE_QUEUE_PREVIEW_LIMIT) or [],
+    }
 
-    try:
-        result["active_queue"] = dl_queries.get_active_ddl_preview(limit=5)
-    except Exception as e:
-        logger.error("[DASHBOARD] Error fetching active queue preview: %s" % e)
 
-    # AI activity: last 5 entries (only if AI configured)
-    # Check both runtime client and saved config (client requires restart)
-    ai_base_url = getattr(comicarr.CONFIG, "AI_BASE_URL", None)
-    if comicarr.AI_CLIENT is not None or ai_base_url:
-        result["ai_configured"] = True
-        try:
-            activity = dashboard_queries.get_recent_ai_activity()
-            result["ai_activity"] = activity or []
-        except Exception as e:
-            logger.error("[DASHBOARD] Error fetching AI activity: %s" % e)
+def get_activity_panel():
+    """Return the bounded recent-activity preview and the window it covers."""
+    cutoff = recent_activity_cutoff().strftime("%Y-%m-%d %H:%M:%S")
+    return {
+        "events": dashboard_queries.get_recent_activity(cutoff) or [],
+        "days": RECENT_ACTIVITY_DAYS,
+    }
 
-    return result
+
+def get_upcoming_panel():
+    """Return this week's releases for series already in the library."""
+    return {"releases": storyarcs_service.get_upcoming(include_downloaded=True) or []}
+
+
+def _has_directory(name):
+    """Return whether a library directory is configured to a non-empty path."""
+    value = getattr(comicarr.CONFIG, name, None)
+    return isinstance(value, str) and bool(value)
+
+
+def get_scan_targets():
+    """Return which libraries the dashboard's scan action can start."""
+    return {"comic": _has_directory("COMIC_DIR"), "manga": _has_directory("MANGA_DIR")}

--- a/frontend/src/components/dashboard/DashboardPanel.tsx
+++ b/frontend/src/components/dashboard/DashboardPanel.tsx
@@ -1,0 +1,113 @@
+import { type ReactNode } from "react";
+import { RefreshCw } from "lucide-react";
+import type { PanelState } from "@/lib/panelState";
+
+/**
+ * The shared shell every dashboard panel renders through.
+ *
+ * A panel has exactly the four states of `PanelState` and the shell owns all
+ * of them, so no panel can invent a fifth — in particular, none can render a
+ * broken source as an empty one. `unavailable` carries a retry scoped to that
+ * panel alone, and `loading` renders a skeleton in the panel's final position
+ * so a slow source resolving does not shift its neighbours
+ * (docs/architecture/dashboard-spec.md §5).
+ */
+
+/** An honest sentence in the panel's own voice — never a blank card. */
+export function PanelNote({ children }: { children: ReactNode }) {
+  return (
+    <div className="font-mono text-[11px] text-muted-foreground py-3">
+      {children}
+    </div>
+  );
+}
+
+/**
+ * A failed panel says so and offers its own retry. The label names the source
+ * so two unavailable panels on one page stay distinguishable.
+ */
+export function PanelUnavailable({
+  label,
+  onRetry,
+  isRetrying = false,
+}: {
+  label: string;
+  onRetry: () => void;
+  isRetrying?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2.5 py-3 font-mono text-[11px]">
+      <span style={{ color: "var(--status-error)" }}>{label} unavailable</span>
+      <button
+        type="button"
+        onClick={onRetry}
+        disabled={isRetrying}
+        className="inline-flex items-center gap-1.5 px-2 py-1 rounded-[5px] border border-border text-muted-foreground hover:text-foreground disabled:opacity-50"
+      >
+        <RefreshCw className={`w-3 h-3 ${isRetrying ? "animate-spin" : ""}`} />
+        {isRetrying ? "retrying…" : "retry"}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Placeholder rows at the height of the real ones. Sized by the caller so the
+ * skeleton occupies the space the resolved content will take.
+ */
+export function PanelSkeleton({
+  rows,
+  rowHeight = 28,
+}: {
+  rows: number;
+  rowHeight?: number;
+}) {
+  return (
+    <div className="py-1.5" aria-hidden="true">
+      {Array.from({ length: rows }, (_, index) => (
+        <div
+          key={index}
+          className="flex items-center"
+          style={{ height: rowHeight }}
+        >
+          <div className="h-2.5 w-full animate-pulse rounded-[2px] bg-primary/10" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Renders the one branch the state selects. Content is a thunk so a panel
+ * never has to build rows out of data it does not have yet.
+ */
+export function PanelBody({
+  state,
+  label,
+  skeleton,
+  empty,
+  onRetry,
+  isRetrying,
+  children,
+}: {
+  state: PanelState;
+  label: string;
+  skeleton: ReactNode;
+  empty: ReactNode;
+  onRetry: () => void;
+  isRetrying?: boolean;
+  children: () => ReactNode;
+}) {
+  if (state === "loading") return <>{skeleton}</>;
+  if (state === "unavailable") {
+    return (
+      <PanelUnavailable
+        label={label}
+        onRetry={onRetry}
+        isRetrying={isRetrying}
+      />
+    );
+  }
+  if (state === "empty") return <PanelNote>{empty}</PanelNote>;
+  return <>{children()}</>;
+}

--- a/frontend/src/components/dashboard/DashboardPanel.tsx
+++ b/frontend/src/components/dashboard/DashboardPanel.tsx
@@ -42,6 +42,7 @@ export function PanelUnavailable({
         type="button"
         onClick={onRetry}
         disabled={isRetrying}
+        aria-label={`Retry ${label}`}
         className="inline-flex items-center gap-1.5 px-2 py-1 rounded-[5px] border border-border text-muted-foreground hover:text-foreground disabled:opacity-50"
       >
         <RefreshCw className={`w-3 h-3 ${isRetrying ? "animate-spin" : ""}`} />

--- a/frontend/src/components/layout/AppStatusBar.tsx
+++ b/frontend/src/components/layout/AppStatusBar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { useDashboard } from "@/hooks/useDashboard";
+import { useDashboardLibrary } from "@/hooks/useDashboard";
 import { useActivityStatus } from "@/hooks/useActivityStatus";
 import { useServerEventsHealth } from "@/contexts/ServerEventsContext";
 import { apiRequest } from "@/lib/api";
@@ -31,7 +31,7 @@ function apiColor(api: ActivityApiState): string | undefined {
  * shared SSE invalidates the activity status query (no second EventSource).
  */
 export default function AppStatusBar() {
-  const dashboard = useDashboard();
+  const library = useDashboardLibrary();
   const activity = useActivityStatus();
   const { live } = useServerEventsHealth();
   const health = useQuery<HealthResponse>({
@@ -41,9 +41,9 @@ export default function AppStatusBar() {
     refetchInterval: STATUS_POLL_MS,
   });
 
-  const libraryPending = dashboard.isPending;
-  const libraryFailed = !dashboard.isPending && !dashboard.data;
-  const librarySeries = dashboard.data?.stats.total_series ?? 0;
+  const libraryPending = library.isPending;
+  const libraryFailed = !library.isPending && !library.data;
+  const librarySeries = library.data?.stats.total_series ?? 0;
 
   const api: ActivityApiState = health.isPending
     ? "checking"

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -1,7 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/api";
 
-interface DashboardDownload {
+/**
+ * One query per dashboard panel.
+ *
+ * There is no aggregate `/api/dashboard` read: a single fan-in payload makes
+ * one broken source blank the whole page, and an unavailable panel then looks
+ * exactly like an empty one. Each hook below backs exactly one panel, so a
+ * failure is scoped to that panel and retried there
+ * (docs/architecture/dashboard-spec.md §5).
+ */
+
+interface DashboardActivityEvent {
   ComicName: string;
   Issue_Number: string;
   DateAdded: string;
@@ -31,40 +41,84 @@ export interface DashboardQueueItem {
   comicid: string | null;
 }
 
-interface DashboardStats {
+export interface DashboardLibraryStats {
   total_series: number;
   total_issues: number;
   total_expected: number;
   completion_pct: number;
-  queue_count: number;
 }
 
-interface DashboardAiActivity {
-  timestamp: string;
-  feature_type: string;
-  action_description: string;
-  prompt_tokens: number;
-  completion_tokens: number;
-  success: boolean;
+interface DashboardLibraryResponse {
+  stats: DashboardLibraryStats;
 }
 
-export interface DashboardData {
-  recently_downloaded: DashboardDownload[];
-  active_queue: DashboardQueueItem[];
-  upcoming_releases: DashboardUpcoming[];
-  stats: DashboardStats;
-  ai_activity: DashboardAiActivity[];
-  ai_configured: boolean;
-  scan_targets: {
-    comic: boolean;
-    manga: boolean;
-  };
+interface DashboardQueueResponse {
+  count: number;
+  items: DashboardQueueItem[];
 }
 
-export function useDashboard() {
-  return useQuery<DashboardData>({
-    queryKey: ["dashboard"],
-    queryFn: () => apiRequest<DashboardData>("GET", "/api/dashboard"),
-    staleTime: 2 * 60 * 1000,
+interface DashboardActivityResponse {
+  events: DashboardActivityEvent[];
+  days: number;
+}
+
+interface DashboardUpcomingResponse {
+  releases: DashboardUpcoming[];
+}
+
+export interface DashboardScanTargets {
+  comic: boolean;
+  manga: boolean;
+}
+
+const PANEL_STALE_TIME = 2 * 60 * 1000;
+
+/** KPI strip: series, issues held, and completion. */
+export function useDashboardLibrary() {
+  return useQuery<DashboardLibraryResponse>({
+    queryKey: ["dashboard", "library"],
+    queryFn: () =>
+      apiRequest<DashboardLibraryResponse>("GET", "/api/dashboard/library"),
+    staleTime: PANEL_STALE_TIME,
+  });
+}
+
+/** Active queue: the count on the KPI strip and the preview below it. */
+export function useDashboardQueue() {
+  return useQuery<DashboardQueueResponse>({
+    queryKey: ["dashboard", "queue"],
+    queryFn: () =>
+      apiRequest<DashboardQueueResponse>("GET", "/api/dashboard/queue"),
+    staleTime: PANEL_STALE_TIME,
+  });
+}
+
+/** Recent activity preview, bounded to the window the response reports. */
+export function useDashboardActivity() {
+  return useQuery<DashboardActivityResponse>({
+    queryKey: ["dashboard", "activity"],
+    queryFn: () =>
+      apiRequest<DashboardActivityResponse>("GET", "/api/dashboard/activity"),
+    staleTime: PANEL_STALE_TIME,
+  });
+}
+
+/** This week's releases for series already in the library. */
+export function useDashboardUpcoming() {
+  return useQuery<DashboardUpcomingResponse>({
+    queryKey: ["dashboard", "upcoming"],
+    queryFn: () =>
+      apiRequest<DashboardUpcomingResponse>("GET", "/api/dashboard/upcoming"),
+    staleTime: PANEL_STALE_TIME,
+  });
+}
+
+/** Which libraries the header's scan action can start. */
+export function useDashboardScanTargets() {
+  return useQuery<DashboardScanTargets>({
+    queryKey: ["dashboard", "scan-targets"],
+    queryFn: () =>
+      apiRequest<DashboardScanTargets>("GET", "/api/dashboard/scan-targets"),
+    staleTime: PANEL_STALE_TIME,
   });
 }

--- a/frontend/src/lib/activityStatus.ts
+++ b/frontend/src/lib/activityStatus.ts
@@ -12,7 +12,7 @@ export type ActivityApiState = "online" | "offline" | "checking";
 export type LiveConnectionState = "connected" | "reconnecting" | "lost";
 
 export interface ActivityStatusSnapshot {
-  /** GET /api/dashboard → stats.total_series; null when unavailable */
+  /** GET /api/dashboard/library → stats.total_series; null when unavailable */
   librarySeries: number | null;
   /** GET /api/health */
   api: ActivityApiState;

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -465,14 +465,11 @@ function wantedIssues(): WantedIssue[] {
   return out;
 }
 
-function dashboardPayload() {
+function dashboardLibraryPayload() {
   const totalSeries = LIBRARY.length;
   const totalIssues = LIBRARY.reduce((sum, s) => sum + (s.Have || 0), 0);
   const totalExpected = LIBRARY.reduce((sum, s) => sum + (s.Total || 0), 0);
   return {
-    recently_downloaded: recentDownloads(),
-    active_queue: [],
-    upcoming_releases: upcomingReleases(),
     stats: {
       total_series: totalSeries,
       total_issues: totalIssues,
@@ -481,8 +478,6 @@ function dashboardPayload() {
         ? Math.round((totalIssues / totalExpected) * 1000) / 10
         : 0,
     },
-    ai_activity: [],
-    ai_configured: false,
   };
 }
 
@@ -672,8 +667,20 @@ export function mockApiResponse(
     // Quiet-count inputs for AppStatusBar (Variant A). Fixture: light open work.
     return { in_flight: 2, attention: 0 };
   }
-  if (m === "GET" && url === "/api/dashboard") {
-    return dashboardPayload();
+  if (m === "GET" && url === "/api/dashboard/library") {
+    return dashboardLibraryPayload();
+  }
+  if (m === "GET" && url === "/api/dashboard/queue") {
+    return { count: 0, items: [] };
+  }
+  if (m === "GET" && url === "/api/dashboard/activity") {
+    return { days: 30, events: recentDownloads() };
+  }
+  if (m === "GET" && url === "/api/dashboard/upcoming") {
+    return { releases: upcomingReleases() };
+  }
+  if (m === "GET" && url === "/api/dashboard/scan-targets") {
+    return { comic: false, manga: false };
   }
   if (m === "GET" && url === "/api/series") {
     return LIBRARY;

--- a/frontend/src/lib/panelState.ts
+++ b/frontend/src/lib/panelState.ts
@@ -1,0 +1,26 @@
+/**
+ * The four states a dashboard panel can be in — and the only place they are
+ * derived. Pure composition; no React, no I/O.
+ *
+ * The point of the enumeration is that "empty" and "unavailable" are separate
+ * answers. A panel whose source failed must never fall through to the empty
+ * sentence, because a broken pipeline would then read as a quiet one — the
+ * failure docs/architecture/dashboard-spec.md exists to prevent.
+ */
+
+export type PanelState = "loading" | "unavailable" | "empty" | "content";
+
+export interface PanelQuery {
+  isPending: boolean;
+  isError: boolean;
+}
+
+/**
+ * Derive a panel's state from its query. `isEmpty` is consulted only once the
+ * query has actually answered — an unanswered panel is never "empty".
+ */
+export function panelState(query: PanelQuery, isEmpty: boolean): PanelState {
+  if (query.isError) return "unavailable";
+  if (query.isPending) return "loading";
+  return isEmpty ? "empty" : "content";
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,11 +1,22 @@
-import { useState, type SubmitEvent } from "react";
+import { useState, type ReactNode, type SubmitEvent } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { ArrowUp, RefreshCw } from "lucide-react";
-import ErrorDisplay from "@/components/ui/ErrorDisplay";
+import {
+  PanelBody,
+  PanelSkeleton,
+} from "@/components/dashboard/DashboardPanel";
+import { panelState, type PanelState } from "@/lib/panelState";
 import { Kbd } from "@/components/ui/kbd";
 import RelativeTime from "@/components/ui/RelativeTime";
 import { useToast } from "@/components/ui/toast";
-import { useDashboard, type DashboardQueueItem } from "@/hooks/useDashboard";
+import {
+  useDashboardActivity,
+  useDashboardLibrary,
+  useDashboardQueue,
+  useDashboardScanTargets,
+  useDashboardUpcoming,
+  type DashboardQueueItem,
+} from "@/hooks/useDashboard";
 import { useChatThreads } from "@/hooks/useLibraryChat";
 import {
   useComicScan,
@@ -17,19 +28,42 @@ import {
 function Kpi({
   label,
   value,
+  state,
+  onRetry,
   borderLeft,
 }: {
   label: string;
   value: string;
+  state: PanelState;
+  onRetry: () => void;
   borderLeft?: boolean;
 }) {
   return (
     <div className={`px-5 py-4 ${borderLeft ? "border-l border-border" : ""}`}>
       <div className="mono-label">{label}</div>
-      <div className="flex items-end gap-2 mt-1.5">
-        <div className="text-[26px] font-semibold tracking-tight leading-none">
-          {value}
-        </div>
+      <div className="flex items-end gap-2 mt-1.5 h-[26px]">
+        {state === "loading" ? (
+          <div
+            aria-hidden="true"
+            className="h-4 w-16 self-center animate-pulse rounded-[2px] bg-primary/10"
+          />
+        ) : state === "unavailable" ? (
+          <div className="flex items-center gap-2 self-center font-mono text-[11px]">
+            <span style={{ color: "var(--status-error)" }}>unavailable</span>
+            <button
+              type="button"
+              onClick={onRetry}
+              aria-label={`Retry ${label}`}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <RefreshCw className="w-3 h-3" />
+            </button>
+          </div>
+        ) : (
+          <div className="text-[26px] font-semibold tracking-tight leading-none">
+            {value}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -50,6 +84,43 @@ function QueueStatus({ status }: { status: DashboardQueueItem["status"] }) {
   );
 }
 
+/** Panel heading plus its count and a link out to the full view. */
+function PanelHeader({
+  title,
+  meta,
+  action,
+}: {
+  title: string;
+  meta: ReactNode;
+  action?: { label: string; to: string };
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 mb-3">
+      <div className="flex items-center gap-2.5">
+        <div className="text-[13px] font-semibold">{title}</div>
+        <div className="font-mono text-[10px] text-muted-foreground tracking-wider uppercase">
+          {meta}
+        </div>
+      </div>
+      {action && (
+        <Link
+          to={action.to}
+          className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
+        >
+          {action.label}
+        </Link>
+      )}
+    </div>
+  );
+}
+
+/** A count that refuses to claim zero for a source that never answered. */
+function countMeta(state: PanelState, count: number, noun: string): string {
+  if (state === "loading") return "…";
+  if (state === "unavailable") return "unavailable";
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
 const ASK_SUGGESTIONS = [
   "Which runs have gaps?",
   "What landed this week?",
@@ -57,7 +128,11 @@ const ASK_SUGGESTIONS = [
 ];
 
 export default function DashboardPage() {
-  const { data, isLoading, error } = useDashboard();
+  const library = useDashboardLibrary();
+  const queue = useDashboardQueue();
+  const activity = useDashboardActivity();
+  const upcoming = useDashboardUpcoming();
+  const scanTargets = useDashboardScanTargets();
   const navigate = useNavigate();
   const chatThreadsQuery = useChatThreads();
   const [question, setQuestion] = useState("");
@@ -80,27 +155,24 @@ export default function DashboardPage() {
   const { data: mangaScanProgress } = useMangaScanProgress();
   const { addToast } = useToast();
 
-  if (error) {
-    return (
-      <div className="p-8">
-        <ErrorDisplay
-          error={error}
-          title="Unable to load dashboard"
-          onRetry={() => window.location.reload()}
-        />
-      </div>
-    );
-  }
-
-  const stats = data?.stats;
-  const downloads = data?.recently_downloaded || [];
-  const activeQueue = data?.active_queue || [];
-  const upcoming = data?.upcoming_releases || [];
+  const stats = library.data?.stats;
+  const queueItems = queue.data?.items ?? [];
+  const queueCount = queue.data?.count ?? 0;
+  const activityEvents = activity.data?.events ?? [];
+  const activityDays = activity.data?.days ?? 30;
+  const upcomingReleases = upcoming.data?.releases ?? [];
 
   const activeSeries = stats?.total_series ?? 0;
   const totalIssues = stats?.total_issues ?? 0;
   const completion = stats?.completion_pct ?? 0;
-  const queueCount = stats?.queue_count ?? 0;
+
+  const libraryState = panelState(library, false);
+  const queueState = panelState(queue, queueItems.length === 0);
+  const queueCountState = panelState(queue, false);
+  const activityState = panelState(activity, activityEvents.length === 0);
+  const upcomingState = panelState(upcoming, upcomingReleases.length === 0);
+  const chatsState = panelState(chatThreadsQuery, recentChats.length === 0);
+
   const comicScanning = comicScanProgress?.status === "scanning";
   const mangaScanning = mangaScanProgress?.status === "scanning";
   const scanPending =
@@ -108,16 +180,29 @@ export default function DashboardPage() {
     mangaScan.isPending ||
     comicScanning ||
     mangaScanning;
-  const canScan = Boolean(
-    data?.scan_targets?.comic || data?.scan_targets?.manga,
-  );
+  const canScan = Boolean(scanTargets.data?.comic || scanTargets.data?.manga);
+
+  // The summary line reports each source separately: a broken one says so
+  // rather than contributing a zero to a line that reads as fact.
+  const summary = [
+    library.isError
+      ? "library unavailable"
+      : library.isPending
+        ? "loading…"
+        : `${activeSeries} series · ${totalIssues} issues`,
+    queue.isError
+      ? "queue unavailable"
+      : queue.isPending
+        ? "loading…"
+        : `${queueCount} in queue`,
+  ].join(" · ");
 
   const handleLibraryScan = async () => {
     const scanRequests: Promise<unknown>[] = [];
-    if (data?.scan_targets?.comic) {
+    if (scanTargets.data?.comic) {
       scanRequests.push(comicScan.mutateAsync());
     }
-    if (data?.scan_targets?.manga) {
+    if (scanTargets.data?.manga) {
       scanRequests.push(mangaScan.mutateAsync());
     }
 
@@ -161,9 +246,7 @@ export default function DashboardPage() {
             Dashboard
           </div>
           <div className="font-mono text-[11px] text-muted-foreground mt-0.5">
-            {isLoading
-              ? "loading…"
-              : `${activeSeries} series · ${totalIssues} issues · ${queueCount} in queue`}
+            {summary}
           </div>
         </div>
         <button
@@ -227,242 +310,236 @@ export default function DashboardPage() {
 
       {/* Everything below the ask bar scrolls inside the page column. */}
       <div className="flex-1 min-h-0 overflow-auto">
-        {/* KPI strip */}
+        {/* KPI strip — the first three read the library, the fourth the queue */}
         <div className="grid grid-cols-2 lg:grid-cols-4 border-b border-border">
           <Kpi
             label="Active series"
-            value={isLoading ? "—" : String(activeSeries)}
+            value={String(activeSeries)}
+            state={libraryState}
+            onRetry={() => void library.refetch()}
           />
           <Kpi
             label="Issues"
-            value={isLoading ? "—" : String(totalIssues)}
+            value={String(totalIssues)}
+            state={libraryState}
+            onRetry={() => void library.refetch()}
             borderLeft
           />
           <Kpi
             label="Completion"
-            value={isLoading ? "—" : `${completion.toFixed(1)}%`}
+            value={`${completion.toFixed(1)}%`}
+            state={libraryState}
+            onRetry={() => void library.refetch()}
             borderLeft
           />
-          <Kpi label="Queue" value={String(queueCount)} borderLeft />
+          <Kpi
+            label="Queue"
+            value={String(queueCount)}
+            state={queueCountState}
+            onRetry={() => void queue.refetch()}
+            borderLeft
+          />
         </div>
 
         {/* Operational summaries */}
         <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] border-b border-border min-h-[320px]">
           {/* Active queue and recent history */}
           <section className="px-5 py-4 lg:border-r lg:border-border">
-            <div className="flex items-center justify-between gap-3 mb-3">
-              <div className="flex items-center gap-2.5">
-                <div className="text-[13px] font-semibold">Active queue</div>
-                <div className="font-mono text-[10px] text-muted-foreground tracking-wider uppercase">
-                  {queueCount} item{queueCount === 1 ? "" : "s"}
-                </div>
-              </div>
-              <Link
-                to="/activity"
-                className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
-              >
-                open queue →
-              </Link>
-            </div>
+            <PanelHeader
+              title="Active queue"
+              meta={countMeta(queueCountState, queueCount, "item")}
+              action={{ label: "open queue →", to: "/activity" }}
+            />
 
-            {isLoading && (
-              <div className="font-mono text-[11px] text-muted-foreground py-3">
-                loading queue…
-              </div>
-            )}
-
-            {!isLoading && activeQueue.length === 0 && (
-              <div className="font-mono text-[11px] text-muted-foreground py-3">
-                queue is clear
-              </div>
-            )}
-
-            <div className="font-mono text-[11px]">
-              {activeQueue.map((item, index) => (
-                <div
-                  key={item.ID}
-                  className="grid items-center gap-2 py-1.5"
-                  style={{
-                    gridTemplateColumns: "minmax(140px, 1fr) 100px 120px",
-                    borderTop:
-                      index > 0
-                        ? "1px solid var(--border-soft, var(--border))"
-                        : "none",
-                  }}
-                >
-                  <div className="min-w-0">
-                    <div className="font-sans text-foreground truncate">
-                      {item.series || item.filename || "Unnamed download"}
-                    </div>
-                    {item.filename && item.filename !== item.series && (
-                      <div className="text-muted-foreground truncate">
-                        {item.filename}
-                      </div>
-                    )}
-                  </div>
-                  <QueueStatus status={item.status} />
-                  <span className="text-muted-foreground truncate text-right">
-                    {item.updated_date ? (
-                      <RelativeTime value={item.updated_date} />
-                    ) : (
-                      "—"
-                    )}
-                  </span>
-                </div>
-              ))}
-            </div>
-
-            <div className="mt-5 pt-4 border-t border-border">
-              <div className="flex items-center justify-between gap-3 mb-3">
-                <div className="flex items-center gap-2.5">
-                  <div className="text-[13px] font-semibold">
-                    Recent activity
-                  </div>
-                  <div className="font-mono text-[10px] text-muted-foreground tracking-wider uppercase">
-                    {downloads.length} event{downloads.length === 1 ? "" : "s"}{" "}
-                    · 30 days
-                  </div>
-                </div>
-                <Link
-                  to="/activity?view=history"
-                  className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
-                >
-                  open history →
-                </Link>
-              </div>
-
-              {isLoading && (
-                <div className="font-mono text-[11px] text-muted-foreground py-4">
-                  loading recent activity…
-                </div>
-              )}
-
-              {!isLoading && downloads.length === 0 && (
-                <div className="font-mono text-[11px] text-muted-foreground py-4">
-                  no activity in the last 30 days —{" "}
-                  <Link
-                    to="/activity?view=history"
-                    className="hover:text-foreground"
-                  >
-                    open full history
-                  </Link>
-                </div>
-              )}
-
-              <div className="font-mono text-[11px]">
-                {downloads.slice(0, 5).map((d, i) => {
-                  const action = d.Status?.toLowerCase() || "—";
-                  const color = action.includes("down")
-                    ? "var(--chart-4)"
-                    : action.includes("post") || action.includes("import")
-                      ? "var(--status-active)"
-                      : action.includes("snatch") || action.includes("queue")
-                        ? "var(--status-paused)"
-                        : "var(--muted-foreground)";
-                  return (
+            <PanelBody
+              state={queueState}
+              label="Active queue"
+              skeleton={<PanelSkeleton rows={3} />}
+              empty="queue is clear"
+              onRetry={() => void queue.refetch()}
+              isRetrying={queue.isFetching}
+            >
+              {() => (
+                <div className="font-mono text-[11px]">
+                  {queueItems.map((item, index) => (
                     <div
-                      key={`${d.ComicID}-${d.IssueID}-${i}`}
+                      key={item.ID}
                       className="grid items-center gap-2 py-1.5"
                       style={{
-                        gridTemplateColumns:
-                          "120px 90px minmax(180px, 1fr) 140px",
+                        gridTemplateColumns: "minmax(140px, 1fr) 100px 120px",
                         borderTop:
-                          i > 0
+                          index > 0
                             ? "1px solid var(--border-soft, var(--border))"
                             : "none",
                       }}
                     >
-                      <RelativeTime value={d.DateAdded} />
-                      <span className="uppercase truncate" style={{ color }}>
-                        {action}
-                      </span>
-                      <div className="flex items-center gap-2 min-w-0">
-                        {d.ComicID && (
-                          <img
-                            src={`/api/metadata/art/${d.ComicID}`}
-                            alt=""
-                            className="w-4 h-6 object-cover rounded-[1px] shrink-0"
-                            onError={(e) => {
-                              e.currentTarget.style.visibility = "hidden";
-                            }}
-                          />
+                      <div className="min-w-0">
+                        <div className="font-sans text-foreground truncate">
+                          {item.series || item.filename || "Unnamed download"}
+                        </div>
+                        {item.filename && item.filename !== item.series && (
+                          <div className="text-muted-foreground truncate">
+                            {item.filename}
+                          </div>
                         )}
-                        <Link
-                          to={`/library/${d.ComicID}`}
-                          className="font-sans text-foreground truncate hover:text-[var(--primary)]"
-                        >
-                          {d.ComicName} #{d.Issue_Number}
-                        </Link>
                       </div>
-                      <span className="text-muted-foreground truncate">
-                        {d.Provider || "—"}
+                      <QueueStatus status={item.status} />
+                      <span className="text-muted-foreground truncate text-right">
+                        {item.updated_date ? (
+                          <RelativeTime value={item.updated_date} />
+                        ) : (
+                          "—"
+                        )}
                       </span>
                     </div>
-                  );
-                })}
-              </div>
+                  ))}
+                </div>
+              )}
+            </PanelBody>
+
+            <div className="mt-5 pt-4 border-t border-border">
+              <PanelHeader
+                title="Recent activity"
+                meta={`${countMeta(activityState, activityEvents.length, "event")} · ${activityDays} days`}
+                action={{
+                  label: "open history →",
+                  to: "/activity?view=history",
+                }}
+              />
+
+              <PanelBody
+                state={activityState}
+                label="Recent activity"
+                skeleton={<PanelSkeleton rows={5} />}
+                empty={
+                  <>
+                    no activity in the last {activityDays} days —{" "}
+                    <Link
+                      to="/activity?view=history"
+                      className="hover:text-foreground"
+                    >
+                      open full history
+                    </Link>
+                  </>
+                }
+                onRetry={() => void activity.refetch()}
+                isRetrying={activity.isFetching}
+              >
+                {() => (
+                  <div className="font-mono text-[11px]">
+                    {activityEvents.slice(0, 5).map((d, i) => {
+                      const action = d.Status?.toLowerCase() || "—";
+                      const color = action.includes("down")
+                        ? "var(--chart-4)"
+                        : action.includes("post") || action.includes("import")
+                          ? "var(--status-active)"
+                          : action.includes("snatch") ||
+                              action.includes("queue")
+                            ? "var(--status-paused)"
+                            : "var(--muted-foreground)";
+                      return (
+                        <div
+                          key={`${d.ComicID}-${d.IssueID}-${i}`}
+                          className="grid items-center gap-2 py-1.5"
+                          style={{
+                            gridTemplateColumns:
+                              "120px 90px minmax(180px, 1fr) 140px",
+                            borderTop:
+                              i > 0
+                                ? "1px solid var(--border-soft, var(--border))"
+                                : "none",
+                          }}
+                        >
+                          <RelativeTime value={d.DateAdded} />
+                          <span
+                            className="uppercase truncate"
+                            style={{ color }}
+                          >
+                            {action}
+                          </span>
+                          <div className="flex items-center gap-2 min-w-0">
+                            {d.ComicID && (
+                              <img
+                                src={`/api/metadata/art/${d.ComicID}`}
+                                alt=""
+                                className="w-4 h-6 object-cover rounded-[1px] shrink-0"
+                                onError={(e) => {
+                                  e.currentTarget.style.visibility = "hidden";
+                                }}
+                              />
+                            )}
+                            <Link
+                              to={`/library/${d.ComicID}`}
+                              className="font-sans text-foreground truncate hover:text-[var(--primary)]"
+                            >
+                              {d.ComicName} #{d.Issue_Number}
+                            </Link>
+                          </div>
+                          <span className="text-muted-foreground truncate">
+                            {d.Provider || "—"}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </PanelBody>
             </div>
           </section>
 
           {/* This week */}
           <section className="px-5 py-4">
-            <div className="flex items-center justify-between gap-3 mb-3">
-              <div className="flex items-center gap-2.5">
-                <div className="text-[13px] font-semibold">This week</div>
-                <div className="font-mono text-[10px] text-muted-foreground tracking-wider uppercase">
-                  {upcoming.length} releases
-                </div>
-              </div>
-              <Link
-                to="/releases?view=mine"
-                className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
-              >
-                view mine →
-              </Link>
-            </div>
+            <PanelHeader
+              title="This week"
+              meta={countMeta(
+                upcomingState,
+                upcomingReleases.length,
+                "release",
+              )}
+              action={{ label: "view mine →", to: "/releases?view=mine" }}
+            />
 
-            {isLoading && (
-              <div className="font-mono text-[11px] text-muted-foreground py-4">
-                loading releases…
-              </div>
-            )}
-
-            {!isLoading && upcoming.length === 0 && (
-              <div className="font-mono text-[11px] text-muted-foreground py-4">
-                nothing upcoming this week
-              </div>
-            )}
-
-            {upcoming.slice(0, 6).map((u, i) => (
-              <div
-                key={`${u.ComicID}-${u.IssueNumber}-${i}`}
-                className="flex items-center gap-2.5 py-2.5"
-                style={{
-                  borderTop:
-                    i > 0
-                      ? "1px solid var(--border-soft, var(--border))"
-                      : "none",
-                }}
-              >
-                <div className="font-mono text-[10px] text-muted-foreground w-12 shrink-0">
-                  {u.IssueDate?.slice(5) || "—"}
-                </div>
-                <div className="flex-1 min-w-0">
-                  <Link
-                    to={`/library/${u.ComicID}`}
-                    className="text-[12px] truncate block hover:text-[var(--primary)]"
+            <PanelBody
+              state={upcomingState}
+              label="This week"
+              skeleton={<PanelSkeleton rows={4} rowHeight={41} />}
+              empty="nothing upcoming this week"
+              onRetry={() => void upcoming.refetch()}
+              isRetrying={upcoming.isFetching}
+            >
+              {() =>
+                upcomingReleases.slice(0, 6).map((u, i) => (
+                  <div
+                    key={`${u.ComicID}-${u.IssueNumber}-${i}`}
+                    className="flex items-center gap-2.5 py-2.5"
+                    style={{
+                      borderTop:
+                        i > 0
+                          ? "1px solid var(--border-soft, var(--border))"
+                          : "none",
+                    }}
                   >
-                    {u.ComicName}
-                  </Link>
-                  <div className="font-mono text-[10px] text-muted-foreground">
-                    #{u.IssueNumber}
+                    <div className="font-mono text-[10px] text-muted-foreground w-12 shrink-0">
+                      {u.IssueDate?.slice(5) || "—"}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <Link
+                        to={`/library/${u.ComicID}`}
+                        className="text-[12px] truncate block hover:text-[var(--primary)]"
+                      >
+                        {u.ComicName}
+                      </Link>
+                      <div className="font-mono text-[10px] text-muted-foreground">
+                        #{u.IssueNumber}
+                      </div>
+                    </div>
+                    <div className="font-mono text-[10px] text-muted-foreground">
+                      {u.Status || "auto"}
+                    </div>
                   </div>
-                </div>
-                <div className="font-mono text-[10px] text-muted-foreground">
-                  {u.Status || "auto"}
-                </div>
-              </div>
-            ))}
+                ))
+              }
+            </PanelBody>
 
             <div className="mt-4 p-3 rounded-[6px] border border-border bg-card">
               <div className="flex items-center justify-between gap-2 mb-1.5">
@@ -474,27 +551,32 @@ export default function DashboardPage() {
                   all →
                 </Link>
               </div>
-              {recentChats.length === 0 ? (
-                <div className="font-mono text-[11px] text-muted-foreground py-1">
-                  no saved chats yet
-                </div>
-              ) : (
-                recentChats.map((thread) => (
-                  <Link
-                    key={thread.id}
-                    to={`/chat/${thread.id}`}
-                    className="block px-2 py-1.5 -mx-1 rounded-[6px] hover:bg-accent"
-                  >
-                    <div className="text-[12px] font-medium truncate">
-                      {thread.title}
-                    </div>
-                    <div className="mono-meta text-[10px]">
-                      {thread.message_count} msgs ·{" "}
-                      <RelativeTime value={thread.updated_at} />
-                    </div>
-                  </Link>
-                ))
-              )}
+              <PanelBody
+                state={chatsState}
+                label="Recent chats"
+                skeleton={<PanelSkeleton rows={3} rowHeight={33} />}
+                empty="no saved chats yet"
+                onRetry={() => void chatThreadsQuery.refetch()}
+                isRetrying={chatThreadsQuery.isFetching}
+              >
+                {() =>
+                  recentChats.map((thread) => (
+                    <Link
+                      key={thread.id}
+                      to={`/chat/${thread.id}`}
+                      className="block px-2 py-1.5 -mx-1 rounded-[6px] hover:bg-accent"
+                    >
+                      <div className="text-[12px] font-medium truncate">
+                        {thread.title}
+                      </div>
+                      <div className="mono-meta text-[10px]">
+                        {thread.message_count} msgs ·{" "}
+                        <RelativeTime value={thread.updated_at} />
+                      </div>
+                    </Link>
+                  ))
+                }
+              </PanelBody>
             </div>
           </section>
         </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { ArrowUp, RefreshCw } from "lucide-react";
 import {
   PanelBody,
   PanelSkeleton,
+  PanelUnavailable,
 } from "@/components/dashboard/DashboardPanel";
 import { panelState, type PanelState } from "@/lib/panelState";
 import { Kbd } from "@/components/ui/kbd";
@@ -121,6 +122,13 @@ function countMeta(state: PanelState, count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
+/** The header's version of the same rule: a fact only once a panel has one. */
+function summarize(state: PanelState, source: string, fact: string): string {
+  if (state === "loading") return "loading…";
+  if (state === "unavailable") return `${source} unavailable`;
+  return fact;
+}
+
 const ASK_SUGGESTIONS = [
   "Which runs have gaps?",
   "What landed this week?",
@@ -180,21 +188,24 @@ export default function DashboardPage() {
     mangaScan.isPending ||
     comicScanning ||
     mangaScanning;
+  // A failed read is not a library that was never configured. The button only
+  // renders once the read succeeded, so "Configure a library directory first"
+  // can never end up naming the wrong cause; a failed read says so instead.
   const canScan = Boolean(scanTargets.data?.comic || scanTargets.data?.manga);
+  const scanTitle = canScan
+    ? "Scan configured comic and manga libraries"
+    : "Configure a library directory first";
 
-  // The summary line reports each source separately: a broken one says so
-  // rather than contributing a zero to a line that reads as fact.
+  // The summary repeats each panel's own verdict rather than re-deriving it,
+  // so a broken source says so instead of contributing a zero that reads as
+  // fact. `panelState` stays the only place the precedence lives.
   const summary = [
-    library.isError
-      ? "library unavailable"
-      : library.isPending
-        ? "loading…"
-        : `${activeSeries} series · ${totalIssues} issues`,
-    queue.isError
-      ? "queue unavailable"
-      : queue.isPending
-        ? "loading…"
-        : `${queueCount} in queue`,
+    summarize(
+      libraryState,
+      "library",
+      `${activeSeries} series · ${totalIssues} issues`,
+    ),
+    summarize(queueCountState, "queue", `${queueCount} in queue`),
   ].join(" · ");
 
   const handleLibraryScan = async () => {
@@ -249,23 +260,27 @@ export default function DashboardPage() {
             {summary}
           </div>
         </div>
-        <button
-          type="button"
-          onClick={() => void handleLibraryScan()}
-          disabled={!canScan || scanPending}
-          title={
-            canScan
-              ? "Scan configured comic and manga libraries"
-              : "Configure a library directory first"
-          }
-          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[5px] border text-[12px] font-medium disabled:opacity-50"
-          style={{ borderColor: "var(--border)" }}
-        >
-          <RefreshCw
-            className={`w-3.5 h-3.5 ${scanPending ? "animate-spin" : ""}`}
+        {scanTargets.isError ? (
+          <PanelUnavailable
+            label="Scan targets"
+            onRetry={() => void scanTargets.refetch()}
+            isRetrying={scanTargets.isFetching}
           />
-          {scanPending ? "Scanning…" : "Scan libraries"}
-        </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void handleLibraryScan()}
+            disabled={!canScan || scanPending}
+            title={scanTitle}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[5px] border text-[12px] font-medium disabled:opacity-50"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <RefreshCw
+              className={`w-3.5 h-3.5 ${scanPending ? "animate-spin" : ""}`}
+            />
+            {scanPending ? "Scanning…" : "Scan libraries"}
+          </button>
+        )}
       </div>
 
       {/* Ask bar — a question here opens as a chat instead of a search */}
@@ -427,7 +442,7 @@ export default function DashboardPage() {
               >
                 {() => (
                   <div className="font-mono text-[11px]">
-                    {activityEvents.slice(0, 5).map((d, i) => {
+                    {activityEvents.map((d, i) => {
                       const action = d.Status?.toLowerCase() || "—";
                       const color = action.includes("down")
                         ? "var(--chart-4)"
@@ -508,7 +523,7 @@ export default function DashboardPage() {
               isRetrying={upcoming.isFetching}
             >
               {() =>
-                upcomingReleases.slice(0, 6).map((u, i) => (
+                upcomingReleases.map((u, i) => (
                   <div
                     key={`${u.ComicID}-${u.IssueNumber}-${i}`}
                     className="flex items-center gap-2.5 py-2.5"

--- a/frontend/tests/components/AppStatusBar.test.tsx
+++ b/frontend/tests/components/AppStatusBar.test.tsx
@@ -110,7 +110,7 @@ describe("AppStatusBar", () => {
 
   it("shows unreachable when library and api are both down", async () => {
     server.use(
-      http.get("/api/dashboard", () =>
+      http.get("/api/dashboard/library", () =>
         HttpResponse.json({ detail: "Database unavailable" }, { status: 503 }),
       ),
       http.get("/api/health", () =>

--- a/frontend/tests/lib/panelState.test.ts
+++ b/frontend/tests/lib/panelState.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { panelState } from "@/lib/panelState";
+
+describe("panelState", () => {
+  it("reports a failed source as unavailable, never as empty", () => {
+    expect(
+      panelState({ isPending: false, isError: true }, true),
+    ).toBe("unavailable");
+  });
+
+  it("prefers unavailable over loading while a failed query refetches", () => {
+    expect(panelState({ isPending: true, isError: true }, false)).toBe(
+      "unavailable",
+    );
+  });
+
+  it("is loading until the query answers", () => {
+    expect(panelState({ isPending: true, isError: false }, true)).toBe(
+      "loading",
+    );
+  });
+
+  it("is empty only once an answer says so", () => {
+    expect(panelState({ isPending: false, isError: false }, true)).toBe("empty");
+  });
+
+  it("has content when the answer is non-empty", () => {
+    expect(panelState({ isPending: false, isError: false }, false)).toBe(
+      "content",
+    );
+  });
+});

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -156,9 +156,38 @@ export const handlers = [
   // Dashboard endpoints
   // -------------------------------------------------------------------------
 
-  http.get("/api/dashboard", () => {
-    return HttpResponse.json({
-      recently_downloaded: [
+  http.get("/api/dashboard/library", () =>
+    HttpResponse.json({
+      stats: {
+        total_series: 10,
+        total_issues: 250,
+        total_expected: 500,
+        completion_pct: 50.0,
+      },
+    }),
+  ),
+
+  http.get("/api/dashboard/queue", () =>
+    HttpResponse.json({
+      count: 2,
+      items: [
+        {
+          ID: "queue-1",
+          series: "Spider-Man",
+          filename: "Spider-Man 001.cbz",
+          status: "Downloading",
+          updated_date: "2026-04-05T12:00:00",
+          site: "DDL(GetComics)",
+          comicid: "1",
+        },
+      ],
+    }),
+  ),
+
+  http.get("/api/dashboard/activity", () =>
+    HttpResponse.json({
+      days: 30,
+      events: [
         {
           ComicName: "Spider-Man",
           Issue_Number: "1",
@@ -170,18 +199,12 @@ export const handlers = [
           ComicImage: "https://example.com/spiderman.jpg",
         },
       ],
-      active_queue: [
-        {
-          ID: "queue-1",
-          series: "Spider-Man",
-          filename: "Spider-Man 001.cbz",
-          status: "Downloading",
-          updated_date: "2026-04-05T12:00:00",
-          site: "DDL(GetComics)",
-          comicid: "1",
-        },
-      ],
-      upcoming_releases: [
+    }),
+  ),
+
+  http.get("/api/dashboard/upcoming", () =>
+    HttpResponse.json({
+      releases: [
         {
           ComicName: "Batman",
           IssueNumber: "5",
@@ -191,18 +214,12 @@ export const handlers = [
           Status: "Wanted",
         },
       ],
-      stats: {
-        total_series: 10,
-        total_issues: 250,
-        total_expected: 500,
-        completion_pct: 50.0,
-        queue_count: 2,
-      },
-      ai_activity: [],
-      ai_configured: false,
-      scan_targets: { comic: true, manga: true },
-    });
-  }),
+    }),
+  ),
+
+  http.get("/api/dashboard/scan-targets", () =>
+    HttpResponse.json({ comic: true, manga: true }),
+  ),
 
   http.post("/api/weekly/refresh", () =>
     HttpResponse.json({

--- a/frontend/tests/pages/DashboardPage.test.tsx
+++ b/frontend/tests/pages/DashboardPage.test.tsx
@@ -277,7 +277,10 @@ describe("DashboardPage", () => {
     const user = userEvent.setup();
     render(<DashboardPage />);
 
-    await user.click(await screen.findByRole("button", { name: /retry/ }));
+    // Each retry is named for its own panel, so it is unambiguous.
+    await user.click(
+      await screen.findByRole("button", { name: "Retry Recent activity" }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Spider-Man #1")).toBeTruthy();
@@ -302,6 +305,25 @@ describe("DashboardPage", () => {
     expect(screen.getAllByText("unavailable").length).toBe(3);
     expect(screen.getByText("2")).toBeTruthy();
     expect(screen.queryByText("50.0%")).toBeNull();
+  });
+
+  it("says so when the scan targets cannot be read", async () => {
+    server.use(
+      http.get("/api/dashboard/scan-targets", () =>
+        HttpResponse.json({ detail: "Config unavailable" }, { status: 503 }),
+      ),
+    );
+
+    render(<DashboardPage />);
+
+    // A failed read must not read as "no library configured".
+    await waitFor(() => {
+      expect(screen.getByText("Scan targets unavailable")).toBeTruthy();
+    });
+    expect(screen.queryByRole("button", { name: "Scan libraries" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Retry Scan targets" }),
+    ).toBeTruthy();
   });
 
   it("renders the recent chats card", async () => {

--- a/frontend/tests/pages/DashboardPage.test.tsx
+++ b/frontend/tests/pages/DashboardPage.test.tsx
@@ -178,21 +178,18 @@ describe("DashboardPage", () => {
 
   it("shows empty states when no data", async () => {
     server.use(
-      http.get("/api/dashboard", () => {
-        return HttpResponse.json({
-          recently_downloaded: [],
-          active_queue: [],
-          upcoming_releases: [],
-          stats: {
-            total_series: 0,
-            total_issues: 0,
-            total_expected: 0,
-            completion_pct: 0,
-          },
-          ai_activity: [],
-          ai_configured: false,
-        });
-      }),
+      http.get("/api/dashboard/queue", () =>
+        HttpResponse.json({ count: 0, items: [] }),
+      ),
+      http.get("/api/dashboard/activity", () =>
+        HttpResponse.json({ days: 30, events: [] }),
+      ),
+      http.get("/api/dashboard/upcoming", () =>
+        HttpResponse.json({ releases: [] }),
+      ),
+      http.get("/api/dashboard/scan-targets", () =>
+        HttpResponse.json({ comic: false, manga: false }),
+      ),
     );
 
     render(<DashboardPage />);
@@ -211,22 +208,8 @@ describe("DashboardPage", () => {
 
   it("links the recent empty state to the full history", async () => {
     server.use(
-      http.get("/api/dashboard", () =>
-        HttpResponse.json({
-          recently_downloaded: [],
-          active_queue: [],
-          upcoming_releases: [],
-          stats: {
-            total_series: 1,
-            total_issues: 1,
-            total_expected: 1,
-            completion_pct: 100,
-            queue_count: 0,
-          },
-          ai_activity: [],
-          ai_configured: false,
-          scan_targets: { comic: false, manga: false },
-        }),
+      http.get("/api/dashboard/activity", () =>
+        HttpResponse.json({ days: 30, events: [] }),
       ),
     );
 
@@ -235,6 +218,90 @@ describe("DashboardPage", () => {
     expect(
       await screen.findByRole("link", { name: "open full history" }),
     ).toBeTruthy();
+  });
+
+  it("keeps every other panel rendered when one source fails", async () => {
+    server.use(
+      http.get("/api/dashboard/activity", () =>
+        HttpResponse.json({ detail: "Database unavailable" }, { status: 503 }),
+      ),
+    );
+
+    render(<DashboardPage />);
+
+    // The failing panel says so; it does not claim a quiet month.
+    await waitFor(() => {
+      expect(screen.getByText("Recent activity unavailable")).toBeTruthy();
+    });
+    expect(screen.queryByText(/no activity in the last 30 days/)).toBeNull();
+
+    // Neighbours still render their own content.
+    expect(screen.getByText("Spider-Man 001.cbz")).toBeTruthy();
+    expect(screen.getByText("Batman")).toBeTruthy();
+    expect(screen.getByText("50.0%")).toBeTruthy();
+  });
+
+  it("retries only the panel that failed", async () => {
+    let activityRequests = 0;
+    let upcomingRequests = 0;
+    server.use(
+      http.get("/api/dashboard/activity", () => {
+        activityRequests += 1;
+        return activityRequests === 1
+          ? HttpResponse.json(
+              { detail: "Database unavailable" },
+              { status: 503 },
+            )
+          : HttpResponse.json({
+              days: 30,
+              events: [
+                {
+                  ComicName: "Spider-Man",
+                  Issue_Number: "1",
+                  DateAdded: "2026-04-05T12:00:00",
+                  Status: "Snatched",
+                  Provider: "nzb",
+                  ComicID: "1",
+                  IssueID: "101",
+                  ComicImage: null,
+                },
+              ],
+            });
+      }),
+      http.get("/api/dashboard/upcoming", () => {
+        upcomingRequests += 1;
+        return HttpResponse.json({ releases: [] });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<DashboardPage />);
+
+    await user.click(await screen.findByRole("button", { name: /retry/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Spider-Man #1")).toBeTruthy();
+    });
+    expect(activityRequests).toBe(2);
+    expect(upcomingRequests).toBe(1);
+  });
+
+  it("reports an unavailable KPI instead of a zero it cannot back", async () => {
+    server.use(
+      http.get("/api/dashboard/library", () =>
+        HttpResponse.json({ detail: "Database unavailable" }, { status: 503 }),
+      ),
+    );
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/library unavailable/)).toBeTruthy();
+    });
+    // The three library tiles report unavailable; the queue tile still counts.
+    expect(screen.getAllByText("unavailable").length).toBe(3);
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.queryByText("50.0%")).toBeNull();
   });
 
   it("renders the recent chats card", async () => {

--- a/tests/unit/test_app_query_migrations.py
+++ b/tests/unit/test_app_query_migrations.py
@@ -24,7 +24,6 @@ from comicarr.app.ai import story_arcs as ai_story_arcs
 from comicarr.app.dashboard import queries as dashboard_queries
 from comicarr.app.weekly import queries as weekly_queries
 from comicarr.tables import (
-    ai_activity_log,
     ai_cache,
     ai_metadata_history,
     comics,
@@ -431,14 +430,6 @@ def test_dashboard_helpers_keep_inclusive_cutoff_order_and_content_type_totals(q
                 },
             ],
         )
-        conn.execute(
-            insert(ai_activity_log),
-            [
-                {"timestamp": "2026-06-10T12:00:00", "feature_type": "older", "success": "true"},
-                {"timestamp": "2026-06-10T12:00:01", "feature_type": "newer", "success": "true"},
-            ],
-        )
-
     recent = dashboard_queries.get_recent_activity("2026-06-10 12:00:00")
     assert [row["IssueID"] for row in recent] == ["newest", "boundary"]
     assert dashboard_queries.get_library_stats() == {
@@ -456,7 +447,6 @@ def test_dashboard_helpers_keep_inclusive_cutoff_order_and_content_type_totals(q
         "comic_have": 5,
         "comic_total": 10,
     }
-    assert [row["feature_type"] for row in dashboard_queries.get_recent_ai_activity()] == ["newer", "older"]
 
 
 def test_weekly_helper_matches_unpadded_week_and_orders_by_title(query_db):

--- a/tests/unit/test_dashboard_service.py
+++ b/tests/unit/test_dashboard_service.py
@@ -7,7 +7,7 @@
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 
-"""Tests for dashboard orchestration around Core query helpers."""
+"""Tests for the dashboard's panel-scoped reads."""
 
 from datetime import datetime
 from types import SimpleNamespace
@@ -20,60 +20,18 @@ from comicarr.app.dashboard import service
 
 @pytest.fixture(autouse=True)
 def _dashboard_dependencies(monkeypatch):
-    """Keep service tests focused on payload/default behavior, not database transport."""
-    runtime = SimpleNamespace(
-        AI_CLIENT=None,
-        CONFIG=SimpleNamespace(AI_BASE_URL=None, COMIC_DIR=None, MANGA_DIR=None),
-    )
+    """Keep service tests focused on panel shape, not database transport."""
+    runtime = SimpleNamespace(CONFIG=SimpleNamespace(COMIC_DIR=None, MANGA_DIR=None))
     monkeypatch.setattr(service, "comicarr", runtime)
     monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", lambda cutoff: [])
     monkeypatch.setattr(service.dashboard_queries, "get_library_stats", lambda content_type=None: None)
-    monkeypatch.setattr(service.dashboard_queries, "get_recent_ai_activity", lambda: [])
     monkeypatch.setattr(service.dl_queries, "count_active_ddl_items", lambda: 0)
     monkeypatch.setattr(service.dl_queries, "get_active_ddl_preview", lambda limit: [])
     monkeypatch.setattr(service.storyarcs_service, "get_upcoming", lambda include_downloaded: [])
 
 
-class TestGetDashboardData:
-    """Test dashboard aggregation and error defaults."""
-
-    def test_returns_recently_downloaded(self, monkeypatch):
-        recent = [{"ComicName": "Spider-Man", "Issue_Number": "1", "IssueID": "200"}]
-        monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", lambda cutoff: recent)
-
-        result = service.get_dashboard_data(None)
-
-        assert result["recently_downloaded"] == recent
-
-    def test_recent_activity_uses_an_inclusive_30_day_cutoff(self, monkeypatch):
-        cutoff = datetime(2026, 6, 10, 12, 0, 0)
-        seen = []
-        monkeypatch.setattr(service, "recent_activity_cutoff", lambda: cutoff)
-        monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", seen.append)
-
-        service.get_dashboard_data(None)
-
-        assert seen == ["2026-06-10 12:00:00"]
-
-    def test_returns_current_week_library_releases(self, monkeypatch):
-        upcoming = [{"ComicName": "Batman", "IssueNumber": "5", "Status": "Wanted"}]
-        get_upcoming = MagicMock(return_value=upcoming)
-        monkeypatch.setattr(service.storyarcs_service, "get_upcoming", get_upcoming)
-
-        result = service.get_dashboard_data(None)
-
-        get_upcoming.assert_called_once_with(include_downloaded=True)
-        assert result["upcoming_releases"] == upcoming
-
-    def test_returns_active_queue_projection(self, monkeypatch):
-        queue_items = [{"ID": "queued-1", "series": "Batman", "status": "Queued"}]
-        get_active_preview = MagicMock(return_value=queue_items)
-        monkeypatch.setattr(service.dl_queries, "get_active_ddl_preview", get_active_preview)
-
-        result = service.get_dashboard_data(None)
-
-        get_active_preview.assert_called_once_with(limit=5)
-        assert result["active_queue"] == queue_items
+class TestLibraryPanel:
+    """The KPI strip's aggregates."""
 
     def test_returns_combined_and_content_type_stats(self, monkeypatch):
         stats = {
@@ -85,14 +43,11 @@ class TestGetDashboardData:
             service.dashboard_queries, "get_library_stats", lambda content_type=None: stats[content_type]
         )
 
-        result = service.get_dashboard_data(None)
-
-        assert result["stats"] == {
+        assert service.get_library_panel()["stats"] == {
             "total_series": 10,
             "total_issues": 250,
             "total_expected": 500,
             "completion_pct": 50.0,
-            "queue_count": 0,
             "manga_series": 2,
             "manga_have": 10,
             "manga_total": 20,
@@ -101,67 +56,6 @@ class TestGetDashboardData:
             "comic_have": 240,
             "comic_total": 480,
         }
-
-    def test_returns_active_queue_count_and_scan_targets(self, monkeypatch):
-        service.comicarr.CONFIG.COMIC_DIR = "/comics"
-        service.comicarr.CONFIG.MANGA_DIR = "/manga"
-        monkeypatch.setattr(service.dl_queries, "count_active_ddl_items", lambda: 3)
-
-        result = service.get_dashboard_data(None)
-
-        assert result["stats"]["queue_count"] == 3
-        assert result["scan_targets"] == {"comic": True, "manga": True}
-
-    def test_queue_count_failure_preserves_other_stats(self, monkeypatch):
-        monkeypatch.setattr(
-            service.dashboard_queries,
-            "get_library_stats",
-            lambda content_type=None: (
-                {"total_series": 1, "total_issues": 1, "total_expected": 1} if content_type is None else None
-            ),
-        )
-        monkeypatch.setattr(
-            service.dl_queries, "count_active_ddl_items", MagicMock(side_effect=RuntimeError("count failed"))
-        )
-
-        result = service.get_dashboard_data(None)
-
-        assert result["stats"]["queue_count"] == 0
-        assert result["stats"]["total_series"] == 1
-
-    def test_returns_ai_activity_when_configured(self, monkeypatch):
-        service.comicarr.AI_CLIENT = MagicMock()
-        activity = [{"feature_type": "search", "success": True}]
-        monkeypatch.setattr(service.dashboard_queries, "get_recent_ai_activity", lambda: activity)
-
-        result = service.get_dashboard_data(None)
-
-        assert result["ai_configured"] is True
-        assert result["ai_activity"] == activity
-
-    def test_ai_not_configured_keeps_empty_activity(self):
-        result = service.get_dashboard_data(None)
-
-        assert result["ai_configured"] is False
-        assert result["ai_activity"] == []
-
-    def test_handles_query_errors_gracefully(self, monkeypatch):
-        monkeypatch.setattr(
-            service.dashboard_queries,
-            "get_recent_activity",
-            MagicMock(side_effect=RuntimeError("connection failed")),
-        )
-        monkeypatch.setattr(
-            service.dashboard_queries,
-            "get_library_stats",
-            MagicMock(side_effect=RuntimeError("connection failed")),
-        )
-
-        result = service.get_dashboard_data(None)
-
-        assert result["recently_downloaded"] == []
-        assert result["upcoming_releases"] == []
-        assert result["stats"] == {"queue_count": 0}
 
     def test_completion_percentage_is_zero_when_no_expected_issues(self, monkeypatch):
         monkeypatch.setattr(
@@ -172,6 +66,93 @@ class TestGetDashboardData:
             ),
         )
 
-        result = service.get_dashboard_data(None)
+        assert service.get_library_panel()["stats"]["completion_pct"] == 0
 
-        assert result["stats"]["completion_pct"] == 0
+    def test_a_failed_read_raises_instead_of_reporting_an_empty_library(self, monkeypatch):
+        monkeypatch.setattr(
+            service.dashboard_queries,
+            "get_library_stats",
+            MagicMock(side_effect=RuntimeError("connection failed")),
+        )
+
+        with pytest.raises(RuntimeError):
+            service.get_library_panel()
+
+
+class TestQueuePanel:
+    """The active-download count and its preview."""
+
+    def test_count_and_preview_share_the_active_predicate(self, monkeypatch):
+        queue_items = [{"ID": "queued-1", "series": "Batman", "status": "Queued"}]
+        get_active_preview = MagicMock(return_value=queue_items)
+        monkeypatch.setattr(service.dl_queries, "count_active_ddl_items", lambda: 3)
+        monkeypatch.setattr(service.dl_queries, "get_active_ddl_preview", get_active_preview)
+
+        panel = service.get_queue_panel()
+
+        get_active_preview.assert_called_once_with(limit=5)
+        assert panel == {"count": 3, "items": queue_items}
+
+    def test_a_failed_count_raises_instead_of_reporting_zero(self, monkeypatch):
+        monkeypatch.setattr(
+            service.dl_queries, "count_active_ddl_items", MagicMock(side_effect=RuntimeError("count failed"))
+        )
+
+        with pytest.raises(RuntimeError):
+            service.get_queue_panel()
+
+
+class TestActivityPanel:
+    """The bounded recent-activity preview."""
+
+    def test_returns_events_and_the_window_they_cover(self, monkeypatch):
+        recent = [{"ComicName": "Spider-Man", "Issue_Number": "1", "IssueID": "200"}]
+        monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", lambda cutoff: recent)
+
+        assert service.get_activity_panel() == {"events": recent, "days": 30}
+
+    def test_uses_an_inclusive_30_day_cutoff(self, monkeypatch):
+        seen = []
+        monkeypatch.setattr(service, "recent_activity_cutoff", lambda: datetime(2026, 6, 10, 12, 0, 0))
+        monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", seen.append)
+
+        service.get_activity_panel()
+
+        assert seen == ["2026-06-10 12:00:00"]
+
+    def test_a_failed_read_raises_instead_of_reporting_a_quiet_month(self, monkeypatch):
+        monkeypatch.setattr(
+            service.dashboard_queries,
+            "get_recent_activity",
+            MagicMock(side_effect=RuntimeError("connection failed")),
+        )
+
+        with pytest.raises(RuntimeError):
+            service.get_activity_panel()
+
+
+class TestUpcomingPanel:
+    """This week's releases for series already in the library."""
+
+    def test_returns_current_week_library_releases(self, monkeypatch):
+        upcoming = [{"ComicName": "Batman", "IssueNumber": "5", "Status": "Wanted"}]
+        get_upcoming = MagicMock(return_value=upcoming)
+        monkeypatch.setattr(service.storyarcs_service, "get_upcoming", get_upcoming)
+
+        panel = service.get_upcoming_panel()
+
+        get_upcoming.assert_called_once_with(include_downloaded=True)
+        assert panel == {"releases": upcoming}
+
+
+class TestScanTargets:
+    """Which libraries the header's scan action can start."""
+
+    def test_reports_each_configured_directory(self):
+        service.comicarr.CONFIG.COMIC_DIR = "/comics"
+        service.comicarr.CONFIG.MANGA_DIR = "/manga"
+
+        assert service.get_scan_targets() == {"comic": True, "manga": True}
+
+    def test_unconfigured_directories_are_not_scan_targets(self):
+        assert service.get_scan_targets() == {"comic": False, "manga": False}

--- a/tests/unit/test_dashboard_service.py
+++ b/tests/unit/test_dashboard_service.py
@@ -23,7 +23,7 @@ def _dashboard_dependencies(monkeypatch):
     """Keep service tests focused on panel shape, not database transport."""
     runtime = SimpleNamespace(CONFIG=SimpleNamespace(COMIC_DIR=None, MANGA_DIR=None))
     monkeypatch.setattr(service, "comicarr", runtime)
-    monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", lambda cutoff: [])
+    monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", lambda cutoff, limit: [])
     monkeypatch.setattr(service.dashboard_queries, "get_library_stats", lambda content_type=None: None)
     monkeypatch.setattr(service.dl_queries, "count_active_ddl_items", lambda: 0)
     monkeypatch.setattr(service.dl_queries, "get_active_ddl_preview", lambda limit: [])
@@ -107,14 +107,19 @@ class TestActivityPanel:
 
     def test_returns_events_and_the_window_they_cover(self, monkeypatch):
         recent = [{"ComicName": "Spider-Man", "Issue_Number": "1", "IssueID": "200"}]
-        monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", lambda cutoff: recent)
+        get_recent = MagicMock(return_value=recent)
+        monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", get_recent)
 
         assert service.get_activity_panel() == {"events": recent, "days": 30}
+        # The count the panel shows and the rows it renders share one bound.
+        assert get_recent.call_args.kwargs["limit"] == 5
 
     def test_uses_an_inclusive_30_day_cutoff(self, monkeypatch):
         seen = []
         monkeypatch.setattr(service, "recent_activity_cutoff", lambda: datetime(2026, 6, 10, 12, 0, 0))
-        monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", seen.append)
+        monkeypatch.setattr(
+            service.dashboard_queries, "get_recent_activity", lambda cutoff, limit: seen.append(cutoff)
+        )
 
         service.get_activity_panel()
 
@@ -144,6 +149,12 @@ class TestUpcomingPanel:
         get_upcoming.assert_called_once_with(include_downloaded=True)
         assert panel == {"releases": upcoming}
 
+    def test_bounds_the_preview_so_the_count_matches_the_rows(self, monkeypatch):
+        releases = [{"ComicName": f"Series {n}"} for n in range(10)]
+        monkeypatch.setattr(service.storyarcs_service, "get_upcoming", lambda include_downloaded: releases)
+
+        assert service.get_upcoming_panel()["releases"] == releases[:6]
+
 
 class TestScanTargets:
     """Which libraries the header's scan action can start."""
@@ -156,3 +167,8 @@ class TestScanTargets:
 
     def test_unconfigured_directories_are_not_scan_targets(self):
         assert service.get_scan_targets() == {"comic": False, "manga": False}
+
+    def test_a_whitespace_only_path_is_not_a_scan_target(self):
+        service.comicarr.CONFIG.COMIC_DIR = "   "
+
+        assert service.get_scan_targets()["comic"] is False

--- a/tests/unit/test_ledger_retention_ux.py
+++ b/tests/unit/test_ledger_retention_ux.py
@@ -12,7 +12,7 @@
 Seams under test (existing product surfaces only — no full UI e2e):
 
 - ``search_service.get_run`` — pruned run id → existing 404 / missing contract
-- ``dashboard_queries.get_recent_ai_activity`` — empty list is honest, not an error
+- ``ai_activity_log`` — an emptied AI log is honestly empty, never tombstoned
 - ``health.get_acquisition_health`` — latest run falls back to newest remaining
   or omits the kind; never invents healthy history from empty
 - ``series_service.get_wanted`` — pruned latest terminal → null acquisition
@@ -37,7 +37,6 @@ from comicarr.app.acquisition.models import ItemOutcome
 from comicarr.app.acquisition.runs import RunLedger
 from comicarr.app.activity import queries as activity_queries
 from comicarr.app.core.context import AppContext
-from comicarr.app.dashboard import queries as dashboard_queries
 from comicarr.app.downloads import journal
 from comicarr.app.search import health
 from comicarr.app.search import service as search_service
@@ -73,6 +72,13 @@ def _ctx():
 
 def _iso(days_ago):
     return (FIXED_NOW - datetime.timedelta(days=days_ago)).isoformat()
+
+
+def _ai_activity_rows(limit=10):
+    """Return the AI activity log newest-first — retention's read side."""
+    stmt = select(ai_activity_log.c.action_description).order_by(ai_activity_log.c.timestamp.desc()).limit(limit)
+    with get_engine().connect() as conn:
+        return [row.action_description for row in conn.execute(stmt)]
 
 
 def _journal_ts(days_ago):
@@ -175,14 +181,12 @@ def test_ai_feed_empty_list_is_honest_after_prune(monkeypatch):
             ],
         )
 
-    assert len(dashboard_queries.get_recent_ai_activity(limit=10)) == 2
+    assert len(_ai_activity_rows()) == 2
 
     summary = retention.run_ledger_retention(now=FIXED_NOW)
     assert summary["ai_activity_log"] == 1
 
-    remaining = dashboard_queries.get_recent_ai_activity(limit=10)
-    assert len(remaining) == 1
-    assert remaining[0]["action_description"] == "young"
+    assert _ai_activity_rows() == ["young"]
 
     # Prune the last young row by forcing age past horizon with keep floor 0.
     with get_engine().begin() as conn:
@@ -192,8 +196,7 @@ def test_ai_feed_empty_list_is_honest_after_prune(monkeypatch):
     summary2 = retention.run_ledger_retention(now=FIXED_NOW)
     assert summary2["ai_activity_log"] == 1
 
-    empty = dashboard_queries.get_recent_ai_activity(limit=10)
-    assert empty == []
+    assert _ai_activity_rows() == []
 
 
 def test_acquisition_health_falls_back_to_newest_remaining_or_omits(monkeypatch):
@@ -435,7 +438,7 @@ def test_no_tombstone_rows_written_by_sweep(monkeypatch):
     retention.run_ledger_retention(now=FIXED_NOW)
 
     assert ledger.get_run("gone") is None
-    assert dashboard_queries.get_recent_ai_activity() == []
+    assert _ai_activity_rows() == []
     # Tables empty — no tombstone substitute rows.
     with get_engine().connect() as conn:
         assert conn.execute(select(func.count()).select_from(acquisition_runs)).scalar() == 0


### PR DESCRIPTION
Implements #577. Part of #576 — the prefactor that makes the four panel slices behind it straightforward.

## The problem

The dashboard fetched one `/api/dashboard` payload. Any failure in it blanked the whole page, and no panel could degrade on its own.

The sharper problem was underneath: `get_dashboard_data` wrapped every section in `try/except` and logged. A failed read therefore arrived at the client as an empty list — a broken panel and a genuinely quiet week were byte-identical. That is precisely the silent failure [§5 of the dashboard spec](https://github.com/frankieramirez/comicarr/blob/main/docs/architecture/dashboard-spec.md) exists to prevent.

## What changed

**Backend.** `GET /api/dashboard` is gone. One route per panel: `/library`, `/queue`, `/activity`, `/upcoming`, `/scan-targets`. The service functions behind them **raise instead of returning a default** — that inversion is the substantive change, not the route split. A panel that cannot be answered is now loud enough for the client to say so.

**Frontend.** Five hooks in `useDashboard.ts`, one per panel. The shared shell is `components/dashboard/DashboardPanel.tsx` (`PanelBody`, `PanelSkeleton`, `PanelUnavailable`, `PanelNote`); the state derivation is the pure `lib/panelState.ts`, so exactly one place decides empty-vs-unavailable and it is unit-testable. `panelState` checks `isError` **before** `isPending`, so a panel refetching after a failure keeps saying unavailable rather than flickering back to a skeleton.

The page-level `ErrorDisplay` early return is deleted — no single query can blank the page any more. The KPI strip is mixed-source (three tiles read the library, the fourth the queue), so `Kpi` takes a state and renders `unavailable` plus a scoped retry in the value slot rather than a zero it cannot back; the header summary line reports each source separately for the same reason.

`AppStatusBar` was the other consumer of the aggregate payload and now reads the library panel.

**Panel content and page order are unchanged by this PR.**

## Two calls worth review

**`get_recent_ai_activity` is deleted.** Its only consumer was the aggregate payload's `ai_activity` field, which no component renders (`AiInsightsPanel` is already dead code taking props). Two tests in `test_ledger_retention_ux.py` were using it as the *read seam* for AI-log retention; they now assert against `ai_activity_log` directly, which is what retention actually manipulates. The log is still written and still pruned.

**Scan targets got their own route** rather than riding on the library panel. The header's scan button is not a panel, and hanging it off the library read would have disabled it whenever library stats failed.

## Verification

- `npm run lint` clean
- 2137 backend tests pass
- 337 frontend tests pass

New coverage: one-panel-fails-others-render, retry-only-the-failed-panel (asserts the neighbour was *not* refetched), the unavailable KPI, the empty paths, and `tests/lib/panelState.test.ts` pinning the derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzBsLP3pDhbiJXBdFiWVj6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard panels now load independently for library stats, queue, activity, upcoming releases, and scan targets.
  * Added loading skeletons, panel-specific unavailable states, and retry actions.
  * Empty results remain distinct from unavailable or loading data.
* **Bug Fixes**
  * Prevented failed panel data from appearing as zero values.
  * Preserved dashboard layout and information order while individual panels refresh or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->