### PR TITLE
feat: Adopt the spec's layout order, reduce Library, demote Ask

### DIFF
--- a/.changeset/eighty-jars-arrive.md
+++ b/.changeset/eighty-jars-arrive.md
@@ -1,0 +1,9 @@
+---
+"comicarr": minor
+---
+
+The dashboard now reads top to bottom in the order the questions actually matter: is the automation healthy, what needs you, what is happening, and only then what your library is. Health leads the page, needs-attention and in-flight sit together on the row beneath it, and recent activity and this week's releases follow. On a narrow window those two stack in the same order rather than reshuffling.
+
+**Library statistics are no longer the hero of the page.** The three large tiles at the top are gone, replaced by a single line of numbers below the timeline — series, issues held, and completion, now labelled **of known issues held** and marked *not a health metric*. Completion counts what is on disk against what Comicarr knows exists; it says nothing about whether downloading works, and it no longer sits next to the health band where it looked like it did.
+
+**Ask moves to the bottom of the page** and loses its suggestion chips. It is a way into chat, not an answer to any of the questions above it, and chips like "Anything stuck in the queue?" were making health claims that the health band now reports properly. The recent-chats card that sat beside "This week" goes with it; chat is reachable from the sidebar and the Ask bar.

--- a/frontend/src/components/dashboard/InFlightLine.tsx
+++ b/frontend/src/components/dashboard/InFlightLine.tsx
@@ -18,7 +18,7 @@ export default function InFlightLine() {
 
   if (status.isPending) {
     return (
-      <div className="px-5 py-2.5 border-b border-border">
+      <div className="px-5 py-2.5">
         <div
           aria-hidden="true"
           className="h-2.5 w-40 animate-pulse rounded-[2px] bg-primary/10"
@@ -29,7 +29,7 @@ export default function InFlightLine() {
 
   if (status.isError) {
     return (
-      <div className="px-5 border-b border-border">
+      <div className="px-5">
         <PanelUnavailable
           label="In flight"
           onRetry={() => void status.refetch()}
@@ -45,7 +45,7 @@ export default function InFlightLine() {
   });
 
   return (
-    <div className="px-5 py-2.5 border-b border-border">
+    <div className="px-5 py-2.5">
       <Link
         to="/activity"
         aria-label="In flight"

--- a/frontend/src/components/dashboard/LibraryRow.tsx
+++ b/frontend/src/components/dashboard/LibraryRow.tsx
@@ -1,0 +1,79 @@
+import { PanelUnavailable } from "@/components/dashboard/DashboardPanel";
+import { useDashboardLibrary } from "@/hooks/useDashboard";
+import { panelState } from "@/lib/panelState";
+
+/**
+ * What the library is, as one row of numbers
+ * (docs/architecture/dashboard-spec.md §3.6).
+ *
+ * It used to be three hero KPI tiles at the top of the page, which read as a
+ * vanity panel and pushed the only actionable content below the fold. It is
+ * ambient — it never changes what the operator does today — so it sits below
+ * the actionable panels and below the timeline, and renders at body size.
+ *
+ * `completion_pct` keeps its definition (`total_issues / total_expected`) but
+ * is labelled as what it is: issues held vs. issues known. It is not a health
+ * metric, and the layout keeps it away from the health band, where adjacency
+ * alone would make it read as one.
+ */
+export default function LibraryRow() {
+  const library = useDashboardLibrary();
+  const state = panelState(library, false);
+  const stats = library.data?.stats;
+
+  if (state === "loading") {
+    return (
+      <div className="px-5 py-3.5 border-b border-border">
+        <div
+          aria-hidden="true"
+          className="h-3 w-64 animate-pulse rounded-[2px] bg-primary/10"
+        />
+      </div>
+    );
+  }
+
+  if (state === "unavailable") {
+    return (
+      <div className="px-5 border-b border-border">
+        <PanelUnavailable
+          label="Library"
+          onRetry={() => void library.refetch()}
+          isRetrying={library.isFetching}
+        />
+      </div>
+    );
+  }
+
+  const series = stats?.total_series ?? 0;
+  const issues = stats?.total_issues ?? 0;
+  const completion = stats?.completion_pct ?? 0;
+
+  return (
+    <div
+      className="px-5 py-3.5 border-b border-border flex flex-wrap items-center gap-x-2 gap-y-1"
+      data-testid="library-row"
+    >
+      <span className="text-[14px]">
+        <span className="font-semibold">{series.toLocaleString()}</span>{" "}
+        <span className="text-muted-foreground">series</span>
+      </span>
+      <span className="text-border" aria-hidden="true">
+        ·
+      </span>
+      <span className="text-[14px]">
+        <span className="font-semibold">{issues.toLocaleString()}</span>{" "}
+        <span className="text-muted-foreground">issues held</span>
+      </span>
+      <span className="text-border" aria-hidden="true">
+        ·
+      </span>
+      <span className="text-[14px]">
+        <span className="font-semibold">{completion.toFixed(1)}%</span>{" "}
+        <span className="text-muted-foreground">of known issues held</span>
+      </span>
+      <span className="ml-auto font-mono text-[11px] text-muted-foreground">
+        not a health metric
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/NeedsAttentionBand.tsx
+++ b/frontend/src/components/dashboard/NeedsAttentionBand.tsx
@@ -37,8 +37,12 @@ function batchSummary(result: BandBatchResult): string {
   const verb = actionLabel(result.action);
   const head =
     result.succeeded === result.processed
-      ? `${verb} — ${result.succeeded} ${result.succeeded === 1 ? "issue" : "issues"}.`
-      : `${verb} ${result.succeeded} of ${result.processed} — ${result.failed} still ${result.failed === 1 ? "needs" : "need"} attention.`;
+      ? `${verb} — ${result.succeeded} ${
+          result.succeeded === 1 ? "issue" : "issues"
+        }.`
+      : `${verb} ${result.succeeded} of ${result.processed} — ${
+          result.failed
+        } still ${result.failed === 1 ? "needs" : "need"} attention.`;
   if (!result.capped) return head;
   return `${head} ${result.skipped_for_cap} left for another go (max ${result.cap} at a time).`;
 }
@@ -54,7 +58,9 @@ function GroupRow({
 }) {
   const accent = stageAccent(group.stage);
   const mixed = group.available_actions.length === 0;
-  const triageGroupHref = `${TRIAGE_HREF}?group=${encodeURIComponent(group.group_key)}`;
+  const triageGroupHref = `${TRIAGE_HREF}?group=${encodeURIComponent(
+    group.group_key,
+  )}`;
 
   return (
     <div
@@ -150,10 +156,7 @@ export default function NeedsAttentionBand() {
 
   if (band.isPending) {
     return (
-      <div
-        className="px-5 py-2.5 border-b border-border"
-        data-testid="needs-attention-loading"
-      >
+      <div className="px-5 py-2.5" data-testid="needs-attention-loading">
         <div
           aria-hidden="true"
           className="h-2.5 w-48 animate-pulse rounded-[2px] bg-primary/10"
@@ -164,7 +167,7 @@ export default function NeedsAttentionBand() {
 
   if (band.isError) {
     return (
-      <div className="px-5 border-b border-border">
+      <div className="px-5">
         <PanelUnavailable
           label="Needs attention"
           onRetry={() => void band.refetch()}
@@ -182,10 +185,7 @@ export default function NeedsAttentionBand() {
 
   if (total === 0) {
     return (
-      <div
-        className="px-5 py-2.5 border-b border-border"
-        data-testid="needs-attention-empty"
-      >
+      <div className="px-5 py-2.5" data-testid="needs-attention-empty">
         <span className="font-mono text-[11px] text-muted-foreground">
           Nothing needs you
         </span>
@@ -196,7 +196,6 @@ export default function NeedsAttentionBand() {
   return (
     <section
       aria-label="Needs attention"
-      className="border-b border-border"
       style={{
         background:
           "var(--status-error-bg, color-mix(in oklab, var(--status-error) 8%, transparent))",

--- a/frontend/src/components/dashboard/RecentActivity.tsx
+++ b/frontend/src/components/dashboard/RecentActivity.tsx
@@ -100,7 +100,10 @@ export default function RecentActivity() {
         : `${events.length} event${events.length === 1 ? "" : "s"} · ${days} days`;
 
   return (
-    <section className="px-5 py-4 lg:border-r lg:border-border">
+    <section
+      className="px-5 py-4 lg:border-r lg:border-border"
+      data-testid="recent-activity"
+    >
       <div className="flex items-center justify-between gap-3 mb-3">
         <div className="flex items-center gap-2.5">
           <div className="text-[13px] font-semibold">Recent activity</div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -8,68 +8,23 @@ import {
 } from "@/components/dashboard/DashboardPanel";
 import HealthBand from "@/components/dashboard/HealthBand";
 import InFlightLine from "@/components/dashboard/InFlightLine";
+import LibraryRow from "@/components/dashboard/LibraryRow";
 import NeedsAttentionBand from "@/components/dashboard/NeedsAttentionBand";
 import RecentActivity from "@/components/dashboard/RecentActivity";
 import { panelState, type PanelState } from "@/lib/panelState";
 import { Kbd } from "@/components/ui/kbd";
-import RelativeTime from "@/components/ui/RelativeTime";
 import { useToast } from "@/components/ui/toast";
 import {
   useDashboardLibrary,
   useDashboardScanTargets,
   useDashboardUpcoming,
 } from "@/hooks/useDashboard";
-import { useChatThreads } from "@/hooks/useLibraryChat";
 import {
   useComicScan,
   useComicScanProgress,
   useMangaScan,
   useMangaScanProgress,
 } from "@/hooks/useImport";
-
-function Kpi({
-  label,
-  value,
-  state,
-  onRetry,
-  borderLeft,
-}: {
-  label: string;
-  value: string;
-  state: PanelState;
-  onRetry: () => void;
-  borderLeft?: boolean;
-}) {
-  return (
-    <div className={`px-5 py-4 ${borderLeft ? "border-l border-border" : ""}`}>
-      <div className="mono-label">{label}</div>
-      <div className="flex items-end gap-2 mt-1.5 h-[26px]">
-        {state === "loading" ? (
-          <div
-            aria-hidden="true"
-            className="h-4 w-16 self-center animate-pulse rounded-[2px] bg-primary/10"
-          />
-        ) : state === "unavailable" ? (
-          <div className="flex items-center gap-2 self-center font-mono text-[11px]">
-            <span style={{ color: "var(--status-error)" }}>unavailable</span>
-            <button
-              type="button"
-              onClick={onRetry}
-              aria-label={`Retry ${label}`}
-              className="text-muted-foreground hover:text-foreground"
-            >
-              <RefreshCw className="w-3 h-3" />
-            </button>
-          </div>
-        ) : (
-          <div className="text-[26px] font-semibold tracking-tight leading-none">
-            {value}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
 
 /** Panel heading plus its count and a link out to the full view. */
 function PanelHeader({
@@ -115,23 +70,12 @@ function summarize(state: PanelState, source: string, fact: string): string {
   return fact;
 }
 
-const ASK_SUGGESTIONS = [
-  "Which runs have gaps?",
-  "What landed this week?",
-  "Anything stuck in the queue?",
-];
-
 export default function DashboardPage() {
   const library = useDashboardLibrary();
   const upcoming = useDashboardUpcoming();
   const scanTargets = useDashboardScanTargets();
   const navigate = useNavigate();
-  const chatThreadsQuery = useChatThreads();
   const [question, setQuestion] = useState("");
-
-  const recentChats = (
-    chatThreadsQuery.data?.pages.flatMap((page) => page.threads) || []
-  ).slice(0, 3);
 
   /** Hand the question to the chat workspace, which asks it on arrival. */
   const handleAsk = (event: SubmitEvent<HTMLFormElement>) => {
@@ -152,11 +96,9 @@ export default function DashboardPage() {
 
   const activeSeries = stats?.total_series ?? 0;
   const totalIssues = stats?.total_issues ?? 0;
-  const completion = stats?.completion_pct ?? 0;
 
   const libraryState = panelState(library, false);
   const upcomingState = panelState(upcoming, upcomingReleases.length === 0);
-  const chatsState = panelState(chatThreadsQuery, recentChats.length === 0);
 
   const comicScanning = comicScanProgress?.status === "scanning";
   const mangaScanning = mangaScanProgress?.status === "scanning";
@@ -180,7 +122,7 @@ export default function DashboardPage() {
   const summary = summarize(
     libraryState,
     "library",
-    `${activeSeries} series · ${totalIssues} issues`,
+    `${activeSeries.toLocaleString()} series · ${totalIssues.toLocaleString()} issues`,
   );
 
   const handleLibraryScan = async () => {
@@ -208,7 +150,9 @@ export default function DashboardPage() {
     if (started === scanRequests.length) {
       addToast({
         type: "success",
-        message: `${started === 2 ? "Comic and manga library scans" : "Library scan"} started.`,
+        message: `${
+          started === 2 ? "Comic and manga library scans" : "Library scan"
+        } started.`,
       });
     } else if (started > 0) {
       addToast({
@@ -262,85 +206,35 @@ export default function DashboardPage() {
           whose answer can require action today (dashboard-spec.md §2, §3.1). */}
       <HealthBand />
 
-      {/* Actionable half of failure visibility (dashboard-spec.md §3.2) */}
-      <NeedsAttentionBand />
-
-      {/* How much work is moving, across every route (dashboard-spec.md §3.3) */}
-      <InFlightLine />
-
-      {/* Ask bar — a question here opens as a chat instead of a search */}
-      <div className="px-5 py-3.5 border-b border-border bg-card/30 flex flex-col gap-2.5">
-        <form
-          onSubmit={handleAsk}
-          className="flex items-center gap-2.5 px-3 py-2.5 rounded-[10px] border border-border bg-card focus-within:border-primary"
-        >
-          <span className="flex size-4.5 shrink-0 items-center justify-center rounded-[5px] bg-primary/15">
-            <span className="size-[5px] rounded-[1px] bg-primary" />
-          </span>
-          <input
-            value={question}
-            onChange={(e) => setQuestion(e.target.value)}
-            aria-label="Ask about your library"
-            placeholder="Ask about your library — gaps, publishers, what to read next…"
-            className="min-w-0 flex-1 bg-transparent text-[14px] outline-none placeholder:text-muted-foreground"
-          />
-          <Kbd className="hidden sm:inline-flex">⌘⇧K</Kbd>
-          <button
-            type="submit"
-            aria-label="Ask Comicarr"
-            disabled={!question.trim()}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] bg-primary text-primary-foreground disabled:opacity-40"
-          >
-            <ArrowUp className="w-3.5 h-3.5" />
-          </button>
-        </form>
-        <div className="flex flex-wrap gap-1.5">
-          {ASK_SUGGESTIONS.map((suggestion) => (
-            <button
-              key={suggestion}
-              type="button"
-              onClick={() => setQuestion(suggestion)}
-              className="h-[26px] px-2.5 rounded-full border border-border text-[12px] text-muted-foreground hover:text-foreground hover:border-ring"
-            >
-              {suggestion}
-            </button>
-          ))}
+      {/* Question 2 — what needs me — and, beside it, how much work is moving
+          (dashboard-spec.md §3.2, §3.3, §4). One row, but two queries: each
+          side still reports its own unavailability and retries alone, so a
+          broken band can never take the in-flight count down with it. */}
+      <div
+        className="border-b border-border flex flex-col lg:flex-row lg:items-start"
+        data-testid="attention-inflight-row"
+      >
+        <div className="min-w-0 flex-1 border-b border-border lg:border-b-0">
+          <NeedsAttentionBand />
+        </div>
+        <div className="shrink-0 lg:border-l lg:border-border">
+          <InFlightLine />
         </div>
       </div>
 
-      {/* Everything below the ask bar scrolls inside the page column. */}
+      {/* Everything below the actionable bands scrolls inside the page column. */}
       <div className="flex-1 min-h-0 overflow-auto">
-        {/* KPI strip — the library, and only the library */}
-        <div className="grid grid-cols-2 lg:grid-cols-3 border-b border-border">
-          <Kpi
-            label="Active series"
-            value={String(activeSeries)}
-            state={libraryState}
-            onRetry={() => void library.refetch()}
-          />
-          <Kpi
-            label="Issues"
-            value={String(totalIssues)}
-            state={libraryState}
-            onRetry={() => void library.refetch()}
-            borderLeft
-          />
-          <Kpi
-            label="Completion"
-            value={`${completion.toFixed(1)}%`}
-            state={libraryState}
-            onRetry={() => void library.refetch()}
-            borderLeft
-          />
-        </div>
-
-        {/* Operational summaries */}
-        <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] border-b border-border min-h-[320px]">
+        {/* Question 3 — what is happening. On narrow viewports these stack in
+            the same priority order: activity first, then what is coming. */}
+        <div
+          className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] border-b border-border min-h-[320px]"
+          data-testid="middle-columns"
+        >
           {/* Narrative recent activity (dashboard-spec.md §3.4) */}
           <RecentActivity />
 
           {/* This week */}
-          <section className="px-5 py-4">
+          <section className="px-5 py-4" data-testid="this-week">
             <PanelHeader
               title="This week"
               meta={countMeta(
@@ -392,45 +286,42 @@ export default function DashboardPage() {
                 ))
               }
             </PanelBody>
-
-            <div className="mt-4 p-3 rounded-[6px] border border-border bg-card">
-              <div className="flex items-center justify-between gap-2 mb-1.5">
-                <div className="mono-label">Recent chats</div>
-                <Link
-                  to="/chat"
-                  className="font-mono text-[10px] text-primary hover:underline"
-                >
-                  all →
-                </Link>
-              </div>
-              <PanelBody
-                state={chatsState}
-                label="Recent chats"
-                skeleton={<PanelSkeleton rows={3} rowHeight={33} />}
-                empty="no saved chats yet"
-                onRetry={() => void chatThreadsQuery.refetch()}
-                isRetrying={chatThreadsQuery.isFetching}
-              >
-                {() =>
-                  recentChats.map((thread) => (
-                    <Link
-                      key={thread.id}
-                      to={`/chat/${thread.id}`}
-                      className="block px-2 py-1.5 -mx-1 rounded-[6px] hover:bg-accent"
-                    >
-                      <div className="text-[12px] font-medium truncate">
-                        {thread.title}
-                      </div>
-                      <div className="mono-meta text-[10px]">
-                        {thread.message_count} msgs ·{" "}
-                        <RelativeTime value={thread.updated_at} />
-                      </div>
-                    </Link>
-                  ))
-                }
-              </PanelBody>
-            </div>
           </section>
+        </div>
+
+        {/* Question 4 — what the library is. Ambient, one row, and deliberately
+            far from the health band (dashboard-spec.md §3.6). */}
+        <LibraryRow />
+
+        {/* Ask — a feature entry point, not an answer to any of §2's questions,
+            so it sits last (dashboard-spec.md §3.8). The suggestion chips are
+            gone: "Anything stuck in the queue?" was health reporting, and the
+            health band now does that properly. */}
+        <div className="px-5 py-3.5" data-testid="ask-bar">
+          <form
+            onSubmit={handleAsk}
+            className="flex items-center gap-2.5 px-3 py-2.5 rounded-[10px] border border-border bg-card focus-within:border-primary"
+          >
+            <span className="flex size-4.5 shrink-0 items-center justify-center rounded-[5px] bg-primary/15">
+              <span className="size-[5px] rounded-[1px] bg-primary" />
+            </span>
+            <input
+              value={question}
+              onChange={(e) => setQuestion(e.target.value)}
+              aria-label="Ask about your library"
+              placeholder="Ask about your library — gaps, publishers, what to read next…"
+              className="min-w-0 flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground"
+            />
+            <Kbd className="hidden sm:inline-flex">⌘⇧K</Kbd>
+            <button
+              type="submit"
+              aria-label="Ask Comicarr"
+              disabled={!question.trim()}
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] bg-primary text-primary-foreground disabled:opacity-40"
+            >
+              <ArrowUp className="w-3.5 h-3.5" />
+            </button>
+          </form>
         </div>
       </div>
     </div>

--- a/frontend/tests/pages/DashboardPage.test.tsx
+++ b/frontend/tests/pages/DashboardPage.test.tsx
@@ -14,6 +14,27 @@ import { http, HttpResponse } from "msw";
 import { createTestQueryClient, render, screen } from "../test-utils";
 import DashboardPage from "@/pages/DashboardPage";
 
+/** Enough of `GET /api/search/health` for the band to resolve to "healthy". */
+const HEALTHY_HEALTH = {
+  viable_route: true,
+  routes: {
+    nzb: {
+      ready: true,
+      reason: "ready",
+      downstream: "sabnzbd",
+      providers: [
+        { name: "nzbgeek", kind: "newznab", blocked: false, attempted: true },
+      ],
+    },
+  },
+  workers: { search: { state: "idle", alive: true, healthy: true } },
+  maintenance: { blocked: false },
+  blocked_producer_count: 0,
+  providers: [
+    { provider: "nzbgeek", lastrun: Math.floor(Date.now() / 1000) - 720 },
+  ],
+};
+
 function LocationProbe() {
   return <div data-testid="location">{useLocation().pathname}</div>;
 }
@@ -39,22 +60,32 @@ describe("DashboardPage", () => {
     });
   });
 
-  it("renders KPI strip with stats", async () => {
+  it("reduces the library to one row of numbers", async () => {
     render(<DashboardPage />);
 
-    // KPI labels appear immediately; values arrive once the query resolves.
     await waitFor(() => {
       expect(screen.getByText("50.0%")).toBeTruthy();
     });
 
-    expect(screen.getByText("Active series")).toBeTruthy();
-    expect(screen.getByText("Issues")).toBeTruthy();
-    expect(screen.getByText("Completion")).toBeTruthy();
+    // One row, not three hero tiles (dashboard-spec.md §3.6).
+    const row = screen.getByTestId("library-row");
+    expect(row.textContent).toBe(
+      "10 series·250 issues held·50.0% of known issues heldnot a health metric",
+    );
+    expect(screen.queryByText("Active series")).toBeNull();
+    expect(screen.queryByText("Completion")).toBeNull();
     // The Queue tile is gone: it counted active DDL items only, so it read
     // "0 queued" while SABnzbd was downloading (dashboard-spec.md §3.7).
     expect(screen.queryByText("Queue")).toBeNull();
-    expect(screen.getByText("10")).toBeTruthy();
-    expect(screen.getByText("250")).toBeTruthy();
+  });
+
+  it("labels completion as issues held vs. issues known", async () => {
+    render(<DashboardPage />);
+
+    // Never "Completion", which reads as a health score — and never adjacent
+    // to the health band, where it would read as one (dashboard-spec.md §3.6).
+    expect(await screen.findByText("of known issues held")).toBeTruthy();
+    expect(screen.getByText("not a health metric")).toBeTruthy();
   });
 
   it("renders the recent activity preview from the narrative stream", async () => {
@@ -119,8 +150,9 @@ describe("DashboardPage", () => {
 
     // Deep-link matches Activity Center subject routing.
     expect(
-      (screen.getByRole("link", { name: "Saga #12" }) as HTMLAnchorElement)
-        .getAttribute("href"),
+      (
+        screen.getByRole("link", { name: "Saga #12" }) as HTMLAnchorElement
+      ).getAttribute("href"),
     ).toBe("/library/42/issue/901");
   });
 
@@ -128,9 +160,7 @@ describe("DashboardPage", () => {
     render(<DashboardPage />);
 
     // The default fixture reports 2 in flight, none of it recovered.
-    expect(
-      await screen.findByRole("link", { name: "In flight" }),
-    ).toBeTruthy();
+    expect(await screen.findByRole("link", { name: "In flight" })).toBeTruthy();
     expect(screen.getByText("2 in flight")).toBeTruthy();
   });
 
@@ -139,7 +169,9 @@ describe("DashboardPage", () => {
 
     // Default mock has zero groups — calm, not an empty card with a heading.
     expect(await screen.findByText("Nothing needs you")).toBeTruthy();
-    expect(screen.queryByRole("region", { name: "Needs attention" })).toBeNull();
+    expect(
+      screen.queryByRole("region", { name: "Needs attention" }),
+    ).toBeNull();
   });
 
   it("qualifies the in-flight count with restart recoveries", async () => {
@@ -300,9 +332,7 @@ describe("DashboardPage", () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/No activity in the last 30 days/),
-      ).toBeTruthy();
+      expect(screen.getByText(/No activity in the last 30 days/)).toBeTruthy();
       expect(screen.getByText("nothing upcoming this week")).toBeTruthy();
     });
     expect(
@@ -408,9 +438,10 @@ describe("DashboardPage", () => {
     await waitFor(() => {
       expect(screen.getByText(/library unavailable/)).toBeTruthy();
     });
-    // All three tiles read the library, so all three report unavailable —
-    // while the in-flight line, on its own endpoint, still answers.
-    expect(screen.getAllByText("unavailable").length).toBe(3);
+    // The row says so once and retries itself — while the in-flight line, on
+    // its own endpoint, still answers.
+    expect(screen.getByText("Library unavailable")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry Library" })).toBeTruthy();
     expect(screen.getByText("2 in flight")).toBeTruthy();
     expect(screen.queryByText("50.0%")).toBeNull();
   });
@@ -434,13 +465,96 @@ describe("DashboardPage", () => {
     ).toBeTruthy();
   });
 
-  it("renders the recent chats card", async () => {
+  it("keeps no chat surface above the fold", async () => {
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Recent chats")).toBeTruthy();
+      expect(screen.getByText("This week")).toBeTruthy();
     });
-    expect(screen.getByRole("link", { name: "all →" })).toBeTruthy();
+    // Ask is demoted to the bottom of the page, and the recent-chats card that
+    // sat beside "This week" goes with it (dashboard-spec.md §3.8).
+    expect(screen.queryByText("Recent chats")).toBeNull();
+    expect(screen.queryByRole("link", { name: "all →" })).toBeNull();
+  });
+
+  it("orders the page by the priority of questions", async () => {
+    server.use(
+      http.get("/api/search/health", () => HttpResponse.json(HEALTHY_HEALTH)),
+    );
+
+    const { container } = render(<DashboardPage />);
+
+    // Wait for every band to have resolved so none is still a skeleton.
+    const health = await screen.findByRole("region", {
+      name: "Acquisition health",
+    });
+    await screen.findByText("Nothing needs you");
+    await screen.findByText("50.0%");
+
+    // §4's vertical order is §2's priority order: health, what needs me, what
+    // is happening, what my library is, and only then the feature entry point.
+    const anchors = [
+      health,
+      ...[
+        "needs-attention-empty",
+        "recent-activity",
+        "library-row",
+        "ask-bar",
+      ].map((id) => {
+        const node = container.querySelector(`[data-testid="${id}"]`);
+        expect(node, `missing ${id}`).toBeTruthy();
+        return node as HTMLElement;
+      }),
+    ];
+
+    for (let i = 1; i < anchors.length; i += 1) {
+      // DOCUMENT_POSITION_FOLLOWING === 4: each anchor precedes the next one.
+      expect(
+        anchors[i - 1].compareDocumentPosition(anchors[i]) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
+
+    // Ambient library numbers are never adjacent to the health band, where
+    // completion would read as a health score (dashboard-spec.md §3.6).
+    expect(health.nextElementSibling).not.toBe(anchors[3]);
+  });
+
+  it("stacks the middle columns in priority order on narrow viewports", async () => {
+    const { container } = render(<DashboardPage />);
+
+    await screen.findByText("This week");
+
+    // The two middle panels share one grid: a single column below `lg`, two
+    // columns above it. Stacking follows source order, so the narrow layout
+    // puts recent activity above this week — the same priority order as wide.
+    const grid = container.querySelector('[data-testid="middle-columns"]');
+    expect(grid).toBeTruthy();
+    expect(grid!.className).toContain("grid-cols-1");
+    expect(grid!.className).toContain("lg:grid-cols-[2fr_1fr]");
+
+    const activity = screen.getByTestId("recent-activity");
+    const week = screen.getByTestId("this-week");
+    expect(grid!.children[0].contains(activity)).toBe(true);
+    expect(grid!.children[1].contains(week)).toBe(true);
+  });
+
+  it("puts needs-attention and in flight on one row without coupling them", async () => {
+    server.use(
+      http.get("/api/activity/band", () =>
+        HttpResponse.json({ detail: "unavailable" }, { status: 503 }),
+      ),
+    );
+
+    render(<DashboardPage />);
+
+    // Sharing a row is a layout fact, not a data one: a failed band still
+    // leaves the in-flight count, on its own endpoint, answering.
+    await waitFor(() => {
+      expect(screen.getByText("Needs attention unavailable")).toBeTruthy();
+    });
+    expect(screen.getByText("2 in flight")).toBeTruthy();
+    expect(screen.getByTestId("attention-inflight-row")).toBeTruthy();
   });
 
   it("hands a typed question to the chat workspace", async () => {
@@ -456,10 +570,7 @@ describe("DashboardPage", () => {
     const ask = await screen.findByRole("textbox", {
       name: "Ask about your library",
     });
-    await user.click(
-      screen.getByRole("button", { name: "Which runs have gaps?" }),
-    );
-    expect((ask as HTMLInputElement).value).toBe("Which runs have gaps?");
+    await user.type(ask, "Which runs have gaps?");
 
     await user.click(screen.getByRole("button", { name: "Ask Comicarr" }));
     await waitFor(() => {


### PR DESCRIPTION
Closes #582 — the assembly ticket for [Wayfinder: build the dashboard the spec describes](https://github.com/frankieramirez/comicarr/issues/576). Implements §2, §3.5, §3.6, §3.8 and §4 of [docs/architecture/dashboard-spec.md](https://github.com/frankieramirez/comicarr/blob/main/docs/architecture/dashboard-spec.md). With this merged, every ticket on that map is closed.

## What changes

**The page runs in §2's priority order.** Health band, then needs-attention beside in-flight on one row, then recent activity beside this week, then library, then Ask. The vertical order *is* the priority order: health leads because it is the only question whose answer can require action today, and the ambient panels sink.

**Attention and in-flight share a row, never a query.** `NeedsAttentionBand` and `InFlightLine` each keep their own read, their own unavailability and their own retry — a failed band still leaves the in-flight count answering, per §5. Each component lost its own `border-b`; the shared row owns it.

**Library drops from hero to ambient (§3.6).** The three large KPI tiles are gone, replaced by `LibraryRow` — one line of numbers below the timeline. Completion keeps its definition (`total_issues / total_expected`) and is now labelled **of known issues held**, with an explicit *not a health metric* note. It is no longer adjacent to the health band, which is the specific adjacency that made it read as a health score.

**Ask moves below the fold (§3.8)** and loses its suggestion chips — "Anything stuck in the queue?" was health reporting, and the health band now does that properly. The recent-chats card that sat beside *This week* goes with it; chat above the fold is exactly what §3.8 demotes. Chat stays reachable from the sidebar and the Ask bar.

**Narrow viewports.** The middle pair is one grid: single column below `lg`, two above. Stacking follows source order, so narrow puts recent activity above this week — the same priority order as wide.

## Design reference

Built from panel **1a** of the imported design, [Comicarr Dashboard.dc.html](https://claude.ai/design/p/30d15d14-cd42-47c3-b8d4-096e6d17f728?file=Comicarr+Dashboard.dc.html) — the reading it scores at *0 spec breaks*.

Panel **1b** is deliberately not implemented. Its 14-day pipeline pulse would make eleven silent days visible before you read anything, which is a real argument — but it aggregates `activity_events`, which `activity-center.md` forbids, and would need a new bounded per-day acquisition endpoint that the map rules out of scope. It is recorded under **Out of scope** on the map so it can return as its own effort. Its other two breaks contradict decisions already locked by #578 and the spec's independent-degradation rule.

## Tests

387 frontend tests pass, three of them new:

- page order matches §4, and the library row is never adjacent to the health band
- the middle columns stack in priority order on narrow viewports
- the attention/in-flight row stays uncoupled: a failing band still leaves the in-flight count rendered

Existing dashboard tests were updated for the new layout — the KPI-strip assertions became library-row assertions, the unavailable-library case now expects one "Library unavailable" with its own retry rather than three tiles, and the ask test types into the input instead of clicking a chip.

`npm run lint` passes end to end. Changeset added (operator-visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NykLekjp5mhnUsCMtCFAVK
