### PR TITLE
refactor: Retire the locale-branched RotatingLogger path

### DIFF
--- a/.changeset/one-logger-every-locale.md
+++ b/.changeset/one-logger-every-locale.md
@@ -1,0 +1,7 @@
+---
+"comicarr": patch
+---
+
+Warnings and errors now reach your logs on Docker. Comicarr chose between two different logging implementations based on your system locale, and the one containers ended up on was missing pieces: certain warnings — "No COMIC_DIR configured", "Cannot find import directory", and others like them — raised an internal error instead of being written down, and unexpected failures were dropped entirely while the server tried to record them. Startup even announced it: *"errors WILL NOT be captured in the logs"*. There is one logging implementation now, the same for every locale, so those messages appear in `comicarr.log`, in `docker logs`, and in the log list in the Web UI like everything else.
+
+Two things to expect after upgrading. Log lines from containers change shape slightly — `INFO :: comicarr.backup_files.539 : MainThread` in place of `INFO :: MainThread : maintenance.py:backup_files:539 :` — so an existing log file will show both styles either side of the upgrade. And with the dial turned all the way down, `docker logs` now shows warnings and errors rather than nothing at all, which is what level 0 was always meant to mean.

--- a/Comicarr.py
+++ b/Comicarr.py
@@ -83,14 +83,6 @@ def main():
     if not comicarr.SYS_ENCODING or comicarr.SYS_ENCODING in ("ANSI_X3.4-1968", "US-ASCII", "ASCII"):
         comicarr.SYS_ENCODING = "UTF-8"
 
-    if not logger.LOG_LANG.startswith("en"):
-        print(
-            "language detected as non-English (%s). Forcing specific logging module - errors WILL NOT be captured in the logs"
-            % logger.LOG_LANG
-        )
-    else:
-        print("log language set to %s" % logger.LOG_LANG)
-
     # Set up and gather command line arguments
     parser = argparse.ArgumentParser(description="Automated Comic Book Downloader")
     subparsers = parser.add_subparsers(title="Subcommands", dest="maintenance")

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -135,8 +135,6 @@ ACQUISITION_WORKERS_BLOCKED = True
 ACQUISITION_BLOCK_REASON = "schema_unavailable"
 LOG_DIR = None
 LOGTYPE = "log"
-LOG_LANG = "en"
-LOG_CHARSET = "UTF-8"
 LOG_LEVEL = None
 LOGLIST = []
 ARGS = None
@@ -444,8 +442,6 @@ def initialize(config_file):
             UPDATER_STATUS, \
             FORCE_STATUS, \
             DB_BACKFILL, \
-            LOG_LANG, \
-            LOG_CHARSET, \
             APILOCK, \
             SEARCHLOCK, \
             DDL_LOCK, \

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -428,21 +428,13 @@ class Config(object):
             comicarr.LOG_LEVEL = (
                 log_level  # set this to the calculated log_leve value so that logs display fine in the GUI
             )
-            if logger.LOG_LANG.startswith("en"):
-                logger.initLogger(
-                    console=True,
-                    log_dir=self.LOG_DIR,
-                    max_logsize=self.MAX_LOGSIZE,
-                    max_logfiles=self.MAX_LOGFILES,
-                    loglevel=log_level,
-                )
-            else:
-                logger.comicarr_log.initLogger(
-                    loglevel=log_level,
-                    log_dir=self.LOG_DIR,
-                    max_logsize=self.MAX_LOGSIZE,
-                    max_logfiles=self.MAX_LOGFILES,
-                )
+            logger.initLogger(
+                console=True,
+                log_dir=self.LOG_DIR,
+                max_logsize=self.MAX_LOGSIZE,
+                max_logfiles=self.MAX_LOGFILES,
+                loglevel=log_level,
+            )
 
         # Validate the live provider authority before backup maintenance is
         # allowed to encrypt historical plaintext with that same authority.

--- a/comicarr/logger.py
+++ b/comicarr/logger.py
@@ -17,8 +17,6 @@
 #  You should have received a copy of the GNU General Public License
 #  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
 
-import inspect
-import locale
 import logging
 import os
 import platform
@@ -30,22 +28,8 @@ from logging import Formatter
 import comicarr
 from comicarr import helpers
 
-# setup logger for non-english (this doesnt carry thru, so check here too)
-try:
-    localeinfo = locale.getdefaultlocale()
-    language = localeinfo[0]
-    charset = localeinfo[1]
-    if any([language is None, charset is None]):
-        raise AttributeError
-except AttributeError:
-    # if it's set to None (ie. dockerized) - default to en_US.UTF-8.
-    if language is None:
-        language = "en_US"
-    if charset is None:
-        charset = "UTF-8"
-
-LOG_LANG = language
-LOG_CHARSET = charset
+# The Web UI log list is an in-memory ring buffer, so it needs a ceiling.
+MAX_LOGLIST_ENTRIES = 2500
 
 
 def current_log_level():
