### PR TITLE
prototype: Settings logs surface variants for wayfinder #616

### DIFF
--- a/frontend/src/components/prototype/PrototypeSwitcher.tsx
+++ b/frontend/src/components/prototype/PrototypeSwitcher.tsx
@@ -1,0 +1,112 @@
+/**
+ * PROTOTYPE ONLY — floating bar to flip ?variant= on a throwaway surface.
+ * Hidden outside Vite DEV builds. Do not ship as product UI.
+ */
+import { useCallback, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export type PrototypeVariantMeta = {
+  key: string;
+  name: string;
+};
+
+type PrototypeSwitcherProps = {
+  variants: PrototypeVariantMeta[];
+  /** search-param name; defaults to "variant" */
+  param?: string;
+};
+
+export function PrototypeSwitcher({
+  variants,
+  param = "variant",
+}: PrototypeSwitcherProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const keys = variants.map((v) => v.key);
+  const currentKey = searchParams.get(param) ?? keys[0] ?? "A";
+  const index = Math.max(0, keys.indexOf(currentKey));
+  const current = variants[index] ?? variants[0];
+
+  const go = useCallback(
+    (nextIndex: number) => {
+      if (variants.length === 0) return;
+      const wrapped = (nextIndex + variants.length) % variants.length;
+      const next = variants[wrapped];
+      setSearchParams(
+        (prev) => {
+          const nextParams = new URLSearchParams(prev);
+          nextParams.set(param, next.key);
+          return nextParams;
+        },
+        { replace: true },
+      );
+    },
+    [variants, param, setSearchParams],
+  );
+
+  useEffect(() => {
+    if (!import.meta.env.DEV || variants.length === 0) return;
+    const onKey = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        go(index - 1);
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        go(index + 1);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [go, index, variants.length]);
+
+  if (!import.meta.env.DEV || variants.length === 0 || !current) return null;
+
+  return (
+    <div
+      className="fixed bottom-4 left-1/2 z-[100] flex -translate-x-1/2 items-center gap-1 rounded-full border px-1.5 py-1 shadow-lg"
+      style={{
+        borderColor: "var(--border)",
+        background: "color-mix(in oklab, var(--card) 92%, black)",
+        boxShadow: "0 8px 28px color-mix(in oklab, black 35%, transparent)",
+      }}
+      role="group"
+      aria-label="Prototype variant switcher"
+    >
+      <button
+        type="button"
+        onClick={() => go(index - 1)}
+        className="grid size-8 place-items-center rounded-full hover:bg-secondary"
+        aria-label="Previous variant"
+      >
+        <ChevronLeft className="size-4" />
+      </button>
+      <div className="min-w-[11rem] px-2 text-center">
+        <div className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+          prototype
+        </div>
+        <div className="text-[12.5px] font-medium leading-tight">
+          {current.key} — {current.name}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => go(index + 1)}
+        className="grid size-8 place-items-center rounded-full hover:bg-secondary"
+        aria-label="Next variant"
+      >
+        <ChevronRight className="size-4" />
+      </button>
+    </div>
+  );
+}
+

--- a/frontend/src/components/prototype/usePrototypeVariant.ts
+++ b/frontend/src/components/prototype/usePrototypeVariant.ts
@@ -1,0 +1,13 @@
+import { useSearchParams } from "react-router-dom";
+import type { PrototypeVariantMeta } from "./PrototypeSwitcher";
+
+export function usePrototypeVariant(
+  variants: PrototypeVariantMeta[],
+  param = "variant",
+): string {
+  const [searchParams] = useSearchParams();
+  const keys = variants.map((v) => v.key);
+  const raw = searchParams.get(param);
+  if (raw && keys.includes(raw)) return raw;
+  return keys[0] ?? "A";
+}

--- a/frontend/src/components/settings/prototype/LogsPrototypeHost.tsx
+++ b/frontend/src/components/settings/prototype/LogsPrototypeHost.tsx
@@ -1,0 +1,80 @@
+/**
+ * PROTOTYPE HOST — Settings → Logs surface variants for wayfinder #616.
+ *
+ * Question: What should the Settings → Logs surface look and behave like?
+ * Three structurally different answers, switchable via ?variant=A|B|C.
+ *
+ * Throwaway: not production. DEV-only entry from SettingsPage.
+ */
+import { useSearchParams } from "react-router-dom";
+import { PrototypeSwitcher } from "@/components/prototype/PrototypeSwitcher";
+import { usePrototypeVariant } from "@/components/prototype/usePrototypeVariant";
+import { LogsVariantA } from "./LogsVariantA";
+import { LogsVariantB } from "./LogsVariantB";
+import { LogsVariantC } from "./LogsVariantC";
+import { LOGS_PROTOTYPE_VARIANTS } from "./logsMeta";
+
+export function LogsPrototypeHost() {
+  const variant = usePrototypeVariant([...LOGS_PROTOTYPE_VARIANTS]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const simulateOverride = searchParams.get("override") !== "0";
+
+  const setSimulateOverride = (on: boolean) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (on) {
+          next.delete("override");
+        } else {
+          next.set("override", "0");
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  return (
+    <>
+      <div
+        className="mb-4 flex flex-wrap items-center justify-between gap-2 rounded-[6px] border border-dashed px-3 py-2"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <div className="text-[12px] text-muted-foreground">
+          <strong className="text-foreground">PROTOTYPE</strong> — mock data,
+          no API writes. Use ← → or the bar below to compare variants.
+        </div>
+        <label className="flex cursor-pointer items-center gap-2 text-[12.5px]">
+          <input
+            type="checkbox"
+            checked={simulateOverride}
+            onChange={(e) => setSimulateOverride(e.target.checked)}
+            className="size-3.5 accent-[var(--primary)]"
+          />
+          Simulate CLI/env override
+        </label>
+      </div>
+
+      {variant === "A" && (
+        <LogsVariantA
+          key={`A-${simulateOverride}`}
+          simulateOverride={simulateOverride}
+        />
+      )}
+      {variant === "B" && (
+        <LogsVariantB
+          key={`B-${simulateOverride}`}
+          simulateOverride={simulateOverride}
+        />
+      )}
+      {variant === "C" && (
+        <LogsVariantC
+          key={`C-${simulateOverride}`}
+          simulateOverride={simulateOverride}
+        />
+      )}
+
+      <PrototypeSwitcher variants={[...LOGS_PROTOTYPE_VARIANTS]} />
+    </>
+  );
+}

--- a/frontend/src/components/settings/prototype/LogsVariantA.tsx
+++ b/frontend/src/components/settings/prototype/LogsVariantA.tsx
@@ -1,0 +1,144 @@
+/**
+ * PROTOTYPE Variant A — Console first
+ * Monospace block is the primary surface; dial + retention live in a slim toolbar.
+ * Structure: terminal pane, not a form.
+ */
+import { useMemo, useState } from "react";
+import { Copy, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  LEVEL_LABELS,
+  MOCK_PARSED_LOGS,
+  SCENARIO_CLEAN,
+  SCENARIO_OVERRIDE,
+  filterByMinLevel,
+  formatRetention,
+  type LogLevelName,
+  type LogsPrototypeScenario,
+} from "./logsMock";
+
+type Props = {
+  simulateOverride: boolean;
+};
+
+function OverrideStrip({ scenario }: { scenario: LogsPrototypeScenario }) {
+  if (scenario.effectiveSource === "config") return null;
+  return (
+    <div
+      className="rounded-[5px] border px-3 py-2 text-[12.5px]"
+      style={{
+        borderColor: "color-mix(in oklab, var(--status-paused) 40%, transparent)",
+        background: "var(--status-paused-bg)",
+        color: "var(--status-paused)",
+      }}
+    >
+      Running at{" "}
+      <strong>
+        {LEVEL_LABELS[scenario.effectiveLevel]} ({scenario.effectiveLevel})
+      </strong>{" "}
+      from {scenario.effectiveSource}. Changing the dial below saves to config
+      and applies live, but a restart will snap back to the higher-priority
+      source until you remove it.
+    </div>
+  );
+}
+
+export function LogsVariantA({ simulateOverride }: Props) {
+  const scenario = simulateOverride ? SCENARIO_OVERRIDE : SCENARIO_CLEAN;
+  // Host remounts on simulateOverride toggle so initial state tracks the scenario.
+  const [savedLevel, setSavedLevel] = useState<0 | 1 | 2>(scenario.savedLevel);
+  const [viewFilter, setViewFilter] = useState<"all" | LogLevelName>("all");
+  const [copied, setCopied] = useState(false);
+
+  const lines = useMemo(
+    () => filterByMinLevel(MOCK_PARSED_LOGS, viewFilter),
+    [viewFilter],
+  );
+  const textBlock = lines.map((l) => l.raw).join("\n");
+
+  const copyAll = async () => {
+    try {
+      await navigator.clipboard.writeText(textBlock);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <div className="text-base font-medium tracking-wide">Logs</div>
+          <div className="text-[13px] text-muted-foreground">
+            Last {MOCK_PARSED_LOGS.length} lines from comicarr.log ·{" "}
+            {formatRetention(scenario.maxLogSizeBytes, scenario.maxLogFiles)} ·{" "}
+            <span className="font-mono text-[12px]">{scenario.logDir}</span>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
+            Level
+            <select
+              className="h-8 rounded-md border bg-background px-2 text-[12.5px] text-foreground"
+              style={{ borderColor: "var(--border)" }}
+              value={savedLevel}
+              onChange={(e) =>
+                setSavedLevel(Number(e.target.value) as 0 | 1 | 2)
+              }
+            >
+              {([0, 1, 2] as const).map((n) => (
+                <option key={n} value={n}>
+                  {n} — {LEVEL_LABELS[n]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
+            Show
+            <select
+              className="h-8 rounded-md border bg-background px-2 text-[12.5px] text-foreground"
+              style={{ borderColor: "var(--border)" }}
+              value={viewFilter}
+              onChange={(e) =>
+                setViewFilter(e.target.value as "all" | LogLevelName)
+              }
+            >
+              <option value="all">All lines</option>
+              <option value="DEBUG">Debug+</option>
+              <option value="INFO">Info+</option>
+              <option value="WARNING">Warning+</option>
+              <option value="ERROR">Error only</option>
+            </select>
+          </label>
+          <Button type="button" variant="outline" size="sm" disabled>
+            <RefreshCw className="size-3.5" />
+            Refresh
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={copyAll}>
+            <Copy className="size-3.5" />
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        </div>
+      </div>
+
+      <OverrideStrip scenario={{ ...scenario, savedLevel }} />
+
+      <pre
+        className="max-h-[min(62vh,640px)] overflow-auto rounded-[6px] border p-3 font-mono text-[11.5px] leading-[1.45] whitespace-pre"
+        style={{
+          borderColor: "var(--border)",
+          background: "color-mix(in oklab, var(--card) 70%, black)",
+        }}
+      >
+        {textBlock || "(no lines match this filter)"}
+      </pre>
+
+      <p className="text-[11px] text-muted-foreground">
+        Prototype note: copy grabs the filtered view only. Level change is local
+        state — no API write.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/prototype/LogsVariantB.tsx
+++ b/frontend/src/components/settings/prototype/LogsVariantB.tsx
@@ -1,0 +1,268 @@
+/**
+ * PROTOTYPE Variant B — Control plane + structured table
+ * Level dial and retention are a first-class control card; logs are a parsed table.
+ * Structure: form-like control plane above, data table below.
+ */
+import { useMemo, useState } from "react";
+import { Copy, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { SettingGroup } from "../SettingGroup";
+import {
+  LEVEL_LABELS,
+  MOCK_PARSED_LOGS,
+  SCENARIO_CLEAN,
+  SCENARIO_OVERRIDE,
+  filterByMinLevel,
+  formatRetention,
+  levelBadgeStyle,
+  type LogLevelName,
+  type LogsPrototypeScenario,
+} from "./logsMock";
+
+type Props = {
+  simulateOverride: boolean;
+};
+
+function LevelSegmented({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: 0 | 1 | 2;
+  onChange: (v: 0 | 1 | 2) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div
+      className="inline-flex rounded-md border p-0.5"
+      style={{ borderColor: "var(--border)", background: "var(--card)" }}
+      role="group"
+      aria-label="Log level"
+    >
+      {([0, 1, 2] as const).map((n) => {
+        const active = value === n;
+        return (
+          <button
+            key={n}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(n)}
+            className="min-w-[5.5rem] rounded-[4px] px-3 py-1.5 text-[12.5px] transition-colors disabled:opacity-50"
+            style={{
+              background: active ? "var(--secondary)" : "transparent",
+              color: active ? "var(--foreground)" : "var(--muted-foreground)",
+              fontWeight: active ? 600 : 400,
+            }}
+          >
+            <div>{LEVEL_LABELS[n]}</div>
+            <div className="text-[10px] font-normal opacity-70">{n}</div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function OverrideCard({ scenario }: { scenario: LogsPrototypeScenario }) {
+  const overridden = scenario.effectiveSource !== "config";
+  return (
+    <div
+      className="rounded-lg border px-3 py-2.5"
+      style={{
+        borderColor: overridden
+          ? "color-mix(in oklab, var(--status-paused) 45%, transparent)"
+          : "var(--border)",
+        background: overridden ? "var(--status-paused-bg)" : "var(--card)",
+      }}
+    >
+      <div className="text-[11px] uppercase tracking-[0.05em] text-muted-foreground">
+        What is actually running
+      </div>
+      <div className="mt-1 text-[13px]">
+        <strong>
+          {LEVEL_LABELS[scenario.effectiveLevel]} ({scenario.effectiveLevel})
+        </strong>
+        <span className="text-muted-foreground">
+          {" "}
+          · from {scenario.effectiveSource}
+        </span>
+      </div>
+      {overridden ? (
+        <p className="mt-1.5 text-[12px] leading-snug text-muted-foreground">
+          A higher-priority source is winning the startup chain. Saving a new
+          level applies it <em>now</em>, but the next restart returns to{" "}
+          {scenario.effectiveSource} until that pin is removed.
+        </p>
+      ) : (
+        <p className="mt-1.5 text-[12px] leading-snug text-muted-foreground">
+          No CLI or environment pin — the config value is what the process uses.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function LogsVariantB({ simulateOverride }: Props) {
+  const scenario = simulateOverride ? SCENARIO_OVERRIDE : SCENARIO_CLEAN;
+  // Host remounts on simulateOverride toggle so initial state tracks the scenario.
+  const [savedLevel, setSavedLevel] = useState<0 | 1 | 2>(scenario.savedLevel);
+  const [viewFilter, setViewFilter] = useState<"all" | LogLevelName>("INFO");
+  const [copied, setCopied] = useState(false);
+
+  const lines = useMemo(
+    () => filterByMinLevel(MOCK_PARSED_LOGS, viewFilter),
+    [viewFilter],
+  );
+
+  const copyFiltered = async () => {
+    const text = lines
+      .map((l) => `${l.timestamp}\t${l.level}\t${l.message}`)
+      .join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <SettingGroup
+        title="Log level"
+        description="One dial. Applies immediately; survives restart only if nothing higher in the chain overrides it."
+      >
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <LevelSegmented value={savedLevel} onChange={setSavedLevel} />
+          <div className="text-[12px] text-muted-foreground sm:text-right">
+            <div>
+              Saved in config:{" "}
+              <span className="font-mono text-foreground">
+                {savedLevel} ({LEVEL_LABELS[savedLevel]})
+              </span>
+            </div>
+            <div className="mt-0.5">
+              Retention{" "}
+              <span className="font-mono text-foreground">
+                {formatRetention(
+                  scenario.maxLogSizeBytes,
+                  scenario.maxLogFiles,
+                )}
+              </span>{" "}
+              <span className="text-[10px] uppercase tracking-wide">
+                read-only
+              </span>
+            </div>
+            <div className="mt-0.5 font-mono text-[11px]">{scenario.logDir}</div>
+          </div>
+        </div>
+        <OverrideCard
+          scenario={{
+            ...scenario,
+            savedLevel,
+          }}
+        />
+      </SettingGroup>
+
+      <SettingGroup
+        title="Recent log"
+        description="Parsed from comicarr.log (last N lines). Secrets already redacted on the server."
+      >
+        <div className="mb-2 flex flex-wrap items-center gap-2">
+          {(["all", "DEBUG", "INFO", "WARNING", "ERROR"] as const).map(
+            (key) => {
+              const active = viewFilter === key;
+              const label =
+                key === "all" ? "All" : key === "DEBUG" ? "Debug+" : key;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => setViewFilter(key)}
+                  className="rounded-full border px-2.5 py-0.5 text-[11.5px]"
+                  style={{
+                    borderColor: active ? "var(--primary)" : "var(--border)",
+                    color: active ? "var(--primary)" : "var(--muted-foreground)",
+                    background: active
+                      ? "color-mix(in oklab, var(--primary) 12%, transparent)"
+                      : "transparent",
+                  }}
+                >
+                  {label}
+                </button>
+              );
+            },
+          )}
+          <div className="ml-auto flex gap-2">
+            <Button type="button" variant="outline" size="sm" disabled>
+              <RefreshCw className="size-3.5" />
+              Refresh
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={copyFiltered}
+            >
+              <Copy className="size-3.5" />
+              {copied ? "Copied" : "Copy filtered"}
+            </Button>
+          </div>
+        </div>
+
+        <div
+          className="max-h-[min(52vh,560px)] overflow-auto rounded-[6px] border"
+          style={{ borderColor: "var(--border)" }}
+        >
+          <table className="w-full border-collapse text-left text-[12px]">
+            <thead
+              className="sticky top-0 z-10 text-[11px] uppercase tracking-[0.04em] text-muted-foreground"
+              style={{ background: "var(--card)" }}
+            >
+              <tr>
+                <th className="px-3 py-2 font-medium whitespace-nowrap">Time</th>
+                <th className="px-2 py-2 font-medium">Level</th>
+                <th className="px-3 py-2 font-medium">Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lines.map((line, i) => (
+                <tr
+                  key={`${line.timestamp}-${i}`}
+                  className="border-t"
+                  style={{ borderColor: "var(--border)" }}
+                >
+                  <td className="px-3 py-1.5 align-top font-mono text-[11px] whitespace-nowrap text-muted-foreground">
+                    {line.timestamp}
+                  </td>
+                  <td className="px-2 py-1.5 align-top">
+                    <span
+                      className="inline-flex rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold"
+                      style={levelBadgeStyle(line.level)}
+                    >
+                      {line.level}
+                    </span>
+                  </td>
+                  <td className="px-3 py-1.5 align-top font-mono text-[11.5px] leading-snug break-all">
+                    {line.message}
+                  </td>
+                </tr>
+              ))}
+              {lines.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="px-3 py-6 text-center text-muted-foreground"
+                  >
+                    No lines match this filter.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </SettingGroup>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/prototype/LogsVariantC.tsx
+++ b/frontend/src/components/settings/prototype/LogsVariantC.tsx
@@ -1,0 +1,207 @@
+/**
+ * PROTOTYPE Variant C — Dial in General, viewer in a sheet
+ * Level + retention live with other settings; logs open as a tool, not a section.
+ * Structure: settings field group + full-height drawer, not a dedicated nav item.
+ */
+import { useMemo, useState } from "react";
+import { Copy, RefreshCw, ScrollText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { SettingField } from "../SettingField";
+import { SettingGroup } from "../SettingGroup";
+import {
+  LEVEL_LABELS,
+  MOCK_PARSED_LOGS,
+  SCENARIO_CLEAN,
+  SCENARIO_OVERRIDE,
+  filterByMinLevel,
+  formatRetention,
+  type LogLevelName,
+} from "./logsMock";
+
+type Props = {
+  simulateOverride: boolean;
+};
+
+export function LogsVariantC({ simulateOverride }: Props) {
+  const scenario = simulateOverride ? SCENARIO_OVERRIDE : SCENARIO_CLEAN;
+  // Host remounts on simulateOverride toggle so initial state tracks the scenario.
+  const [savedLevel, setSavedLevel] = useState<0 | 1 | 2>(scenario.savedLevel);
+  const [open, setOpen] = useState(false);
+  const [viewFilter, setViewFilter] = useState<"all" | LogLevelName>("all");
+  const [copied, setCopied] = useState(false);
+
+  const lines = useMemo(
+    () => filterByMinLevel(MOCK_PARSED_LOGS, viewFilter),
+    [viewFilter],
+  );
+  const textBlock = lines.map((l) => l.raw).join("\n");
+  const overridden = scenario.effectiveSource !== "config";
+
+  const copyAll = async () => {
+    try {
+      await navigator.clipboard.writeText(textBlock);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div
+        className="rounded-[6px] border border-dashed px-3 py-2 text-[12px] text-muted-foreground"
+        style={{ borderColor: "var(--border)" }}
+      >
+        This variant pretends you are still on{" "}
+        <strong className="text-foreground">General</strong> — logging is a
+        settings group, not its own nav item. The viewer is a tool you open.
+      </div>
+
+      <SettingGroup
+        title="Content Sources"
+        description="Placeholder — existing General content sits above."
+      >
+        <SettingField
+          label="Comics (Comic Vine)"
+          type="checkbox"
+          checked
+          readOnly
+          helpText="Shown only so density matches the real General tab."
+        />
+      </SettingGroup>
+
+      <SettingGroup
+        title="Logging"
+        description="Verbosity dial and retention ceiling. Open the viewer when you need to paste lines into an issue."
+      >
+        <SettingField
+          label="Log level"
+          type="select"
+          value={savedLevel}
+          onChange={(v) => setSavedLevel(Number(v) as 0 | 1 | 2)}
+          options={[
+            { value: 0, label: "0 — Warning (errors and warnings only)" },
+            { value: 1, label: "1 — Info (default)" },
+            { value: 2, label: "2 — Debug (everything)" },
+          ]}
+          helpText="Applies immediately. Stored in config.ini as LOG_LEVEL."
+        />
+
+        {overridden && (
+          <div
+            className="rounded-lg border px-3 py-2 text-[12.5px]"
+            style={{
+              borderColor:
+                "color-mix(in oklab, var(--status-paused) 40%, transparent)",
+              background: "var(--status-paused-bg)",
+              color: "var(--status-paused)",
+            }}
+          >
+            Process is running at{" "}
+            <strong>
+              {LEVEL_LABELS[scenario.effectiveLevel]} (
+              {scenario.effectiveLevel})
+            </strong>{" "}
+            via {scenario.effectiveSource}, not the saved config value (
+            {savedLevel}). Restart will re-apply the pin.
+          </div>
+        )}
+
+        <SettingField
+          label="Retention"
+          value={formatRetention(
+            scenario.maxLogSizeBytes,
+            scenario.maxLogFiles,
+          )}
+          type="text"
+          readOnly
+          helpText={`Rotated files under ${scenario.logDir}. Not editable here.`}
+        />
+
+        <div className="pt-1">
+          <Button type="button" onClick={() => setOpen(true)}>
+            <ScrollText className="size-3.5" />
+            Open log viewer
+          </Button>
+        </div>
+      </SettingGroup>
+
+      <SettingGroup
+        title="Directories"
+        description="Placeholder — rest of General continues below."
+      >
+        <SettingField
+          label="Log Directory"
+          value={scenario.logDir}
+          type="text"
+          readOnly
+          helpText="Already on General today; retention above is the new context."
+        />
+      </SettingGroup>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent
+          side="right"
+          className="flex w-full flex-col gap-0 p-0 sm:max-w-xl"
+        >
+          <SheetHeader className="border-b px-4 py-3" style={{ borderColor: "var(--border)" }}>
+            <SheetTitle className="text-[15px]">comicarr.log</SheetTitle>
+            <SheetDescription className="text-[12px]">
+              Last {MOCK_PARSED_LOGS.length} lines · redacted server-side
+            </SheetDescription>
+          </SheetHeader>
+
+          <div
+            className="flex flex-wrap items-center gap-2 border-b px-4 py-2"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <label className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
+              Show
+              <select
+                className="h-8 rounded-md border bg-background px-2 text-[12.5px] text-foreground"
+                style={{ borderColor: "var(--border)" }}
+                value={viewFilter}
+                onChange={(e) =>
+                  setViewFilter(e.target.value as "all" | LogLevelName)
+                }
+              >
+                <option value="all">All</option>
+                <option value="DEBUG">Debug+</option>
+                <option value="INFO">Info+</option>
+                <option value="WARNING">Warning+</option>
+                <option value="ERROR">Error</option>
+              </select>
+            </label>
+            <div className="ml-auto flex gap-2">
+              <Button type="button" variant="outline" size="sm" disabled>
+                <RefreshCw className="size-3.5" />
+                Refresh
+              </Button>
+              <Button type="button" variant="outline" size="sm" onClick={copyAll}>
+                <Copy className="size-3.5" />
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </div>
+          </div>
+
+          <pre
+            className="min-h-0 flex-1 overflow-auto p-3 font-mono text-[11.5px] leading-[1.45] whitespace-pre"
+            style={{
+              background: "color-mix(in oklab, var(--card) 70%, black)",
+            }}
+          >
+            {textBlock || "(no lines match this filter)"}
+          </pre>
+        </SheetContent>
+      </Sheet>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/prototype/logsMeta.ts
+++ b/frontend/src/components/settings/prototype/logsMeta.ts
@@ -1,0 +1,22 @@
+/** PROTOTYPE — variant keys and labels (kept out of component files for fast refresh). */
+
+export const VARIANT_A_META = {
+  key: "A",
+  name: "Console first",
+} as const;
+
+export const VARIANT_B_META = {
+  key: "B",
+  name: "Control + table",
+} as const;
+
+export const VARIANT_C_META = {
+  key: "C",
+  name: "General + sheet",
+} as const;
+
+export const LOGS_PROTOTYPE_VARIANTS = [
+  VARIANT_A_META,
+  VARIANT_B_META,
+  VARIANT_C_META,
+] as const;

--- a/frontend/src/components/settings/prototype/logsMock.ts
+++ b/frontend/src/components/settings/prototype/logsMock.ts
@@ -1,0 +1,150 @@
+/**
+ * PROTOTYPE ONLY — mock payload for the Settings → Logs surface designs.
+ * Real shape of file lines matches comicarr/logger.py file formatter.
+ */
+
+export type LogLevelName = "DEBUG" | "INFO" | "WARNING" | "ERROR";
+
+export type ParsedLogLine = {
+  raw: string;
+  timestamp: string;
+  level: LogLevelName;
+  message: string;
+};
+
+/** Matches file formatter: "%(asctime)s - %(levelname)-7s :: …" */
+export const MOCK_RAW_LOGS: string[] = [
+  "11-Aug-2026 14:28:01 - INFO    :: comicarr.config.read : MainThread : Config file loaded from /config/comicarr/config.ini",
+  "11-Aug-2026 14:28:01 - INFO    :: comicarr.app.main : MainThread : Comicarr starting on 0.0.0.0:8090",
+  "11-Aug-2026 14:28:02 - DEBUG  :: comicarr.db : MainThread : Opening SQLite connection pool",
+  "11-Aug-2026 14:28:03 - INFO    :: comicarr.scheduler : MainThread : Scheduled job rsscheck every 360 min",
+  "11-Aug-2026 14:29:11 - INFO    :: comicarr.search.search : Thread-3 : Searching for Batman (2016) #142",
+  "11-Aug-2026 14:29:12 - DEBUG  :: comicarr.search.providers : Thread-3 : Querying NZBGeek for Batman 2016 142",
+  "11-Aug-2026 14:29:14 - WARNING :: comicarr.search.providers : Thread-3 : Indexer NZBGeek returned 0 results (rate limit header present)",
+  "11-Aug-2026 14:29:15 - INFO    :: comicarr.search.search : Thread-3 : No snatch candidate for Batman (2016) #142",
+  "11-Aug-2026 14:30:02 - ERROR   :: comicarr.downloaders.qbittorrent : Thread-5 : Failed to connect to qBittorrent at http://qbittorrent:8080 — Connection refused",
+  "11-Aug-2026 14:30:02 - WARNING :: comicarr.app.downloads : Thread-5 : Handoff failed; recording fail_reason=client_unreachable",
+  "11-Aug-2026 14:31:40 - INFO    :: comicarr.importer : Thread-2 : Scanning library root /comics (3 series)",
+  "11-Aug-2026 14:31:41 - DEBUG  :: comicarr.filechecker : Thread-2 : Matched Batman_2016_142.cbz → ComicID 85943 IssueID 991201",
+  "11-Aug-2026 14:32:00 - INFO    :: comicarr.postprocessor : Thread-2 : Post-processed Batman (2016) #142",
+  "11-Aug-2026 14:32:18 - DEBUG  :: comicarr.cv : Thread-7 : ComicVine volume/85943 cache hit",
+  "11-Aug-2026 14:33:01 - INFO    :: comicarr.app.system.service : MainThread : Log level set to 2 by the Settings page",
+  "11-Aug-2026 14:33:02 - DEBUG  :: comicarr.logger : MainThread : Rebuilt handlers at threshold DEBUG",
+  "11-Aug-2026 14:33:44 - WARNING :: comicarr.rsscheck : Thread-4 : Feed fetch timed out after 30s for https://example.invalid/rss",
+  "11-Aug-2026 14:34:10 - ERROR   :: comicarr.app.series.service : Thread-8 : Refresh failed for ComicID 404: upstream 503",
+  "11-Aug-2026 14:34:55 - INFO    :: comicarr.app.activity.events : MainThread : activity recorded kind=search_failed",
+  "11-Aug-2026 14:35:02 - DEBUG  :: comicarr.helpers : MainThread : redact_sensitive_text scanned 0 provider secrets",
+];
+
+const LINE_RE =
+  /^(\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2}) - (\w+)\s*::\s*(.*)$/;
+
+export function parseLogLine(raw: string): ParsedLogLine {
+  const match = raw.match(LINE_RE);
+  if (!match) {
+    return {
+      raw,
+      timestamp: "",
+      level: "INFO",
+      message: raw,
+    };
+  }
+  const level = (match[2].trim().toUpperCase() || "INFO") as LogLevelName;
+  return {
+    raw,
+    timestamp: match[1],
+    level: (["DEBUG", "INFO", "WARNING", "ERROR"] as LogLevelName[]).includes(
+      level,
+    )
+      ? level
+      : "INFO",
+    message: match[3],
+  };
+}
+
+export const MOCK_PARSED_LOGS = MOCK_RAW_LOGS.map(parseLogLine);
+
+export type LevelSource =
+  | "config"
+  | "environment"
+  | "startup argument"
+  | "default";
+
+export type LogsPrototypeScenario = {
+  /** Value stored in config.ini / form (what Settings edits). */
+  savedLevel: 0 | 1 | 2;
+  /** Level the running process is actually using. */
+  effectiveLevel: 0 | 1 | 2;
+  effectiveSource: LevelSource;
+  logDir: string;
+  maxLogSizeBytes: number;
+  maxLogFiles: number;
+};
+
+/** Honest override: CLI pinned quiet, UI still shows saved 1. */
+export const SCENARIO_OVERRIDE: LogsPrototypeScenario = {
+  savedLevel: 1,
+  effectiveLevel: 0,
+  effectiveSource: "startup argument",
+  logDir: "/config/comicarr/logs",
+  maxLogSizeBytes: 10_000_000,
+  maxLogFiles: 5,
+};
+
+/** No override: Settings is the bottom of the chain and wins at rest. */
+export const SCENARIO_CLEAN: LogsPrototypeScenario = {
+  savedLevel: 1,
+  effectiveLevel: 1,
+  effectiveSource: "config",
+  logDir: "/config/comicarr/logs",
+  maxLogSizeBytes: 10_000_000,
+  maxLogFiles: 5,
+};
+
+export const LEVEL_LABELS: Record<0 | 1 | 2, string> = {
+  0: "Warning",
+  1: "Info",
+  2: "Debug",
+};
+
+export function formatRetention(bytes: number, files: number): string {
+  const mb = Math.round(bytes / 1_000_000);
+  return `${mb} MB × ${files} files`;
+}
+
+export function filterByMinLevel(
+  lines: ParsedLogLine[],
+  min: "all" | LogLevelName,
+): ParsedLogLine[] {
+  if (min === "all") return lines;
+  const order: LogLevelName[] = ["DEBUG", "INFO", "WARNING", "ERROR"];
+  const minIdx = order.indexOf(min);
+  return lines.filter((line) => order.indexOf(line.level) >= minIdx);
+}
+
+export function levelBadgeStyle(
+  level: LogLevelName,
+): Record<string, string> {
+  switch (level) {
+    case "ERROR":
+      return {
+        color: "var(--status-error)",
+        background: "var(--status-error-bg)",
+      };
+    case "WARNING":
+      return {
+        color: "var(--status-paused)",
+        background: "var(--status-paused-bg)",
+      };
+    case "DEBUG":
+      return {
+        color: "var(--muted-foreground)",
+        background: "var(--secondary)",
+      };
+    default:
+      return {
+        color: "var(--status-active)",
+        background: "var(--status-active-bg)",
+      };
+  }
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -13,6 +13,7 @@ import { NotificationsTab } from "@/components/settings/NotificationsTab";
 import { MediaManagementTab } from "@/components/settings/MediaManagementTab";
 import { AcquisitionHealthTab } from "@/components/settings/AcquisitionHealthTab";
 import { AboutTab } from "@/components/settings/AboutTab";
+import { LogsPrototypeHost } from "@/components/settings/prototype/LogsPrototypeHost";
 import { SaveButton } from "@/components/settings/SaveButton";
 import PageHeader from "@/components/layout/PageHeader";
 import { prepareConfigSaveData } from "@/lib/configSave";
@@ -35,7 +36,9 @@ type SectionId =
   | "notifications"
   | "clients"
   | "ai"
-  | "about";
+  | "about"
+  // PROTOTYPE — Settings → Logs surface (#616). DEV-only nav entry.
+  | "logs";
 
 const SECTIONS: { id: SectionId; label: string }[] = [
   { id: "general", label: "General" },
@@ -48,6 +51,9 @@ const SECTIONS: { id: SectionId; label: string }[] = [
   { id: "clients", label: "Download clients" },
   { id: "ai", label: "AI" },
   { id: "about", label: "About" },
+  ...(import.meta.env.DEV
+    ? ([{ id: "logs" as const, label: "Logs (prototype)" }] as const)
+    : []),
 ];
 
 const SECTION_IDS = new Set(SECTIONS.map((s) => s.id));
@@ -396,6 +402,9 @@ export default function SettingsPage() {
             {section === "clients" && <DownloadClientsTab {...tabProps} />}
             {section === "ai" && <AiTab {...tabProps} />}
             {section === "about" && <AboutTab {...aboutProps} />}
+            {import.meta.env.DEV && section === "logs" && (
+              <LogsPrototypeHost />
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Throwaway DEV-only Settings → **Logs (prototype)** surface with three UI variants used to lock [Design the Settings log surface](https://github.com/frankieramirez/comicarr/issues/616). Design is decided; this branch is the prototype artifact for [Build the Settings log viewer and level control](https://github.com/frankieramirez/comicarr/issues/617).

## Changes

- Three switchable variants (`?variant=A|B|C`): console-first, control plane + table, General + sheet
- Shared prototype switcher and mock log/override scenarios
- DEV-only nav entry on Settings; hidden outside Vite DEV

## Design outcome (already closed on #616)

Winner shape: **A structure + B override honesty content + C mismatch-only rule**. Production build lands in #617 and should remove this host rather than promote it.

## Test plan

- [ ] `cd frontend && npm run dev` → open Settings → **Logs (prototype)**
- [ ] Cycle A/B/C (bottom bar or arrow keys); toggle **Simulate CLI/env override**
- [ ] Confirm production build has no Logs nav entry (`import.meta.env.DEV` gate)

Part of #611 · closes nothing (design closed on #616; build is #617)