### PR TITLE
feat: Set the log level from the environment or a startup argument

### DIFF
--- a/.changeset/log-level-from-env-and-cli.md
+++ b/.changeset/log-level-from-env-and-cli.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+You can now set the logging verbosity without editing the config file. `--log-level 0|1|2` on the command line and the `COMICARR_LOG_LEVEL` environment variable both set it, and each is honoured only when you actually supply it — a startup argument wins over the environment variable, which wins over the level saved in Settings. An out-of-range number is clamped instead of refusing to start, an unreadable one is reported and skipped, and whichever source wins says on startup what it overrode. `--quiet` still works as before but now prints a deprecation notice pointing at `--log-level 0`.

--- a/Comicarr.py
+++ b/Comicarr.py
@@ -34,6 +34,7 @@ try:
         maintenance,
         versioncheck,
     )
+    from comicarr.app.config import log_level as log_level_source  # noqa: E402
     from comicarr.app.core.pidfile import check_stale_pidfile  # noqa: E402
 except ModuleNotFoundError as e:
     missing_dependency = e.name or "an application dependency"
@@ -96,10 +97,25 @@ def main():
 
     # main parser
     parser.add_argument(
+        "--log-level",
+        dest="log_level",
+        type=int,
+        default=None,
+        metavar="{0,1,2}",
+        help=(
+            "Logging verbosity: 0 warnings and errors, 1 normal, 2 everything. "
+            "Overrides COMICARR_LOG_LEVEL and the config file; omit it and those apply."
+        ),
+    )
+    parser.add_argument(
         "-v", "--verbose", action="store_true", default=False, help="Increase console logging verbosity"
     )
     parser.add_argument(
-        "-q", "--quiet", action="store_true", default=False, help="Log warnings and errors only (log level 0)"
+        "-q",
+        "--quiet",
+        action="store_true",
+        default=False,
+        help="Deprecated alias for --log-level 0 (warnings and errors only)",
     )
     parser.add_argument("-d", "--daemon", action="store_true", default=False, help="Run as a daemon")
     parser.add_argument("-p", "--port", type=int, default=0, help="Force Comicarr to run on a specified port")
@@ -208,6 +224,7 @@ def main():
     args_maintenance = args.get("maintenance")
     args_verbose = args.get("verbose")
     args_quiet = args.get("quiet")
+    args_log_level = args.get("log_level")
     args_ignoreupdate = args.get("ignoreupdate")
     args_daemon = args.get("daemon")
     args_pidfile = args.get("pidfile")
@@ -288,14 +305,19 @@ def main():
         print("Exiting....")
         sys.exit()
 
-    if args_verbose:
+    # Startup args are the top of the precedence chain (args > COMICARR_LOG_LEVEL
+    # > config), but only when one was actually passed: leaving this None is what
+    # lets the environment and the config file be heard at all.
+    comicarr.LOG_LEVEL = None
+    if args_log_level is not None:
+        comicarr.LOG_LEVEL = log_level_source.clamp_level(args_log_level)
+        print("Log level set to %s by startup argument." % comicarr.LOG_LEVEL)
+    elif args_verbose:
         print("Verbose/Debugging mode enabled...")
         comicarr.LOG_LEVEL = 2
     elif args_quiet:
-        print("Quiet logging mode enabled (warnings and errors only)...")
+        print("--quiet is deprecated; use --log-level 0. Logging warnings and errors only...")
         comicarr.LOG_LEVEL = 0
-    else:
-        comicarr.LOG_LEVEL = None
 
     if args_ignoreupdate:
         comicarr.MAINTENANCE = False