@@ -70,291 +54,172 @@ def threshold_for_level(loglevel):
     return logging.DEBUG
 
 
-if not LOG_LANG.startswith("en"):
-    # Simple rotating log handler that uses RotatingFileHandler
-    class RotatingLogger(object):
-        def __init__(self, filename):
+# Comicarr logger
+logger = logging.getLogger("comicarr")
 
-            self.filename = filename
-            self.filehandler = None
-            self.consolehandler = None
 
-        def stopLogger(self):
-            lg = logging.getLogger("comicarr")
-            lg.removeHandler(self.filehandler)
-            lg.removeHandler(self.consolehandler)
+class LogListHandler(logging.Handler):
+    """
+    Log handler for Web UI.
+    """
 
-        def handle_exception(self, exc_type, exc_value, exc_traceback):
-            if issubclass(exc_type, KeyboardInterrupt):
-                sys.__excepthook__(exc_type, exc_value, exc_traceback)
-                return
-            logger.exception("Uncaught Exception", excinfo=(exc_type, exc_value, exc_traceback))
-            sys.__excepthook__(exc_type, exc_value, None)
-            return
+    def emit(self, record):
+        message = self.format(record)
+        message = message.replace("\n", "<br />")
+        comicarr.LOGLIST.insert(0, (helpers.now(), message, record.levelname, record.threadName))
+        # Bound the buffer. Without this the list grows for the life of the
+        # process; a long-running install eventually pays for it in memory.
+        del comicarr.LOGLIST[MAX_LOGLIST_ENTRIES:]
 
-        def initLogger(self, loglevel=1, log_dir=None, max_logsize=None, max_logfiles=None):
-            import sys
 
-            sys.excepthook = RotatingLogger.handle_exception
+def initLogger(console=True, log_dir=False, init=False, loglevel=1, max_logsize=None, max_logfiles=5):
+    # concurrentLogHandler/0.8.7 (to deal with windows locks)
+    # since this only happens on windows boxes, if it's nix/mac use the default logger.
+    if platform.system() == "Windows":
+        try:
+            from ConcurrentLogHandler.cloghandler import ConcurrentRotatingFileHandler as RFHandler
 
