### PR TITLE
fix: Stop the Docker image pinning the log level

### DIFF
--- a/.changeset/docker-stops-pinning-log-level.md
+++ b/.changeset/docker-stops-pinning-log-level.md
@@ -1,0 +1,7 @@
+---
+"comicarr": patch
+---
+
+Docker containers now log normally. The image used to start Comicarr with `--quiet` hardcoded, so `docker logs` showed almost nothing and no setting could raise it — the level you chose in Settings was overruled on every start. That argument is gone: containers now run at the normal level, `docker logs` shows what the server is doing, and the level is yours to set. Change it in Settings, or set `COMICARR_LOG_LEVEL` to `0`, `1`, or `2` in your compose file when you want it fixed regardless of Settings. The container banner says which of the two is in effect at startup.
+
+Expect more output than before after upgrading — that is the fix, not a side effect. Turn it down in Settings if you want less.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,19 @@ In **Settings**, configure:
 
 If you are migrating from Mylar3, the first-run onboarding wizard can import an existing install. For Docker, mount the Mylar3 config directory read-only (see comments in `docker-compose.yml`, typically at `/mylar3`).
 
+### Logging verbosity
+
+One dial, three levels: **0** warnings and errors, **1** normal (the default), **2** everything. It applies to the console, the log file, and the log list in the web UI alike.
+
+Set it wherever suits the install — a startup argument wins over the environment variable, which wins over the level saved in Settings, and each only counts when you actually supply it:
+
+```bash
+docker run -e COMICARR_LOG_LEVEL=2 ...   # Docker / Compose
+python3 Comicarr.py --log-level 2        # source install
+```
+
+Changing it in **Settings** takes effect immediately, no restart. Leave `COMICARR_LOG_LEVEL` unset unless you are debugging: setting it wins over Settings on every restart. (`--quiet` still works as an alias for `--log-level 0`, but it is deprecated.)
+
 ## Project Structure
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,10 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
+      # Logging verbosity: 0 warnings and errors, 1 normal, 2 everything.
+      # Leave it commented out to control the level from Settings — setting it
+      # here wins over Settings on every restart, which is what you want while
+      # debugging and not what you want the rest of the time.
+      # - COMICARR_LOG_LEVEL=2
     restart: unless-stopped
     stop_grace_period: 30s

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,11 @@ echo "  PUID:  ${PUID}"
 echo "  PGID:  ${PGID}"
 echo "  UMASK: ${UMASK}"
 echo "  TZ:    ${TZ:-not set}"
+if [ -n "${COMICARR_LOG_LEVEL}" ]; then
+    echo "  LOG:   level ${COMICARR_LOG_LEVEL} (COMICARR_LOG_LEVEL)"
+else
+    echo "  LOG:   level from Settings; set COMICARR_LOG_LEVEL to 0, 1 or 2 to override"
+fi
 echo "───────────────────────────────────"
 
 # Create group — use existing group if GID is already taken
@@ -57,6 +62,13 @@ for dir in /comics /downloads /manga; do
     fi
 done
 
-# Drop privileges and exec the application
+# Drop privileges and exec the application.
+#
+# No verbosity argument here, deliberately: a startup argument outranks both
+# COMICARR_LOG_LEVEL and the level saved in Settings, so hardcoding one takes
+# the dial away from the operator entirely. That is #610 — the image passed
+# --quiet, and no amount of configuration could raise the level past it.
+# gosu execs in place and keeps the environment, so COMICARR_LOG_LEVEL reaches
+# the app from here.
 exec gosu comicarr python /opt/comicarr/Comicarr.py \
-    --nolaunch --quiet --datadir /config/comicarr "$@"
+    --nolaunch --datadir /config/comicarr "$@"

--- a/docs/architecture/logging-levels.md
+++ b/docs/architecture/logging-levels.md
@@ -118,10 +118,30 @@ Three defects came out of it, all fixed alongside the retirement:
 - Failing to create the log directory dropped `LOG_DIR` only when `QUIET` was
   false, so a quiet process kept an uncreatable path and lost the recovery.
 
-## Not covered here
+## Not covered here — and "not covered" includes Docker
 