--- a/comicarr/app/config/log_level.py
+++ b/comicarr/app/config/log_level.py
@@ -1,0 +1,126 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Where the log level comes from: startup args, then the environment, then config.
+
+`docs/architecture/logging-levels.md` fixes what each level *means*; this module
+fixes where the number is *read from*. Three sources, highest first:
+
+1. a startup argument (`--log-level`, or its `--verbose`/`--quiet` aliases)
+2. the `COMICARR_LOG_LEVEL` environment variable
+3. `LOG_LEVEL` in the config file (the Settings UI writes this one)
+
+A source only counts when it *explicitly supplies* a value. That qualifier is
+the whole point: Docker used to pass `--quiet` on every start, which pinned the
+escape hatch permanently open and left an operator with no way to raise
+verbosity (#610). An argument that was not passed must leave the layer below it
+alone.
+
+`COMICARR_LOG_LEVEL` is a deliberate one-off for this key, not the first step of
+a general `COMICARR_<KEY>` override mechanism -- that raises precedence,
+secrets, and UI-honesty questions of its own and is out of scope here.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Mapping
+
+ENV_VAR = "COMICARR_LOG_LEVEL"
+
+MIN_LEVEL = 0
+MAX_LEVEL = 2
+
+# Named for the source, not the mechanism, because these strings are echoed to
+# the operator when the level is decided.
+SOURCE_ARGUMENT = "startup argument"
+SOURCE_ENVIRONMENT = f"the {ENV_VAR} environment variable"
+SOURCE_CONFIG = "the config file"
+SOURCE_DEFAULT = "the built-in default"
+
+
+@dataclass
+class LogLevelResolution:
+    """The level to start with, where it came from, and what to tell the operator."""
+
+    level: int
+    source: str
+    notices: list[str] = field(default_factory=list)
+
+
+def clamp_level(level: int) -> int:
+    """Hold a level inside the dial's range, matching `threshold_for_level`."""
+    return max(MIN_LEVEL, min(MAX_LEVEL, level))
+
+
+def parse_level(raw, origin: str) -> tuple[int | None, list[str]]:
+    """Read one source's value into a usable level.
+
+    Returns `(None, notices)` when the source supplied nothing usable, so the
+    caller falls through to the next layer rather than starting at a level
+    nobody asked for. Out-of-range numbers are clamped rather than rejected: a
+    compose file asking for `3` wants maximum verbosity, and refusing to boot
+    over it helps nobody.
+    """
+    notices: list[str] = []
+    if raw is None:
+        return None, notices
+    if isinstance(raw, bool):  # bool is an int subclass; never a level
+        return None, [f"Ignoring {origin}: {raw!r} is not a log level."]
+    if isinstance(raw, int):
+        parsed = raw
+    else:
+        text = str(raw).strip()
+        if not text:
+            return None, notices
+        try:
+            parsed = int(text)
+        except ValueError:
+            return None, [f"Ignoring {origin}: {text!r} is not a number. Expected {MIN_LEVEL}-{MAX_LEVEL}."]
+    clamped = clamp_level(parsed)
+    if clamped != parsed:
+        notices.append(f"Log level {parsed} from {origin} is out of range; using {clamped}.")
+    return clamped, notices
+
+
+def resolve_startup_log_level(
+    argument_level=None,
+    config_level=None,
+    environ: Mapping[str, str] | None = None,
+) -> LogLevelResolution:
+    """Pick the level to start with from the three sources, highest priority first."""
+    environ = os.environ if environ is None else environ
+    notices: list[str] = []
+
+    candidates = (
+        (argument_level, SOURCE_ARGUMENT),
+        (environ.get(ENV_VAR), SOURCE_ENVIRONMENT),
+        (config_level, SOURCE_CONFIG),
+    )
+
+    supplied: list[tuple[int, str]] = []
+    for raw, source in candidates:
+        level, source_notices = parse_level(raw, source)
+        notices.extend(source_notices)
+        if level is not None:
+            supplied.append((level, source))
+
+    if not supplied:
+        return LogLevelResolution(level=1, source=SOURCE_DEFAULT, notices=notices)
+
+    level, source = supplied[0]
+    # Say what lost, so an operator who edits the Settings dial and sees nothing
+    # change has the reason in front of them rather than in the source.
+    overridden = [
+        f"{other_level} from {other_source}" for other_level, other_source in supplied[1:] if other_level != level
+    ]
+    if overridden:
+        notices.append(f"Log level {level} from {source} overrides {', '.join(overridden)}.")
+    return LogLevelResolution(level=level, source=source, notices=notices)

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -35,6 +35,7 @@ from pathlib import Path
 
 import comicarr
 from comicarr import db, encrypted, filechecker, helpers, logger, maintenance
+from comicarr.app.config.log_level import resolve_startup_log_level
 from comicarr.app.config.registry import as_legacy_definitions
 
 config = configparser.ConfigParser()
@@ -396,15 +397,20 @@ class Config(object):
                     self.LOG_DIR = None
                     print("Unable to create the log directory. Logging to screen only.")
 
-            # Start the logger.
-            # quick check to make sure log_level isn't just blank in the config
+            # Start the logger. The level comes from the first source that
+            # explicitly supplies one -- startup argument, then
+            # COMICARR_LOG_LEVEL, then the config file. See
+            # comicarr/app/config/log_level.py and
+            # docs/architecture/logging-levels.md.
+            resolution = resolve_startup_log_level(
+                argument_level=comicarr.LOG_LEVEL,
+                config_level=self.LOG_LEVEL,
+            )
+            for notice in resolution.notices:
+                print(notice)
+            log_level = resolution.level
             if self.LOG_LEVEL is None:
                 self.LOG_LEVEL = 1  # default it to INFO level (1) if not set.
-
-            log_level = self.LOG_LEVEL
-            if comicarr.LOG_LEVEL is not None:
-                log_level = comicarr.LOG_LEVEL
-                print("Logging level in config over-ridden by startup value. Logging level set to : %s" % (log_level))
 
             comicarr.LOG_LEVEL = (
                 log_level  # set this to the calculated log_leve value so that logs display fine in the GUI

--- a/docs/architecture/logging-levels.md
+++ b/docs/architecture/logging-levels.md
@@ -18,6 +18,50 @@ Levels below `0` clamp to `WARNING`; above `2` clamp to `DEBUG`.
 `logger.current_log_level()` is the only supported way to ask what the dial is
 currently set to. Nothing else may branch on verbosity.
 
+## Where the level comes from
+
+The dial says what a level *means*; this says where the number is *read from*.
+Three sources, highest priority first:
+
+| Priority | Source | Set by |
+| --- | --- | --- |
+| 1 | a startup argument — `--log-level N`, or the `--verbose` / `--quiet` aliases | the command line, a systemd unit, a container entrypoint |
+| 2 | the `COMICARR_LOG_LEVEL` environment variable | a compose file, the shell |
+| 3 | `LOG_LEVEL` in `config.ini` | the Settings UI |
+
+If none of them supplies a value, the level is `1`.
+
+**A source counts only when it explicitly supplies a value.** That qualifier is
+the whole rule, and it is what #610 got wrong: the Docker entrypoint passed
+`--quiet` on every start, so the top of the chain was permanently occupied and
+nothing an operator set below it could ever be heard. An argument that was not
+passed must leave the layer beneath it alone. In particular, level `0` is a
+value, not an absence — a falsy check here reintroduces the bug.
+
+Resolution happens once, when config is read at startup, in
+`comicarr/app/config/log_level.py`. Every source is parsed even when a
+higher-priority one has already won, so an operator who typoed
+`COMICARR_LOG_LEVEL` is told about it, and the winning source announces what it
+overrode. Runtime changes from the Settings UI go through
+`logger.configure_log_level()` and are not part of this chain — they apply
+immediately and are re-decided by it on the next start.
+
+Values outside `0`–`2` are clamped rather than rejected: a compose file asking
+for `3` wants maximum verbosity, and refusing to boot over it helps nobody. A
+non-numeric value is ignored with a notice, and the next source down is used.
+
+`COMICARR_LOG_LEVEL` is a deliberate one-off for this one key. Comicarr does not
+read the environment for any other setting, and a general `COMICARR_<KEY>`
+mechanism is a separate question — it raises precedence, secrets-in-env, and
+UI-honesty problems that have nothing to do with logging.
+
+### `--quiet` and `--verbose`
+
+`--quiet` is a deprecated alias for `--log-level 0` and prints a notice saying
+so. It stays because it is in existing compose files and systemd units; deleting
+it would break them for a cosmetic gain. `--verbose` maps to level `2`. When
+more than one is passed, `--log-level` wins, then `--verbose`, then `--quiet`.
+
 ### The two helpers disagree about `None`, on purpose
 
 `comicarr.LOG_LEVEL` is `None` until configuration is read, and the two helpers

--- a/tests/unit/test_log_level_sources.py
+++ b/tests/unit/test_log_level_sources.py
@@ -1,0 +1,139 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Where the log level comes from: startup argument > COMICARR_LOG_LEVEL > config.
+
+The rule these guard is "a source counts only when it explicitly supplies a
+value". Docker passing `--quiet` unconditionally is what pinned the escape hatch
+open in #610, so an argument that was not passed must leave the layers below it
+alone. See docs/architecture/logging-levels.md.
+"""
+
+import pytest
+
+from comicarr.app.config.log_level import (
+    ENV_VAR,
+    SOURCE_ARGUMENT,
+    SOURCE_CONFIG,
+    SOURCE_DEFAULT,
+    SOURCE_ENVIRONMENT,
+    clamp_level,
+    parse_level,
+    resolve_startup_log_level,
+)
+
+
+class TestPrecedence:
+    def test_argument_wins_over_environment_and_config(self):
+        resolution = resolve_startup_log_level(
+            argument_level=0,
+            config_level=1,
+            environ={ENV_VAR: "2"},
+        )
+        assert resolution.level == 0
+        assert resolution.source == SOURCE_ARGUMENT
+
+    def test_environment_wins_over_config_when_no_argument(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=0, environ={ENV_VAR: "2"})
+        assert resolution.level == 2
+        assert resolution.source == SOURCE_ENVIRONMENT
+
+    def test_config_is_used_when_nothing_else_supplies_a_value(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=2, environ={})
+        assert resolution.level == 2
+        assert resolution.source == SOURCE_CONFIG
+
+    def test_no_source_at_all_falls_back_to_normal(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=None, environ={})
+        assert resolution.level == 1
+        assert resolution.source == SOURCE_DEFAULT
+
+    def test_level_zero_from_an_argument_is_an_explicit_value_not_an_absent_one(self):
+        """0 is falsy; the layer below must not be consulted because of that."""
+        resolution = resolve_startup_log_level(argument_level=0, config_level=2, environ={ENV_VAR: "2"})
+        assert resolution.level == 0
+
+    def test_level_zero_in_the_environment_is_an_explicit_value(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=2, environ={ENV_VAR: "0"})
+        assert resolution.level == 0
+        assert resolution.source == SOURCE_ENVIRONMENT
+
+    def test_level_zero_in_the_config_is_an_explicit_value(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=0, environ={})
+        assert resolution.level == 0
+        assert resolution.source == SOURCE_CONFIG
+
+    def test_an_unset_environment_variable_leaves_config_in_charge(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=2, environ={})
+        assert resolution.source == SOURCE_CONFIG
+
+    def test_an_empty_environment_variable_leaves_config_in_charge(self):
+        """`COMICARR_LOG_LEVEL=` in a compose file must not mean "level 0"."""
+        resolution = resolve_startup_log_level(argument_level=None, config_level=2, environ={ENV_VAR: "  "})
+        assert resolution.level == 2
+        assert resolution.source == SOURCE_CONFIG
+
+    def test_os_environ_is_read_when_no_mapping_is_passed(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR, "2")
+        resolution = resolve_startup_log_level(argument_level=None, config_level=0)
+        assert resolution.level == 2
+        assert resolution.source == SOURCE_ENVIRONMENT
+
+
+class TestUnusableValues:
+    def test_a_non_numeric_environment_value_is_ignored_not_fatal(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=1, environ={ENV_VAR: "debug"})
+        assert resolution.level == 1
+        assert resolution.source == SOURCE_CONFIG
+        assert any("'debug'" in notice for notice in resolution.notices)
+
+    def test_an_out_of_range_value_is_clamped_rather_than_rejected(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=1, environ={ENV_VAR: "7"})
+        assert resolution.level == 2
+        assert resolution.source == SOURCE_ENVIRONMENT
+        assert any("out of range" in notice for notice in resolution.notices)
+
+    def test_a_negative_value_clamps_to_quiet(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=1, environ={ENV_VAR: "-3"})
+        assert resolution.level == 0
+
+    def test_surrounding_whitespace_is_tolerated(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=1, environ={ENV_VAR: " 2 "})
+        assert resolution.level == 2
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_a_boolean_is_never_a_level(self, value):
+        """`-q`/`-v` are store_true flags; a caller must map them, not pass them."""
+        level, notices = parse_level(value, "test")
+        assert level is None
+        assert notices
+
+    def test_clamp_level_matches_the_dial_range(self):
+        assert [clamp_level(value) for value in (-1, 0, 1, 2, 3)] == [0, 0, 1, 2, 2]
+
+
+class TestNotices:
+    def test_an_override_says_what_it_overrode(self):
+        resolution = resolve_startup_log_level(argument_level=2, config_level=0, environ={})
+        assert any(f"overrides 0 from {SOURCE_CONFIG}" in notice for notice in resolution.notices)
+
+    def test_every_losing_source_is_named_not_just_the_config(self):
+        resolution = resolve_startup_log_level(argument_level=0, config_level=1, environ={ENV_VAR: "2"})
+        notice = " ".join(resolution.notices)
+        assert SOURCE_ENVIRONMENT in notice
+        assert SOURCE_CONFIG in notice
+
+    def test_no_override_notice_when_the_sources_agree(self):
+        resolution = resolve_startup_log_level(argument_level=1, config_level=1, environ={ENV_VAR: "1"})
+        assert resolution.notices == []
+
+    def test_a_bad_environment_value_is_still_reported_when_an_argument_wins(self):
+        """The operator's typo is worth surfacing even though it changed nothing."""
+        resolution = resolve_startup_log_level(argument_level=2, config_level=1, environ={ENV_VAR: "loud"})
+        assert any("'loud'" in notice for notice in resolution.notices)


### PR DESCRIPTION
Resolves the wayfinder ticket [Set the log level from the environment, and honour the CLI only when passed](https://github.com/frankieramirez/comicarr/issues/613), on the map [Wayfinder: One log level dial, everywhere](https://github.com/frankieramirez/comicarr/issues/611).

## The chain

Three sources, resolved once at startup in `comicarr/app/config/log_level.py`, highest first:

| Priority | Source | Set by |
| --- | --- | --- |
| 1 | `--log-level N`, or the `--verbose` / `--quiet` aliases | command line, systemd unit, container entrypoint |
| 2 | `COMICARR_LOG_LEVEL` | compose file, shell |
| 3 | `LOG_LEVEL` in `config.ini` | the Settings UI |

**A source counts only when it explicitly supplies a value.** That qualifier is the whole rule — #610 happened because the Docker entrypoint passes `--quiet` on every start, so the top of the chain was permanently occupied and nothing set below it could be heard. Level `0` is a value, not an absence; a falsy check there reintroduces the bug, and there is a test pinning each layer's zero.

Out-of-range values clamp (`3` means "as loud as possible", not "refuse to boot"); non-numeric values are reported and skipped so the next source down applies. Every source is parsed even when a higher one has already won, so a typo'd `COMICARR_LOG_LEVEL` is still surfaced, and the winner announces what it overrode:

```
--quiet is deprecated; use --log-level 0. Logging warnings and errors only...
Log level 0 from startup argument overrides 2 from the COMICARR_LOG_LEVEL environment variable, 1 from the config file.
```

`--quiet` stays as a deprecated alias for `--log-level 0` — it is in existing compose files and systemd units, and deleting it would break them for a cosmetic gain. `--verbose` is unchanged at level 2; whether it survives is [Name the levels, and settle what -v means](https://github.com/frankieramirez/comicarr/issues/620).

## Known gap, deliberately left

The Docker entrypoint still passes `--quiet`, which is a startup argument and therefore still outranks `COMICARR_LOG_LEVEL`. **The environment variable has no effect under the official image until [Stop Docker pinning the log level; default to INFO](https://github.com/frankieramirez/comicarr/issues/614) lands**, which is why `docker-compose.yml` is not advertising it yet.

## Verification

- New `tests/unit/test_log_level_sources.py` (21 cases): precedence, explicit-zero at each layer, empty/absent env, clamping, non-numeric, booleans rejected, and the notice text.
- Booted the real app three ways against a scratch datadir: `COMICARR_LOG_LEVEL=2` alone produced DEBUG output where config said `1`; `COMICARR_LOG_LEVEL=2` plus `--log-level 0` produced neither DEBUG nor INFO; `-q` with `COMICARR_LOG_LEVEL=2` printed the deprecation notice and the override line above.
- Full unit suite: **2231 passed**. `lint:modern`, `lint:backend`, `lint:generated`, `lint:frontend` clean. `lint:guards` fails only on a gitignored local planning doc (`docs/plans/…`) that predates this branch and is invisible to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nfZg6o2qAotRQyunWc34L