-            logging.getLogger("apscheduler.scheduler").setLevel(logging.WARN)
-            logging.getLogger("apscheduler.threadpool").setLevel(logging.WARN)
-            logging.getLogger("apscheduler.scheduler").propagate = False
-            logging.getLogger("apscheduler.threadpool").propagate = False
-            lg = logging.getLogger("comicarr")
-            lg.setLevel(logging.DEBUG)
-
-            if log_dir is not None:
-                self.filename = os.path.join(log_dir, self.filename)
-
-                # concurrentLogHandler/0.8.7 (to deal with windows locks)
-                # since this only happens on windows boxes, if it's nix/mac use the default logger.
-                if comicarr.OS_DETECT == "Windows":
-                    try:
-                        from ConcurrentLogHandler.cloghandler import ConcurrentRotatingFileHandler as RFHandler
-
-                        comicarr.LOGTYPE = "clog"
-                    except ImportError:
-                        comicarr.LOGTYPE = "log"
-                        from logging.handlers import RotatingFileHandler as RFHandler
-                else:
-                    comicarr.LOGTYPE = "log"
-                    from logging.handlers import RotatingFileHandler as RFHandler
-
-                filehandler = RFHandler(self.filename, maxBytes=max_logsize, backupCount=max_logfiles)
-
-                filehandler.setLevel(logging.DEBUG)
-
-                fileformatter = logging.Formatter("%(asctime)s - %(levelname)-7s :: %(message)s", "%d-%b-%Y %H:%M:%S")
-
-                filehandler.setFormatter(fileformatter)
-                lg.addHandler(filehandler)
-                self.filehandler = filehandler
-
-            if loglevel:
-                consolehandler = logging.StreamHandler()
-                if loglevel == 1:
-                    consolehandler.setLevel(logging.INFO)
-                if loglevel >= 2:
-                    consolehandler.setLevel(logging.DEBUG)
-                consoleformatter = logging.Formatter("%(asctime)s - %(levelname)s :: %(message)s", "%d-%b-%Y %H:%M:%S")
-                consolehandler.setFormatter(consoleformatter)
-                lg.addHandler(consolehandler)
-                self.consolehandler = consolehandler
-
-        @staticmethod
-        def log(message, level, *args, **kwargs):
-            logger = logging.getLogger("comicarr")
-
-            threadname = threading.currentThread().getName()
-
-            # Get the frame data of the method that made the original logger call
-            if len(inspect.stack()) > 2:
-                frame = inspect.getframeinfo(inspect.stack()[2][0])
-                program = os.path.basename(frame.filename)
-                method = frame.function
-                lineno = frame.lineno
-            else:
-                program = ""
-                method = ""
-                lineno = ""
-
-            if level != "DEBUG" or current_log_level() >= 2:
-                comicarr.LOGLIST.insert(0, (helpers.now(), message, level, threadname))
-                if len(comicarr.LOGLIST) > 2500:
-                    del comicarr.LOGLIST[-1]
-
-            message = "%s : %s:%s:%s : %s" % (threadname, program, method, lineno, message)
-            if level == "DEBUG":
-                logger.debug(message, *args, **kwargs)
-            elif level == "INFO":
-                logger.info(message, *args, **kwargs)
-            elif level == "WARNING":
-                logger.warning(message, *args, **kwargs)
-            else:
-                logger.error(message, *args, **kwargs)
-
-    comicarr_log = RotatingLogger("comicarr.log")
-    filename = "comicarr.log"
-
-    def debug(message, *args, **kwargs):
-        if current_log_level() > 1:
-            comicarr_log.log(message, "DEBUG", *args, **kwargs)
-
-    def fdebug(message, *args, **kwargs):
-        if current_log_level() > 1:
-            comicarr_log.log(message, "DEBUG", *args, **kwargs)
-
-    def info(message, *args, **kwargs):
-        if current_log_level() > 0:
-            comicarr_log.log(message, "INFO", *args, **kwargs)
-
-    def warn(message, *args, **kwargs):
-        comicarr_log.log(message, "WARNING", *args, **kwargs)
-
-    def error(message, *args, **kwargs):
-        comicarr_log.log(message, "ERROR", *args, **kwargs)
-
-else:
-    # Comicarr logger
-    logger = logging.getLogger("comicarr")
-
-    class LogListHandler(logging.Handler):
-        """
-        Log handler for Web UI.
-        """
-
-        def emit(self, record):
-            message = self.format(record)
-            message = message.replace("\n", "<br />")
-            comicarr.LOGLIST.insert(0, (helpers.now(), message, record.levelname, record.threadName))
-
-    def initLogger(console=True, log_dir=False, init=False, loglevel=1, max_logsize=None, max_logfiles=5):
-        # concurrentLogHandler/0.8.7 (to deal with windows locks)
-        # since this only happens on windows boxes, if it's nix/mac use the default logger.
-        if platform.system() == "Windows":
-            try:
-                from ConcurrentLogHandler.cloghandler import ConcurrentRotatingFileHandler as RFHandler
-
-                comicarr.LOGTYPE = "clog"
-            except ImportError:
-                comicarr.LOGTYPE = "log"
-                from logging.handlers import RotatingFileHandler as RFHandler
-        else:
+            comicarr.LOGTYPE = "clog"
+        except ImportError:
             comicarr.LOGTYPE = "log"
             from logging.handlers import RotatingFileHandler as RFHandler
+    else:
+        comicarr.LOGTYPE = "log"
+        from logging.handlers import RotatingFileHandler as RFHandler
 
-        if all([init is True, max_logsize is None]):
+    if all([init is True, max_logsize is None]):
+        max_logsize = 1000000  # 1 MB
+    else:
+        if max_logsize is None:
             max_logsize = 1000000  # 1 MB
-        else:
-            if max_logsize is None:
-                max_logsize = 1000000  # 1 MB
 
-        """
-        Setup logging for Comicarr. It uses the logger instance with the name
-        'comicarr'. Three log handlers are added:
+    """
+    Setup logging for Comicarr. It uses the logger instance with the name
+    'comicarr'. Three log handlers are added:
 
-        * RotatingFileHandler: for the file comicarr.log
-        * LogListHandler: for Web UI
-        * StreamHandler: for console
-        """
+    * RotatingFileHandler: for the file comicarr.log
+    * LogListHandler: for Web UI
+    * StreamHandler: for console
+    """
 
-        logging.getLogger("apscheduler.scheduler").setLevel(logging.WARN)
-        logging.getLogger("apscheduler.threadpool").setLevel(logging.WARN)
-        logging.getLogger("apscheduler.scheduler").propagate = False
-        logging.getLogger("apscheduler.threadpool").propagate = False
-        # Close and remove old handlers. This is required to reinit the loggers
-        # at runtime
-        for handler in logger.handlers[:]:
-            # Just make sure it is cleaned up.
-            if isinstance(handler, RFHandler):
-                handler.close()
-            elif isinstance(handler, logging.StreamHandler):
-                handler.flush()
+    logging.getLogger("apscheduler.scheduler").setLevel(logging.WARN)
+    logging.getLogger("apscheduler.threadpool").setLevel(logging.WARN)
+    logging.getLogger("apscheduler.scheduler").propagate = False
+    logging.getLogger("apscheduler.threadpool").propagate = False
+    # Close and remove old handlers. This is required to reinit the loggers
+    # at runtime
+    for handler in logger.handlers[:]:
+        # Just make sure it is cleaned up.
+        if isinstance(handler, RFHandler):
+            handler.close()
+        elif isinstance(handler, logging.StreamHandler):
+            handler.flush()
 