-The non-English `RotatingLogger` path (`logger.py`, taken when `LOG_LANG` does
-not start with `en`) does **not** implement this contract: its file handler is
-pinned at `DEBUG` and its `initLogger` takes no `console` argument at all.
-Whether it adopts the contract or is retired is tracked on
-[Wayfinder: One log level dial, everywhere](https://github.com/frankieramirez/comicarr/issues/611).
+The `RotatingLogger` path (`logger.py`, taken when `LOG_LANG` does not start
+with `en`) does **not** implement this contract. Read it as the *non-English*
+path and you will conclude it is a rare edge case. It is not:
+
+**Every Docker install takes it.** `python:3.12-slim` sets `LANG=C.UTF-8`, so
+`locale.getdefaultlocale()` returns `('C', 'UTF-8')` and `LOG_LANG` is `"C"`.
+Verified inside an image built from this repo — the giveaway in `docker logs` is
+the message format, `INFO :: MainThread : maintenance.py:backup_files:539 :`
+rather than the English path's `INFO :: comicarr.backup_files.539 : MainThread`.
+
+On that path the dial is enforced in the module-level `debug()` / `info()`
+wrappers rather than by handler levels, so the log *file* does follow it. The
+console does not: `initLogger` creates the `StreamHandler` inside `if loglevel:`,
+so **level 0 attaches no console sink at all** and `docker logs` goes silent
+rather than showing warnings and errors. That is the same shape as the #610
+defect — a level that removes a sink instead of raising its threshold — and it
+is why the contract's "level 0 is not silence" rule is currently aspirational
+for containers.
+
+One consequence worth knowing before designing a fix: a single `ENV
+LANG=en_US.UTF-8` in the `Dockerfile` would move every container onto the
+contract-compliant path without touching `logger.py`. Whether that, adopting the
+contract in `RotatingLogger`, or retiring the path is right is the decision on
+[Decide the fate of the non-English RotatingLogger path](https://github.com/frankieramirez/comicarr/issues/619),
+under [Wayfinder: One log level dial, everywhere](https://github.com/frankieramirez/comicarr/issues/611).


### PR DESCRIPTION
Resolves the wayfinder ticket [Stop Docker pinning the log level; default to INFO](https://github.com/frankieramirez/comicarr/issues/614), on the map [Wayfinder: One log level dial, everywhere](https://github.com/frankieramirez/comicarr/issues/611). This is the change #610 actually asked for.

## What changed

`docker/entrypoint.sh` no longer passes `--quiet`. A startup argument outranks both `COMICARR_LOG_LEVEL` and the level saved in Settings ([the precedence chain](https://github.com/frankieramirez/comicarr/issues/613)), so hardcoding one in the image took the dial away from the operator entirely. Containers now inherit the normal default of `1`, and `COMICARR_LOG_LEVEL` reaches the app — `gosu` execs in place and keeps the environment.

The entrypoint banner now reports which source is in force:

```
  LOG:   level 2 (COMICARR_LOG_LEVEL)
  LOG:   level from Settings; set COMICARR_LOG_LEVEL to 0, 1 or 2 to override
```

`docker-compose.yml` carries `COMICARR_LOG_LEVEL` commented out, with the reason to leave it that way (setting it beats Settings on every restart), and the README gains a short *Logging verbosity* section.

## Verified against a real image

Built from this tree and run three ways, ~40s each, fresh `/config` volume:

| Run | DEBUG | INFO | Notes |
| --- | --- | --- | --- |
| default | 0 | 53 | previously **silent**; setup token now visible as a normal log line |
| `COMICARR_LOG_LEVEL=2` | 31 | 53 | env var reaches the app |
| `COMICARR_LOG_LEVEL=0` | 0 | 0 | prints `Log level 0 from the COMICARR_LOG_LEVEL environment variable overrides 1 from the config file.` and echoes the setup token to stdout, so first-run setup is still completable |

Full unit suite **2231 passed**; `lint:modern`, `lint:backend`, `lint:generated`, `lint:frontend` clean, `sh -n` on the entrypoint clean. (`lint:guards` fails only on a gitignored local `docs/plans/` file that predates this branch and is invisible to CI.)

## The container run turned up a real finding

**Every Docker install runs the non-English `RotatingLogger` path.** `python:3.12-slim` sets `LANG=C.UTF-8`, so `locale.getdefaultlocale()` returns `('C', 'UTF-8')` and `LOG_LANG` is `"C"`. The tell in `docker logs` is the message format: `INFO :: MainThread : maintenance.py:backup_files:539 :` instead of the English path's `INFO :: comicarr.backup_files.539 : MainThread`.

That path does not implement the level contract. Its console handler is created inside `if loglevel:`, so **level 0 attaches no console sink at all** — `docker logs` goes silent rather than showing warnings and errors, which is the same shape as the #610 defect. The log file does follow the dial there, because filtering happens in the module-level `info()`/`debug()` wrappers.

Nothing here depends on fixing it, and fixing it is [Decide the fate of the non-English RotatingLogger path](https://github.com/frankieramirez/comicarr/issues/619)'s call — that ticket is much more central than its title suggests. The finding is written into `docs/architecture/logging-levels.md`, including the observation that a single `ENV LANG=en_US.UTF-8` in the Dockerfile would move every container onto the compliant path without touching `logger.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nfZg6o2qAotRQyunWc34L