### PR TITLE
feat: Show in-flight work and delete the Queue tile

### DIFF
--- a/.changeset/lucky-pandas-count.md
+++ b/.changeset/lucky-pandas-count.md
@@ -1,0 +1,7 @@
+---
+"comicarr": minor
+---
+
+The dashboard now says how much work is moving right now, across every download route — one line reading "12 in flight", and "12 in flight (3 recovered from a restart)" when some of that work has already survived a restart. The two figures are never added together: the recovered ones are part of the total, not extra.
+
+The **Queue** tile is gone. It counted direct downloads only, so an operator running SABnzbd saw "0 queued" while SABnzbd was actively downloading — a claim the dashboard could not back. The in-flight line answers the same question honestly for every route, and it reads the same source as the status indicator in the footer, so the two can never disagree. If that source cannot be read, the line says so instead of reporting a quiet system.

--- a/comicarr/app/dashboard/router.py
+++ b/comicarr/app/dashboard/router.py
@@ -30,14 +30,6 @@ def get_library():
     return service.get_library_panel()
 
 
-@router.get("/queue", dependencies=[Depends(require_session)])
-def get_queue():
-    """Return the active-download count and preview."""
-    from comicarr.app.dashboard import service
-
-    return service.get_queue_panel()
-
-
 @router.get("/activity", dependencies=[Depends(require_session)])
 def get_activity():
     """Return the bounded recent-activity preview."""

--- a/comicarr/app/dashboard/service.py
+++ b/comicarr/app/dashboard/service.py
@@ -21,16 +21,13 @@ from datetime import datetime, timedelta
 
 import comicarr
 from comicarr.app.dashboard import queries as dashboard_queries
-from comicarr.app.downloads import queries as dl_queries
 from comicarr.app.storyarcs import service as storyarcs_service
 
 RECENT_ACTIVITY_DAYS = 30
 
 # Every panel's preview is bounded here rather than in the client. A panel that
 # renders fewer rows than it counts is claiming a number it is not showing, so
-# the count and the list share one bound — the rule ``get_queue_panel`` already
-# followed by sharing the active DDL predicate.
-ACTIVE_QUEUE_PREVIEW_LIMIT = 5
+# a count and the list under it always share one bound.
 RECENT_ACTIVITY_PREVIEW_LIMIT = 5
 UPCOMING_PREVIEW_LIMIT = 6
 
@@ -73,18 +70,6 @@ def get_library_panel():
         result["comic_total"] = comic_stats.get("comic_total", 0) or 0
 
     return {"stats": result}
-
-
-def get_queue_panel():
-    """Return the active-download count and its bounded preview.
-
-    Count and preview share the active DDL predicate deliberately, so the
-    tile and the list below it can never disagree.
-    """
-    return {
-        "count": dl_queries.count_active_ddl_items(),
-        "items": dl_queries.get_active_ddl_preview(limit=ACTIVE_QUEUE_PREVIEW_LIMIT) or [],
-    }
 
 
 def get_activity_panel():