-            logger.removeHandler(handler)
+        logger.removeHandler(handler)
 
-        # Configure the logger to accept all messages
-        logger.propagate = False
+    # Configure the logger to accept all messages
+    logger.propagate = False
 
-        # One threshold, derived once, applied to the logger and to every sink.
-        # Setting it unconditionally matters: the old code left the level alone
-        # at loglevel 0, so turning the dial *down* at runtime never took effect
-        # and level 0 silently inherited root's WARNING by accident.
-        threshold = logging.INFO if init is True else threshold_for_level(loglevel)
-        logger.setLevel(threshold)
+    # One threshold, derived once, applied to the logger and to every sink.
+    # Setting it unconditionally matters: the old code left the level alone
+    # at loglevel 0, so turning the dial *down* at runtime never took effect
+    # and level 0 silently inherited root's WARNING by accident.
+    threshold = logging.INFO if init is True else threshold_for_level(loglevel)
+    logger.setLevel(threshold)
 
-        # Add list logger
-        loglist_handler = LogListHandler()
-        loglist_handler.setLevel(threshold)
-        logger.addHandler(loglist_handler)
+    # Add list logger
+    loglist_handler = LogListHandler()
+    loglist_handler.setLevel(threshold)
+    logger.addHandler(loglist_handler)
 
-        # Setup file logger
-        if log_dir:
-            filename = os.path.join(log_dir, "comicarr.log")
-            file_formatter = Formatter(
-                "%(asctime)s - %(levelname)-7s :: %(name)s.%(funcName)s.%(lineno)s : %(threadName)s : %(message)s",
-                "%d-%b-%Y %H:%M:%S",
-            )
-            file_handler = RFHandler(filename, "a", maxBytes=max_logsize, backupCount=max_logfiles)
-            file_handler.setLevel(threshold)
-            file_handler.setFormatter(file_formatter)
+    # Setup file logger
+    if log_dir:
+        filename = os.path.join(log_dir, "comicarr.log")
+        file_formatter = Formatter(
+            "%(asctime)s - %(levelname)-7s :: %(name)s.%(funcName)s.%(lineno)s : %(threadName)s : %(message)s",
+            "%d-%b-%Y %H:%M:%S",
+        )
+        file_handler = RFHandler(filename, "a", maxBytes=max_logsize, backupCount=max_logfiles)
+        file_handler.setLevel(threshold)
+        file_handler.setFormatter(file_formatter)
 
-            logger.addHandler(file_handler)
+        logger.addHandler(file_handler)
 
-        # Setup console logger
-        if console:
-            console_formatter = logging.Formatter(
-                "%(asctime)s - %(levelname)s :: %(name)s.%(funcName)s.%(lineno)s : %(threadName)s : %(message)s",
-                "%d-%b-%Y %H:%M:%S",
-            )
-            console_handler = logging.StreamHandler()
-            console_handler.setFormatter(console_formatter)
-            console_handler.setLevel(threshold)
+    # Setup console logger
+    if console:
+        console_formatter = logging.Formatter(
+            "%(asctime)s - %(levelname)s :: %(name)s.%(funcName)s.%(lineno)s : %(threadName)s : %(message)s",
+            "%d-%b-%Y %H:%M:%S",
+        )
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(console_formatter)
+        console_handler.setLevel(threshold)
 
-            logger.addHandler(console_handler)
+        logger.addHandler(console_handler)
 
-        # Install exception hooks
-        initHooks()
+    # Install exception hooks
+    initHooks()
 
-    def initHooks(global_exceptions=True, thread_exceptions=True, pass_original=True):
-        """
-        This method installs exception catching mechanisms. Any exception caught
-        will pass through the exception hook, and will be logged to the logger as
-        an error. Additionally, a traceback is provided.
 
-        This is very useful for crashing threads and any other bugs, that may not
-        be exposed when running as daemon.
+def initHooks(global_exceptions=True, thread_exceptions=True, pass_original=True):
+    """
+    This method installs exception catching mechanisms. Any exception caught
+    will pass through the exception hook, and will be logged to the logger as
+    an error. Additionally, a traceback is provided.
 
