### PR TITLE
ci: Path-filter frontend and backend GitHub Actions jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
 
 jobs:
   # ===========================================================================
+  # Path detection (shared with Test Suite)
+  # ===========================================================================
+  changes:
+    name: Detect changes
+    uses: ./.github/workflows/detect-changes.yml
+
+  # ===========================================================================
   # PR Title Lint (conventional commits)
   # ===========================================================================
   pr-title:
@@ -37,69 +44,111 @@ jobs:
 
   # ===========================================================================
   # Frontend Lint & Build
+  # Always runs: this job name is a required status check. When there are no
+  # frontend-relevant paths, report success without installing or linting.
   # ===========================================================================
   frontend-ci:
     name: Frontend Lint & Build
+    needs: changes
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
 
     steps:
+      - name: Skip frontend CI (no relevant changes)
+        if: needs.changes.outputs.frontend != 'true'
+        run: |
+          echo "No frontend-relevant paths changed; skipping Frontend Lint & Build."
+          {
+            echo "### Frontend Lint & Build"
+            echo
+            echo "Skipped — no frontend-relevant changes."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v7
+        if: needs.changes.outputs.frontend == 'true'
 
       - uses: actions/setup-node@v7
+        if: needs.changes.outputs.frontend == 'true'
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
 
       - name: Install dependencies
+        if: needs.changes.outputs.frontend == 'true'
+        working-directory: frontend
         run: npm ci
 
       - name: Lint
+        if: needs.changes.outputs.frontend == 'true'
+        working-directory: frontend
         run: npm run lint
 
       - name: Format check
+        if: needs.changes.outputs.frontend == 'true'
+        working-directory: frontend
         run: npm run format:check
 
       - name: Typecheck
+        if: needs.changes.outputs.frontend == 'true'
+        working-directory: frontend
         run: npm run typecheck
 
       - name: Build
+        if: needs.changes.outputs.frontend == 'true'
+        working-directory: frontend
         run: npm run build
 
   # ===========================================================================
   # Backend Lint
+  # Always runs: this job name is a required status check. When there are no
+  # backend-relevant paths, report success without installing or linting.
   # ===========================================================================
   backend-lint:
     name: Backend Lint
+    needs: changes
     runs-on: ubuntu-latest
 
     steps:
+      - name: Skip backend lint (no relevant changes)
+        if: needs.changes.outputs.backend != 'true'
+        run: |
+          echo "No backend-relevant paths changed; skipping Backend Lint."
+          {
+            echo "### Backend Lint"
+            echo
+            echo "Skipped — no backend-relevant changes."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v7
+        if: needs.changes.outputs.backend == 'true'
 
       - name: Set up Python 3.11
+        if: needs.changes.outputs.backend == 'true'
         uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
       # Pin to match uv.lock / ruff-pre-commit rev so local hooks and CI agree.
       - name: Install linting tools
+        if: needs.changes.outputs.backend == 'true'
         run: pip install "ruff==0.15.7"
 
       - name: Run ruff linter
+        if: needs.changes.outputs.backend == 'true'
         run: ruff check comicarr/ --output-format=github
 
       - name: Run modern backend quality ratchet
+        if: needs.changes.outputs.backend == 'true'
         run: python scripts/run_ruff.py modern
 
       # Deleting a module-level global cannot make its reassignment fail, so
       # the only gate against GLOBAL_MESSAGES coming back is a source scan.
       - name: Check retired globals stay retired
+        if: needs.changes.outputs.backend == 'true'
         run: python scripts/check_retired_globals.py
 
       - name: Run ruff formatter check
+        if: needs.changes.outputs.backend == 'true'
         run: ruff format --check comicarr/
 
       # The generated TypeScript is a backend artifact — its input is the config
@@ -107,4 +156,5 @@ jobs:
       # The generator loads registry.py by path and needs no project deps, so
       # this runs on the ruff-only install above.
       - name: Check generated settings types are fresh
+        if: needs.changes.outputs.backend == 'true'
         run: python scripts/generate_config_types.py --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
   changes:
     name: Detect changes
     uses: ./.github/workflows/detect-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
 
   # ===========================================================================
   # PR Title Lint (conventional commits)

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -20,9 +20,9 @@ jobs:
   detect:
     name: Detect changes
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
+    # Permissions come from the caller job (must grant pull-requests: read so
+    # dorny/paths-filter can list PR files). Do not request more here — nested
+    # jobs cannot escalate beyond what the caller allows.
     outputs:
       backend: ${{ steps.resolve.outputs.backend }}
       frontend: ${{ steps.resolve.outputs.frontend }}

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -1,0 +1,93 @@
+# Shared path detection for CI and Test Suite.
+# Callers that gate required checks must still *run* those jobs and no-op when
+# the matching output is false — skipped required checks block merges.
+name: Detect path changes
+
+on:
+  workflow_call:
+    outputs:
+      backend:
+        description: Backend-relevant paths changed (or forced full run)
+        value: ${{ jobs.detect.outputs.backend }}
+      frontend:
+        description: Frontend-relevant paths changed (or forced full run)
+        value: ${{ jobs.detect.outputs.frontend }}
+      e2e:
+        description: Paths that warrant E2E (or forced full run)
+        value: ${{ jobs.detect.outputs.e2e }}
+
+jobs:
+  detect:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.resolve.outputs.backend }}
+      frontend: ${{ steps.resolve.outputs.frontend }}
+      e2e: ${{ steps.resolve.outputs.e2e }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # schedule / workflow_dispatch have no useful path diff — run everything.
+      - name: Force full run for schedule and manual dispatch
+        id: force
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          echo "backend=true" >> "$GITHUB_OUTPUT"
+          echo "frontend=true" >> "$GITHUB_OUTPUT"
+          echo "e2e=true" >> "$GITHUB_OUTPUT"
+
+      - name: Filter changed paths
+        id: filter
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            backend:
+              - 'comicarr/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - 'Comicarr.py'
+              - 'comictagger.py'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'alembic/**'
+              - 'alembic.ini'
+              - '.pre-commit-config.yaml'
+              - 'frontend/src/types/config.generated.ts'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/test.yml'
+              - '.github/workflows/detect-changes.yml'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/test.yml'
+              - '.github/workflows/detect-changes.yml'
+            e2e:
+              - 'frontend/**'
+              - 'comicarr/**'
+              - 'Comicarr.py'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'alembic/**'
+              - 'alembic.ini'
+              - 'Dockerfile'
+              - 'docker/**'
+              - 'docker-compose.yml'
+              - '.github/workflows/test.yml'
+              - '.github/workflows/detect-changes.yml'
+
+      - name: Resolve outputs
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "backend=${{ steps.force.outputs.backend }}" >> "$GITHUB_OUTPUT"
+            echo "frontend=${{ steps.force.outputs.frontend }}" >> "$GITHUB_OUTPUT"
+            echo "e2e=${{ steps.force.outputs.e2e }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "backend=${{ steps.filter.outputs.backend }}" >> "$GITHUB_OUTPUT"
+            echo "frontend=${{ steps.filter.outputs.frontend }}" >> "$GITHUB_OUTPUT"
+            echo "e2e=${{ steps.filter.outputs.e2e }}" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
   changes:
     name: Detect changes
     uses: ./.github/workflows/detect-changes.yml
+    permissions:
+      contents: read
+      pull-requests: read
 
   # ===========================================================================
   # Backend Python Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,19 @@ on:
 
 jobs:
   # ===========================================================================
+  # Path detection (shared with CI)
+  # ===========================================================================
+  changes:
+    name: Detect changes
+    uses: ./.github/workflows/detect-changes.yml
+
+  # ===========================================================================
   # Backend Python Tests
   # ===========================================================================
   backend-tests:
     name: Backend Tests (Python ${{ matrix.python-version }})
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -63,6 +72,8 @@ jobs:
 
   migration-dialects:
     name: Schema migrations (${{ matrix.dialect }})
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -137,6 +148,8 @@ jobs:
   # ===========================================================================
   frontend-tests:
     name: Frontend Tests
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -177,11 +190,21 @@ jobs:
 
   # ===========================================================================
   # E2E Tests
+  # Runs when app surfaces change. Unit jobs that were skipped (other side of
+  # the monorepo) do not block; a failing unit job on a side that *did* change
+  # still blocks E2E.
   # ===========================================================================
   e2e-tests:
     name: E2E Smoke Tests
     runs-on: ubuntu-latest
-    needs: [backend-tests, frontend-tests]
+    needs: [changes, backend-tests, frontend-tests]
+    if: >-
+      always()
+      && !cancelled()
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.e2e == 'true'
+      && (needs.changes.outputs.backend != 'true' || needs.backend-tests.result == 'success')
+      && (needs.changes.outputs.frontend != 'true' || needs.frontend-tests.result == 'success')
 
     steps:
       - uses: actions/checkout@v7
@@ -251,8 +274,18 @@ jobs:
   e2e-full-tests:
     name: E2E Full Tests
     runs-on: ubuntu-latest
-    needs: [backend-tests, frontend-tests]
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    needs: [changes, backend-tests, frontend-tests]
+    if: >-
+      always()
+      && !cancelled()
+      && needs.changes.result == 'success'
+      && (
+        github.event_name == 'schedule'
+        || github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'push' && needs.changes.outputs.e2e == 'true')
+      )
+      && (needs.changes.outputs.backend != 'true' || needs.backend-tests.result == 'success')
+      && (needs.changes.outputs.frontend != 'true' || needs.frontend-tests.result == 'success')
 
     steps:
       - uses: actions/checkout@v7
