### PR TITLE
feat: Surface needs-attention groups on the dashboard

### DIFF
--- a/.changeset/clear-badgers-point.md
+++ b/.changeset/clear-badgers-point.md
@@ -1,0 +1,7 @@
+---
+"comicarr": minor
+---
+
+The dashboard now surfaces what needs your attention, not just whether the machinery is up. Below the health band it lists the same needs-attention groups the Activity Center already knows about — the series, the reason in plain language, and the actions that clear them — and when nothing is waiting it says so with a single quiet line: **Nothing needs you**.
+
+That sentence is only trustworthy next to the health band's last-successful-search line. Together they close the gap that let downloads stay broken for weeks while the dashboard looked fine: the health band catches a stalled pipeline, and this one catches the specific releases that already need a human decision. Actions taken here (retry, search again, import, stop wanting) are the same exits as on the full triage route, and the count updates as soon as they land — no manual refresh.

--- a/frontend/src/components/dashboard/NeedsAttentionBand.tsx
+++ b/frontend/src/components/dashboard/NeedsAttentionBand.tsx
@@ -1,0 +1,262 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { AlertTriangle } from "lucide-react";
+import {
+  actionLabel,
+  stageAccent,
+  type AttentionGroup,
+  type BandAction,
+} from "@/components/activity/timeline";
+import { StopWantingDialog } from "@/components/activity/attention/StopWantingDialog";
+import { PanelUnavailable } from "@/components/dashboard/DashboardPanel";
+import { useToast } from "@/components/ui/toast";
+import {
+  useActivityBand,
+  useBandBatchResolution,
+  type BandBatchResult,
+} from "@/hooks/useActivity";
+
+/**
+ * Needs-attention on the dashboard (docs/architecture/dashboard-spec.md §3.2).
+ *
+ * This is the *actionable* half of failure visibility — the health band covers
+ * infrastructure; this surface shows the specific releases that already need a
+ * human decision. It reads `GET /api/activity/band` (group envelope, not rows)
+ * and resolves through the same `POST /api/downloads/needs-attention/...`
+ * exits the triage route uses, so an action here has the same effect and the
+ * count refreshes without a manual reload.
+ *
+ * Zero groups is a single quiet "Nothing needs you" line, not an empty card.
+ * That sentence is only trustworthy alongside the health band's
+ * last-successful-search line.
+ */
+
+const TRIAGE_HREF = "/activity/attention";
+
+function batchSummary(result: BandBatchResult): string {
+  const verb = actionLabel(result.action);
+  const head =
+    result.succeeded === result.processed
+      ? `${verb} — ${result.succeeded} ${result.succeeded === 1 ? "issue" : "issues"}.`
+      : `${verb} ${result.succeeded} of ${result.processed} — ${result.failed} still ${result.failed === 1 ? "needs" : "need"} attention.`;
+  if (!result.capped) return head;
+  return `${head} ${result.skipped_for_cap} left for another go (max ${result.cap} at a time).`;
+}
+
+function GroupRow({
+  group,
+  busy,
+  onAction,
+}: {
+  group: AttentionGroup;
+  busy: boolean;
+  onAction: (action: BandAction, group: AttentionGroup) => void;
+}) {
+  const accent = stageAccent(group.stage);
+  const mixed = group.available_actions.length === 0;
+  const triageGroupHref = `${TRIAGE_HREF}?group=${encodeURIComponent(group.group_key)}`;
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-3 gap-y-1.5 py-1.5"
+      data-testid="needs-attention-group"
+    >
+      <span
+        className="h-1.5 w-1.5 shrink-0 rounded-full"
+        style={{ background: accent }}
+        aria-hidden="true"
+      />
+      <div className="min-w-0 flex-1 font-mono text-[11px]">
+        {group.comicid ? (
+          <Link
+            to={`/library/${group.comicid}`}
+            className="text-foreground hover:text-[var(--primary)]"
+          >
+            {group.series_label}
+          </Link>
+        ) : (
+          <span className="text-foreground">{group.series_label}</span>
+        )}
+        {group.member_count > 1 && (
+          <span className="text-muted-foreground"> ×{group.member_count}</span>
+        )}
+        <span className="text-muted-foreground"> — {group.reason_phrase}</span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        {mixed ? (
+          <Link
+            to={triageGroupHref}
+            className="font-mono text-[10px] text-muted-foreground hover:text-foreground"
+          >
+            open triage →
+          </Link>
+        ) : (
+          group.available_actions.map((action) => (
+            <button
+              key={action}
+              type="button"
+              disabled={busy}
+              onClick={() => onAction(action, group)}
+              className="rounded-[4px] border px-2 py-1 font-mono text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-60"
+              style={{ borderColor: "var(--border)" }}
+            >
+              {actionLabel(action)}
+              {action === "stop_wanting" && group.member_count > 1 ? "…" : ""}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function NeedsAttentionBand() {
+  const band = useActivityBand();
+  const batch = useBandBatchResolution();
+  const { addToast } = useToast();
+  const [confirming, setConfirming] = useState<{
+    releaseKeys: string[];
+    seriesLabel?: string;
+  } | null>(null);
+
+  const runAction = async (action: BandAction, releaseKeys: string[]) => {
+    if (releaseKeys.length === 0) return;
+    try {
+      const result = await batch.mutateAsync({ action, releaseKeys });
+      addToast({
+        type: result.partial ? "info" : "success",
+        message: batchSummary(result),
+      });
+    } catch (err) {
+      addToast({
+        type: "error",
+        message:
+          err instanceof Error
+            ? err.message
+            : `Unable to ${actionLabel(action).toLowerCase()} these issues.`,
+      });
+    }
+  };
+
+  const onGroupAction = (action: BandAction, group: AttentionGroup) => {
+    const releaseKeys = group.members.map((member) => member.release_key);
+    if (action === "stop_wanting" && releaseKeys.length >= 2) {
+      setConfirming({ releaseKeys, seriesLabel: group.series_label });
+      return;
+    }
+    void runAction(action, releaseKeys);
+  };
+
+  if (band.isPending) {
+    return (
+      <div
+        className="px-5 py-2.5 border-b border-border"
+        data-testid="needs-attention-loading"
+      >
+        <div
+          aria-hidden="true"
+          className="h-2.5 w-48 animate-pulse rounded-[2px] bg-primary/10"
+        />
+      </div>
+    );
+  }
+
+  if (band.isError) {
+    return (
+      <div className="px-5 border-b border-border">
+        <PanelUnavailable
+          label="Needs attention"
+          onRetry={() => void band.refetch()}
+          isRetrying={band.isFetching}
+        />
+      </div>
+    );
+  }
+
+  const groups = band.data?.results ?? [];
+  const total = band.data?.total ?? groups.length;
+  const previewCap = band.data?.preview_cap ?? 5;
+  const preview = groups.slice(0, previewCap);
+  const more = Math.max(0, total - preview.length);
+
+  if (total === 0) {
+    return (
+      <div
+        className="px-5 py-2.5 border-b border-border"
+        data-testid="needs-attention-empty"
+      >
+        <span className="font-mono text-[11px] text-muted-foreground">
+          Nothing needs you
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Needs attention"
+      className="border-b border-border"
+      style={{
+        background:
+          "var(--status-error-bg, color-mix(in oklab, var(--status-error) 8%, transparent))",
+      }}
+      data-testid="needs-attention-band"
+    >
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-5 pt-3 pb-1.5">
+        <AlertTriangle
+          className="h-3.5 w-3.5"
+          style={{ color: "var(--status-error)" }}
+          aria-hidden="true"
+        />
+        <span
+          className="font-mono text-[11px] uppercase tracking-[0.1em]"
+          style={{ color: "var(--status-error)" }}
+        >
+          {total} need{total === 1 ? "s" : ""} attention
+        </span>
+        <Link
+          to={TRIAGE_HREF}
+          className="ml-auto font-mono text-[11px] hover:underline"
+          style={{ color: "var(--status-error)" }}
+        >
+          See all {total} →
+        </Link>
+      </div>
+
+      <div className="px-5 pb-3">
+        {preview.map((group) => (
+          <GroupRow
+            key={group.group_key}
+            group={group}
+            busy={batch.isPending}
+            onAction={onGroupAction}
+          />
+        ))}
+        {more > 0 && (
+          <Link
+            to={TRIAGE_HREF}
+            className="mt-1 inline-block font-mono text-[11px] text-muted-foreground hover:text-foreground"
+            data-testid="needs-attention-more"
+          >
+            +{more} more…
+          </Link>
+        )}
+      </div>
+
+      {confirming && (
+        <StopWantingDialog
+          count={confirming.releaseKeys.length}
+          seriesLabel={confirming.seriesLabel}
+          busy={batch.isPending}
+          onCancel={() => setConfirming(null)}
+          onConfirm={() => {
+            const { releaseKeys } = confirming;
+            setConfirming(null);
+            void runAction("stop_wanting", releaseKeys);
+          }}
+        />
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/dashboard/DashboardPanel";
 import HealthBand from "@/components/dashboard/HealthBand";
 import InFlightLine from "@/components/dashboard/InFlightLine";
+import NeedsAttentionBand from "@/components/dashboard/NeedsAttentionBand";
 import { panelState, type PanelState } from "@/lib/panelState";
 import { Kbd } from "@/components/ui/kbd";
 import RelativeTime from "@/components/ui/RelativeTime";
@@ -264,6 +265,9 @@ export default function DashboardPage() {
       {/* Health band — above every other panel, because it is the only one
           whose answer can require action today (dashboard-spec.md §2, §3.1). */}
       <HealthBand />
+
+      {/* Actionable half of failure visibility (dashboard-spec.md §3.2) */}
+      <NeedsAttentionBand />
 
       {/* How much work is moving, across every route (dashboard-spec.md §3.3) */}
       <InFlightLine />

--- a/frontend/tests/components/NeedsAttentionBand.test.tsx
+++ b/frontend/tests/components/NeedsAttentionBand.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * Dashboard needs-attention band (dashboard-spec.md §3.2).
+ *
+ * Covers the three band shapes the ticket names — nothing waiting, a short
+ * list under the cap, and a list that folds the rest into triage — plus an
+ * in-place action so the count updates without a manual refresh.
+ */
+
+import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/server";
+import { render, screen, waitFor } from "../test-utils";
+import NeedsAttentionBand from "@/components/dashboard/NeedsAttentionBand";
+
+function group(overrides: Record<string, unknown> = {}) {
+  return {
+    group_key: "42|postprocess_error",
+    comicid: "42",
+    series_label: "Saga",
+    base_reason: "postprocess_error",
+    reason_phrase: "post-processing failed",
+    member_count: 1,
+    newest_updated_at: "2026-08-03 12:00:00",
+    oldest_updated_at: "2026-08-03 12:00:00",
+    stage: "failed",
+    available_actions: ["retry", "stop_wanting"],
+    members: [
+      {
+        release_key: "rk-1",
+        issue_label: "Saga #12",
+        issueid: "iss-1",
+        stage: "failed",
+        available_actions: ["retry", "stop_wanting"],
+        updated_date: "2026-08-03 12:00:00",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function bandHandler(
+  groups: ReturnType<typeof group>[],
+  opts: { total?: number; preview_cap?: number } = {},
+) {
+  const preview_cap = opts.preview_cap ?? 5;
+  const total = opts.total ?? groups.length;
+  return http.get("/api/activity/band", () =>
+    HttpResponse.json({
+      results: groups,
+      total,
+      member_total: groups.reduce((n, g) => n + g.member_count, 0),
+      preview_cap,
+    }),
+  );
+}
+
+describe("NeedsAttentionBand", () => {
+  it("renders one quiet line when nothing needs attention", async () => {
+    server.use(bandHandler([]));
+
+    render(<NeedsAttentionBand />);
+
+    expect(await screen.findByText("Nothing needs you")).toBeTruthy();
+    expect(screen.queryByRole("region", { name: "Needs attention" })).toBeNull();
+    expect(screen.queryByText(/need attention/i)).toBeNull();
+  });
+
+  it("shows the group count and each group's phrase under the cap", async () => {
+    server.use(
+      bandHandler([
+        group(),
+        group({
+          group_key: "7|search_error",
+          comicid: "7",
+          series_label: "Invincible",
+          reason_phrase: "search failed",
+          members: [
+            {
+              release_key: "rk-2",
+              issue_label: "Invincible #1",
+              issueid: "iss-2",
+              stage: "failed",
+              available_actions: ["retry", "stop_wanting"],
+              updated_date: "2026-08-03 11:00:00",
+            },
+          ],
+        }),
+      ]),
+    );
+
+    render(<NeedsAttentionBand />);
+
+    expect(
+      await screen.findByRole("region", { name: "Needs attention" }),
+    ).toBeTruthy();
+    expect(screen.getByText("2 need attention")).toBeTruthy();
+    expect(screen.getByText("Saga")).toBeTruthy();
+    expect(screen.getByText(/post-processing failed/)).toBeTruthy();
+    expect(screen.getByText("Invincible")).toBeTruthy();
+    expect(screen.getByText(/search failed/)).toBeTruthy();
+    expect(screen.getAllByTestId("needs-attention-group")).toHaveLength(2);
+    expect(screen.queryByTestId("needs-attention-more")).toBeNull();
+    // Group-level actions match the triage route's exits.
+    expect(screen.getAllByRole("button", { name: "Retry" })).toHaveLength(2);
+  });
+
+  it("folds groups past the preview cap into a triage link", async () => {
+    const groups = Array.from({ length: 5 }, (_, i) =>
+      group({
+        group_key: `${i}|r`,
+        comicid: String(i),
+        series_label: `Series ${i}`,
+        members: [
+          {
+            release_key: `rk-${i}`,
+            issue_label: `Series ${i} #1`,
+            issueid: `iss-${i}`,
+            stage: "failed",
+            available_actions: ["retry", "stop_wanting"],
+            updated_date: "2026-08-03 12:00:00",
+          },
+        ],
+      }),
+    );
+    // Server can report a total larger than the rows it returned (band envelope).
+    server.use(bandHandler(groups, { total: 8, preview_cap: 5 }));
+
+    render(<NeedsAttentionBand />);
+
+    expect(await screen.findByText("8 need attention")).toBeTruthy();
+    expect(screen.getAllByTestId("needs-attention-group")).toHaveLength(5);
+    const more = await screen.findByTestId("needs-attention-more");
+    expect(more.textContent).toContain("+3 more");
+    expect(more.getAttribute("href")).toBe("/activity/attention");
+    expect(
+      screen.getByRole("link", { name: "See all 8 →" }).getAttribute("href"),
+    ).toBe("/activity/attention");
+  });
+
+  it("runs a group action through the same batch endpoint and refreshes the band", async () => {
+    const requests: Array<{ action: string; release_keys: string[] }> = [];
+    let hits = 0;
+    server.use(
+      http.get("/api/activity/band", () => {
+        hits += 1;
+        // After a successful action the band is empty — the count moves without
+        // the operator refreshing.
+        if (hits > 1) {
+          return HttpResponse.json({
+            results: [],
+            total: 0,
+            member_total: 0,
+            preview_cap: 5,
+          });
+        }
+        return HttpResponse.json({
+          results: [group()],
+          total: 1,
+          member_total: 1,
+          preview_cap: 5,
+        });
+      }),
+      http.post("/api/downloads/needs-attention/batch", async ({ request }) => {
+        const body = (await request.json()) as {
+          action: string;
+          release_keys: string[];
+        };
+        requests.push(body);
+        return HttpResponse.json({
+          success: true,
+          partial: false,
+          action: body.action,
+          requested: 1,
+          processed: 1,
+          succeeded: 1,
+          failed: 0,
+          capped: false,
+          skipped_for_cap: 0,
+          cap: 25,
+          results: [{ release_key: "rk-1", ok: true, status: "retried" }],
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(<NeedsAttentionBand />);
+
+    expect(await screen.findByText("1 needs attention")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(requests).toEqual([
+        { action: "retry", release_keys: ["rk-1"] },
+      ]);
+    });
+    expect(await screen.findByText("Nothing needs you")).toBeTruthy();
+    expect(screen.queryByText("1 needs attention")).toBeNull();
+  });
+
+  it("says so when the band cannot be read", async () => {
+    server.use(
+      http.get("/api/activity/band", () =>
+        HttpResponse.json({ detail: "unavailable" }, { status: 503 }),
+      ),
+    );
+
+    render(<NeedsAttentionBand />);
+
+    expect(await screen.findByText("Needs attention unavailable")).toBeTruthy();
+    expect(screen.queryByText("Nothing needs you")).toBeNull();
+  });
+});

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -145,6 +145,17 @@ export const handlers = [
     HttpResponse.json({ in_flight: 2, attention: 0 }),
   ),
 
+  // Needs-attention groups (dashboard §3.2 / Activity Center band). Default
+  // empty so a page that mounts the band never invents trouble.
+  http.get("/api/activity/band", () =>
+    HttpResponse.json({
+      results: [],
+      total: 0,
+      member_total: 0,
+      preview_cap: 5,
+    }),
+  ),
+
   http.get("/api/downloads/queue", () =>
     HttpResponse.json({
       queue: [],

--- a/frontend/tests/pages/DashboardPage.test.tsx
+++ b/frontend/tests/pages/DashboardPage.test.tsx
@@ -86,6 +86,14 @@ describe("DashboardPage", () => {
     expect(screen.getByText("2 in flight")).toBeTruthy();
   });
 
+  it("surfaces a quiet needs-attention line on the default empty band", async () => {
+    render(<DashboardPage />);
+
+    // Default mock has zero groups — calm, not an empty card with a heading.
+    expect(await screen.findByText("Nothing needs you")).toBeTruthy();
+    expect(screen.queryByRole("region", { name: "Needs attention" })).toBeNull();
+  });
+
   it("qualifies the in-flight count with restart recoveries", async () => {
     server.use(
       http.get("/api/activity/status", () =>


### PR DESCRIPTION
## Summary

The dashboard now shows what needs your attention below the health band — the same needs-attention groups as the Activity Center, with operator phrases and the shared resolution actions — so a stalled release is visible without opening triage. When nothing is waiting it says **Nothing needs you** rather than rendering an empty card.

Closes #580. Part of #576 (dashboard-spec.md §3.2).

## Changes

- Add `NeedsAttentionBand` on `DashboardPage`, reading `GET /api/activity/band` (group envelope) and resolving via the existing `POST /api/downloads/needs-attention/...` batch exits
- Zero groups → quiet line; under cap → group rows with actions; over cap → top N plus fold into `/activity/attention`
- Tests cover empty / under cap / over cap / in-place action refresh / unavailable; default MSW band fixture is empty
- Operator-facing changeset for the new surface

## Test plan

- [ ] `cd frontend && npm run test:run -- tests/components/NeedsAttentionBand.test.tsx tests/pages/DashboardPage.test.tsx`
- [ ] `npm run lint`
- [ ] Dashboard with zero attention: quiet "Nothing needs you" below health band
- [ ] Dashboard with a few groups: count, phrases, Retry / Stop wanting (etc.) work and count updates without refresh
- [ ] More groups than `preview_cap`: "+N more…" and "See all" land on `/activity/attention`
- [ ] Band endpoint failure: panel says unavailable with its own retry; neighbours still render