--- a/frontend/src/components/dashboard/InFlightLine.tsx
+++ b/frontend/src/components/dashboard/InFlightLine.tsx
@@ -1,0 +1,70 @@
+import { Link } from "react-router-dom";
+import { useActivityStatus } from "@/hooks/useActivityStatus";
+import { inFlightView } from "@/lib/inFlight";
+import { PanelUnavailable } from "@/components/dashboard/DashboardPanel";
+
+/**
+ * How much work is moving right now, across every route
+ * (docs/architecture/dashboard-spec.md §3.3).
+ *
+ * It reads `GET /api/activity/status` and nothing else. That is the same
+ * source the global status indicator reads, so the two can never disagree —
+ * the point of replacing the Queue tile, which counted active DDL items only
+ * and so read "0 queued" while SABnzbd was actively downloading (§3.7).
+ *
+ * A failed read says so rather than falling through to "nothing in flight":
+ * an unread count is not a quiet system.
+ */
+export default function InFlightLine() {
+  const status = useActivityStatus();
+
+  if (status.isPending) {
+    return (
+      <div
+        className="px-5 py-2.5 border-b border-border"
+        data-testid="in-flight-loading"
+      >
+        <div
+          aria-hidden="true"
+          className="h-2.5 w-40 animate-pulse rounded-[2px] bg-primary/10"
+        />
+      </div>
+    );
+  }
+
+  if (status.isError) {
+    return (
+      <div className="px-5 border-b border-border">
+        <PanelUnavailable
+          label="In flight"
+          onRetry={() => void status.refetch()}
+          isRetrying={status.isFetching}
+        />
+      </div>
+    );
+  }
+
+  const view = inFlightView({
+    inFlight: status.data?.in_flight ?? 0,
+    recoveryPending: status.data?.recovery_pending,
+  });
+
+  return (
+    <div
+      className="px-5 py-2.5 border-b border-border"
+      data-testid="in-flight"
+      data-busy={view.busy}
+    >
+      <Link
+        to="/activity"
+        aria-label="In flight"
+        className="font-mono text-[11px] hover:text-foreground"
+        style={{
+          color: view.busy ? "var(--status-active)" : "var(--muted-foreground)",
+        }}
+      >
+        {view.text}
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/InFlightLine.tsx
+++ b/frontend/src/components/dashboard/InFlightLine.tsx
@@ -7,23 +7,18 @@ import { PanelUnavailable } from "@/components/dashboard/DashboardPanel";
  * How much work is moving right now, across every route
  * (docs/architecture/dashboard-spec.md §3.3).
  *
- * It reads `GET /api/activity/status` and nothing else. That is the same
- * source the global status indicator reads, so the two can never disagree —
- * the point of replacing the Queue tile, which counted active DDL items only
- * and so read "0 queued" while SABnzbd was actively downloading (§3.7).
- *
- * A failed read says so rather than falling through to "nothing in flight":
- * an unread count is not a quiet system.
+ * It reads `GET /api/activity/status` and nothing else — the same source the
+ * global status indicator reads, so the two can never disagree. That is the
+ * point of replacing the Queue tile, which counted active DDL items only and
+ * so read "0 queued" while SABnzbd was actively downloading (§3.7). A failed
+ * read says so rather than falling through to "nothing in flight".
  */
 export default function InFlightLine() {
   const status = useActivityStatus();
 
   if (status.isPending) {
     return (
-      <div
-        className="px-5 py-2.5 border-b border-border"
-        data-testid="in-flight-loading"
-      >
+      <div className="px-5 py-2.5 border-b border-border">
         <div
           aria-hidden="true"
           className="h-2.5 w-40 animate-pulse rounded-[2px] bg-primary/10"
@@ -50,11 +45,7 @@ export default function InFlightLine() {
   });
 
   return (
-    <div
-      className="px-5 py-2.5 border-b border-border"
-      data-testid="in-flight"
-      data-busy={view.busy}
-    >
+    <div className="px-5 py-2.5 border-b border-border">
       <Link
         to="/activity"
         aria-label="In flight"

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -31,16 +31,6 @@ interface DashboardUpcoming {
   Status: string;
 }
 
-export interface DashboardQueueItem {
-  ID: string;
-  series: string;
-  filename: string;
-  status: string | null;
-  updated_date: string | null;
-  site: string | null;
-  comicid: string | null;
-}
-
 export interface DashboardLibraryStats {
   total_series: number;
   total_issues: number;
@@ -50,11 +40,6 @@ export interface DashboardLibraryStats {
 
 interface DashboardLibraryResponse {
   stats: DashboardLibraryStats;
-}
-
-interface DashboardQueueResponse {
-  count: number;
-  items: DashboardQueueItem[];
 }
 
 interface DashboardActivityResponse {
@@ -79,16 +64,6 @@ export function useDashboardLibrary() {
     queryKey: ["dashboard", "library"],
     queryFn: () =>
       apiRequest<DashboardLibraryResponse>("GET", "/api/dashboard/library"),
-    staleTime: PANEL_STALE_TIME,
-  });
-}
-
-/** Active queue: the count on the KPI strip and the preview below it. */
-export function useDashboardQueue() {
-  return useQuery<DashboardQueueResponse>({
-    queryKey: ["dashboard", "queue"],
-    queryFn: () =>
-      apiRequest<DashboardQueueResponse>("GET", "/api/dashboard/queue"),
     staleTime: PANEL_STALE_TIME,
   });
 }

--- a/frontend/src/lib/inFlight.ts
+++ b/frontend/src/lib/inFlight.ts
@@ -1,63 +1,41 @@
 /**
- * The in-flight line's reading of `GET /api/activity/status` — the whole
- * derivation, pure, with no React and no I/O
- * (docs/architecture/dashboard-spec.md §3.3).
+ * The in-flight line's reading of `GET /api/activity/status` — pure, with no
+ * React and no I/O (docs/architecture/dashboard-spec.md §3.3).
  *
- * Two rules shape it:
- *
- * 1. **One definition of the count.** `/api/activity/status` is it. The line
- *    never re-derives "how much work is moving" from a table, which is how the
- *    old Queue tile came to report DDL items only and read "0 queued" while
- *    SABnzbd was downloading.
- * 2. **Recovery qualifies, never adds.** `recovery_pending` is a *subset* of
- *    `in_flight` — work that has already survived a restart. Summing the two
- *    would double-count it, so it only ever appears in parentheses.
+ * `recovery_pending` is a *subset* of `in_flight`: work that has already
+ * survived a restart. Summing the two would double-count it, so it only ever
+ * appears as a qualifier in parentheses.
  */
 
 export interface InFlightSnapshot {
-  /** `in_flight` — total open work across every route. */
   inFlight: number;
-  /** `recovery_pending` — the subset that survived a restart. */
   recoveryPending?: number;
 }
 
 export interface InFlightView {
-  /** The whole line, ready to render. */
   text: string;
-  /** Total open work. Zero renders the quiet phrasing rather than a count. */
-  count: number;
-  /** The qualifier, already bounded by `count`. Zero means no qualifier. */
-  recovered: number;
-  /** `true` when there is work moving — the loud half of the two states. */
+  /** There is work moving — the loud half of the two states. */
   busy: boolean;
 }
 
-/** A count we can stand behind: whole, finite, and never negative. */
-function count(value: unknown): number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
-    : 0;
-}
-
-/**
- * Compose the in-flight line.
- *
- * `recoveryPending` is bounded by `inFlight` because the API defines it as a
- * subset of it: a payload claiming more recovered than in flight contradicts
- * itself, and the subset bound is the only reading of it that stays true to
- * the total. It is still never added to the total.
- */
-export function inFlightView(snapshot: InFlightSnapshot): InFlightView {
-  const total = count(snapshot.inFlight);
-  const recovered = Math.min(count(snapshot.recoveryPending), total);
-
-  if (total === 0) {
-    return { text: "nothing in flight", count: 0, recovered: 0, busy: false };
+export function inFlightView({
+  inFlight,
+  recoveryPending = 0,
+}: InFlightSnapshot): InFlightView {
+  if (inFlight <= 0) {
+    return { text: "nothing in flight", busy: false };
   }
 
-  const head = `${total} in flight`;
-  const text =
-    recovered > 0 ? `${head} (${recovered} recovered from a restart)` : head;
+  // Bounded by the total because the API defines it as a subset of it: a
+  // payload claiming more recovered than in flight contradicts itself, and the
+  // subset bound is the only reading of it that keeps the total true.
+  const recovered = Math.min(recoveryPending, inFlight);
 
-  return { text, count: total, recovered, busy: true };
+  return {
+    text:
+      recovered > 0
+        ? `${inFlight} in flight (${recovered} recovered from a restart)`
+        : `${inFlight} in flight`,
+    busy: true,
+  };
 }

--- a/frontend/src/lib/inFlight.ts
+++ b/frontend/src/lib/inFlight.ts
@@ -1,0 +1,63 @@
+/**
+ * The in-flight line's reading of `GET /api/activity/status` — the whole
+ * derivation, pure, with no React and no I/O
+ * (docs/architecture/dashboard-spec.md §3.3).
+ *
+ * Two rules shape it:
+ *
+ * 1. **One definition of the count.** `/api/activity/status` is it. The line
+ *    never re-derives "how much work is moving" from a table, which is how the
+ *    old Queue tile came to report DDL items only and read "0 queued" while
+ *    SABnzbd was downloading.
+ * 2. **Recovery qualifies, never adds.** `recovery_pending` is a *subset* of
+ *    `in_flight` — work that has already survived a restart. Summing the two
+ *    would double-count it, so it only ever appears in parentheses.
+ */
+
+export interface InFlightSnapshot {
+  /** `in_flight` — total open work across every route. */
+  inFlight: number;
+  /** `recovery_pending` — the subset that survived a restart. */
+  recoveryPending?: number;
+}
+
+export interface InFlightView {
+  /** The whole line, ready to render. */
+  text: string;
+  /** Total open work. Zero renders the quiet phrasing rather than a count. */
+  count: number;
+  /** The qualifier, already bounded by `count`. Zero means no qualifier. */
+  recovered: number;
+  /** `true` when there is work moving — the loud half of the two states. */
+  busy: boolean;
+}
+
+/** A count we can stand behind: whole, finite, and never negative. */
+function count(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : 0;
+}
+
+/**
+ * Compose the in-flight line.
+ *
+ * `recoveryPending` is bounded by `inFlight` because the API defines it as a
+ * subset of it: a payload claiming more recovered than in flight contradicts
+ * itself, and the subset bound is the only reading of it that stays true to
+ * the total. It is still never added to the total.
+ */
+export function inFlightView(snapshot: InFlightSnapshot): InFlightView {
+  const total = count(snapshot.inFlight);
+  const recovered = Math.min(count(snapshot.recoveryPending), total);
+
+  if (total === 0) {
+    return { text: "nothing in flight", count: 0, recovered: 0, busy: false };
+  }
+
+  const head = `${total} in flight`;
+  const text =
+    recovered > 0 ? `${head} (${recovered} recovered from a restart)` : head;
+
+  return { text, count: total, recovered, busy: true };
+}

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -665,13 +665,10 @@ export function mockApiResponse(
   }
   if (m === "GET" && url === "/api/activity/status") {
     // Quiet-count inputs for AppStatusBar (Variant A). Fixture: light open work.
-    return { in_flight: 2, attention: 0 };
+    return { in_flight: 2, recovery_pending: 1, attention: 0 };
   }
   if (m === "GET" && url === "/api/dashboard/library") {
     return dashboardLibraryPayload();
-  }
-  if (m === "GET" && url === "/api/dashboard/queue") {
-    return { count: 0, items: [] };
   }
   if (m === "GET" && url === "/api/dashboard/activity") {
     return { days: 30, events: recentDownloads() };

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -7,6 +7,7 @@ import {
   PanelUnavailable,
 } from "@/components/dashboard/DashboardPanel";
 import HealthBand from "@/components/dashboard/HealthBand";
+import InFlightLine from "@/components/dashboard/InFlightLine";
 import { panelState, type PanelState } from "@/lib/panelState";
 import { Kbd } from "@/components/ui/kbd";
 import RelativeTime from "@/components/ui/RelativeTime";
@@ -14,10 +15,8 @@ import { useToast } from "@/components/ui/toast";
 import {
   useDashboardActivity,
   useDashboardLibrary,
-  useDashboardQueue,
   useDashboardScanTargets,
   useDashboardUpcoming,
-  type DashboardQueueItem,
 } from "@/hooks/useDashboard";
 import { useChatThreads } from "@/hooks/useLibraryChat";
 import {
@@ -68,21 +67,6 @@ function Kpi({
         )}
       </div>
     </div>
-  );
-}
-
-function QueueStatus({ status }: { status: DashboardQueueItem["status"] }) {
-  const color =
-    status === "Failed"
-      ? "var(--status-error)"
-      : status === "Downloading"
-        ? "var(--status-active)"
-        : "var(--status-paused)";
-
-  return (
-    <span className="uppercase truncate" style={{ color }}>
-      {status || "Queued"}
-    </span>
   );
 }
 
@@ -138,7 +122,6 @@ const ASK_SUGGESTIONS = [
 
 export default function DashboardPage() {
   const library = useDashboardLibrary();
-  const queue = useDashboardQueue();
   const activity = useDashboardActivity();
   const upcoming = useDashboardUpcoming();
   const scanTargets = useDashboardScanTargets();
@@ -165,8 +148,6 @@ export default function DashboardPage() {
   const { addToast } = useToast();
 
   const stats = library.data?.stats;
-  const queueItems = queue.data?.items ?? [];
-  const queueCount = queue.data?.count ?? 0;
   const activityEvents = activity.data?.events ?? [];
   const activityDays = activity.data?.days ?? 30;
   const upcomingReleases = upcoming.data?.releases ?? [];
@@ -176,8 +157,6 @@ export default function DashboardPage() {
   const completion = stats?.completion_pct ?? 0;
 
   const libraryState = panelState(library, false);
-  const queueState = panelState(queue, queueItems.length === 0);
-  const queueCountState = panelState(queue, false);
   const activityState = panelState(activity, activityEvents.length === 0);
   const upcomingState = panelState(upcoming, upcomingReleases.length === 0);
   const chatsState = panelState(chatThreadsQuery, recentChats.length === 0);
@@ -199,15 +178,14 @@ export default function DashboardPage() {
 
   // The summary repeats each panel's own verdict rather than re-deriving it,
   // so a broken source says so instead of contributing a zero that reads as
-  // fact. `panelState` stays the only place the precedence lives.
-  const summary = [
-    summarize(
-      libraryState,
-      "library",
-      `${activeSeries} series · ${totalIssues} issues`,
-    ),
-    summarize(queueCountState, "queue", `${queueCount} in queue`),
-  ].join(" · ");
+  // fact. `panelState` stays the only place the precedence lives. Open work is
+  // deliberately absent here: `InFlightLine` is the one place that reports it,
+  // from the one endpoint that defines it (dashboard-spec.md §3.3).
+  const summary = summarize(
+    libraryState,
+    "library",
+    `${activeSeries} series · ${totalIssues} issues`,
+  );
 
   const handleLibraryScan = async () => {
     const scanRequests: Promise<unknown>[] = [];
@@ -288,6 +266,10 @@ export default function DashboardPage() {
           whose answer can require action today (dashboard-spec.md §2, §3.1). */}
       <HealthBand />
 
+      {/* How much work is moving, across every route (§3.3). Sits directly
+          under the band; §4's final placement lands with the layout pass. */}
+      <InFlightLine />
+
       {/* Ask bar — a question here opens as a chat instead of a search */}
       <div className="px-5 py-3.5 border-b border-border bg-card/30 flex flex-col gap-2.5">
         <form
@@ -330,8 +312,8 @@ export default function DashboardPage() {
 
       {/* Everything below the ask bar scrolls inside the page column. */}
       <div className="flex-1 min-h-0 overflow-auto">
-        {/* KPI strip — the first three read the library, the fourth the queue */}
-        <div className="grid grid-cols-2 lg:grid-cols-4 border-b border-border">
+        {/* KPI strip — the library, and only the library */}
+        <div className="grid grid-cols-2 lg:grid-cols-3 border-b border-border">
           <Kpi
             label="Active series"
             value={String(activeSeries)}
@@ -352,159 +334,94 @@ export default function DashboardPage() {
             onRetry={() => void library.refetch()}
             borderLeft
           />
-          <Kpi
-            label="Queue"
-            value={String(queueCount)}
-            state={queueCountState}
-            onRetry={() => void queue.refetch()}
-            borderLeft
-          />
         </div>
 
         {/* Operational summaries */}
         <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] border-b border-border min-h-[320px]">
-          {/* Active queue and recent history */}
+          {/* Recent history */}
           <section className="px-5 py-4 lg:border-r lg:border-border">
             <PanelHeader
-              title="Active queue"
-              meta={countMeta(queueCountState, queueCount, "item")}
-              action={{ label: "open queue →", to: "/activity" }}
+              title="Recent activity"
+              meta={`${countMeta(activityState, activityEvents.length, "event")} · ${activityDays} days`}
+              action={{
+                label: "open history →",
+                to: "/activity?view=history",
+              }}
             />
 
             <PanelBody
-              state={queueState}
-              label="Active queue"
-              skeleton={<PanelSkeleton rows={3} />}
-              empty="queue is clear"
-              onRetry={() => void queue.refetch()}
-              isRetrying={queue.isFetching}
+              state={activityState}
+              label="Recent activity"
+              skeleton={<PanelSkeleton rows={5} />}
+              empty={
+                <>
+                  no activity in the last {activityDays} days —{" "}
+                  <Link
+                    to="/activity?view=history"
+                    className="hover:text-foreground"
+                  >
+                    open full history
+                  </Link>
+                </>
+              }
+              onRetry={() => void activity.refetch()}
+              isRetrying={activity.isFetching}
             >
               {() => (
                 <div className="font-mono text-[11px]">
-                  {queueItems.map((item, index) => (
-                    <div
-                      key={item.ID}
-                      className="grid items-center gap-2 py-1.5"
-                      style={{
-                        gridTemplateColumns: "minmax(140px, 1fr) 100px 120px",
-                        borderTop:
-                          index > 0
-                            ? "1px solid var(--border-soft, var(--border))"
-                            : "none",
-                      }}
-                    >
-                      <div className="min-w-0">
-                        <div className="font-sans text-foreground truncate">
-                          {item.series || item.filename || "Unnamed download"}
+                  {activityEvents.map((d, i) => {
+                    const action = d.Status?.toLowerCase() || "—";
+                    const color = action.includes("down")
+                      ? "var(--chart-4)"
+                      : action.includes("post") || action.includes("import")
+                        ? "var(--status-active)"
+                        : action.includes("snatch") || action.includes("queue")
+                          ? "var(--status-paused)"
+                          : "var(--muted-foreground)";
+                    return (
+                      <div
+                        key={`${d.ComicID}-${d.IssueID}-${i}`}
+                        className="grid items-center gap-2 py-1.5"
+                        style={{
+                          gridTemplateColumns:
+                            "120px 90px minmax(180px, 1fr) 140px",
+                          borderTop:
+                            i > 0
+                              ? "1px solid var(--border-soft, var(--border))"
+                              : "none",
+                        }}
+                      >
+                        <RelativeTime value={d.DateAdded} />
+                        <span className="uppercase truncate" style={{ color }}>
+                          {action}
+                        </span>
+                        <div className="flex items-center gap-2 min-w-0">
+                          {d.ComicID && (
+                            <img
+                              src={`/api/metadata/art/${d.ComicID}`}
+                              alt=""
+                              className="w-4 h-6 object-cover rounded-[1px] shrink-0"
+                              onError={(e) => {
+                                e.currentTarget.style.visibility = "hidden";
+                              }}
+                            />
+                          )}
+                          <Link
+                            to={`/library/${d.ComicID}`}
+                            className="font-sans text-foreground truncate hover:text-[var(--primary)]"
+                          >
+                            {d.ComicName} #{d.Issue_Number}
+                          </Link>
                         </div>
-                        {item.filename && item.filename !== item.series && (
-                          <div className="text-muted-foreground truncate">
-                            {item.filename}
-                          </div>
-                        )}
+                        <span className="text-muted-foreground truncate">
+                          {d.Provider || "—"}
+                        </span>
                       </div>
-                      <QueueStatus status={item.status} />
-                      <span className="text-muted-foreground truncate text-right">
-                        {item.updated_date ? (
-                          <RelativeTime value={item.updated_date} />
-                        ) : (
-                          "—"
-                        )}
-                      </span>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </PanelBody>
-
-            <div className="mt-5 pt-4 border-t border-border">
-              <PanelHeader
-                title="Recent activity"
-                meta={`${countMeta(activityState, activityEvents.length, "event")} · ${activityDays} days`}
-                action={{
-                  label: "open history →",
-                  to: "/activity?view=history",
-                }}
-              />
-
-              <PanelBody
-                state={activityState}
-                label="Recent activity"
-                skeleton={<PanelSkeleton rows={5} />}
-                empty={
-                  <>
-                    no activity in the last {activityDays} days —{" "}
-                    <Link
-                      to="/activity?view=history"
-                      className="hover:text-foreground"
-                    >
-                      open full history
-                    </Link>
-                  </>
-                }
-                onRetry={() => void activity.refetch()}
-                isRetrying={activity.isFetching}
-              >
-                {() => (
-                  <div className="font-mono text-[11px]">
-                    {activityEvents.map((d, i) => {
-                      const action = d.Status?.toLowerCase() || "—";
-                      const color = action.includes("down")
-                        ? "var(--chart-4)"
-                        : action.includes("post") || action.includes("import")
-                          ? "var(--status-active)"
-                          : action.includes("snatch") ||
-                              action.includes("queue")
-                            ? "var(--status-paused)"
-                            : "var(--muted-foreground)";
-                      return (
-                        <div
-                          key={`${d.ComicID}-${d.IssueID}-${i}`}
-                          className="grid items-center gap-2 py-1.5"
-                          style={{
-                            gridTemplateColumns:
-                              "120px 90px minmax(180px, 1fr) 140px",
-                            borderTop:
-                              i > 0
-                                ? "1px solid var(--border-soft, var(--border))"
-                                : "none",
-                          }}
-                        >
-                          <RelativeTime value={d.DateAdded} />
-                          <span
-                            className="uppercase truncate"
-                            style={{ color }}
-                          >
-                            {action}
-                          </span>
-                          <div className="flex items-center gap-2 min-w-0">
-                            {d.ComicID && (
-                              <img
-                                src={`/api/metadata/art/${d.ComicID}`}
-                                alt=""
-                                className="w-4 h-6 object-cover rounded-[1px] shrink-0"
-                                onError={(e) => {
-                                  e.currentTarget.style.visibility = "hidden";
-                                }}
-                              />
-                            )}
-                            <Link
-                              to={`/library/${d.ComicID}`}
-                              className="font-sans text-foreground truncate hover:text-[var(--primary)]"
-                            >
-                              {d.ComicName} #{d.Issue_Number}
-                            </Link>
-                          </div>
-                          <span className="text-muted-foreground truncate">
-                            {d.Provider || "—"}
-                          </span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </PanelBody>
-            </div>
           </section>
 
           {/* This week */}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -368,14 +368,16 @@ export default function DashboardPage() {
               {() => (
                 <div className="font-mono text-[11px]">
                   {activityEvents.map((d, i) => {
-                    const action = d.Status?.toLowerCase() || "—";
-                    const color = action.includes("down")
-                      ? "var(--chart-4)"
-                      : action.includes("post") || action.includes("import")
-                        ? "var(--status-active)"
-                        : action.includes("snatch") || action.includes("queue")
-                          ? "var(--status-paused)"
-                          : "var(--muted-foreground)";
+                    // Status is title-case at the API; render and match as-is.
+                    const action = d.Status || "—";
+                    const color =
+                      action === "Downloaded"
+                        ? "var(--chart-4)"
+                        : action === "Post-Processed" || action === "Imported"
+                          ? "var(--status-active)"
+                          : action === "Snatched" || action === "Queued"
+                            ? "var(--status-paused)"
+                            : "var(--muted-foreground)";
                     return (
                       <div
                         key={`${d.ComicID}-${d.IssueID}-${i}`}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -179,8 +179,7 @@ export default function DashboardPage() {
   // The summary repeats each panel's own verdict rather than re-deriving it,
   // so a broken source says so instead of contributing a zero that reads as
   // fact. `panelState` stays the only place the precedence lives. Open work is
-  // deliberately absent here: `InFlightLine` is the one place that reports it,
-  // from the one endpoint that defines it (dashboard-spec.md §3.3).
+  // absent here on purpose: `InFlightLine` is the only place that reports it.
   const summary = summarize(
     libraryState,
     "library",
@@ -266,8 +265,7 @@ export default function DashboardPage() {
           whose answer can require action today (dashboard-spec.md §2, §3.1). */}
       <HealthBand />
 
-      {/* How much work is moving, across every route (§3.3). Sits directly
-          under the band; §4's final placement lands with the layout pass. */}
+      {/* How much work is moving, across every route (dashboard-spec.md §3.3) */}
       <InFlightLine />
 
       {/* Ask bar — a question here opens as a chat instead of a search */}

--- a/frontend/tests/lib/inFlight.test.ts
+++ b/frontend/tests/lib/inFlight.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { inFlightView } from "@/lib/inFlight";
+
+describe("inFlightView", () => {
+  it("says nothing is in flight rather than reporting a bare zero", () => {
+    const view = inFlightView({ inFlight: 0, recoveryPending: 0 });
+
+    expect(view.text).toBe("nothing in flight");
+    expect(view.count).toBe(0);
+    expect(view.busy).toBe(false);
+  });
+
+  it("reports the count on its own when nothing was recovered", () => {
+    const view = inFlightView({ inFlight: 12, recoveryPending: 0 });
+
+    expect(view.text).toBe("12 in flight");
+    expect(view.recovered).toBe(0);
+    expect(view.busy).toBe(true);
+  });
+
+  it("qualifies the count with restart recoveries instead of summing them", () => {
+    const view = inFlightView({ inFlight: 12, recoveryPending: 3 });
+
+    // 12 is the total; the 3 are *part of* it, so 15 must never appear.
+    expect(view.text).toBe("12 in flight (3 recovered from a restart)");
+    expect(view.count).toBe(12);
+    expect(view.recovered).toBe(3);
+  });
+
+  it("treats a missing recovery figure as no qualifier", () => {
+    expect(inFlightView({ inFlight: 4 }).text).toBe("4 in flight");
+  });
+
+  it("keeps the qualifier a subset of the total", () => {
+    // `recovery_pending` is defined as a subset of `in_flight`; a payload that
+    // contradicts that must not make the parenthetical exceed the total.
+    const view = inFlightView({ inFlight: 2, recoveryPending: 5 });
+
+    expect(view.text).toBe("2 in flight (2 recovered from a restart)");
+    expect(view.count).toBe(2);
+  });
+
+  it("refuses counts it cannot stand behind", () => {
+    expect(inFlightView({ inFlight: -3 }).text).toBe("nothing in flight");
+    expect(inFlightView({ inFlight: Number.NaN }).busy).toBe(false);
+    expect(inFlightView({ inFlight: 3.7, recoveryPending: 1.9 }).text).toBe(
+      "3 in flight (1 recovered from a restart)",
+    );
+  });
+});

--- a/frontend/tests/lib/inFlight.test.ts
+++ b/frontend/tests/lib/inFlight.test.ts
@@ -6,7 +6,6 @@ describe("inFlightView", () => {
     const view = inFlightView({ inFlight: 0, recoveryPending: 0 });
 
     expect(view.text).toBe("nothing in flight");
-    expect(view.count).toBe(0);
     expect(view.busy).toBe(false);
   });
 
@@ -14,17 +13,14 @@ describe("inFlightView", () => {
     const view = inFlightView({ inFlight: 12, recoveryPending: 0 });
 
     expect(view.text).toBe("12 in flight");
-    expect(view.recovered).toBe(0);
     expect(view.busy).toBe(true);
   });
 
   it("qualifies the count with restart recoveries instead of summing them", () => {
-    const view = inFlightView({ inFlight: 12, recoveryPending: 3 });
-
-    // 12 is the total; the 3 are *part of* it, so 15 must never appear.
-    expect(view.text).toBe("12 in flight (3 recovered from a restart)");
-    expect(view.count).toBe(12);
-    expect(view.recovered).toBe(3);
+    // 12 is the total; the 3 are part of it, so 15 must never appear.
+    expect(inFlightView({ inFlight: 12, recoveryPending: 3 }).text).toBe(
+      "12 in flight (3 recovered from a restart)",
+    );
   });
 
   it("treats a missing recovery figure as no qualifier", () => {
@@ -32,19 +28,8 @@ describe("inFlightView", () => {
   });
 
   it("keeps the qualifier a subset of the total", () => {
-    // `recovery_pending` is defined as a subset of `in_flight`; a payload that
-    // contradicts that must not make the parenthetical exceed the total.
-    const view = inFlightView({ inFlight: 2, recoveryPending: 5 });
-
-    expect(view.text).toBe("2 in flight (2 recovered from a restart)");
-    expect(view.count).toBe(2);
-  });
-
-  it("refuses counts it cannot stand behind", () => {
-    expect(inFlightView({ inFlight: -3 }).text).toBe("nothing in flight");
-    expect(inFlightView({ inFlight: Number.NaN }).busy).toBe(false);
-    expect(inFlightView({ inFlight: 3.7, recoveryPending: 1.9 }).text).toBe(
-      "3 in flight (1 recovered from a restart)",
+    expect(inFlightView({ inFlight: 2, recoveryPending: 5 }).text).toBe(
+      "2 in flight (2 recovered from a restart)",
     );
   });
 });

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -167,23 +167,6 @@ export const handlers = [
     }),
   ),
 
-  http.get("/api/dashboard/queue", () =>
-    HttpResponse.json({
-      count: 2,
-      items: [
-        {
-          ID: "queue-1",
-          series: "Spider-Man",
-          filename: "Spider-Man 001.cbz",
-          status: "Downloading",
-          updated_date: "2026-04-05T12:00:00",
-          site: "DDL(GetComics)",
-          comicid: "1",
-        },
-      ],
-    }),
-  ),
-
   http.get("/api/dashboard/activity", () =>
     HttpResponse.json({
       days: 30,

--- a/frontend/tests/pages/DashboardPage.test.tsx
+++ b/frontend/tests/pages/DashboardPage.test.tsx
@@ -50,31 +50,84 @@ describe("DashboardPage", () => {
     expect(screen.getByText("Active series")).toBeTruthy();
     expect(screen.getByText("Issues")).toBeTruthy();
     expect(screen.getByText("Completion")).toBeTruthy();
-    expect(screen.getByText("Queue")).toBeTruthy();
+    // The Queue tile is gone: it counted active DDL items only, so it read
+    // "0 queued" while SABnzbd was downloading (dashboard-spec.md §3.7).
+    expect(screen.queryByText("Queue")).toBeNull();
     expect(screen.getByText("10")).toBeTruthy();
     expect(screen.getByText("250")).toBeTruthy();
   });
 
-  it("renders separate active queue and recent activity previews", async () => {
+  it("renders the recent activity preview without a queue panel", async () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Active queue")).toBeTruthy();
       expect(screen.getByText("Recent activity")).toBeTruthy();
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Downloading")).toBeTruthy();
-      expect(screen.getByText("Spider-Man 001.cbz")).toBeTruthy();
       expect(screen.getByText("Spider-Man #1")).toBeTruthy();
     });
     expect(screen.getAllByText(/ago$/).length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: "open history →" })).toBeTruthy();
+
+    // Nothing on the page claims a queue depth any more.
+    expect(screen.queryByText("Active queue")).toBeNull();
+    expect(screen.queryByRole("link", { name: "open queue →" })).toBeNull();
+    expect(screen.queryByText(/in queue/)).toBeNull();
+  });
+
+  it("reports in-flight work from the activity status endpoint", async () => {
+    render(<DashboardPage />);
+
+    // The default fixture reports 2 in flight, none of it recovered.
     expect(
-      screen.getByRole("link", { name: "open queue →" }),
+      await screen.findByRole("link", { name: "In flight" }),
     ).toBeTruthy();
+    expect(screen.getByText("2 in flight")).toBeTruthy();
+  });
+
+  it("qualifies the in-flight count with restart recoveries", async () => {
+    server.use(
+      http.get("/api/activity/status", () =>
+        HttpResponse.json({ in_flight: 12, recovery_pending: 3, attention: 0 }),
+      ),
+    );
+
+    render(<DashboardPage />);
+
+    // Qualified, never summed: 12 total, of which 3 survived a restart.
     expect(
-      screen.getByRole("link", { name: "open history →" }),
+      await screen.findByText("12 in flight (3 recovered from a restart)"),
     ).toBeTruthy();
+    expect(screen.queryByText("15 in flight")).toBeNull();
+  });
+
+  it("says nothing is in flight rather than nothing at all", async () => {
+    server.use(
+      http.get("/api/activity/status", () =>
+        HttpResponse.json({ in_flight: 0, recovery_pending: 0, attention: 0 }),
+      ),
+    );
+
+    render(<DashboardPage />);
+
+    expect(await screen.findByText("nothing in flight")).toBeTruthy();
+  });
+
+  it("says so when the in-flight count cannot be read", async () => {
+    server.use(
+      http.get("/api/activity/status", () =>
+        HttpResponse.json({ detail: "unavailable" }, { status: 503 }),
+      ),
+    );
+
+    render(<DashboardPage />);
+
+    // An unread count is not a quiet system.
+    await waitFor(() => {
+      expect(screen.getByText("In flight unavailable")).toBeTruthy();
+    });
+    expect(screen.queryByText("nothing in flight")).toBeNull();
   });
 
   it("starts scans for each configured library from the dashboard", async () => {
@@ -178,9 +231,6 @@ describe("DashboardPage", () => {
 
   it("shows empty states when no data", async () => {
     server.use(
-      http.get("/api/dashboard/queue", () =>
-        HttpResponse.json({ count: 0, items: [] }),
-      ),
       http.get("/api/dashboard/activity", () =>
         HttpResponse.json({ days: 30, events: [] }),
       ),
@@ -195,7 +245,6 @@ describe("DashboardPage", () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("queue is clear")).toBeTruthy();
       expect(screen.getByText(/no activity in the last 30 days/)).toBeTruthy();
       expect(screen.getByText("nothing upcoming this week")).toBeTruthy();
     });
@@ -236,7 +285,7 @@ describe("DashboardPage", () => {
     expect(screen.queryByText(/no activity in the last 30 days/)).toBeNull();
 
     // Neighbours still render their own content.
-    expect(screen.getByText("Spider-Man 001.cbz")).toBeTruthy();
+    expect(screen.getByText("2 in flight")).toBeTruthy();
     expect(screen.getByText("Batman")).toBeTruthy();
     expect(screen.getByText("50.0%")).toBeTruthy();
   });
@@ -301,9 +350,10 @@ describe("DashboardPage", () => {
     await waitFor(() => {
       expect(screen.getByText(/library unavailable/)).toBeTruthy();
     });
-    // The three library tiles report unavailable; the queue tile still counts.
+    // All three tiles read the library, so all three report unavailable —
+    // while the in-flight line, on its own endpoint, still answers.
     expect(screen.getAllByText("unavailable").length).toBe(3);
-    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getByText("2 in flight")).toBeTruthy();
     expect(screen.queryByText("50.0%")).toBeNull();
   });
 

--- a/frontend/tests/pages/DashboardPage.test.tsx
+++ b/frontend/tests/pages/DashboardPage.test.tsx
@@ -123,7 +123,6 @@ describe("DashboardPage", () => {
 
     render(<DashboardPage />);
 
-    // An unread count is not a quiet system.
     await waitFor(() => {
       expect(screen.getByText("In flight unavailable")).toBeTruthy();
     });

--- a/tests/unit/test_dashboard_service.py
+++ b/tests/unit/test_dashboard_service.py
@@ -25,8 +25,6 @@ def _dashboard_dependencies(monkeypatch):
     monkeypatch.setattr(service, "comicarr", runtime)
     monkeypatch.setattr(service.dashboard_queries, "get_recent_activity", lambda cutoff, limit: [])
     monkeypatch.setattr(service.dashboard_queries, "get_library_stats", lambda content_type=None: None)
-    monkeypatch.setattr(service.dl_queries, "count_active_ddl_items", lambda: 0)
-    monkeypatch.setattr(service.dl_queries, "get_active_ddl_preview", lambda limit: [])
     monkeypatch.setattr(service.storyarcs_service, "get_upcoming", lambda include_downloaded: [])
 
 
@@ -77,29 +75,6 @@ class TestLibraryPanel:
 
         with pytest.raises(RuntimeError):
             service.get_library_panel()
-
-
-class TestQueuePanel:
-    """The active-download count and its preview."""
-
-    def test_count_and_preview_share_the_active_predicate(self, monkeypatch):
-        queue_items = [{"ID": "queued-1", "series": "Batman", "status": "Queued"}]
-        get_active_preview = MagicMock(return_value=queue_items)
-        monkeypatch.setattr(service.dl_queries, "count_active_ddl_items", lambda: 3)
-        monkeypatch.setattr(service.dl_queries, "get_active_ddl_preview", get_active_preview)
-
-        panel = service.get_queue_panel()
-
-        get_active_preview.assert_called_once_with(limit=5)
-        assert panel == {"count": 3, "items": queue_items}
-
-    def test_a_failed_count_raises_instead_of_reporting_zero(self, monkeypatch):
-        monkeypatch.setattr(
-            service.dl_queries, "count_active_ddl_items", MagicMock(side_effect=RuntimeError("count failed"))
-        )
-
-        with pytest.raises(RuntimeError):
-            service.get_queue_panel()
 
 
 class TestActivityPanel:


### PR DESCRIPTION
Implements §3.3 and §3.7 of [docs/architecture/dashboard-spec.md](https://github.com/frankieramirez/comicarr/blob/main/docs/architecture/dashboard-spec.md). Closes #579, part of #576.

## What changed

The dashboard now says how much work is moving right now, across every download route — one line, read only from `GET /api/activity/status`. That is the same source the global status indicator reads, so the two can never disagree, and the count is never re-derived from another table.

`frontend/src/lib/inFlight.ts` holds the whole reading as a pure function; `InFlightLine.tsx` is the thin component around it. Three rules are encoded there rather than in the markup:

- **Recovery qualifies, never adds.** `recovery_pending` is a *subset* of `in_flight`, so it only ever appears in parentheses — `12 in flight (3 recovered from a restart)`. It is also bounded by the total: a payload claiming more recovered than in flight contradicts itself, and the subset bound is the only reading that keeps the total true. `15` cannot be produced by any payload.
- **Zero reads "nothing in flight"**, not a bare `0` — a count with no noun beside it is the shape the Queue tile had.
- **A failed read renders `In flight unavailable`** with its own retry, never the quiet phrasing. An unread count is not a quiet system; same rule the health band follows for absence of evidence.

## The Queue removal goes past the tile

§3.7 removes Queue **as a panel**, so three things went, not one:

- the **Queue** stat tile (KPI strip is now three tiles, all reading the library),
- the **Active queue** DDL preview panel — titled "Active queue" and metered "2 items", it made the same route-incomplete claim in prose,
- the page-header summary segment `N in queue`.

All three counted active DDL items only, so an operator running SABnzbd saw `0 queued` while SAB was downloading. With no consumer left, `GET /api/dashboard/queue` and `service.get_queue_panel()` are deleted rather than left unreachable — the route was only introduced in #583, so nothing external can depend on it. `count_active_ddl_items` and `get_active_ddl_preview` stay in `downloads/queries.py` with their own tests.

## Deliberately not in this PR

- **Placement is provisional.** The line sits directly under the health band. §4 pairs it with the needs-attention band, which does not exist yet — #580 builds it and #582 pairs them. Nothing here presumes that row's shape.
- **The "Anything stuck in the queue?" ask chip stands.** It is a question, not a claim of queue depth; §3.8's chip cleanup belongs to #582.
- **The DDL preview list is not rehomed.** §3.7 says it "belongs on the downloads page"; it is not there and no ticket places it. Ruled out of scope on the map rather than silently carried here.

## Verification

- `npm run lint` clean across all five lanes
- 377 frontend tests, 2137 backend tests pass
- Tests cover zero in flight, in flight without recovery, in flight with recovery pending, the contradictory-payload bound, and an unreadable endpoint — at both the pure-function and page level
- Changeset `lucky-pandas-count.md` (minor, operator-facing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LT9RXXsLJFqHumADfTFek

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a unified in-flight activity indicator to the dashboard.
  - In-progress work now includes clear counts and recovered work when applicable.
  - Added loading, unavailable, and retry states for activity status.
  - Recent activity is now the primary operational panel, with direct links to activity details.

- **Improvements**
  - Simplified dashboard metrics to focus on library totals.
  - Removed the separate Queue tile and queue panel from the dashboard.
  - Improved handling of incomplete, invalid, or unavailable status data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->