### PR TITLE
docs: define Support bundle terminology

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,3 +19,7 @@ Who issued a Series' identifier: ComicVine, MangaDex (`md-` prefix), or MyAnimeL
 ## Chapter source
 
 The MangaDex UUID a manga Series polls for new chapters. MangaDex Series carry it in their ComicID; MyAnimeList Series supply metadata from MAL but keep the chapter source in `MangaDexID`, and have none until it is resolved.
+
+## Support bundle
+
+A downloadable archive of allowlisted diagnostic data, engineered for public issue attachment after operator review. If its contents appear sensitive, the operator shares it privately with maintainers instead; CarePackage is the legacy implementation name, not the user-facing term.


### PR DESCRIPTION
## Summary

- define the canonical user-facing term **Support bundle** in the domain glossary
- record that CarePackage is a legacy implementation name only
- preserve the disclosure boundary established by the completed specification work

## Why

The completed [Support bundle Wayfinder map](https://github.com/frankieramirez/comicarr/issues/599) established terminology and operator-review requirements that contributors need available in the repository before implementation begins. This focused documentation change records that domain definition without implementing or advertising the feature.

Supports the implementation handoff in #590.

## Impact

Documentation only. There is no runtime or user-interface behavior change.

## Validation

- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance describing Support bundles as downloadable archives of approved diagnostic data for public issue attachments.
  * Recommended private sharing when bundles contain sensitive information.
  * Documented CarePackage as the legacy name for Support bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->