### PR TITLE
feat: Accept log level names, and deprecate --verbose

### DIFF
--- a/.changeset/log-levels-have-names.md
+++ b/.changeset/log-levels-have-names.md
@@ -1,0 +1,11 @@
+---
+"comicarr": patch
+---
+
+The log level can now be set by name as well as by number. `warning`, `info`, and `debug` work anywhere the number did — `--log-level debug` on the command line, `COMICARR_LOG_LEVEL=debug` in your compose file, or `LOG_LEVEL = debug` in `config.ini`. Numbers are unchanged, so nothing you already have needs editing, and capitalisation does not matter.
+
+The names describe what each level actually does: level `0` is `warning` because it emits warnings and errors. It was previously described as "quiet", which suggested silence and was never true — turning the dial down has always kept failures visible.
+
+Startup messages now name the level both ways, so it is obvious which setting produced it: `Log level 2 (debug) from startup argument overrides 1 (info) from the config file`.
+
+`--verbose` and `-v` are now deprecated aliases for `--log-level debug`, joining `--quiet` and `-q` (aliases for `--log-level warning`). All four keep working and will continue to — they print a note pointing at `--log-level`, which is the one flag that sets the level directly.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,10 @@ Who issued a Series' identifier: ComicVine, MangaDex (`md-` prefix), or MyAnimeL
 
 The MangaDex UUID a manga Series polls for new chapters. MangaDex Series carry it in their ComicID; MyAnimeList Series supply metadata from MAL but keep the chapter source in `MangaDexID`, and have none until it is resolved.
 
+## Log level
+
+Comicarr's single verbosity dial, named by the severity it admits: `0` warning, `1` info, `2` debug. Level `0` means warnings and errors, not silence, which is why it is never called "quiet" — `--quiet` and `--verbose` are flag spellings, not level names.
+
 ## Support bundle
 
 A downloadable archive of allowlisted diagnostic data, engineered for public issue attachment after operator review. If its contents appear sensitive, the operator shares it privately with maintainers instead; CarePackage is the legacy implementation name, not the user-facing term.

--- a/Comicarr.py
+++ b/Comicarr.py
@@ -91,23 +91,26 @@ def main():
     parser.add_argument(
         "--log-level",
         dest="log_level",
-        type=int,
         default=None,
-        metavar="{0,1,2}",
+        metavar="{0,1,2|warning,info,debug}",
         help=(
-            "Logging verbosity: 0 warnings and errors, 1 normal, 2 everything. "
+            "Logging verbosity: 0/warning warnings and errors, 1/info normal, 2/debug everything. "
             "Overrides COMICARR_LOG_LEVEL and the config file; omit it and those apply."
         ),
     )
     parser.add_argument(
-        "-v", "--verbose", action="store_true", default=False, help="Increase console logging verbosity"
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Deprecated alias for --log-level debug (everything)",
     )
     parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
         default=False,
-        help="Deprecated alias for --log-level 0 (warnings and errors only)",
+        help="Deprecated alias for --log-level warning (warnings and errors only)",
     )
     parser.add_argument("-d", "--daemon", action="store_true", default=False, help="Run as a daemon")
     parser.add_argument("-p", "--port", type=int, default=0, help="Force Comicarr to run on a specified port")
@@ -300,15 +303,25 @@ def main():
     # Startup args are the top of the precedence chain (args > COMICARR_LOG_LEVEL
     # > config), but only when one was actually passed: leaving this None is what
     # lets the environment and the config file be heard at all.
+    #
+    # `--log-level` accepts a number or a name; an unusable value supplies
+    # nothing, so it falls through to the aliases and then to the layers below
+    # rather than blocking the boot over a typo.
     comicarr.LOG_LEVEL = None
     if args_log_level is not None:
-        comicarr.LOG_LEVEL = log_level_source.clamp_level(args_log_level)
-        print("Log level set to %s by startup argument." % comicarr.LOG_LEVEL)
-    elif args_verbose:
-        print("Verbose/Debugging mode enabled...")
+        argument_level, argument_notices = log_level_source.parse_level(
+            args_log_level, log_level_source.SOURCE_ARGUMENT
+        )
+        for notice in argument_notices:
+            print(notice)
+        if argument_level is not None:
+            comicarr.LOG_LEVEL = argument_level
+            print("Log level set to %s by startup argument." % log_level_source.describe_level(argument_level))
+    if comicarr.LOG_LEVEL is None and args_verbose:
+        print("--verbose is deprecated; use --log-level debug. Log level set to 2 (debug).")
         comicarr.LOG_LEVEL = 2
