### PR TITLE
fix: fold folder scan diagnostics into debug logging

### DIFF
--- a/.changeset/folder-scan-follows-debug.md
+++ b/.changeset/folder-scan-follows-debug.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Debug logging now includes useful folder-scan diagnostics without a second hidden switch. Comicarr removes the legacy `folder_scan_log_verbose` setting during the configuration upgrade; set the single Log level to `2 · Debug` when diagnosing scan matching. Candidate-heavy scans now summarize their work per input file instead of flooding the log with one line for every comparison.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,8 @@ The MangaDex UUID a manga Series polls for new chapters. MangaDex Series carry i
 
 Comicarr's single verbosity dial, named by the severity it admits: `0` warning, `1` info, `2` debug. Level `0` means warnings and errors, not silence, which is why it is never called "quiet" — `--quiet` and `--verbose` are flag spellings, not level names.
 
+Subsystem diagnostics, including folder-scan diagnostics, are Debug entries rather than independent verbosity controls. High-volume operations summarize their diagnostics instead of introducing another dial.
+
 ## Support bundle
 
 A downloadable archive of allowlisted diagnostic data, engineered for public issue attachment after operator review. If its contents appear sensitive, the operator shares it privately with maintainers instead; CarePackage is the legacy implementation name, not the user-facing term.