@@ -318,18 +351,37 @@ jobs:
 
   # ===========================================================================
   # Summary Job
+  # Skipped jobs (path-filtered) are treated as pass; only real failures fail CI.
   # ===========================================================================
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [backend-tests, frontend-tests, e2e-tests, e2e-full-tests, migration-dialects]
+    needs: [changes, backend-tests, frontend-tests, e2e-tests, e2e-full-tests, migration-dialects]
     if: always()
 
     steps:
       - name: Check test results
         run: |
+          echo "changes=${{ needs.changes.result }}"
+          echo "backend-tests=${{ needs.backend-tests.result }}"
+          echo "frontend-tests=${{ needs.frontend-tests.result }}"
+          echo "e2e-tests=${{ needs.e2e-tests.result }}"
+          echo "e2e-full-tests=${{ needs.e2e-full-tests.result }}"
+          echo "migration-dialects=${{ needs.migration-dialects.result }}"
+
+          if [ "${{ needs.changes.result }}" == "failure" ] || [ "${{ needs.changes.result }}" == "cancelled" ]; then
+            echo "Path detection failed!"
+            exit 1
+          fi
+
           if [ "${{ needs.backend-tests.result }}" == "failure" ] || [ "${{ needs.frontend-tests.result }}" == "failure" ] || [ "${{ needs.e2e-tests.result }}" == "failure" ] || [ "${{ needs.e2e-full-tests.result }}" == "failure" ] || [ "${{ needs.migration-dialects.result }}" == "failure" ]; then
             echo "Some tests failed!"
             exit 1
           fi
