### PR TITLE
feat: Add the dashboard health band with the last-successful-search line

### DIFF
--- a/.changeset/lucky-owls-listen.md
+++ b/.changeset/lucky-owls-listen.md
@@ -1,0 +1,9 @@
+---
+"comicarr": patch
+---
+
+The dashboard now opens with a health band that answers the only question worth opening it for: is anything broken right now? It reports whether a download route is usable, how many indexers are responding, and whether the workers are running — one quiet line when everything is fine, amber naming the specific component when it is not, and red with a link straight to the settings page that fixes it when nothing can get through.
+
+Alongside those it carries a **last successful search** line, which is the one that matters most. Every other signal reports the state of a component; this one reports whether searching has actually produced anything lately, and it goes amber once nothing has run for twice your search interval. That is the reading that catches the failure the rest of the page cannot: for weeks, downloads could be completely broken while every component reported itself fine and the dashboard looked like a quiet week. This line would have read "11 days ago".
+
+The band never guesses in your favour. If the health check itself cannot be reached, it says "Cannot determine health" rather than going quiet — an unanswered question is not good news. And the last-successful-search line is never hidden, at any age, including when nothing has ever run.

--- a/frontend/src/components/dashboard/HealthBand.tsx
+++ b/frontend/src/components/dashboard/HealthBand.tsx
@@ -1,0 +1,174 @@
+import { useSyncExternalStore } from "react";
+import { AlertTriangle, Check, RefreshCw } from "lucide-react";
+import { Link } from "react-router-dom";
+import { useSearchHealth } from "@/hooks/useAcquisitionHealth";
+import { useConfig } from "@/hooks/useConfig";
+import {
+  DEFAULT_SEARCH_INTERVAL_MINUTES,
+  healthBandView,
+  type HealthBandView,
+  type HealthTone,
+} from "@/lib/healthBand";
+
+/**
+ * The top of the dashboard: quiet when the automation is fine, unmissable when
+ * it is not (docs/architecture/dashboard-spec.md §3.1).
+ *
+ * It is a band rather than a card because it is not one panel among panels —
+ * it is the answer to the only question whose answer can require action today.
+ * Its one hard rule: it never infers health from the absence of bad news. A
+ * failing health endpoint renders degraded ("Cannot determine health"), never
+ * healthy and never absent.
+ */
+
+/** How often the last-successful-search age re-reads the clock. */
+const TICK_MS = 30_000;
+
+function subscribeToClock(onTick: () => void): () => void {
+  const tick = setInterval(onTick, TICK_MS);
+  return () => clearInterval(tick);
+}
+
+/**
+ * The wall clock, read as the external system it is — reading it during render
+ * would be impure, and the last-successful-search age has to keep growing while
+ * the page sits open. Quantized to the tick so the snapshot is stable between
+ * ticks; nothing here needs sub-half-minute precision.
+ */
+function readClock(): number {
+  return Math.floor(Date.now() / TICK_MS) * TICK_MS;
+}
+
+function useNow(): number {
+  return useSyncExternalStore(subscribeToClock, readClock, readClock);
+}
+
+const TONE_COLOR: Record<HealthTone, string> = {
+  healthy: "var(--status-active)",
+  degraded: "var(--status-paused)",
+  blocked: "var(--status-error)",
+};
+
+const TONE_BG: Record<HealthTone, string> = {
+  healthy: "transparent",
+  degraded: "var(--status-paused-bg)",
+  blocked: "var(--status-error-bg)",
+};
+
+/** A row for a signal that needs the operator's eye, with its fix link. */
+function SignalRow({ signal }: { signal: HealthBandView["signals"][number] }) {
+  return (
+    <div className="flex items-center gap-2 font-mono text-[11px]">
+      <AlertTriangle
+        className="w-3 h-3 shrink-0"
+        style={{ color: TONE_COLOR[signal.tone] }}
+        aria-hidden="true"
+      />
+      <span style={{ color: TONE_COLOR[signal.tone] }}>{signal.text}</span>
+      {signal.fix && (
+        <Link
+          to={signal.fix.to}
+          className="text-muted-foreground hover:text-foreground underline decoration-dotted"
+        >
+          {signal.fix.label} →
+        </Link>
+      )}
+    </div>
+  );
+}
+
+export default function HealthBand() {
+  const health = useSearchHealth();
+  const config = useConfig();
+  const now = useNow();
+
+  if (health.isPending) {
+    return (
+      <div
+        className="px-5 py-3 border-b border-border"
+        data-testid="health-band-loading"
+      >
+        {/* Two rows at the height of the resolved band, so it does not shift. */}
+        <div aria-hidden="true" className="flex flex-col gap-2">
+          <div className="h-2.5 w-72 animate-pulse rounded-[2px] bg-primary/10" />
+          <div className="h-2.5 w-52 animate-pulse rounded-[2px] bg-primary/10" />
+        </div>
+      </div>
+    );
+  }
+
+  // A failed read is `unknown`, not healthy: `healthBandView` renders degraded
+  // for a null payload rather than letting a missing answer read as a good one.
+  const view = healthBandView({
+    health: health.isError ? null : (health.data ?? null),
+    searchIntervalMinutes:
+      config.data?.search_interval ?? DEFAULT_SEARCH_INTERVAL_MINUTES,
+    now,
+  });
+
+  const quiet = view.signals.filter((signal) => signal.tone === "healthy");
+  const loud = view.signals.filter((signal) => signal.tone !== "healthy");
+
+  return (
+    <section
+      aria-label="Acquisition health"
+      data-tone={view.tone}
+      className="px-5 py-3 border-b border-border"
+      style={{
+        background: TONE_BG[view.tone],
+        boxShadow:
+          view.tone === "healthy"
+            ? undefined
+            : `inset 3px 0 0 ${TONE_COLOR[view.tone]}`,
+      }}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+        <div className="flex flex-col gap-1.5 min-w-0">
+          {loud.map((signal) => (
+            <SignalRow key={signal.key} signal={signal} />
+          ))}
+
+          {quiet.length > 0 && (
+            <div className="flex items-center gap-2 font-mono text-[11px] text-muted-foreground">
+              {loud.length === 0 && (
+                <Check
+                  className="w-3 h-3 shrink-0"
+                  style={{ color: TONE_COLOR.healthy }}
+                  aria-hidden="true"
+                />
+              )}
+              <span className="truncate">
+                {quiet.map((signal) => signal.text).join(" · ")}
+              </span>
+            </div>
+          )}
+
+          {/* Never hidden, in any state, at any age. */}
+          <div
+            className="font-mono text-[11px]"
+            style={{
+              color: view.lastSearch.stale
+                ? TONE_COLOR.degraded
+                : "var(--muted-foreground)",
+            }}
+          >
+            {view.lastSearch.text}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => void health.refetch()}
+          disabled={health.isFetching}
+          aria-label="Recheck acquisition health"
+          className="inline-flex shrink-0 items-center gap-1.5 px-2 py-1 rounded-[5px] border border-border font-mono text-[11px] text-muted-foreground hover:text-foreground disabled:opacity-50"
+        >
+          <RefreshCw
+            className={`w-3 h-3 ${health.isFetching ? "animate-spin" : ""}`}
+          />
+          {health.isFetching ? "checking…" : "recheck"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/hooks/useAcquisitionHealth.ts
+++ b/frontend/src/hooks/useAcquisitionHealth.ts
@@ -271,6 +271,24 @@ export function sanitizeAcquisitionMessage(value: unknown): string {
 }
 
 /**
+ * The acquisition-health read on its own, for callers that need the health
+ * projection and nothing else — the dashboard health band reads only
+ * `/api/search/health` (docs/architecture/dashboard-spec.md §3.1) and has no use
+ * for the scheduler and diagnostics reads `useAcquisitionHealth` also polls.
+ *
+ * Same query key, so the two share one cache entry and can never disagree.
+ */
+export function useSearchHealth() {
+  return useQuery<AcquisitionHealthResponse>({
+    queryKey: ["acquisition", "health"],
+    queryFn: () =>
+      apiRequest<AcquisitionHealthResponse>("GET", "/api/search/health"),
+    staleTime: 5_000,
+    refetchInterval: HEALTH_POLL_MS,
+  });
+}
+
+/**
  * Load the independent health projections and expose session-cookie-backed
  * repair operations. A repair is only polled after the operator has applied
  * or rolled it back; preview remains read-only and token-bound.

--- a/frontend/src/lib/healthBand.ts
+++ b/frontend/src/lib/healthBand.ts
@@ -1,0 +1,389 @@
+/**
+ * The health band's reading of `GET /api/search/health` — the whole derivation,
+ * pure, with no React and no I/O (docs/architecture/dashboard-spec.md §3.1).
+ *
+ * Two rules shape everything here:
+ *
+ * 1. **Absence of evidence is not health.** A missing payload is `unknown`, and
+ *    `unknown` renders degraded. Every signal that cannot be substantiated says
+ *    so rather than falling through to the healthy phrasing.
+ * 2. **Last successful search fails loud on absence.** Every other signal
+ *    reports the state of a component; this one reports whether the pipeline has
+ *    actually produced a result. It degrades past 2× `SEARCH_INTERVAL` and is
+ *    never hidden — in the failure that motivated the spec, every component
+ *    reported itself fine while this line read "11 days ago".
+ */
+
+import { formatDistanceStrict } from "date-fns";
+import type {
+  AcquisitionHealthResponse,
+  AcquisitionRouteHealth,
+  AcquisitionWorkerHealth,
+} from "@/hooks/useAcquisitionHealth";
+import { sanitizeAcquisitionMessage } from "@/hooks/useAcquisitionHealth";
+
+/** Quiet, amber, red — in escalating order, which is also their precedence. */
+export type HealthTone = "healthy" | "degraded" | "blocked";
+
+const TONE_RANK: Record<HealthTone, number> = {
+  healthy: 0,
+  degraded: 1,
+  blocked: 2,
+};
+
+/** Where a blocked signal is fixed. Blocked names the component *and* links. */
+export interface HealthFix {
+  label: string;
+  to: string;
+}
+
+export interface HealthSignal {
+  /** Stable identity for keys and tests, never rendered. */
+  key: "route" | "indexers" | "workers" | "gate" | "unknown";
+  tone: HealthTone;
+  text: string;
+  fix?: HealthFix;
+}
+
+export interface LastSearchLine {
+  /** Epoch seconds of the newest completed provider search, if there is one. */
+  at: number | null;
+  /** Past 2× `SEARCH_INTERVAL`, or never having run at all. */
+  stale: boolean;
+  text: string;
+}
+
+export interface HealthBandView {
+  tone: HealthTone;
+  /** `true` when the endpoint itself could not be read. Renders degraded. */
+  unknown: boolean;
+  signals: HealthSignal[];
+  lastSearch: LastSearchLine;
+}
+
+const SETTINGS_CLIENTS = "/settings?section=clients";
+const SETTINGS_SEARCH = "/settings?section=search";
+const SETTINGS_ACQUISITION = "/settings?section=acquisition";
+
+/** Registry default for `SEARCH_INTERVAL`, in minutes. */
+export const DEFAULT_SEARCH_INTERVAL_MINUTES = 1440;
+
+/** Downstream keys as `_downstream_readiness` reports them. */
+const DOWNSTREAM_LABELS: Record<string, string> = {
+  sabnzbd: "SABnzbd",
+  nzbget: "NZBGet",
+  blackhole: "Blackhole",
+  qbittorrent: "qBittorrent",
+  transmission: "Transmission",
+  deluge: "Deluge",
+  rtorrent: "rTorrent",
+  utorrent: "uTorrent",
+  watchfolder: "Watch folder",
+  local: "Direct download",
+};
+
+/**
+ * Route blockers, nearest-to-ready first, so the phrase names the smallest
+ * remaining gap. Mirrors `_ROUTE_REASON_RANK` in `comicarr/app/search/health.py`.
+ */
+const ROUTE_REASONS: Array<[string, string]> = [
+  ["providers_temporarily_blocked", "every indexer is temporarily blocked"],
+  ["path_not_ready", "the download directory is not reachable"],
+  ["client_not_ready", "the download client is not configured"],
+  [
+    "unsupported_restart_correlation",
+    "the configured client cannot be verified after a restart",
+  ],
+  ["disabled", "no route is enabled"],
+];
+
+const WORKER_LABELS: Record<string, string> = {
+  search: "Search",
+  downloader: "Download",
+  download: "Download",
+  postprocess: "Post-processing",
+  postprocessing: "Post-processing",
+  post_processing: "Post-processing",
+};
+
+/** A finite, positive epoch — the client-side twin of `health.py::_timestamp`. */
+function timestamp(value: unknown): number | null {
+  const seconds = Number(value);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+}
+
+function label(key: string, labels: Record<string, string>): string {
+  return labels[key.toLowerCase()] ?? key;
+}
+
+/** "a", "a and b", "a, b, and c". */
+function listPhrase(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function alive(worker: AcquisitionWorkerHealth): boolean {
+  return Boolean(worker.alive ?? worker.live ?? worker.healthy);
+}
+
+/** The nearest-to-ready blocker across the routes that are not ready. */
+function routeBlocker(routes: Array<[string, AcquisitionRouteHealth]>): string {
+  const reasons = new Set(
+    routes
+      .filter(([, route]) => !route.ready)
+      .map(([, route]) =>
+        String(route.reason ?? "")
+          .trim()
+          .toLowerCase(),
+      ),
+  );
+  for (const [reason, phrase] of ROUTE_REASONS) {
+    if (reasons.has(reason)) return phrase;
+  }
+  // A maintenance fence puts its own reason in `reason`; the gate signal names
+  // it, so the route signal stays silent rather than repeating it verbatim.
+  return "";
+}
+
+function routeSignal(health: AcquisitionHealthResponse): HealthSignal {
+  const routes = Object.entries(health.routes ?? {});
+  const ready = routes.filter(([, route]) => route.ready);
+
+  if (health.viable_route && ready.length > 0) {
+    const names = Array.from(
+      new Set(
+        ready.map(([, route]) =>
+          label(String(route.downstream ?? ""), DOWNSTREAM_LABELS),
+        ),
+      ),
+    ).filter(Boolean);
+    return {
+      key: "route",
+      tone: "healthy",
+      // "ready", not "reachable": the payload reports configured readiness, and
+      // claiming reachability it has not probed is the false-confidence §6.1
+      // rules out.
+      text:
+        names.length > 0
+          ? `${names.join(" + ")} ready`
+          : "Download route ready",
+    };
+  }
+
+  const blocker = routeBlocker(routes);
+  return {
+    key: "route",
+    tone: "blocked",
+    text: blocker
+      ? `No usable download route — ${blocker}`
+      : "No usable download route",
+    fix: { label: "open download clients", to: SETTINGS_CLIENTS },
+  };
+}
+
+function indexerSignal(health: AcquisitionHealthResponse): HealthSignal {
+  const byName = new Map<string, boolean>();
+  for (const route of Object.values(health.routes ?? {})) {
+    for (const provider of route.providers ?? []) {
+      const name = String(provider.name ?? "").trim();
+      if (!name) continue;
+      // Blocked on any route is blocked: a provider shared by two routes is
+      // still one unreachable indexer, not half of one.
+      byName.set(
+        name,
+        (byName.get(name) ?? false) || Boolean(provider.blocked),
+      );
+    }
+  }
+
+  const total = byName.size;
+  if (total === 0) {
+    return {
+      key: "indexers",
+      tone: "degraded",
+      text: "No indexers configured",
+      fix: { label: "open search providers", to: SETTINGS_SEARCH },
+    };
+  }
+
+  const blocked = Array.from(byName.values()).filter(Boolean).length;
+  if (blocked === 0) {
+    return {
+      key: "indexers",
+      tone: "healthy",
+      text: `${total} of ${total} indexers responding`,
+    };
+  }
+  return {
+    key: "indexers",
+    tone: blocked === total ? "blocked" : "degraded",
+    text: `${plural(blocked, "indexer")} unreachable`,
+    fix: { label: "open search providers", to: SETTINGS_SEARCH },
+  };
+}
+
+function workerSignal(health: AcquisitionHealthResponse): HealthSignal {
+  const workers = Object.entries(health.workers ?? {});
+
+  // No heartbeats at all, or the projection itself failed. Either way the band
+  // cannot claim the workers are up.
+  if (
+    workers.length === 0 ||
+    (workers.length === 1 && workers[0][0] === "unavailable")
+  ) {
+    return {
+      key: "workers",
+      tone: "degraded",
+      text: "Cannot determine worker liveness",
+      fix: { label: "open acquisition health", to: SETTINGS_ACQUISITION },
+    };
+  }
+
+  const down = workers.filter(([, worker]) => !alive(worker));
+  if (down.length === 0) {
+    const names = workers.map(([name]) => label(name, WORKER_LABELS));
+    return {
+      key: "workers",
+      tone: "healthy",
+      text: `${listPhrase(names)} running`,
+    };
+  }
+
+  const names = down.map(([name]) => label(name, WORKER_LABELS));
+  return {
+    key: "workers",
+    tone: "degraded",
+    text: `${listPhrase(names)} worker${down.length === 1 ? "" : "s"} not running`,
+    fix: { label: "open acquisition health", to: SETTINGS_ACQUISITION },
+  };
+}
+
+/**
+ * The runtime acquisition gate. Silent when open — a healthy band is one quiet
+ * line, and "gate open" is not news.
+ */
+function gateSignal(health: AcquisitionHealthResponse): HealthSignal | null {
+  const maintenance = health.maintenance;
+  if (maintenance?.blocked) {
+    const reason = maintenance.reason
+      ? sanitizeAcquisitionMessage(maintenance.reason)
+      : "";
+    return {
+      key: "gate",
+      tone: "degraded",
+      text: reason
+        ? `Paused for maintenance: ${reason}`
+        : "Paused for maintenance",
+      fix: { label: "open acquisition health", to: SETTINGS_ACQUISITION },
+    };
+  }
+
+  const deferred = Number(health.blocked_producer_count ?? 0);
+  if (Number.isFinite(deferred) && deferred > 0) {
+    return {
+      key: "gate",
+      tone: "degraded",
+      text: `${plural(deferred, "producer")} deferred`,
+      fix: { label: "open acquisition health", to: SETTINGS_ACQUISITION },
+    };
+  }
+  return null;
+}
+
+/**
+ * The newest completed provider search. Never hidden, and loud on absence:
+ * "never" is the reading a pipeline that has produced nothing deserves.
+ */
+function lastSearchLine(
+  health: AcquisitionHealthResponse | null,
+  searchIntervalMinutes: number,
+  now: number,
+): LastSearchLine {
+  if (!health) {
+    return { at: null, stale: true, text: "Last successful search: unknown" };
+  }
+
+  const runs = (health.providers ?? [])
+    .map((provider) => timestamp(provider.lastrun))
+    .filter((value): value is number => value !== null);
+  const at = runs.length > 0 ? Math.max(...runs) : null;
+  if (at === null) {
+    return { at: null, stale: true, text: "Last successful search: never" };
+  }
+
+  const interval =
+    Number.isFinite(searchIntervalMinutes) && searchIntervalMinutes > 0
+      ? searchIntervalMinutes
+      : DEFAULT_SEARCH_INTERVAL_MINUTES;
+  const ageSeconds = now / 1000 - at;
+  const age = formatDistanceStrict(new Date(at * 1000), new Date(now));
+  return {
+    at,
+    stale: ageSeconds > interval * 60 * 2,
+    text: `Last successful search: ${age} ago`,
+  };
+}
+
+function worstTone(tones: HealthTone[]): HealthTone {
+  return tones.reduce<HealthTone>(
+    (worst, tone) => (TONE_RANK[tone] > TONE_RANK[worst] ? tone : worst),
+    "healthy",
+  );
+}
+
+/**
+ * Read the band. `health` is `null` when the endpoint could not be read — which
+ * is `unknown`, and renders degraded, never healthy and never absent.
+ */
+export function healthBandView({
+  health,
+  searchIntervalMinutes = DEFAULT_SEARCH_INTERVAL_MINUTES,
+  now,
+}: {
+  health: AcquisitionHealthResponse | null;
+  searchIntervalMinutes?: number;
+  now: number;
+}): HealthBandView {
+  const lastSearch = lastSearchLine(health, searchIntervalMinutes, now);
+
+  if (!health) {
+    return {
+      tone: "degraded",
+      unknown: true,
+      signals: [
+        {
+          key: "unknown",
+          tone: "degraded",
+          text: "Cannot determine health",
+          fix: { label: "open acquisition health", to: SETTINGS_ACQUISITION },
+        },
+      ],
+      lastSearch,
+    };
+  }
+
+  const gate = gateSignal(health);
+  const signals: HealthSignal[] = [
+    routeSignal(health),
+    indexerSignal(health),
+    workerSignal(health),
+    ...(gate ? [gate] : []),
+  ];
+
+  return {
+    tone: worstTone([
+      ...signals.map((signal) => signal.tone),
+      // A stale last-successful-search degrades the whole band even when every
+      // component reports itself fine. That combination *is* the silent failure.
+      lastSearch.stale ? "degraded" : "healthy",
+    ]),
+    unknown: false,
+    signals,
+    lastSearch,
+  };
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,6 +6,7 @@ import {
   PanelSkeleton,
   PanelUnavailable,
 } from "@/components/dashboard/DashboardPanel";
+import HealthBand from "@/components/dashboard/HealthBand";
 import { panelState, type PanelState } from "@/lib/panelState";
 import { Kbd } from "@/components/ui/kbd";
 import RelativeTime from "@/components/ui/RelativeTime";
@@ -282,6 +283,10 @@ export default function DashboardPage() {
           </button>
         )}
       </div>
+
+      {/* Health band — above every other panel, because it is the only one
+          whose answer can require action today (dashboard-spec.md §2, §3.1). */}
+      <HealthBand />
 
       {/* Ask bar — a question here opens as a chat instead of a search */}
       <div className="px-5 py-3.5 border-b border-border bg-card/30 flex flex-col gap-2.5">

--- a/frontend/tests/components/HealthBand.test.tsx
+++ b/frontend/tests/components/HealthBand.test.tsx
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/server";
+import { renderMinimal, screen, waitFor } from "../test-utils";
+import HealthBand from "@/components/dashboard/HealthBand";
+
+const MINUTE_MS = 60_000;
+
+/** Epoch seconds, `minutes` before now — the shape `provider_searches` stores. */
+function minutesAgo(minutes: number): number {
+  return Math.floor((Date.now() - minutes * MINUTE_MS) / 1000);
+}
+
+function installHealth(payload: unknown) {
+  server.use(http.get("/api/search/health", () => HttpResponse.json(payload)));
+}
+
+/** `SEARCH_INTERVAL` in minutes, so a test can place a run either side of 2×. */
+function installConfig(searchInterval: number) {
+  server.use(
+    http.get("/api/config", () =>
+      HttpResponse.json({ search_interval: searchInterval }),
+    ),
+  );
+}
+
+const healthyPayload = {
+  viable_route: true,
+  routes: {
+    nzb: {
+      ready: true,
+      reason: "ready",
+      downstream: "sabnzbd",
+      providers: [
+        { name: "nzbgeek", kind: "newznab", blocked: false, attempted: true },
+        { name: "drunkenslug", kind: "newznab", blocked: false, attempted: true },
+      ],
+    },
+  },
+  workers: { search: { state: "idle", alive: true, healthy: true } },
+  maintenance: { blocked: false },
+  blocked_producer_count: 0,
+  providers: [{ provider: "nzbgeek", lastrun: minutesAgo(12) }],
+};
+
+/** The band once its queries have answered, whatever they answered. */
+async function band(): Promise<HTMLElement> {
+  return await screen.findByRole("region", { name: "Acquisition health" });
+}
+
+describe("HealthBand", () => {
+  it("renders healthy as one quiet line above the last-successful-search", async () => {
+    installHealth(healthyPayload);
+    installConfig(1440);
+
+    renderMinimal(<HealthBand />);
+
+    expect((await band()).getAttribute("data-tone")).toBe("healthy");
+    expect(
+      screen.getByText(
+        "SABnzbd ready · 2 of 2 indexers responding · Search running",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Last successful search: 12 minutes ago"),
+    ).toBeTruthy();
+  });
+
+  it("names the degraded component and keeps the healthy ones quiet", async () => {
+    installHealth({
+      ...healthyPayload,
+      workers: {
+        search: { alive: true },
+        postprocess: { state: "stopped", alive: false },
+      },
+    });
+    installConfig(1440);
+
+    renderMinimal(<HealthBand />);
+
+    expect((await band()).getAttribute("data-tone")).toBe("degraded");
+    expect(screen.getByText("Post-processing worker not running")).toBeTruthy();
+    expect(screen.getByText(/SABnzbd ready · 2 of 2 indexers responding/)).toBeTruthy();
+  });
+
+  it("links a blocked route to where it is fixed", async () => {
+    installHealth({
+      ...healthyPayload,
+      viable_route: false,
+      routes: {
+        nzb: { ready: false, reason: "client_not_ready", downstream: "sabnzbd" },
+      },
+    });
+    installConfig(1440);
+
+    renderMinimal(<HealthBand />);
+
+    expect((await band()).getAttribute("data-tone")).toBe("blocked");
+    expect(
+      screen.getByText(
+        "No usable download route — the download client is not configured",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: "open download clients →" })
+        .getAttribute("href"),
+    ).toBe("/settings?section=clients");
+  });
+
+  it("renders degraded, not healthy and not absent, when the endpoint fails", async () => {
+    server.use(
+      http.get("/api/search/health", () => new HttpResponse(null, { status: 500 })),
+    );
+    installConfig(1440);
+
+    renderMinimal(<HealthBand />);
+
+    expect((await band()).getAttribute("data-tone")).toBe("degraded");
+    expect(screen.getByText("Cannot determine health")).toBeTruthy();
+    // Absence of evidence is never health, and the load-bearing line still shows.
+    expect(screen.queryByText(/indexers responding/)).toBeNull();
+    expect(screen.getByText("Last successful search: unknown")).toBeTruthy();
+  });
+
+  it("degrades on a stale last successful search while every component reports fine", async () => {
+    installHealth({
+      ...healthyPayload,
+      providers: [{ provider: "nzbgeek", lastrun: minutesAgo(11 * 1440) }],
+    });
+    installConfig(1440);
+
+    renderMinimal(<HealthBand />);
+
+    expect((await band()).getAttribute("data-tone")).toBe("degraded");
+    expect(screen.getByText("Last successful search: 11 days ago")).toBeTruthy();
+    // No component complained. The band says so anyway — the silent failure.
+    expect(
+      screen.getByText(
+        "SABnzbd ready · 2 of 2 indexers responding · Search running",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("never hides the last-successful-search line, even having never run", async () => {
+    installHealth({ ...healthyPayload, providers: [] });
+    installConfig(1440);
+
+    renderMinimal(<HealthBand />);
+
+    expect((await band()).getAttribute("data-tone")).toBe("degraded");
+    expect(screen.getByText("Last successful search: never")).toBeTruthy();
+  });
+
+  it("occupies its final position while loading, rather than popping in", async () => {
+    installHealth(healthyPayload);
+    installConfig(1440);
+
+    renderMinimal(<HealthBand />);
+
+    expect(screen.getByTestId("health-band-loading")).toBeTruthy();
+    await waitFor(() =>
+      expect(screen.queryByTestId("health-band-loading")).toBeNull(),
+    );
+  });
+});

--- a/frontend/tests/lib/healthBand.test.ts
+++ b/frontend/tests/lib/healthBand.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SEARCH_INTERVAL_MINUTES,
+  healthBandView,
+} from "@/lib/healthBand";
+import type { AcquisitionHealthResponse } from "@/hooks/useAcquisitionHealth";
+
+const NOW = Date.UTC(2026, 7, 8, 12, 0, 0);
+const MINUTE = 60;
+
+/** Epoch seconds, `minutes` before `NOW`. */
+function minutesAgo(minutes: number): number {
+  return NOW / 1000 - minutes * MINUTE;
+}
+
+/** Everything fine: one ready route, both indexers clear, the worker alive. */
+function healthy(
+  overrides: Partial<AcquisitionHealthResponse> = {},
+): AcquisitionHealthResponse {
+  return {
+    viable_route: true,
+    routes: {
+      nzb: {
+        ready: true,
+        reason: "ready",
+        downstream: "sabnzbd",
+        providers: [
+          {
+            name: "nzbgeek",
+            kind: "newznab",
+            blocked: false,
+            attempted: true,
+            last_attempt: minutesAgo(10),
+          },
+          {
+            name: "drunkenslug",
+            kind: "newznab",
+            blocked: false,
+            attempted: true,
+            last_attempt: minutesAgo(10),
+          },
+        ],
+      },
+      torrent: { ready: false, reason: "disabled", downstream: "disabled" },
+    },
+    workers: {
+      search: { state: "idle", alive: true, healthy: true },
+    },
+    maintenance: { blocked: false },
+    blocked_producer_count: 0,
+    providers: [{ provider: "nzbgeek", lastrun: minutesAgo(10) }],
+    ...overrides,
+  };
+}
+
+function view(health: AcquisitionHealthResponse | null, interval?: number) {
+  return healthBandView({
+    health,
+    searchIntervalMinutes: interval,
+    now: NOW,
+  });
+}
+
+function signal(
+  result: ReturnType<typeof view>,
+  key: "route" | "indexers" | "workers" | "gate" | "unknown",
+) {
+  return result.signals.find((item) => item.key === key);
+}
+
+describe("healthBandView", () => {
+  describe("healthy", () => {
+    it("reads as one quiet set of signals with no fix links", () => {
+      const result = view(healthy());
+
+      expect(result.tone).toBe("healthy");
+      expect(result.unknown).toBe(false);
+      expect(result.signals.map((item) => item.text)).toEqual([
+        "SABnzbd ready",
+        "2 of 2 indexers responding",
+        "Search running",
+      ]);
+      expect(result.signals.every((item) => item.fix === undefined)).toBe(true);
+    });
+
+    it("stays silent about an open acquisition gate", () => {
+      expect(signal(view(healthy()), "gate")).toBeUndefined();
+    });
+
+    it("names every ready route's downstream client", () => {
+      const health = healthy();
+      health.routes!.torrent = {
+        ready: true,
+        reason: "ready",
+        downstream: "qbittorrent",
+      };
+
+      expect(signal(view(health), "route")!.text).toBe(
+        "SABnzbd + qBittorrent ready",
+      );
+    });
+  });
+
+  describe("degraded", () => {
+    it("names the specific worker that is not running", () => {
+      const health = healthy({
+        workers: {
+          search: { alive: true },
+          postprocess: { state: "stopped", alive: false },
+        },
+      });
+      const result = view(health);
+
+      expect(result.tone).toBe("degraded");
+      expect(signal(result, "workers")).toMatchObject({
+        tone: "degraded",
+        text: "Post-processing worker not running",
+      });
+    });
+
+    it("cannot claim liveness when no worker has ever reported one", () => {
+      const result = view(healthy({ workers: {} }));
+
+      expect(result.tone).toBe("degraded");
+      expect(signal(result, "workers")!.text).toBe(
+        "Cannot determine worker liveness",
+      );
+    });
+
+    it("treats a failed worker projection as unknown, not as one dead worker", () => {
+      const result = view(
+        healthy({ workers: { unavailable: { state: "unavailable" } } }),
+      );
+
+      expect(signal(result, "workers")!.text).toBe(
+        "Cannot determine worker liveness",
+      );
+    });
+
+    it("counts some-but-not-all blocked indexers as degraded", () => {
+      const health = healthy();
+      health.routes!.nzb!.providers![0]!.blocked = true;
+      const result = view(health);
+
+      expect(result.tone).toBe("degraded");
+      expect(signal(result, "indexers")).toMatchObject({
+        tone: "degraded",
+        text: "1 indexer unreachable",
+      });
+    });
+
+    it("counts an indexer blocked on any route as one unreachable indexer", () => {
+      const health = healthy();
+      health.routes!.torrent = {
+        ready: false,
+        reason: "providers_temporarily_blocked",
+        providers: [
+          {
+            name: "nzbgeek",
+            kind: "newznab",
+            blocked: true,
+            attempted: true,
+            last_attempt: null,
+          },
+        ],
+      };
+
+      expect(signal(view(health), "indexers")!.text).toBe(
+        "1 indexer unreachable",
+      );
+    });
+
+    it("reports a closed maintenance gate with its sanitized reason", () => {
+      const result = view(
+        healthy({
+          maintenance: { blocked: true, reason: "repair token=do-not-render" },
+        }),
+      );
+
+      expect(result.tone).toBe("degraded");
+      expect(signal(result, "gate")!.text).toBe(
+        "Paused for maintenance: repair token=[redacted]",
+      );
+      expect(signal(result, "gate")!.text).not.toContain("do-not-render");
+    });
+
+    it("reports deferred producers even while the gate is open", () => {
+      const result = view(healthy({ blocked_producer_count: 2 }));
+
+      expect(result.tone).toBe("degraded");
+      expect(signal(result, "gate")!.text).toBe("2 producers deferred");
+    });
+  });
+
+  describe("blocked", () => {
+    it("names the nearest blocker and links to where the route is fixed", () => {
+      const health = healthy({
+        viable_route: false,
+        routes: {
+          nzb: {
+            ready: false,
+            reason: "client_not_ready",
+            downstream: "sabnzbd",
+          },
+          torrent: { ready: false, reason: "disabled", downstream: "disabled" },
+        },
+      });
+      const result = view(health);
+
+      expect(result.tone).toBe("blocked");
+      expect(signal(result, "route")).toMatchObject({
+        tone: "blocked",
+        text: "No usable download route — the download client is not configured",
+        fix: { to: "/settings?section=clients" },
+      });
+    });
+
+    it("prefers the blocker nearest to ready when routes disagree", () => {
+      const result = view(
+        healthy({
+          viable_route: false,
+          routes: {
+            nzb: { ready: false, reason: "disabled" },
+            torrent: { ready: false, reason: "path_not_ready" },
+          },
+        }),
+      );
+
+      expect(signal(result, "route")!.text).toBe(
+        "No usable download route — the download directory is not reachable",
+      );
+    });
+
+    it("is blocked, not degraded, when every indexer is unreachable", () => {
+      const health = healthy();
+      for (const provider of health.routes!.nzb!.providers!) {
+        provider.blocked = true;
+      }
+
+      expect(signal(view(health), "indexers")!.tone).toBe("blocked");
+      expect(view(health).tone).toBe("blocked");
+    });
+
+    it("refuses to call a route ready when nothing is", () => {
+      const result = view(healthy({ viable_route: true, routes: {} }));
+
+      expect(signal(result, "route")!.tone).toBe("blocked");
+      expect(signal(result, "route")!.text).toBe("No usable download route");
+    });
+  });
+
+  describe("unknown", () => {
+    it("renders degraded when the endpoint could not be read", () => {
+      const result = view(null);
+
+      expect(result.tone).toBe("degraded");
+      expect(result.unknown).toBe(true);
+      expect(result.signals).toHaveLength(1);
+      expect(result.signals[0]).toMatchObject({
+        key: "unknown",
+        tone: "degraded",
+        text: "Cannot determine health",
+      });
+    });
+
+    it("still reports a last-successful-search line, as unknown", () => {
+      expect(view(null).lastSearch).toMatchObject({
+        at: null,
+        stale: true,
+        text: "Last successful search: unknown",
+      });
+    });
+  });
+
+  describe("last successful search", () => {
+    it("reads the newest provider run, whichever provider it came from", () => {
+      const result = view(
+        healthy({
+          providers: [
+            { provider: "a", lastrun: minutesAgo(600) },
+            { provider: "b", lastrun: minutesAgo(12) },
+          ],
+        }),
+      );
+
+      expect(result.lastSearch.at).toBe(minutesAgo(12));
+      expect(result.lastSearch.text).toBe("Last successful search: 12 minutes ago");
+      expect(result.lastSearch.stale).toBe(false);
+    });
+
+    it("fails loud on absence rather than omitting the line", () => {
+      const result = view(healthy({ providers: [] }));
+
+      expect(result.lastSearch).toMatchObject({
+        at: null,
+        stale: true,
+        text: "Last successful search: never",
+      });
+      expect(result.tone).toBe("degraded");
+    });
+
+    it("ignores a legacy zero or non-numeric lastrun", () => {
+      const result = view(
+        healthy({
+          providers: [
+            { provider: "a", lastrun: 0 },
+            { provider: "b", lastrun: null },
+          ],
+        }),
+      );
+
+      expect(result.lastSearch.text).toBe("Last successful search: never");
+    });
+
+    it("degrades past 2× SEARCH_INTERVAL even when every component is fine", () => {
+      const result = view(
+        healthy({ providers: [{ provider: "a", lastrun: minutesAgo(11 * 1440) }] }),
+        1440,
+      );
+
+      // The silent failure: nothing reports an error, and the pipeline has
+      // produced nothing for eleven days.
+      expect(result.signals.every((item) => item.tone === "healthy")).toBe(true);
+      expect(result.lastSearch.stale).toBe(true);
+      expect(result.lastSearch.text).toBe("Last successful search: 11 days ago");
+      expect(result.tone).toBe("degraded");
+    });
+
+    it("scales the threshold with the configured interval", () => {
+      const providers = [{ provider: "a", lastrun: minutesAgo(90) }];
+
+      expect(view(healthy({ providers }), 30).lastSearch.stale).toBe(true);
+      expect(view(healthy({ providers }), 120).lastSearch.stale).toBe(false);
+    });
+
+    it("falls back to the registry default for a nonsensical interval", () => {
+      const providers = [{ provider: "a", lastrun: minutesAgo(1441) }];
+
+      expect(view(healthy({ providers }), 0).lastSearch.stale).toBe(false);
+      expect(
+        view(healthy({ providers }), DEFAULT_SEARCH_INTERVAL_MINUTES).lastSearch
+          .stale,
+      ).toBe(false);
+      expect(
+        view(
+          healthy({
+            providers: [
+              { provider: "a", lastrun: minutesAgo(2 * DEFAULT_SEARCH_INTERVAL_MINUTES + 1) },
+            ],
+          }),
+          0,
+        ).lastSearch.stale,
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Implements #578. Part of #576. Implements §3.1 of [docs/architecture/dashboard-spec.md](https://github.com/frankieramirez/comicarr/blob/main/docs/architecture/dashboard-spec.md).

## What this adds

A full-width band leading the dashboard, reading `GET /api/search/health` — the API has existed since #501 and the dashboard has never used it.

- **Viable download route** — "SABnzbd + qBittorrent ready", or "No usable download route" naming the nearest blocker and linking to `/settings?section=clients`.
- **Indexer reachability** — "4 of 4 indexers responding", or "2 indexers unreachable"; blocked, not degraded, when *every* indexer is unreachable.
- **Worker liveness** — "Search running", or the specific worker: "Post-processing worker not running".
- **Acquisition gate** — silent when open, "Paused for maintenance" with a sanitized reason when the runtime fence is closed, and deferred-producer counts when there are any.
- **Last successful search** — always, at any age.

## The rule it enforces

The band never infers health from the absence of bad news:

- A failing health endpoint is `unknown` → renders **degraded** ("Cannot determine health"), never healthy and never absent.
- No worker heartbeats at all, or a failed worker projection, reads as "Cannot determine worker liveness" — not as workers that are up.
- A stale last-successful-search degrades the whole band **even when every signal reports itself fine**. That combination is precisely the silent failure the spec exists to prevent: for weeks downloads were broken while every component looked healthy and this line would have read "11 days ago".
- The last-successful-search line degrades past 2× `SEARCH_INTERVAL` and is never hidden — including "never" when nothing has ever run.

## Two deliberate wording deviations from the spec's examples

- The route signal says **"ready"**, not the spec's illustrative "reachable". `client_ready` reports *configured* readiness; claiming a reachability the payload never probed is exactly the false confidence §6.1 rules out.
- The indexer signal keeps the spec's **"responding"** — that one *is* derived from real failures (the provider blocklist), so it is substantiated.

## Shape

`frontend/src/lib/healthBand.ts` holds the entire reading as a pure function of the payload plus a clock — no React, no I/O — so all five states are testable directly. The component is presentation plus a `useSyncExternalStore` subscription to the wall clock, so the age keeps growing while the page sits open without an impure render.

`useSearchHealth` is additive and shares `useAcquisitionHealth`'s query key, so the settings tab and the band can never disagree, and the dashboard does not also poll the scheduler and diagnostics reads it has no use for.

The band sits directly below the page header, above every other panel. Page order below it is unchanged — #582 adopts the spec's full layout.

## Verification

- 22 pure tests over `healthBandView` (healthy, degraded, blocked, unknown, stale, never, threshold scaling, secret redaction).
- 7 render tests over `HealthBand`, including the failing endpoint and the loading skeleton holding its position.
- Full suite: 367 passed. `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyPVcu6FibGfzoDyQUXbLS