--- a/comicarr/app/config/registry.py
+++ b/comicarr/app/config/registry.py
@@ -114,7 +114,7 @@ class ConfigKey:
 # ---------------------------------------------------------------------------
 
 _KEYS: tuple[ConfigKey, ...] = (
-    ConfigKey("CONFIG_VERSION", int, "General", 17),
+    ConfigKey("CONFIG_VERSION", int, "General", 18),
     ConfigKey("MINIMAL_INI", bool, "General", False),
     ConfigKey("CACHE_DIR", str, "General", None, readable=True),
     ConfigKey("DYNAMIC_UPDATE", int, "General", 0),
@@ -136,7 +136,6 @@ _KEYS: tuple[ConfigKey, ...] = (
     ConfigKey("UPDATE_ENDED", bool, "General", False),
     ConfigKey("NEWCOM_DIR", str, "Update", None),
     ConfigKey("FFTONEWCOM_DIR", bool, "Update", False),
-    ConfigKey("FOLDER_SCAN_LOG_VERBOSE", bool, "General", False),
     ConfigKey("INTERFACE", str, "General", "carbon"),
     ConfigKey("CORRECT_METADATA", bool, "General", False),
     ConfigKey("MOVE_FILES", bool, "General", False),

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -254,7 +254,7 @@ class Config(object):
                 count = 0
 
             # this is the current version at this particular point in time.
-            self.newconfig = 17
+            self.newconfig = 18
 
             OLDCONFIG_VERSION = 0
             if count == 0:
@@ -503,6 +503,14 @@ class Config(object):
                     logger.info(
                         "[CONFIG] Removed host_return: the SABnzbd handoff now uploads the "
                         "nzb directly and no download client is given a Comicarr address."
+                    )
+            if self.CONFIG_VERSION < 18:
+                # Folder-scan diagnostics now follow the single LOG_LEVEL dial;
+                # remove the retired, hidden verbosity switch from old configs.
+                if config.has_option("General", "folder_scan_log_verbose"):
+                    config.remove_option("General", "folder_scan_log_verbose")
+                    logger.info(
+                        "[CONFIG] Removed folder_scan_log_verbose: folder-scan diagnostics now follow LOG_LEVEL=debug."
                     )
             self.OLDCONFIG_VERSION = str(self.CONFIG_VERSION)
             self.CONFIG_VERSION = self.newconfig

--- a/comicarr/filechecker.py
+++ b/comicarr/filechecker.py
@@ -311,13 +311,12 @@ class FileChecker(object):
         if self.sarc and comicarr.CONFIG.READ2FILENAME:
             removest = modfilename.find("-")  # the - gets removed above so we test for the first blank space...
             logger.fdebug(
-                "[SARC] Checking filename for Reading Order sequence - Reading Sequence Order found #: %s"
-                % modfilename[:removest]
+                "[SARC] Checking filename for Reading Order sequence - candidate: %s" % modfilename[:removest]
             )
             if modfilename[:removest].isdigit() and removest <= 3:
                 reading_order = {"reading_sequence": str(modfilename[:removest]), "filename": filename[removest + 1 :]}
                 modfilename = modfilename[removest + 1 :]
-                logger.fdebug("[SARC] Removed Reading Order sequence from subname. Now set to : %s" % modfilename)
+                logger.fdebug("[SARC] Validated and removed Reading Order sequence. Filename is now: %s" % modfilename)
 
         # make sure all the brackets are properly spaced apart
         if modfilename.find(r"\s") == -1:

--- a/comicarr/filechecker.py
+++ b/comicarr/filechecker.py
@@ -310,16 +310,14 @@ class FileChecker(object):
         # if it's a story-arc, make sure to remove any leading reading order #'s
         if self.sarc and comicarr.CONFIG.READ2FILENAME:
             removest = modfilename.find("-")  # the - gets removed above so we test for the first blank space...
-            if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                logger.fdebug(
-                    "[SARC] Checking filename for Reading Order sequence - Reading Sequence Order found #: %s"
-                    % modfilename[:removest]
-                )
+            logger.fdebug(
+                "[SARC] Checking filename for Reading Order sequence - Reading Sequence Order found #: %s"
+                % modfilename[:removest]
+            )
             if modfilename[:removest].isdigit() and removest <= 3:
                 reading_order = {"reading_sequence": str(modfilename[:removest]), "filename": filename[removest + 1 :]}
                 modfilename = modfilename[removest + 1 :]
-                if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                    logger.fdebug("[SARC] Removed Reading Order sequence from subname. Now set to : %s" % modfilename)
+                logger.fdebug("[SARC] Removed Reading Order sequence from subname. Now set to : %s" % modfilename)
 
         # make sure all the brackets are properly spaced apart
         if modfilename.find(r"\s") == -1:
@@ -1846,11 +1844,7 @@ class FileChecker(object):
                     == re.sub(r"[\|\s]", "", nspace_seriesname.lower()).strip()
                 ]
                 if len(loopchk) > 0 and loopchk[0] != "":
-                    if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                        logger.fdebug("[FILECHECKER] This should be an alternate: %s" % loopchk)
                     if any(["annual" in series_name.lower(), "special" in series_name.lower()]):
-                        if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                            logger.fdebug("[FILECHECKER] Annual/Special detected - proceeding")
                         enable_annual = True
 
                 else:
@@ -1866,13 +1860,9 @@ class FileChecker(object):
                     loopchk.append(nspace_watchcomic)
                     if any(["annual" in nspace_seriesname.lower(), "special" in nspace_seriesname.lower()]):
                         if "biannual" in nspace_seriesname.lower():
-                            if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                                logger.fdebug("[FILECHECKER] BiAnnual detected - wouldn't Deadpool be proud?")
                             nspace_seriesname = re.sub("biannual", "", nspace_seriesname).strip()
                             enable_annual = True
                         elif "annual" in nspace_seriesname.lower():
-                            if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                                logger.fdebug("[FILECHECKER] Annual detected - proceeding cautiously.")
                             off_year_check = re.findall(r"(\d{4})(?=[\s]|annual\b|$)", self.watchcomic, flags=re.I)
                             if off_year_check:
                                 n_name = "%s%s" % (off_year_check[0], "annual")
@@ -1880,50 +1870,22 @@ class FileChecker(object):
                             nspace_seriesname = re.sub("annual", "", nspace_seriesname.lower()).strip()
                             enable_annual = False
                         elif "special" in nspace_seriesname.lower():
-                            if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                                logger.fdebug("[FILECHECKER] Special detected - proceeding cautiously.")
                             nspace_seriesname = re.sub("special", "", nspace_seriesname).strip()
                             enable_annual = False
 
-                if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                    logger.fdebug(
-                        "[FILECHECKER] Complete matching list of names to this file [%s] : %s" % (len(loopchk), loopchk)
-                    )
-
-                for loopit in loopchk:
-                    # now that we have the list of all possible matches for the watchcomic + alternate search names, we go through the list until we find a match.
-                    modseries_name = loopit
-                    if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                        logger.fdebug("[FILECHECKER] AS_Tuple : %s" % self.AS_Tuple)
-                        for ATS in self.AS_Tuple:
-                            if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                                logger.fdebug(
-                                    "[FILECHECKER] %s comparing to %s" % (ATS["AS_Alternate"], nspace_seriesname)
-                                )
-                            if (
-                                re.sub(r"\|", "", ATS["AS_Alternate"].lower()).strip()
-                                == re.sub(r"\|", "", nspace_seriesname.lower()).strip()
-                            ):
-                                if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                                    logger.fdebug("[FILECHECKER] Associating ComiciD : %s" % ATS["ComicID"])
-                                annual_comicid = str(ATS["ComicID"])
-                                modseries_name = ATS["AS_Alternate"]
-                                break
-
-                    logger.fdebug("[FILECHECKER] %s - watchlist match on : %s" % (modseries_name, filename))
+                for ATS in self.AS_Tuple:
+                    if (
+                        re.sub(r"\|", "", ATS["AS_Alternate"].lower()).strip()
+                        == re.sub(r"\|", "", nspace_seriesname.lower()).strip()
+                    ):
+                        annual_comicid = str(ATS["ComicID"])
+                        break
 
             if enable_annual:
                 if annual_comicid is not None:
-                    if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                        logger.fdebug("enable annual is on")
-                        logger.fdebug("annual comicid is %s" % annual_comicid)
                     if "biannual" in nspace_watchcomic.lower():
-                        if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                            logger.fdebug("bi annual detected")
                         justthedigits = "BiAnnual %s" % justthedigits
                     elif "annual" in nspace_watchcomic.lower():
-                        if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                            logger.fdebug("annual detected")
                         justthedigits = "Annual %s" % justthedigits
                     elif "special" in nspace_watchcomic.lower():
                         justthedigits = "Special %s" % justthedigits
@@ -2152,16 +2114,10 @@ class FileChecker(object):
                     # if it's !! present, it's the comicid associated with the series as an added annual.
                     # extract the !!, store it and then remove it so things will continue.
                     as_start = AS_Alternate.find("!!")
-                    if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                        logger.fdebug("as_start: %s --- %s" % (as_start, AS_Alternate[as_start:]))
                     as_end = AS_Alternate.find("##", as_start)
                     if as_end == -1:
                         as_end = len(AS_Alternate)
-                    if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                        logger.fdebug("as_start: %s --- %s" % (as_end, AS_Alternate[as_start:as_end]))
                     AS_ComicID = AS_Alternate[as_start + 2 : as_end]
-                    if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                        logger.fdebug("[FILECHECKER] Extracted comicid for given annual : %s" % AS_ComicID)
                     AS_Alternate = re.sub("!!" + str(AS_ComicID), "", AS_Alternate)
                     AS_tupled = True
                 as_dyninfo = self.dynamic_replace(AS_Alternate)
@@ -2318,10 +2274,6 @@ def calculate_match_confidence(parsed_info, comic_info):
         ratio = difflib.SequenceMatcher(None, parsed_name, comic_name).ratio()
         name_score = int(ratio * 40)
         score += name_score
-        if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-            logger.fdebug(
-                '[CONFIDENCE] Name match: "%s" vs "%s" = %.2f (%d pts)' % (parsed_name, comic_name, ratio, name_score)
-            )
 
     # 2. Year Match (15 pts)
     parsed_year = parsed_info.get("issue_year") or parsed_info.get("ComicYear")

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -57,6 +57,26 @@ _POSTPROCESS_JOURNAL_STAGE = PostProcessJournalStage()
 _POSTPROCESS_INPUT_STAGE = PostProcessInputStage()
 
 
+def format_scan_summary(filename, candidate_count, selected_items, annual_count, story_arc):
+    """Format the bounded Debug summary emitted once for each scanned file."""
+    selected = (
+        ", ".join("%s/%s" % (item.get("ComicID", "?"), item.get("ComicName", "?")) for item in selected_items) or "none"
+    )
+    return "[SCAN SUMMARY] %s: candidates=%s, selected=%s, annual_or_special=%s, story_arc=%s" % (
+        filename,
+        candidate_count,
+        selected,
+        annual_count,
+        story_arc,
+    )
+
+
+def log_scan_summary(module, filename, candidate_count, selected_items, annual_count, story_arc):
+    logger.fdebug(
+        "%s%s" % (module, format_scan_summary(filename, candidate_count, selected_items, annual_count, story_arc))
+    )
+
+
 class PostProcessor(object):
     """
     A class which will process a media file according to the post processing settings in the config.
@@ -666,7 +686,6 @@ class PostProcessor(object):
                     self.comicid = cid["ComicID"]
                 else:
                     if "_" in self.issueid:
-                        logger.fdebug("Story Arc post-processing request detected.")
                         self.issuearcid = self.issueid
                         self.issueid = None
                         logger.fdebug(
@@ -713,6 +732,8 @@ class PostProcessor(object):
             oneoff_issuelist = []
             manual_list = []
             for fl in filelist["comiclist"]:
+                manual_list_start = len(manual_list)
+                story_the_arcs = False
                 if (
                     all([fl["series_name"] is not None, fl["series_name"] != ""])
                     and comicarr.CONFIG.IGNORE_COVERS is True
@@ -1132,7 +1153,6 @@ class PostProcessor(object):
                             #    continue
                 watchvals = []
                 for wv in comicseries:
-                    logger.info("Now checking: %s [%s]" % (wv["ComicName"], wv["ComicID"]))
                     # do some extra checks in here to ignore these types:
                     # check for valid issue number - if not, don't even bother checking it
                     try:
@@ -1201,11 +1221,6 @@ class PostProcessor(object):
                     wv_latestissue = wv["LatestIssue"]
                     wv_intlatestissue = wv["intLatestIssue"]
                     wv_forcecontinuing = bool(wv["ForceContinuing"])
-                    if comicarr.CONFIG.FOLDER_SCAN_LOG_VERBOSE:
-                        logger.fdebug(
-                            "Queuing to Check: %s [%s] -- %s" % (wv["ComicName"], wv["ComicYear"], wv["ComicID"])
-                        )
-
                     # force it to use the Publication Date of the latest issue instead of the Latest Date (which could be anything)
                     ld_check = db.select_one(
                         select(issues.c.ReleaseDate, issues.c.Issue_Number, issues.c.Int_IssueNumber)
@@ -2076,6 +2091,16 @@ class PostProcessor(object):
                             "%s[MATCH: %s - %s] We matched by name for this series, but cannot find a corresponding issue number in the series list."
                             % (module, cs["ComicName"], cs["ComicID"])
                         )
+
+                selected_items = manual_list[manual_list_start:]
+                log_scan_summary(
+                    module,
+                    fl["comicfilename"],
+                    len(watchvals),
+                    selected_items,
+                    sum(1 for item in selected_items if item.get("AnnualType")),
+                    story_the_arcs,
+                )
 
                 # we should setup for manual post-processing of story-arc issues here
                 # we can also search by ComicID to just grab those particular arcs as an alternative as well (not done)

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -77,6 +77,14 @@ def log_scan_summary(module, filename, candidate_count, selected_items, annual_c
     )
 
 
+def summarize_scan_matches(normal_items, arc_items):
+    """Build summary fields from the matches selected for one input file."""
+    selected_items = normal_items + arc_items
+    annual_count = sum(1 for item in selected_items if item.get("AnnualType"))
+    story_arc = bool(arc_items or any(item.get("IssueArcID") for item in normal_items))
+    return selected_items, annual_count, story_arc
+
+
 class PostProcessor(object):
     """
     A class which will process a media file according to the post processing settings in the config.
@@ -733,7 +741,7 @@ class PostProcessor(object):
             manual_list = []
             for fl in filelist["comiclist"]:
                 manual_list_start = len(manual_list)
-                story_the_arcs = False
+                manual_arclist_start = len(manual_arclist)
                 if (
                     all([fl["series_name"] is not None, fl["series_name"] != ""])
                     and comicarr.CONFIG.IGNORE_COVERS is True
@@ -2092,16 +2100,6 @@ class PostProcessor(object):
                             % (module, cs["ComicName"], cs["ComicID"])
                         )
 
-                selected_items = manual_list[manual_list_start:]
-                log_scan_summary(
-                    module,
-                    fl["comicfilename"],
-                    len(watchvals),
-                    selected_items,
-                    sum(1 for item in selected_items if item.get("AnnualType")),
-                    story_the_arcs,
-                )
-
                 # we should setup for manual post-processing of story-arc issues here
                 # we can also search by ComicID to just grab those particular arcs as an alternative as well (not done)
 
@@ -2922,6 +2920,19 @@ class PostProcessor(object):
                                 )  # helpers.conversion(fl['comicfilename'])))
                                 self.matched = True
                                 break