-        The default exception hook is still considered, if pass_original is True.
-        """
+    This is very useful for crashing threads and any other bugs, that may not
+    be exposed when running as daemon.
 
-        def excepthook(*exception_info):
-            # We should always catch this to prevent loops!
-            try:
-                message = "".join(traceback.format_exception(*exception_info))
-                logger.error("Uncaught exception: %s", message)
-            except:
-                pass
+    The default exception hook is still considered, if pass_original is True.
+    """
 
-            # Original excepthook
-            if pass_original:
-                sys.__excepthook__(*exception_info)
+    def excepthook(*exception_info):
+        # We should always catch this to prevent loops!
+        try:
+            message = "".join(traceback.format_exception(*exception_info))
+            logger.error("Uncaught exception: %s", message)
+        except Exception:
+            pass
 
-        # Global exception hook
-        if global_exceptions:
-            sys.excepthook = excepthook
+        # Original excepthook
+        if pass_original:
+            sys.__excepthook__(*exception_info)
 
-        # Thread exception hook
-        if thread_exceptions:
-            old_init = threading.Thread.__init__
+    # Global exception hook
+    if global_exceptions:
+        sys.excepthook = excepthook
 
-            def new_init(self, *args, **kwargs):
-                old_init(self, *args, **kwargs)
-                old_run = self.run
+    # Thread exception hook
+    if thread_exceptions:
+        old_init = threading.Thread.__init__
 
-                def new_run(*args, **kwargs):
-                    try:
-                        old_run(*args, **kwargs)
-                    except (KeyboardInterrupt, SystemExit):
-                        raise
-                    except:
-                        excepthook(*sys.exc_info())
+        def new_init(self, *args, **kwargs):
+            old_init(self, *args, **kwargs)
+            old_run = self.run
 
-                self.run = new_run
+            def new_run(*args, **kwargs):
+                try:
+                    old_run(*args, **kwargs)
+                except (KeyboardInterrupt, SystemExit):
+                    raise
+                except Exception:
+                    excepthook(*sys.exc_info())
 
-            # Monkey patch the run() by monkey patching the __init__ method
-            threading.Thread.__init__ = new_init
+            self.run = new_run
 
-    # Expose logger methods
-    info = logger.info
-    warn = logger.warn
-    error = logger.error
-    debug = logger.debug
-    warning = logger.warning
-    message = logger.info
-    exception = logger.exception
-    fdebug = logger.debug
+        # Monkey patch the run() by monkey patching the __init__ method
+        threading.Thread.__init__ = new_init
+
+
+# Expose logger methods
+info = logger.info
+warn = logger.warn
+error = logger.error
+debug = logger.debug
+warning = logger.warning
+message = logger.info
+exception = logger.exception
+fdebug = logger.debug
 
 
 def configure_log_level(level):
@@ -362,19 +227,10 @@ def configure_log_level(level):
     if level is None:
         level = 1
     comicarr.LOG_LEVEL = level
-    if LOG_LANG.startswith("en"):
-        initLogger(
-            console=True,
-            log_dir=comicarr.CONFIG.LOG_DIR,
-            max_logsize=comicarr.CONFIG.MAX_LOGSIZE,
-            max_logfiles=comicarr.CONFIG.MAX_LOGFILES,
-            loglevel=level,
-        )
-    else:
-        comicarr_log.stopLogger()
-        comicarr_log.initLogger(
-            loglevel=level,
-            log_dir=comicarr.CONFIG.LOG_DIR,
-            max_logsize=comicarr.CONFIG.MAX_LOGSIZE,
-            max_logfiles=comicarr.CONFIG.MAX_LOGFILES,
-        )
+    initLogger(
+        console=True,
+        log_dir=comicarr.CONFIG.LOG_DIR,
+        max_logsize=comicarr.CONFIG.MAX_LOGSIZE,
+        max_logfiles=comicarr.CONFIG.MAX_LOGFILES,
+        loglevel=level,
+    )

--- a/docs/architecture/logging-levels.md
+++ b/docs/architecture/logging-levels.md
@@ -142,30 +142,61 @@ Three defects came out of it, all fixed alongside the retirement:
 - Failing to create the log directory dropped `LOG_DIR` only when `QUIET` was
   false, so a quiet process kept an uncreatable path and lost the recovery.
 
-## Not covered here — and "not covered" includes Docker
+## One logger, every locale
 
-The `RotatingLogger` path (`logger.py`, taken when `LOG_LANG` does not start
-with `en`) does **not** implement this contract. Read it as the *non-English*
-path and you will conclude it is a rare edge case. It is not:
+The contract above now covers every install. It did not always: `logger.py` used
+to branch at import on `LOG_LANG` and build an entirely separate
+`RotatingLogger` when the locale did not start with `en`. That branch was
+retired in #619, and the history is worth keeping because the shape of the bug
+recurs.
 