-    elif args_quiet:
-        print("--quiet is deprecated; use --log-level 0. Logging warnings and errors only...")
+    if comicarr.LOG_LEVEL is None and args_quiet:
+        print("--quiet is deprecated; use --log-level warning. Log level set to 0 (warning).")
         comicarr.LOG_LEVEL = 0
 
     if args_ignoreupdate:

--- a/comicarr/app/config/log_level.py
+++ b/comicarr/app/config/log_level.py
@@ -16,6 +16,10 @@ fixes where the number is *read from*. Three sources, highest first:
 2. the `COMICARR_LOG_LEVEL` environment variable
 3. `LOG_LEVEL` in the config file (the Settings UI writes this one)
 
+Each of them accepts the level in either notation -- `0`/`1`/`2` or
+`warning`/`info`/`debug` -- and the integer is what gets stored, whichever form
+was typed.
+
 A source only counts when it *explicitly supplies* a value. That qualifier is
 the whole point: Docker used to pass `--quiet` on every start, which pinned the
 escape hatch permanently open and left an operator with no way to raise
@@ -37,6 +41,19 @@ ENV_VAR = "COMICARR_LOG_LEVEL"
 
 MIN_LEVEL = 0
 MAX_LEVEL = 2
+
+# One name per level, and the threshold picks it: level 0 is `WARNING`, so it is
+# called `warning`. The tempting `quiet`/`normal`/`verbose` triple is not here on
+# purpose -- level 0 emits warnings and errors, and a dial labelled "quiet" is
+# the same lie #610 was about. `warn`, `error`, and `critical` are rejected too:
+# the first is a second name for one level, and the last two name a severity no
+# level can deliver on its own.
+LEVEL_NAMES = {"warning": 0, "info": 1, "debug": 2}
+NAME_FOR_LEVEL = {level: name for name, level in LEVEL_NAMES.items()}
+
+# Every source accepts both notations, so every rejection describes both. One
+# string because the CLI notice and the Settings HTTP error must not drift.
+ACCEPTED_FORMS = "%s-%s or one of %s" % (MIN_LEVEL, MAX_LEVEL, ", ".join(LEVEL_NAMES))
 
 # Named for the source, not the mechanism, because these strings are echoed to
 # the operator when the level is decided.
@@ -65,8 +82,23 @@ def clamp_level(level: int) -> int:
     return max(MIN_LEVEL, min(MAX_LEVEL, level))
 
 