+
+                selected_items, annual_count, story_arc_matched = summarize_scan_matches(
+                    manual_list[manual_list_start:],
+                    manual_arclist[manual_arclist_start:],
+                )
+                log_scan_summary(
+                    module,
+                    fl["comicfilename"],
+                    len(watchvals),
+                    selected_items,
+                    annual_count,
+                    story_arc_matched,
+                )
 
             if filelist["comiccount"] > 0:
                 logger.fdebug(

--- a/docs/architecture/logging-levels.md
+++ b/docs/architecture/logging-levels.md
@@ -184,6 +184,14 @@ choose by what they are actually asking.
 
 ## Two rules that fall out of it
 
+**Subsystem diagnostics are entries, not dials.** Folder scanning used to put
+some of its `DEBUG` entries behind `FOLDER_SCAN_LOG_VERBOSE`, a hidden legacy
+`config.ini` key. That made level `2` an incomplete promise: an operator could
+ask for everything and still miss the matching details they needed. Folder-scan
+diagnostics now follow the log level like every other entry. High-cardinality
+matching work is summarized per input file instead of requiring a second switch
+to keep candidate-by-candidate chatter manageable.
+
 **Level 0 is "warnings and errors", not silence.** An operator who turns the
 dial down is asking for less noise, not for failures to be hidden. This is why
 the setup-token announcement in `app/system/service.py` echoes to stdout at

--- a/frontend/tests/e2e/support-bundle.smoke.spec.ts
+++ b/frontend/tests/e2e/support-bundle.smoke.spec.ts
@@ -37,7 +37,7 @@ test("Settings → About creates a Support bundle ZIP", async ({
   );
 
   await page.goto("/settings?section=about");
-  await expect(page.getByText("Support bundle")).toBeVisible();
+  await expect(page.getByText("Support bundle", { exact: true })).toBeVisible();
   await expect(page.getByText("1. Create")).toBeVisible();
   await expect(page.getByText("2. Inspect")).toBeVisible();
   await expect(page.getByText("3. Share")).toBeVisible();
@@ -87,7 +87,12 @@ test("Settings → About creates a Support bundle ZIP", async ({
   }
 
   // Unauthenticated request cannot invoke the endpoint.
-  const bare = await page.context().browser()!.newContext();
+  const bare = await page
+    .context()
+    .browser()!
+    .newContext({
+      storageState: { cookies: [], origins: [] },
+    });
   const bareResp = await bare.request.post("/api/system/support-bundle", {
     headers: { "X-Requested-With": "ComicarrFrontend" },
   });

--- a/tests/unit/test_config_version_migrations.py
+++ b/tests/unit/test_config_version_migrations.py
@@ -7,7 +7,7 @@
 #  the Free Software Foundation, either version 3 of the License, or
 #  (at your option) any later version.
 
-"""CONFIG_VERSION migrations: 15 → 16 (CHECK_GITHUB) and 16 → 17 (host_return)."""
+"""CONFIG_VERSION migrations: 15 → 16 → 17 → 18."""
 
 import configparser
 from pathlib import Path
@@ -64,10 +64,10 @@ check_github_on_startup = True
 
     assert cfg.read(startup=False) is cfg
 
-    assert cfg.CONFIG_VERSION == 17
+    assert cfg.CONFIG_VERSION == 18
     assert cfg.CHECK_GITHUB is True
     assert REGISTRY["CHECK_GITHUB"].default is True
-    assert REGISTRY["CONFIG_VERSION"].default == 17
+    assert REGISTRY["CONFIG_VERSION"].default == 18
     assert "AUTO_UPDATE" not in REGISTRY
     assert "CHECK_GITHUB_ON_STARTUP" not in REGISTRY
 
@@ -94,7 +94,7 @@ check_github = False
 
     assert cfg.read(startup=False) is cfg
 
-    assert cfg.CONFIG_VERSION == 17
+    assert cfg.CONFIG_VERSION == 18
     assert cfg.CHECK_GITHUB is False
 
 
@@ -121,7 +121,7 @@ host_return = http://comicarr.example:8090/
 
     assert cfg.read(startup=False) is cfg
 
-    assert cfg.CONFIG_VERSION == 17
+    assert cfg.CONFIG_VERSION == 18
     assert "HOST_RETURN" not in REGISTRY
     assert not hasattr(cfg, "HOST_RETURN")
 
@@ -129,3 +129,29 @@ host_return = http://comicarr.example:8090/
     assert "host_return" not in text
     # Neighbouring keys in the same section survive the scrub.
     assert "http_port" in text
+
+
+def test_migration_removes_legacy_folder_scan_verbosity(tmp_path, monkeypatch):
+    """17 → 18 removes the hidden scan switch and explains the new policy once."""
+    cfg, ini = _load_config(
+        tmp_path,
+        monkeypatch,
+        """[General]
+config_version = 17
+minimal_ini = False
+folder_scan_log_verbose = True
+""",
+    )
+    info = MagicMock()
+    monkeypatch.setattr(config_module.logger, "info", info)
+
+    assert cfg.read(startup=False) is cfg
+
+    assert cfg.CONFIG_VERSION == 18
+    assert REGISTRY["CONFIG_VERSION"].default == 18
+    assert "FOLDER_SCAN_LOG_VERBOSE" not in REGISTRY
+    assert not hasattr(cfg, "FOLDER_SCAN_LOG_VERBOSE")
+    assert "folder_scan_log_verbose" not in ini.read_text(encoding="utf-8").lower()
+    info.assert_any_call(
+        "[CONFIG] Removed folder_scan_log_verbose: folder-scan diagnostics now follow LOG_LEVEL=debug."
+    )

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -34,7 +34,7 @@ from tests.conftest import placement_result
 if comicarr.LOG_LEVEL is None:
     comicarr.LOG_LEVEL = 0
 
-from comicarr.postprocessor import PostProcessor, log_scan_summary
+from comicarr.postprocessor import PostProcessor, log_scan_summary, summarize_scan_matches
 
 
 def test_scan_summary_emits_one_bounded_line_without_candidate_chatter():
@@ -49,6 +49,17 @@ def test_scan_summary_emits_one_bounded_line_without_candidate_chatter():
     assert "annual_or_special=1" in message
     assert "story_arc=True" in message
     assert "Now checking" not in message
+
+
+def test_scan_summary_reports_a_selected_story_arc_after_matching():
+    normal = [{"ComicID": "42", "ComicName": "Saga"}]
+    arc = [{"ComicID": "42", "ComicName": "Saga: Compendium One", "IssueArcID": "S7"}]
+
+    selected, annual_count, story_arc = summarize_scan_matches(normal, arc)
+
+    assert selected == normal + arc
+    assert annual_count == 0
+    assert story_arc is True
 
 
 def _make_pp(nzb_name, nzb_folder, comicid=None, issueid=None, apicall=False):

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -34,7 +34,21 @@ from tests.conftest import placement_result
 if comicarr.LOG_LEVEL is None:
     comicarr.LOG_LEVEL = 0
 
-from comicarr.postprocessor import PostProcessor
+from comicarr.postprocessor import PostProcessor, log_scan_summary
+
+
+def test_scan_summary_emits_one_bounded_line_without_candidate_chatter():
+    selected = [{"ComicID": "42", "ComicName": "Saga"}]
+    with patch("comicarr.postprocessor.logger.fdebug") as fdebug:
+        log_scan_summary("[PP] ", "Saga 1.cbz", 3, selected, 1, True)
+
+    fdebug.assert_called_once()
+    message = fdebug.call_args.args[0]
+    assert "candidates=3" in message
+    assert "selected=42/Saga" in message
+    assert "annual_or_special=1" in message
+    assert "story_arc=True" in message
+    assert "Now checking" not in message
 
 
 def _make_pp(nzb_name, nzb_folder, comicid=None, issueid=None, apicall=False):


### PR DESCRIPTION
## Summary

- retire the hidden `FOLDER_SCAN_LOG_VERBOSE` configuration switch so folder-scan diagnostics follow the single Debug level
- replace candidate-by-candidate scan chatter with one bounded per-file summary containing candidate count and selected outcome
- migrate existing configuration files to version 18, removing the legacy key with a one-time explanation
- document the logging contract and add an operator-facing changeset

## Why

Comicarr promised one verbosity dial, but folder scanning still hid some Debug output behind a second legacy `config.ini` key that was not exposed in Settings. Operators could select `2 · Debug` and still miss matching diagnostics.

The old switch also masked a separate problem: nested candidate loops could emit roughly files × candidate-series messages. The useful fix is to summarize that work, not preserve another dial.

## Impact

Existing installs migrate to config version 18 and have `folder_scan_log_verbose` removed. Operators now use the normal log-level control for scan diagnostics. Candidate-heavy scans produce a concise `[SCAN SUMMARY]` line per processed input file instead of per-candidate chatter.

Implements the final decision from #621 and completes the execution map in #611.

## Validation

- `pytest tests/unit -q` — 2,299 passed
- focused logging, migration, file-checker, and post-processing tests — 57 passed
- `npm run lint` — passed, including Ruff, guards, generated config types, ESLint, and Prettier
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added concise per-file folder-scan summaries at Debug level, including candidate, match, annual/special, and story-arc details.
* **Bug Fixes**
  * Improved visibility of story-arc reading-order diagnostics.
  * Reduced excessive per-candidate debug output during scans.
* **Configuration**
  * Removed the obsolete folder-scan verbosity setting.
  * Existing configurations are automatically migrated to the updated format.
* **Documentation**
  * Clarified that folder-scan diagnostics are controlled by the global log level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->