-**Every Docker install takes it.** `python:3.12-slim` sets `LANG=C.UTF-8`, so
-`locale.getdefaultlocale()` returns `('C', 'UTF-8')` and `LOG_LANG` is `"C"`.
-Verified inside an image built from this repo — the giveaway in `docker logs` is
-the message format, `INFO :: MainThread : maintenance.py:backup_files:539 :`
-rather than the English path's `INFO :: comicarr.backup_files.539 : MainThread`.
+**It was never the non-English path — it was the Docker path.**
+`python:3.12-slim` sets `LANG=C.UTF-8`, so `locale.getdefaultlocale()` returned
+`('C', 'UTF-8')`, `LOG_LANG` was `"C"`, and `"C".startswith("en")` is false.
+Every container took the branch. Reading it as a rare non-English edge case is
+what let it survive a decade.
 
-On that path the dial is enforced in the module-level `debug()` / `info()`
-wrappers rather than by handler levels, so the log *file* does follow it. The
-console does not: `initLogger` creates the `StreamHandler` inside `if loglevel:`,
-so **level 0 attaches no console sink at all** and `docker logs` goes silent
-rather than showing warnings and errors. That is the same shape as the #610
-defect — a level that removes a sink instead of raising its threshold — and it
-is why the contract's "level 0 is not silence" rule is currently aspirational
-for containers.
+What it actually cost:
 