+def describe_level(level: int) -> str:
+    """Render a level the way every operator-facing surface says it: `2 (debug)`.
+
+    The number is what an operator's `config.ini` and compose file contain; the
+    name is what `--help` and the Settings dial show them. Saying both keeps the
+    two notations from drifting apart in anyone's head.
+    """
+    return "%s (%s)" % (level, NAME_FOR_LEVEL[clamp_level(level)])
+
+
 def parse_level(raw, origin: str) -> tuple[int | None, list[str]]:
     """Read one source's value into a usable level.
+
+    Both notations are accepted from every source -- `2` and `debug` are the same
+    instruction, so an operator who reads `Debug` on the Settings dial can type
+    `--log-level debug` and have it work. Names are matched case-insensitively
+    and never need clamping; a number does.
 
     Returns `(None, notices)` when the source supplied nothing usable, so the
     caller falls through to the next layer rather than starting at a level
@@ -85,13 +117,16 @@ def parse_level(raw, origin: str) -> tuple[int | None, list[str]]:
         text = str(raw).strip()
         if not text:
             return None, notices
+        named = LEVEL_NAMES.get(text.casefold())
+        if named is not None:
+            return named, notices
         try:
             parsed = int(text)
         except ValueError:
-            return None, [f"Ignoring {origin}: {text!r} is not a number. Expected {MIN_LEVEL}-{MAX_LEVEL}."]
+            return None, [f"Ignoring {origin}: {text!r} is not a log level. Expected {ACCEPTED_FORMS}."]
     clamped = clamp_level(parsed)
     if clamped != parsed:
-        notices.append(f"Log level {parsed} from {origin} is out of range; using {clamped}.")
+        notices.append(f"Log level {parsed} from {origin} is out of range; using {describe_level(clamped)}.")
     return clamped, notices
 
 
@@ -124,8 +159,10 @@ def resolve_startup_log_level(
     # Say what lost, so an operator who edits the Settings dial and sees nothing
     # change has the reason in front of them rather than in the source.
     overridden = [
-        f"{other_level} from {other_source}" for other_level, other_source in supplied[1:] if other_level != level
+        f"{describe_level(other_level)} from {other_source}"
+        for other_level, other_source in supplied[1:]
+        if other_level != level
     ]
     if overridden:
-        notices.append(f"Log level {level} from {source} overrides {', '.join(overridden)}.")
+        notices.append(f"Log level {describe_level(level)} from {source} overrides {', '.join(overridden)}.")
     return LogLevelResolution(level=level, source=source, notices=notices)

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -44,7 +44,7 @@ from comicarr import db, logger
 from comicarr.app.acquisition.models import DispatchState
 from comicarr.app.common.dates import normalize_utc_datetime
 from comicarr.app.common.redaction import redact_sensitive_text
-from comicarr.app.config.log_level import MAX_LEVEL, MIN_LEVEL, SOURCE_SETTINGS, parse_level
+from comicarr.app.config.log_level import ACCEPTED_FORMS, SOURCE_SETTINGS, parse_level
 from comicarr.app.config.registry import (
     readable_keys,
     scheduler_job_intervals,
@@ -407,16 +407,18 @@ def update_config(ctx, key_values):
     level_notices = []
     if "LOG_LEVEL" in filtered:
         # Read by the same rules as every other source of the level, so a value
-        # typed into Settings behaves like one passed on the command line:
-        # out of range clamps, non-numeric is refused. A startup source is
-        # clamped rather than rejected because refusing to boot helps nobody;
-        # an HTTP request can simply be told it was wrong, and persisting
-        # garbage would leave the level silently ignored at the next start.
+        # typed into Settings behaves like one passed on the command line: both
+        # notations are accepted, out of range clamps, and anything else is
+        # refused. A startup source is clamped rather than rejected because
+        # refusing to boot helps nobody; an HTTP request can simply be told it
+        # was wrong, and persisting garbage would leave the level silently
+        # ignored at the next start. Whichever form arrives, an integer is what
+        # gets stored.
         level, level_notices = parse_level(filtered["LOG_LEVEL"], SOURCE_SETTINGS)
         if level is None:
             return {
                 "success": False,
-                "error": "LOG_LEVEL must be a number between %s and %s" % (MIN_LEVEL, MAX_LEVEL),
+                "error": "LOG_LEVEL must be %s" % ACCEPTED_FORMS,
             }
         filtered["LOG_LEVEL"] = level
 

--- a/docs/architecture/logging-levels.md
+++ b/docs/architecture/logging-levels.md
@@ -8,11 +8,30 @@ the logger and to every sink it feeds. There is no second dial.
 
 | Level | Threshold | Console | `comicarr.log` | Web UI log list |
 | --- | --- | --- | --- | --- |
-| `0` — quiet | `WARNING` | warnings and errors | warnings and errors | warnings and errors |
-| `1` — normal (default) | `INFO` | info and above | info and above | info and above |
-| `2` — verbose | `DEBUG` | everything | everything | everything |
+| `0` — `warning` | `WARNING` | warnings and errors | warnings and errors | warnings and errors |
+| `1` — `info` (default) | `INFO` | info and above | info and above | info and above |
+| `2` — `debug` | `DEBUG` | everything | everything | everything |
 
 Levels below `0` clamp to `WARNING`; above `2` clamp to `DEBUG`.
+
+### The names are determined, not chosen
+
+Each level *is* a stdlib threshold, so the threshold names it. That rules out
+the obvious `quiet` / `normal` / `verbose` triple, which this document used
+until #620: level `0` emits warnings and errors, and calling it "quiet" is the
+same class of lie as #610 — a control describing behaviour the process does not
+have. An operator who reads "quiet" and hears "silence" will turn the dial down
+and believe failures stopped.
+
+There is exactly one name per level. `warn` is refused as a second spelling of
+one level; `error` and `critical` are refused because no level delivers them —
+`--log-level error` could only mean "warnings and errors", which is level `0`
+under a name that promises something narrower.
+
+`quiet` and `verbose` survive only as the flag spellings `--quiet` and
+`--verbose`, which is a different thing from a level name and is covered below.
+Neither is accepted as a *value*: `--log-level` was `type=int` before #620, so
+nobody could ever have typed them and there is no back-compatibility to keep.
 
 `logger.threshold_for_level()` is the only place this mapping lives, and
 `logger.current_log_level()` is the only supported way to ask what the dial is
@@ -31,6 +50,18 @@ Three sources, highest priority first:
 
 If none of them supplies a value, the level is `1`.
 
+**Every source accepts both notations.** `--log-level debug`,
+`COMICARR_LOG_LEVEL=debug`, `LOG_LEVEL = debug` in `config.ini`, and a `"debug"`
+sent to the Settings endpoint all mean level `2`. Matching is
+case-insensitive and tolerates surrounding whitespace. One grammar everywhere is
+the point: an operator who reads `Debug` on the Settings dial and types
+`--log-level debug` must not meet an error, and a source that quietly accepted
+less than its neighbours would only ever be discovered by tripping over it.
+
+**The stored value is always the integer.** A name is normalised by
+`parse_level` at the boundary and never reaches `config.ini`, so `LOG_LEVEL`
+stays the `int` the registry declares and the generated frontend types expect.
+
 **A source counts only when it explicitly supplies a value.** That qualifier is
 the whole rule, and it is what #610 got wrong: the Docker entrypoint passed
 `--quiet` on every start, so the top of the chain was permanently occupied and
@@ -46,7 +77,13 @@ overrode.
 
 Values outside `0`–`2` are clamped rather than rejected: a compose file asking
 for `3` wants maximum verbosity, and refusing to boot over it helps nobody. A
-non-numeric value is ignored with a notice, and the next source down is used.
+value that is neither a number nor one of the three names is ignored with a
+notice, and the next source down is used.
+
+Operator-facing text names the level in both notations — `Log level 2 (debug)
+from startup argument overrides 1 (info) from the config file`. The number is
+what an operator's config and compose files contain; the name is what `--help`
+and the Settings dial show them. `describe_level()` is the single renderer.
 
 `COMICARR_LOG_LEVEL` is a deliberate one-off for this one key. Comicarr does not
 read the environment for any other setting, and a general `COMICARR_<KEY>`
@@ -69,22 +106,37 @@ is the realistic case), the save still reports success and the failure is
 logged; the level applies at the next start.
 
 The value is read by `parse_level`, exactly as the three startup sources are,
-so a level typed into Settings clamps to range the same way. It differs on one
-point: a non-numeric value is *refused* with an error rather than ignored. A
-startup source has a layer beneath it to fall through to, and an HTTP request
-has somewhere to put the complaint — persisting `"verbose"` would leave the
-operator's setting silently discarded at the next start.
+so a level typed into Settings clamps to range the same way and accepts the same
+two notations. It differs on one point: an unrecognised value is *refused* with
+an error rather than ignored. A startup source has a layer beneath it to fall
+through to, and an HTTP request has somewhere to put the complaint — persisting
+`"loud"` would leave the operator's setting silently discarded at the next
+start. The rejection names both accepted forms, from the same `ACCEPTED_FORMS`
+string the startup notice uses, so the two can never describe different rules.
 
 On the next start the chain runs again, so a startup argument or
 `COMICARR_LOG_LEVEL` will override what Settings saved. That is the documented
 precedence, and it is why the winning source announces what it overrode.
 
+The dial itself shows number, name, and consequence together — `0 · Warning —
+warnings and errors` — rather than a bare one-word label. The number is what the
+operator's config file contains, the name is what the CLI accepts, and the
+consequence is what stops the next "I set it to 0 and expected silence". This
+supersedes the `quiet / normal / verbose` labels locked while designing the
+surface; the layout of that design is unaffected.
+
 ### `--quiet` and `--verbose`
 
-`--quiet` is a deprecated alias for `--log-level 0` and prints a notice saying
-so. It stays because it is in existing compose files and systemd units; deleting
-it would break them for a cosmetic gain. `--verbose` maps to level `2`. When
-more than one is passed, `--log-level` wins, then `--verbose`, then `--quiet`.
+Both are deprecated aliases — `--quiet` for `--log-level warning`, `--verbose`
+for `--log-level debug` — and both print a notice saying so. Both keep their
+short forms `-q` and `-v`, and neither has a removal date: they are in existing
+compose files and systemd units, and deleting them would break those for a
+cosmetic gain. `--log-level` is the only flag that sets the dial directly.
+
+When more than one is passed, `--log-level` wins, then `--verbose`, then
+`--quiet`. A `--log-level` whose value is unusable supplies *nothing*, so it
+loses to an alias that was also passed — same rule as the precedence chain, one
+level down.
 
 ### The two helpers disagree about `None`, on purpose
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2777,7 +2777,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2787,7 +2787,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4061,7 +4061,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -6152,7 +6152,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
       "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {

--- a/frontend/src/components/prototype/PrototypeSwitcher.tsx
+++ b/frontend/src/components/prototype/PrototypeSwitcher.tsx
@@ -109,4 +109,3 @@ export function PrototypeSwitcher({
     </div>
   );
 }
-

--- a/frontend/src/components/settings/prototype/LogsPrototypeHost.tsx
+++ b/frontend/src/components/settings/prototype/LogsPrototypeHost.tsx
@@ -41,8 +41,8 @@ export function LogsPrototypeHost() {
         style={{ borderColor: "var(--border)" }}
       >
         <div className="text-[12px] text-muted-foreground">
-          <strong className="text-foreground">PROTOTYPE</strong> — mock data,
-          no API writes. Use ← → or the bar below to compare variants.
+          <strong className="text-foreground">PROTOTYPE</strong> — mock data, no
+          API writes. Use ← → or the bar below to compare variants.
         </div>
         <label className="flex cursor-pointer items-center gap-2 text-[12.5px]">
           <input

--- a/frontend/src/components/settings/prototype/LogsVariantA.tsx
+++ b/frontend/src/components/settings/prototype/LogsVariantA.tsx
@@ -27,7 +27,8 @@ function OverrideStrip({ scenario }: { scenario: LogsPrototypeScenario }) {
     <div
       className="rounded-[5px] border px-3 py-2 text-[12.5px]"
       style={{
-        borderColor: "color-mix(in oklab, var(--status-paused) 40%, transparent)",
+        borderColor:
+          "color-mix(in oklab, var(--status-paused) 40%, transparent)",
         background: "var(--status-paused-bg)",
         color: "var(--status-paused)",
       }}

--- a/frontend/src/components/settings/prototype/LogsVariantB.tsx
+++ b/frontend/src/components/settings/prototype/LogsVariantB.tsx
@@ -154,7 +154,9 @@ export function LogsVariantB({ simulateOverride }: Props) {
                 read-only
               </span>
             </div>
-            <div className="mt-0.5 font-mono text-[11px]">{scenario.logDir}</div>
+            <div className="mt-0.5 font-mono text-[11px]">
+              {scenario.logDir}
+            </div>
           </div>
         </div>
         <OverrideCard
@@ -183,7 +185,9 @@ export function LogsVariantB({ simulateOverride }: Props) {
                   className="rounded-full border px-2.5 py-0.5 text-[11.5px]"
                   style={{
                     borderColor: active ? "var(--primary)" : "var(--border)",
-                    color: active ? "var(--primary)" : "var(--muted-foreground)",
+                    color: active
+                      ? "var(--primary)"
+                      : "var(--muted-foreground)",
                     background: active
                       ? "color-mix(in oklab, var(--primary) 12%, transparent)"
                       : "transparent",
@@ -221,7 +225,9 @@ export function LogsVariantB({ simulateOverride }: Props) {
               style={{ background: "var(--card)" }}
             >
               <tr>
-                <th className="px-3 py-2 font-medium whitespace-nowrap">Time</th>
+                <th className="px-3 py-2 font-medium whitespace-nowrap">
+                  Time
+                </th>
                 <th className="px-2 py-2 font-medium">Level</th>
                 <th className="px-3 py-2 font-medium">Message</th>
               </tr>

--- a/frontend/src/components/settings/prototype/LogsVariantC.tsx
+++ b/frontend/src/components/settings/prototype/LogsVariantC.tsx
@@ -107,8 +107,8 @@ export function LogsVariantC({ simulateOverride }: Props) {
           >
             Process is running at{" "}
             <strong>
-              {LEVEL_LABELS[scenario.effectiveLevel]} (
-              {scenario.effectiveLevel})
+              {LEVEL_LABELS[scenario.effectiveLevel]} ({scenario.effectiveLevel}
+              )
             </strong>{" "}
             via {scenario.effectiveSource}, not the saved config value (
             {savedLevel}). Restart will re-apply the pin.
@@ -152,7 +152,10 @@ export function LogsVariantC({ simulateOverride }: Props) {
           side="right"
           className="flex w-full flex-col gap-0 p-0 sm:max-w-xl"
         >
-          <SheetHeader className="border-b px-4 py-3" style={{ borderColor: "var(--border)" }}>
+          <SheetHeader
+            className="border-b px-4 py-3"
+            style={{ borderColor: "var(--border)" }}
+          >
             <SheetTitle className="text-[15px]">comicarr.log</SheetTitle>
             <SheetDescription className="text-[12px]">
               Last {MOCK_PARSED_LOGS.length} lines · redacted server-side
@@ -185,7 +188,12 @@ export function LogsVariantC({ simulateOverride }: Props) {
                 <RefreshCw className="size-3.5" />
                 Refresh
               </Button>
-              <Button type="button" variant="outline" size="sm" onClick={copyAll}>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={copyAll}
+              >
                 <Copy className="size-3.5" />
                 {copied ? "Copied" : "Copy"}
               </Button>

--- a/frontend/src/components/settings/prototype/logsMock.ts
+++ b/frontend/src/components/settings/prototype/logsMock.ts
@@ -65,10 +65,7 @@ export function parseLogLine(raw: string): ParsedLogLine {
 export const MOCK_PARSED_LOGS = MOCK_RAW_LOGS.map(parseLogLine);
 
 export type LevelSource =
-  | "config"
-  | "environment"
-  | "startup argument"
-  | "default";
+  "config" | "environment" | "startup argument" | "default";
 
 export type LogsPrototypeScenario = {
   /** Value stored in config.ini / form (what Settings edits). */
@@ -122,9 +119,7 @@ export function filterByMinLevel(
   return lines.filter((line) => order.indexOf(line.level) >= minIdx);
 }
 
-export function levelBadgeStyle(
-  level: LogLevelName,
-): Record<string, string> {
+export function levelBadgeStyle(level: LogLevelName): Record<string, string> {
   switch (level) {
     case "ERROR":
       return {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -402,9 +402,7 @@ export default function SettingsPage() {
             {section === "clients" && <DownloadClientsTab {...tabProps} />}
             {section === "ai" && <AiTab {...tabProps} />}
             {section === "about" && <AboutTab {...aboutProps} />}
-            {import.meta.env.DEV && section === "logs" && (
-              <LogsPrototypeHost />
-            )}
+            {import.meta.env.DEV && section === "logs" && <LogsPrototypeHost />}
           </div>
         </div>
       </div>

--- a/tests/unit/test_log_level_sources.py
+++ b/tests/unit/test_log_level_sources.py
@@ -18,12 +18,14 @@ alone. See docs/architecture/logging-levels.md.
 import pytest
 
 from comicarr.app.config.log_level import (
+    ACCEPTED_FORMS,
     ENV_VAR,
     SOURCE_ARGUMENT,
     SOURCE_CONFIG,
     SOURCE_DEFAULT,
     SOURCE_ENVIRONMENT,
     clamp_level,
+    describe_level,
     parse_level,
     resolve_startup_log_level,
 )
@@ -86,12 +88,63 @@ class TestPrecedence:
         assert resolution.source == SOURCE_ENVIRONMENT
 
 
+class TestNames:
+    """Both notations mean the same thing, from every source (#620)."""
+
+    @pytest.mark.parametrize(("name", "expected"), [("warning", 0), ("info", 1), ("debug", 2)])
+    def test_each_level_has_a_name(self, name, expected):
+        level, notices = parse_level(name, "test")
+        assert level == expected
+        assert notices == []
+
+    @pytest.mark.parametrize("spelling", ["DEBUG", "Debug", "  debug  "])
+    def test_names_are_case_insensitive_and_trimmed(self, spelling):
+        level, _ = parse_level(spelling, "test")
+        assert level == 2
+
+    def test_a_name_wins_from_the_environment_like_a_number_would(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=0, environ={ENV_VAR: "debug"})
+        assert resolution.level == 2
+        assert resolution.source == SOURCE_ENVIRONMENT
+
+    def test_a_name_in_the_config_file_is_read_too(self):
+        """Nothing writes one, but a hand-edited config.ini must not be narrower."""
+        resolution = resolve_startup_log_level(argument_level=None, config_level="warning", environ={})
+        assert resolution.level == 0
+        assert resolution.source == SOURCE_CONFIG
+
+    @pytest.mark.parametrize("rejected", ["quiet", "normal", "verbose"])
+    def test_the_retired_vocabulary_is_not_accepted_as_a_value(self, rejected):
+        """`--log-level` was type=int, so nobody could ever have typed these."""
+        level, notices = parse_level(rejected, "test")
+        assert level is None
+        assert notices
+
+    @pytest.mark.parametrize("rejected", ["warn", "error", "critical"])
+    def test_names_no_level_can_honour_are_refused(self, rejected):
+        """`error` would have to mean level 0, which also emits warnings."""
+        level, notices = parse_level(rejected, "test")
+        assert level is None
+        assert notices
+
+    def test_describe_level_carries_both_notations(self):
+        assert [describe_level(level) for level in (0, 1, 2)] == ["0 (warning)", "1 (info)", "2 (debug)"]
+
+    def test_accepted_forms_names_both_notations(self):
+        for form in ("0-2", "warning", "info", "debug"):
+            assert form in ACCEPTED_FORMS
+
+
 class TestUnusableValues:
-    def test_a_non_numeric_environment_value_is_ignored_not_fatal(self):
-        resolution = resolve_startup_log_level(argument_level=None, config_level=1, environ={ENV_VAR: "debug"})
+    def test_an_unrecognised_environment_value_is_ignored_not_fatal(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=1, environ={ENV_VAR: "loud"})
         assert resolution.level == 1
         assert resolution.source == SOURCE_CONFIG
-        assert any("'debug'" in notice for notice in resolution.notices)
+        assert any("'loud'" in notice for notice in resolution.notices)
+
+    def test_the_rejection_notice_names_both_accepted_forms(self):
+        _, notices = parse_level("loud", "test")
+        assert any(ACCEPTED_FORMS in notice for notice in notices)
 
     def test_an_out_of_range_value_is_clamped_rather_than_rejected(self):
         resolution = resolve_startup_log_level(argument_level=None, config_level=1, environ={ENV_VAR: "7"})
@@ -99,7 +152,7 @@ class TestUnusableValues:
         assert resolution.source == SOURCE_ENVIRONMENT
         assert any("out of range" in notice for notice in resolution.notices)
 
-    def test_a_negative_value_clamps_to_quiet(self):
+    def test_a_negative_value_clamps_to_warning(self):
         resolution = resolve_startup_log_level(argument_level=None, config_level=1, environ={ENV_VAR: "-3"})
         assert resolution.level == 0
 
@@ -121,7 +174,15 @@ class TestUnusableValues:
 class TestNotices:
     def test_an_override_says_what_it_overrode(self):
         resolution = resolve_startup_log_level(argument_level=2, config_level=0, environ={})
-        assert any(f"overrides 0 from {SOURCE_CONFIG}" in notice for notice in resolution.notices)
+        assert any(f"overrides 0 (warning) from {SOURCE_CONFIG}" in notice for notice in resolution.notices)
+
+    def test_an_override_notice_names_the_winner_in_both_notations(self):
+        resolution = resolve_startup_log_level(argument_level=2, config_level=0, environ={})
+        assert any(f"Log level 2 (debug) from {SOURCE_ARGUMENT}" in notice for notice in resolution.notices)
+
+    def test_a_clamp_notice_names_the_level_it_settled_on(self):
+        resolution = resolve_startup_log_level(argument_level=None, config_level=None, environ={ENV_VAR: "7"})
+        assert any("using 2 (debug)" in notice for notice in resolution.notices)
 
     def test_every_losing_source_is_named_not_just_the_config(self):
         resolution = resolve_startup_log_level(argument_level=0, config_level=1, environ={ENV_VAR: "2"})

--- a/tests/unit/test_settings_log_level.py
+++ b/tests/unit/test_settings_log_level.py
@@ -35,6 +35,7 @@ import pytest
 
 import comicarr
 from comicarr import logger as comicarr_logger
+from comicarr.app.config.log_level import ACCEPTED_FORMS
 from comicarr.app.core.context import AppContext
 from comicarr.app.system import service as system_service
 from comicarr.config import config_transaction_lock
@@ -205,19 +206,28 @@ class TestTheValueIsReadByTheSameRulesAsEverySource:
         assert stubbed_save.config.LOG_LEVEL == clamped
         assert stubbed_save.applied == [clamped]
 
-    @pytest.mark.parametrize("raw", ["verbose", True, 2.5])
+    @pytest.mark.parametrize("raw", ["verbose", "loud", True, 2.5])
     def test_a_non_level_is_refused_rather_than_persisted(self, stubbed_save, raw):
         """Persisting garbage would be ignored at the next start -- silently.
 
         Startup sources fall through to the next layer instead of refusing to
-        boot. An HTTP request has somewhere to put the complaint.
+        boot. An HTTP request has somewhere to put the complaint. "verbose" is
+        refused with the rest: it is a flag spelling, never a level name (#620).
         """
         result = stubbed_save(log_level=raw)
 
         assert result["success"] is False
-        assert "LOG_LEVEL must be a number between 0 and 2" == result["error"]
+        assert "LOG_LEVEL must be %s" % ACCEPTED_FORMS == result["error"]
         assert stubbed_save.config.transactions == []
         assert stubbed_save.applied == []
+
+    @pytest.mark.parametrize("name, stored", [("warning", 0), ("info", 1), ("debug", 2), ("DEBUG", 2)])
+    def test_a_name_is_accepted_and_persisted_as_its_integer(self, stubbed_save, name, stored):
+        """The endpoint is no narrower than the CLI, and config.ini stays typed."""
+        assert stubbed_save(log_level=name) == {"success": True}
+
+        assert stubbed_save.config.LOG_LEVEL == stored
+        assert stubbed_save.applied == [stored]
 
 
 class TestTheRunningLevelOnlyFollowsADurableSave:


### PR DESCRIPTION
Resolves #620, under the map in #611.

## What changes for an operator

The log level can be set by name as well as by number — `warning`, `info`, `debug` — from every source that already accepted the number:

```
--log-level debug
COMICARR_LOG_LEVEL=debug
LOG_LEVEL = debug        # config.ini
{"LOG_LEVEL": "debug"}   # Settings endpoint
```

Numbers are unchanged, so no existing compose file or `config.ini` needs editing. Matching is case-insensitive and tolerates whitespace. The stored value is always the integer, so `LOG_LEVEL` stays the `int` the registry declares and the generated frontend types expect.

Startup text now names the level both ways:

```
Log level 2 (debug) from startup argument overrides 1 (info) from the config file.
```

`--verbose`/`-v` joins `--quiet`/`-q` as a deprecated alias — for `--log-level debug` — and gains the notice it lacked. All four keep working with no removal date.

## Why these names

The threshold picks the name. Level `0` is `WARNING`, so it is `warning`. That retires the `quiet` / `normal` / `verbose` triple this repo used until now: level 0 emits warnings and errors, and a dial labelled "quiet" describes behaviour the process does not have — the same class of lie as #610, which is what this whole map exists to fix.

There is exactly one name per level. `warn` is refused as a second spelling; `error` and `critical` are refused because no level delivers them — `--log-level error` could only mean "warnings and errors", which is level 0 under a name promising something narrower. `quiet` and `verbose` are refused as *values*: `--log-level` was `type=int` before this, so nobody could ever have typed them and there is no back-compatibility to keep.

## Notes for reviewers

- **One grammar, one rejection string.** `ACCEPTED_FORMS` backs both the startup notice and the Settings HTTP error, so the two can never describe different rules. The startup/HTTP split is unchanged: startup sources fall through to the next layer, HTTP refuses outright (#615's locked reasoning).
- **An unusable `--log-level` supplies nothing**, so it loses to `--verbose`/`--quiet` if those were also passed — the precedence chain's rule, one level down. Verified live: `--log-level loud` prints the notice and falls through without setting a level.
- **This supersedes part of #616.** That ticket locked `quiet / normal / verbose` as the Settings dial labels; they become number + name + consequence (`0 · Warning — warnings and errors`). The layout of that design is untouched. #617 has not been built yet, so nothing shipped needs changing — a note is on that ticket.
- **First commit is unrelated.** `npm run lint` fails on `main`: the prototype variants from 385fd17b were never run through prettier. Formatting only, split into its own commit.

## Verification

- `npm run lint` — green (including the frontend lane, after the formatting commit)
- `uv run pytest tests/unit` — 2283 passed
- Live against a real boot: `--verbose` and `--quiet` print their deprecation notices and set 2/0 with both notations in the override line; `--log-level debug` emits DEBUG output; `--log-level loud` falls through with a notice
- `CONTEXT.md` gains a **Log level** entry — the missing glossary term is why two vocabularies could drift apart in the first place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017C59FwfLS6s2w419WqCd6f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log levels now support the names `warning`, `info`, and `debug`, alongside existing numeric values and aliases.
  * Named values are case-insensitive and accepted consistently in startup options and Settings.
  * Messages now display both numeric and named level representations.
* **Deprecations**
  * `--verbose` and `-v` are deprecated; use `--log-level debug` instead. Existing aliases remain supported.
* **Documentation**
  * Updated logging-level guidance, terminology, precedence, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->