-          echo "All tests passed!"
+
+          if [ "${{ needs.backend-tests.result }}" == "cancelled" ] || [ "${{ needs.frontend-tests.result }}" == "cancelled" ] || [ "${{ needs.e2e-tests.result }}" == "cancelled" ] || [ "${{ needs.e2e-full-tests.result }}" == "cancelled" ] || [ "${{ needs.migration-dialects.result }}" == "cancelled" ]; then
+            echo "Some tests were cancelled!"
+            exit 1
+          fi
+
+          echo "All required tests passed (skipped path-filtered jobs are OK)."


### PR DESCRIPTION
## TLDR

Frontend-only PRs no longer pay for backend pytest/migrations (and vice versa). Required lint checks still report green when their side is unchanged so branch protection keeps working.

## Description

- Add a shared `detect-changes` workflow (`dorny/paths-filter`) that labels backend / frontend / e2e path sets; schedule and `workflow_dispatch` force a full run.
- **CI:** `Backend Lint` and `Frontend Lint & Build` always run (required checks) but no-op when their paths did not change.
- **Test Suite:** backend tests, migration dialects, and frontend tests skip when irrelevant; E2E smoke runs when either app surface changes and does not wait on a skipped opposite-side unit job.

## Path sets (summary)

| Filter | Triggers |
|--------|----------|
| backend | `comicarr/`, `tests/`, `scripts/`, deps lockfiles, alembic, generated config types, CI workflow files |
| frontend | `frontend/`, CI workflow files |
| e2e | frontend + backend app surfaces, Docker entrypoints, test workflow |

No changeset — CI-only, no operator-visible app behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Automated checks now run selectively based on whether frontend, backend, migration, or end-to-end files changed.
  * Required checks remain visible even when no applicable changes are detected.
  * Scheduled and manually triggered runs continue to execute comprehensive validation.
  * Overall workflow summaries now clearly report detection results and test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->