-One consequence worth knowing before designing a fix: a single `ENV
-LANG=en_US.UTF-8` in the `Dockerfile` would move every container onto the
-contract-compliant path without touching `logger.py`. Whether that, adopting the
-contract in `RotatingLogger`, or retiring the path is right is the decision on
-[Decide the fate of the non-English RotatingLogger path](https://github.com/frankieramirez/comicarr/issues/619),
-under [Wayfinder: One log level dial, everywhere](https://github.com/frankieramirez/comicarr/issues/611).
+- **`logger.warning` and `logger.exception` did not exist on it.** The branch
+  defined only `debug`, `fdebug`, `info`, `warn`, and `error`. The 21
+  `logger.warning(...)` call sites — including `comicsync.py`'s "No COMIC_DIR
+  configured" and `importinbox.py`'s missing-import-directory warning — raised
+  `AttributeError` instead of logging. The 7 `logger.exception(...)` call sites
+  are all inside `except` blocks, so the handler raised while handling the
+  error and the original traceback was lost.
+- **`sys.excepthook` was never functional.** `initLogger` assigned the *unbound*
+  `RotatingLogger.handle_exception`, whose signature takes four parameters while
+  Python calls the hook with three; its body also referenced a module-global
+  `logger` that only existed in the other branch. `Comicarr.py` said as much at
+  startup — *"errors WILL NOT be captured in the logs"*.
+- **Level 0 attached no console sink at all**, because the `StreamHandler` was
+  built inside `if loglevel:`. Same shape as the #610 defect: a level that
+  removes a sink instead of raising its threshold.
+- **It never did the encoding job it existed for.** `LOG_CHARSET` was assigned
+  at import and read by nothing, anywhere. No `encoding=` on the file handler,
+  no charset handling of any kind. The only real differences were the formatter
+  string and enforcing the dial in the module-level wrappers rather than at
+  handler level.
+
+The one thing it got right was capping the Web UI buffer at 2500 entries.
+`LogListHandler` had no cap, so retiring the branch without carrying that across
+would have handed every Docker install an unbounded in-memory list. The cap now
+lives on `logger.MAX_LOGLIST_ENTRIES` and applies everywhere.
+
+`LOG_LANG` and `LOG_CHARSET` are in `RETIRED_GLOBALS`
+(`scripts/check_retired_globals.py`). Pinning `ENV LANG=en_US.UTF-8` in the
+`Dockerfile` was considered and rejected: it would have moved containers onto
+the working path while leaving non-English bare-metal installs still dropping
+warnings, and made correctness depend on an environment variable any operator
+can override.
+
+**One log format now.** Containers previously wrote
+`INFO :: MainThread : maintenance.py:backup_files:539 :` and now write the
+standard `INFO :: comicarr.backup_files.539 : MainThread`. An existing
+`comicarr.log` therefore contains both formats across the upgrade boundary —
+a constraint on anything that parses the file, noted on
+[Build the Settings log viewer and level control](https://github.com/frankieramirez/comicarr/issues/617).
+
+Charted under
+[Wayfinder: One log level dial, everywhere](https://github.com/frankieramirez/comicarr/issues/611).

--- a/scripts/check_retired_globals.py
+++ b/scripts/check_retired_globals.py
@@ -44,6 +44,18 @@ RETIRED_GLOBALS = {
         "cleared. Gate on logger.current_log_level(), or pass an explicit "
         "console= flag to logger.initLogger()."
     ),
+    "LOG_LANG": (
+        "retired with the RotatingLogger branch (#611/#619). Branching the "
+        "logger on locale gave non-English installs — which is every Docker "
+        "install, since python:3.12-slim sets LANG=C.UTF-8 — a second "
+        "implementation that dropped logger.warning and logger.exception "
+        "entirely. There is one logger for every locale now."
+    ),
+    "LOG_CHARSET": (
+        "retired with the RotatingLogger branch (#611/#619). It was assigned "
+        "at import and never read by anything, which is the clearest evidence "
+        "the locale branch never did the encoding job it claimed to."
+    ),
 }
 
 # Trees that hold source. Prose keeps the history — the ADR names the retired

--- a/tests/unit/test_logger_levels.py
+++ b/tests/unit/test_logger_levels.py
@@ -21,11 +21,6 @@ import pytest
 import comicarr
 from comicarr import logger as comicarr_logger
 
-pytestmark = pytest.mark.skipif(
-    not comicarr_logger.LOG_LANG.startswith("en"),
-    reason="the non-English RotatingLogger path does not implement this contract yet",
-)
-
 LEVEL_THRESHOLDS = {0: logging.WARNING, 1: logging.INFO, 2: logging.DEBUG}
 
 
@@ -157,3 +152,52 @@ def test_current_log_level_treats_unconfigured_as_quiet(monkeypatch, configured,
     monkeypatch.setattr(comicarr, "LOG_LEVEL", configured, raising=False)
 
     assert comicarr_logger.current_log_level() == expected
+
+
+@pytest.mark.parametrize("name", ["info", "debug", "fdebug", "warn", "warning", "error", "exception", "message"])
+def test_every_logging_helper_the_codebase_calls_exists(name):
+    """Regression for #619: the retired locale branch defined only five of these.
+
+    ``logger.warning`` (21 call sites) and ``logger.exception`` (7, all inside
+    ``except`` blocks) were missing on the non-English path — the path *every*
+    Docker install took, because python:3.12-slim sets LANG=C.UTF-8. Calling
+    them raised AttributeError instead of logging, so warnings were dropped and
+    error handlers raised while handling the error.
+    """
+    assert callable(getattr(comicarr_logger, name))
+
+
+def test_warnings_and_exceptions_reach_the_sinks(isolated_logger, monkeypatch):
+    """The two helpers the retired branch omitted must actually emit."""
+    monkeypatch.setattr(comicarr, "LOGLIST", [], raising=False)
+    isolated_logger(0)
+
+    comicarr_logger.warning("[COMIC-SCAN] No COMIC_DIR configured")
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        comicarr_logger.exception("handled")
+
+    emitted = [entry[1] for entry in comicarr.LOGLIST]
+    assert any("No COMIC_DIR configured" in line for line in emitted)
+    assert any("handled" in line for line in emitted)
+
+
+def test_the_web_ui_log_list_is_bounded(isolated_logger, monkeypatch):
+    """LOGLIST is an in-memory buffer for the life of the process, so it needs a cap.
+
+    The retired locale branch trimmed at 2500; ``LogListHandler`` never did.
+    Retiring that branch without carrying the cap across would have handed every
+    Docker install an unbounded list.
+    """
+    monkeypatch.setattr(comicarr, "LOGLIST", [], raising=False)
+    monkeypatch.setattr(comicarr_logger, "MAX_LOGLIST_ENTRIES", 10)
+    isolated_logger(2)
+
+    for index in range(25):
+        comicarr_logger.info("entry-%s" % index)
+
+    assert len(comicarr.LOGLIST) == 10
+    # Newest first, so the cap must drop the *oldest* entries.
+    assert "entry-24" in comicarr.LOGLIST[0][1]
+    assert not any("entry-0 " in entry[1] for entry in comicarr.LOGLIST)

--- a/tests/unit/test_orphaned_runtime_paths.py
+++ b/tests/unit/test_orphaned_runtime_paths.py
@@ -178,7 +178,6 @@ def test_configure_log_level_keeps_the_console_attached_at_every_level(monkeypat
     config = SimpleNamespace(LOG_DIR="/tmp/logs", MAX_LOGSIZE=1024, MAX_LOGFILES=3)
     monkeypatch.setattr(comicarr, "CONFIG", config, raising=False)
     monkeypatch.setattr(comicarr, "LOG_LEVEL", 1, raising=False)
-    monkeypatch.setattr(logger, "LOG_LANG", "en_US", raising=False)
     monkeypatch.setattr(logger, "initLogger", lambda **kwargs: calls.append(kwargs), raising=False)
 
     logger.configure_log_level(0)

--- a/tests/unit/test_settings_log_level.py
+++ b/tests/unit/test_settings_log_level.py
@@ -39,11 +39,6 @@ from comicarr.app.core.context import AppContext
 from comicarr.app.system import service as system_service
 from comicarr.config import config_transaction_lock
 
-english_logger_only = pytest.mark.skipif(
-    not comicarr_logger.LOG_LANG.startswith("en"),
-    reason="the non-English RotatingLogger path does not implement this contract yet",
-)
-
 
 class FakeConfig:
     """Enough config to persist a level and rebuild the handlers over it.
@@ -140,7 +135,6 @@ def _emitted(message):
     return any(message in entry[1] for entry in comicarr.LOGLIST)
 
 
-@english_logger_only
 class TestASavedLevelChangesWhatIsEmitted:
     def test_raising_the_level_starts_emitting_debug(self, settings_save):
         comicarr_logger.debug("before-raise")


### PR DESCRIPTION
Resolves #619, under [Wayfinder: One log level dial, everywhere](https://github.com/frankieramirez/comicarr/issues/611).

## The framing was too generous

The ticket asked whether the `RotatingLogger` path should **adopt** the level contract or be **retired**. Probing the real module under the Docker locale says there was never a working implementation to adopt:

```
LOG_LANG = 'C'   -> RotatingLogger path: True
  logger.warning     -> *** MISSING ***
  logger.exception   -> *** MISSING ***
  logger.message     -> *** MISSING ***
  logger.initLogger  -> *** MISSING ***

logger.warning('[COMIC-SCAN] No COMIC_DIR configured…')
  -> AttributeError: module 'comicarr.logger' has no attribute 'warning'
```

**This was never the non-English path.** `python:3.12-slim` sets `LANG=C.UTF-8`, so `"C".startswith("en")` is false and every container took the branch. Reading it as a rare edge case is what let it survive a decade.

## What it cost

| Defect | Reach |
| --- | --- |
| `logger.warning` undefined | 21 call sites — `comicsync.py:76` "No COMIC_DIR configured", `importinbox.py:72`, `mangasync.py:81`, `config.py:1835`. Raised `AttributeError` instead of logging. |
| `logger.exception` undefined | 7 call sites, **all inside `except` blocks** (`search.py` ×3, `weeklypull.py` ×2) — the handler raised while handling the error, losing the original traceback. |
| `sys.excepthook` non-functional | Installed the *unbound* `RotatingLogger.handle_exception` — 4 params, called with 3 — whose body referenced a module-global `logger` that only existed in the other branch. |
| Level 0 attached no console sink | `StreamHandler` built inside `if loglevel:`. Same shape as #610: a level that removes a sink instead of raising its threshold. |

`Comicarr.py` already said it out loud at startup: *"Forcing specific logging module - errors WILL NOT be captured in the logs"*.

And it never did the encoding job it existed for — `LOG_CHARSET` was assigned at `logger.py:48` and **read by nothing, anywhere**. No `encoding=` on the file handler, no charset handling at all. The only real differences were the formatter string and enforcing the dial in the module-level wrappers rather than at handler level.

## Why retire rather than adopt, or pin `LANG`

Adopting keeps two implementations of one contract in sync forever, paying maintenance rent for a branch whose stated purpose it demonstrably never served. Pinning `ENV LANG=en_US.UTF-8` in the `Dockerfile` — the one-liner #614's resolution surfaced — hides the bug for containers while leaving non-English bare-metal installs still dropping warnings, and makes correctness depend on a variable any operator can override in compose.

## The regression this nearly introduced

The retired branch capped `comicarr.LOGLIST` at 2500 entries. `LogListHandler` **had no cap at all** — so retiring as-is would have handed every Docker install an unbounded in-memory list that grows for the life of the process. The cap comes across as `logger.MAX_LOGLIST_ENTRIES` and now applies on every path.

## Verification

`tests/unit/test_logger_levels.py` and `tests/unit/test_settings_log_level.py` both `skipif`-ed on this path, so it was entirely uncovered. Both now run under every locale:

- `LANG=C.UTF-8` — **46 passed**, previously **0 ran**
- Full unit suite — **2259 passed**
- `npm run lint` — modern, guards, backend, generated all clean. Frontend lane unrunnable locally (`frontend/node_modules` absent); no frontend files touched.

New coverage: every helper the codebase calls exists and emits, and the `LOGLIST` cap drops oldest-first.

`LOG_LANG` and `LOG_CHARSET` added to `RETIRED_GLOBALS`.

## Carried forward to #617

Containers previously wrote `INFO :: MainThread : maintenance.py:backup_files:539 :` and now write the standard `INFO :: comicarr.backup_files.539 : MainThread`. **An existing `comicarr.log` will contain both formats across the upgrade boundary** — a constraint on anything that parses the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEH1VFAC5tWL1MKoCopziB