### PR TITLE
fix: Make pack search workable and absorb legacy torznab config

### DIFF
--- a/.changeset/legacy-torznab-fields-migrate.md
+++ b/.changeset/legacy-torznab-fields-migrate.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Hand-edited legacy `torznab_*` fields under `[Torznab]` in config.ini no longer sit silently inert. A complete legacy entry (name, host, API key, category) is folded into the real multi-provider `extra_torznabs` list on startup and the stale keys are removed; an incomplete one is called out in the log with a pointer to the Settings UI instead of being ignored. (#631)

--- a/.changeset/pack-search-actually-works.md
+++ b/.changeset/pack-search-actually-works.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Pack and bundle releases can now actually be matched. Each series page has two new Search options — **Allow packs** accepts multi-issue/volume bundle releases (the norm for manga and manhwa torrents), and **Ignore book type** lets results through when the release's book type (TPB, GN, …) differs from the series. These per-series flags existed in the database but had no way to be set, so packs were rejected for every series. Pack matching also no longer requires the 32P tracker to be enabled — any torrent or Torznab provider qualifies once torrent search is on. (#632, #633)

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -42,6 +42,8 @@ COMICS_COLUMNS = [
     t_comics.c.DetailURL.label("DetailURL"),
     t_comics.c.ComicLocation.label("ComicLocation"),
     t_comics.c.ContentType.label("ContentType"),
+    t_comics.c.AllowPacks.label("AllowPacks"),
+    t_comics.c.IgnoreType.label("IgnoreType"),
 ]
 
 ISSUES_COLUMNS = [
@@ -166,6 +168,22 @@ def delete_comic(comic_id):
         conn.execute(delete(t_comics).where(t_comics.c.ComicID == comic_id))
         conn.execute(delete(t_issues).where(t_issues.c.ComicID == comic_id))
         conn.execute(delete(t_upcoming).where(t_upcoming.c.ComicID == comic_id))
+
+
+def get_comic_search_settings(comic_id):
+    """Get the per-series search flags (pack matching / booktype override)."""
+    return db.select_one(
+        select(t_comics.c.ComicID, t_comics.c.AllowPacks, t_comics.c.IgnoreType).where(t_comics.c.ComicID == comic_id)
+    )
+
+
+def update_comic_search_settings(comic_id, values):
+    """Persist per-series search flags.
+
+    ``AllowPacks`` is a Text column read as ``== 1 / == "1"`` by search.py, so
+    it is stored as "1"/"0" strings; ``IgnoreType`` is an Integer flag column.
+    """
+    db.upsert("comics", values, {"ComicID": comic_id})
 
 
 def pause_comic(comic_id):

--- a/comicarr/app/series/router.py
+++ b/comicarr/app/series/router.py
@@ -84,6 +84,34 @@ def delete_series(
     return result
 
 
+@router.patch("/series/{comic_id}/search-settings", dependencies=[Depends(require_session)])
+def update_series_search_settings(
+    comic_id: str,
+    request_body: dict = None,
+    ctx: AppContext = Depends(get_context),
+):
+    """Update per-series search flags (pack matching / booktype override)."""
+    if request_body is None:
+        request_body = {}
+
+    allow_packs = request_body.get("allow_packs")
+    ignore_type = request_body.get("ignore_type")
+    for name, value in (("allow_packs", allow_packs), ("ignore_type", ignore_type)):
+        if value is not None and not isinstance(value, bool):
+            return JSONResponse(status_code=400, content={"detail": "%s must be a boolean" % name})
+    if allow_packs is None and ignore_type is None:
+        return JSONResponse(
+            status_code=400,
+            content={"detail": "Provide at least one of allow_packs, ignore_type"},
+        )
+
+    result = series_service.update_search_settings(ctx, comic_id, allow_packs=allow_packs, ignore_type=ignore_type)
+    if not result["success"]:
+        status = 404 if "not found" in result.get("error", "").lower() else 400
+        return JSONResponse(status_code=status, content={"detail": result.get("error")})
+    return result
+
+
 @router.put("/series/{comic_id}/pause", dependencies=[Depends(require_session)])
 def pause_series(comic_id: str, ctx: AppContext = Depends(get_context)):
     """Pause a comic series."""

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -405,6 +405,39 @@ def delete_comic(ctx, comic_id, delete_directory=False):
     }
 
 
+def update_search_settings(ctx, comic_id, allow_packs=None, ignore_type=None):
+    """Update the per-series search flags (#633).
+
+    ``allow_packs`` gates pack/bundle release matching; ``ignore_type`` lets
+    results through the booktype-mismatch check in search_filer. Both are
+    partial — omitted (None) fields are left untouched.
+    """
+    existing = series_queries.get_comic_search_settings(comic_id)
+    if not existing:
+        return {"success": False, "error": "ComicID %s not found in watchlist" % comic_id}
+
+    values = {}
+    if allow_packs is not None:
+        # Text column read as == 1 / == "1" by search.py — store "1"/"0".
+        values["AllowPacks"] = "1" if allow_packs else "0"
+    if ignore_type is not None:
+        values["IgnoreType"] = 1 if ignore_type else 0
+
+    if not values:
+        return {"success": False, "error": "No search settings provided"}
+
+    series_queries.update_comic_search_settings(comic_id, values)
+    logger.fdebug("[SERIES] Updated search settings for %s: %s" % (comic_id, values))
+    updated = series_queries.get_comic_search_settings(comic_id)
+    return {
+        "success": True,
+        "settings": {
+            "allow_packs": updated["AllowPacks"] in (1, "1"),
+            "ignore_type": bool(updated["IgnoreType"]),
+        },
+    }
+
+
 def pause_comic(ctx, comic_id):
     """Set comic status to Paused."""
     series_queries.pause_comic(comic_id)

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -569,6 +569,7 @@ class Config(object):
                     config.remove_option("Torznab", option)
             self.TORZNAB_NAME = None
             self.TORZNAB_HOST = None
+            self.TORZNAB_VERIFY = None
             self.TORZNAB_APIKEY = None
             self.TORZNAB_CATEGORY = None
             self.WRITE_THE_CONFIG = True
@@ -592,7 +593,13 @@ class Config(object):
             return
 
         canonical_name = str(legacy["name"]).strip().casefold()
-        existing_names = {str(entry[0] or entry[1]).strip().casefold() for entry in self.EXTRA_TORZNABS}
+        # Provider names must be unique across BOTH extras lists — validation
+        # shares one namespace for newznabs and torznabs.
+        existing_names = {
+            str(entry[0] or entry[1]).strip().casefold()
+            for entries in (self.EXTRA_NEWZNABS, self.EXTRA_TORZNABS)
+            for entry in entries
+        }
         if canonical_name in existing_names | self._reserved_provider_names():
             logger.warn(
                 "[CONFIG] Legacy torznab_* fields under [Torznab] reuse the provider name "

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -591,7 +591,23 @@ class Config(object):
             _scrub()
             return
 
-        comicarr.PROVIDER_START_ID += 1
+        canonical_name = str(legacy["name"]).strip().casefold()
+        existing_names = {str(entry[0] or entry[1]).strip().casefold() for entry in self.EXTRA_TORZNABS}
+        if canonical_name in existing_names | self._reserved_provider_names():
+            logger.warn(
+                "[CONFIG] Legacy torznab_* fields under [Torznab] reuse the provider name "
+                "'%s' and are NOT used for searching. Rename or remove the legacy fields, or "
+                "configure the provider via the Settings UI (extra_torznabs) instead." % legacy["name"]
+            )
+            return
+
+        # Skip ids held by the built-in providers (experimental/DDL) or
+        # _validate_loaded_provider_extras will reject the migrated entry.
+        reserved_ids = self._reserved_provider_ids()
+        candidate_id = comicarr.PROVIDER_START_ID + 1
+        while candidate_id in reserved_ids:
+            candidate_id += 1
+        comicarr.PROVIDER_START_ID = candidate_id
         self.EXTRA_TORZNABS.append(
             (
                 legacy["name"],
@@ -600,7 +616,7 @@ class Config(object):
                 legacy["apikey"],
                 legacy["category"],
                 str(int(bool(self.ENABLE_TORZNAB))),
-                comicarr.PROVIDER_START_ID,
+                candidate_id,
             )
         )
         logger.info(

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -523,6 +523,7 @@ class Config(object):
         extra_newznabs, extra_torznabs = self.get_extras()
         self.EXTRA_NEWZNABS = extra_newznabs
         self.EXTRA_TORZNABS = extra_torznabs
+        self._absorb_legacy_torznab()
         self.IGNORED_PUBLISHERS = self.get_ignored_pubs()
 
         provider_migration_needed = self._load_provider_extra_credentials()
@@ -538,6 +539,76 @@ class Config(object):
             if self.writeconfig(startup=startup) is False:
                 raise OSError("Unable to persist configuration")
         return self
+
+    def _absorb_legacy_torznab(self):
+        """Fold populated legacy torznab_* fields into EXTRA_TORZNABS (#631).
+
+        The single-provider [Torznab] fields were retired at config_version 8,
+        but the keys still exist and a hand-edited config.ini can repopulate
+        them on any modern version — where they were silently inert. Runs on
+        every read so the entry is either migrated or loudly flagged.
+        """
+        legacy = {
+            "name": self.TORZNAB_NAME,
+            "host": self.TORZNAB_HOST,
+            "apikey": self.TORZNAB_APIKEY,
+            "category": self.TORZNAB_CATEGORY,
+        }
+        if all(value is None for value in legacy.values()):
+            return
+
+        def _scrub():
+            for option in (
+                "torznab_name",
+                "torznab_host",
+                "torznab_verify",
+                "torznab_apikey",
+                "torznab_category",
+            ):
+                if config.has_option("Torznab", option):
+                    config.remove_option("Torznab", option)
+            self.TORZNAB_NAME = None
+            self.TORZNAB_HOST = None
+            self.TORZNAB_APIKEY = None
+            self.TORZNAB_CATEGORY = None
+            self.WRITE_THE_CONFIG = True
+
+        missing = [key for key, value in legacy.items() if value is None]
+        if missing:
+            logger.warn(
+                "[CONFIG] Legacy torznab_* fields under [Torznab] are set but incomplete "
+                "(missing: %s) and are NOT used for searching. Configure the provider via "
+                "the Settings UI (extra_torznabs) instead. Ignoring the legacy entry."
+                % ", ".join("torznab_%s" % m for m in missing)
+            )
+            return
+
+        if any(str(existing[1]).strip() == str(legacy["host"]).strip() for existing in self.EXTRA_TORZNABS):
+            logger.warn(
+                "[CONFIG] Legacy torznab_* fields under [Torznab] duplicate an existing "
+                "extra_torznabs entry for %s. Removing the inert legacy fields." % legacy["host"]
+            )
+            _scrub()
+            return
+
+        comicarr.PROVIDER_START_ID += 1
+        self.EXTRA_TORZNABS.append(
+            (
+                legacy["name"],
+                legacy["host"],
+                self.TORZNAB_VERIFY,
+                legacy["apikey"],
+                legacy["category"],
+                str(int(bool(self.ENABLE_TORZNAB))),
+                comicarr.PROVIDER_START_ID,
+            )
+        )
+        logger.info(
+            "[CONFIG] Migrated legacy torznab_* fields under [Torznab] into extra_torznabs "
+            "as provider '%s' (%s). The legacy single-provider fields are no longer read; "
+            "manage this provider via the Settings UI from now on." % (legacy["name"], legacy["host"])
+        )
+        _scrub()
 
     def config_update(self):
         logger.info("Updating Configuration from %s to %s" % (self.CONFIG_VERSION, self.newconfig))

--- a/comicarr/rsscheck.py
+++ b/comicarr/rsscheck.py
@@ -1238,12 +1238,15 @@ def nzbdbsearch(
                                 "RSS": nzb["RSS"],
                                 "ComicID": nzb["ComicID"],
                                 "ComicName_Filesafe": nzb["ComicName_Filesafe"],
-                                "AllowPacks": bool(nzb["AllowPacks"]),
+                                # AllowPacks is a Text column storing "1"/"0";
+                                # bool() would treat "0" as True.
+                                "AllowPacks": nzb["AllowPacks"] in (1, "1"),
                                 "OneOff": bool(nzb["OneOff"]),
                                 "TorrentID_32P": nzb["TorrentID_32P"],
                                 "DigitalDate": nzb["DigitalDate"],
                                 "booktype": nzb["BookType"],
-                                "ignore_booktype": bool(nzb["Ignore_Booktype"]),
+                                # Same Text-column hazard as AllowPacks above.
+                                "ignore_booktype": nzb["Ignore_Booktype"] in (1, "1", True),
                             },
                         }
                     )

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -909,9 +909,10 @@ def NZB_SEARCH(
     smode=None,
 ):
 
-    if any([allow_packs == 1, allow_packs == "1"]) and all(
-        [comicarr.CONFIG.ENABLE_TORRENT_SEARCH, comicarr.CONFIG.ENABLE_32P]
-    ):
+    # Pack eligibility only requires torrent search to be enabled; historically it
+    # was also gated behind ENABLE_32P, which blocked packs from every other
+    # torrent/Torznab provider (#632).
+    if any([allow_packs == 1, allow_packs == "1", allow_packs is True]) and comicarr.CONFIG.ENABLE_TORRENT_SEARCH:
         allow_packs = True
     else:
         allow_packs = False

--- a/frontend/src/hooks/useSeries.ts
+++ b/frontend/src/hooks/useSeries.ts
@@ -175,6 +175,35 @@ export function useResumeSeries(): UseMutationResult<unknown, Error, string> {
   });
 }
 
+export interface SeriesSearchSettingsInput {
+  comicId: string;
+  allowPacks?: boolean;
+  ignoreType?: boolean;
+}
+
+/**
+ * Update per-series search flags (pack matching / booktype override)
+ */
+export function useUpdateSeriesSearchSettings(): UseMutationResult<
+  unknown,
+  Error,
+  SeriesSearchSettingsInput
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ comicId, allowPacks, ignoreType }) =>
+      apiRequest("PATCH", `/api/series/${comicId}/search-settings`, {
+        ...(allowPacks !== undefined && { allow_packs: allowPacks }),
+        ...(ignoreType !== undefined && { ignore_type: ignoreType }),
+      }),
+    onSuccess: (_, { comicId }) => {
+      queryClient.invalidateQueries({ queryKey: ["series"] });
+      queryClient.invalidateQueries({ queryKey: ["series", comicId] });
+    },
+  });
+}
+
 /**
  * Refresh series metadata
  */

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import StatusBadge from "@/components/StatusBadge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -31,6 +32,7 @@ import {
   useSearchMissingPreview,
   useSearchRun,
   useSeriesDetail,
+  useUpdateSeriesSearchSettings,
 } from "@/hooks/useSeries";
 import type {
   ComicOrManga,
@@ -163,6 +165,7 @@ export default function SeriesDetailPage() {
   const confirmSearch = useConfirmSearchMissing();
   const searchRun = useSearchRun(searchRunId);
   const retrySearchRun = useRetrySearchRun();
+  const searchSettingsMutation = useUpdateSeriesSearchSettings();
 
   const fetchSearchPreview = async () => {
     setPreview(null);
@@ -300,6 +303,29 @@ export default function SeriesDetailPage() {
     summary?.completionPercent ??
     (total > 0 ? Math.round((have / total) * 100) : 0);
   const isPaused = comic.Status?.toLowerCase() === "paused";
+  const allowPacks = comic.AllowPacks === 1 || comic.AllowPacks === "1";
+  const ignoreType = Boolean(comic.IgnoreType);
+
+  const handleSearchSettingChange = async (
+    setting: "allowPacks" | "ignoreType",
+    value: boolean,
+  ) => {
+    if (!comicId) return;
+    try {
+      await searchSettingsMutation.mutateAsync({
+        comicId,
+        ...(setting === "allowPacks"
+          ? { allowPacks: value }
+          : { ignoreType: value }),
+      });
+    } catch {
+      addToast({
+        type: "error",
+        title: "Error",
+        description: "Failed to update search settings",
+      });
+    }
+  };
   const isManga =
     comic.ContentType === "manga" ||
     comicId?.startsWith("md-") ||
@@ -611,6 +637,49 @@ export default function SeriesDetailPage() {
                 </div>
               ))}
             </div>
+          </div>
+          <div
+            className="border-t px-3 py-2.5"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <div
+              className="mb-2 font-mono text-[10px] uppercase tracking-[0.1em]"
+              style={{ color: "var(--text-muted)" }}
+            >
+              Search options
+            </div>
+            {[
+              {
+                key: "allowPacks" as const,
+                label: "Allow packs",
+                title:
+                  "Accept pack/bundle releases (multi-issue or volume torrents) when searching",
+                checked: allowPacks,
+              },
+              {
+                key: "ignoreType" as const,
+                label: "Ignore book type",
+                title:
+                  "Match results even when the release's book type (TPB, GN…) differs from this series",
+                checked: ignoreType,
+              },
+            ].map(({ key, label, title, checked }) => (
+              <label
+                key={key}
+                title={title}
+                className="flex cursor-pointer items-center justify-between gap-2 py-1 font-mono text-[10px]"
+              >
+                <span style={{ color: "var(--text-muted)" }}>{label}</span>
+                <Checkbox
+                  checked={checked}
+                  disabled={searchSettingsMutation.isPending}
+                  onCheckedChange={(value) =>
+                    void handleSearchSettingChange(key, value)
+                  }
+                  aria-label={label}
+                />
+              </label>
+            ))}
           </div>
         </div>
       </div>

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -71,6 +71,10 @@ export interface Comic {
   AlternateSearch?: string | null;
   ComicVersion?: string | null;
   ContentType?: ContentType | null;
+  /** Per-series pack/bundle matching flag — Text column, "1" when enabled */
+  AllowPacks?: string | number | null;
+  /** Per-series booktype-mismatch override — Integer flag column */
+  IgnoreType?: number | null;
 }
 
 /** Issue entity */

--- a/tests/unit/test_config_version_migrations.py
+++ b/tests/unit/test_config_version_migrations.py
@@ -155,3 +155,63 @@ folder_scan_log_verbose = True
     info.assert_any_call(
         "[CONFIG] Removed folder_scan_log_verbose: folder-scan diagnostics now follow LOG_LEVEL=debug."
     )
+
+
+def test_legacy_torznab_fields_absorbed_on_modern_config(tmp_path, monkeypatch):
+    """#631: torznab_* single-provider fields repopulated on a modern config are
+    folded into extra_torznabs instead of sitting silently inert."""
+    cfg, ini = _load_config(
+        tmp_path,
+        monkeypatch,
+        """[General]
+config_version = 18
+minimal_ini = False
+encrypt_passwords = False
+
+[Torznab]
+enable_torznab = True
+torznab_name = Nyaa
+torznab_host = http://prowlarr.example:9696/1/api
+torznab_apikey = abc123
+torznab_category = 8020
+""",
+    )
+
+    assert cfg.read(startup=False) is cfg
+
+    hosts = [entry[1] for entry in cfg.EXTRA_TORZNABS]
+    assert "http://prowlarr.example:9696/1/api" in hosts
+    migrated = cfg.EXTRA_TORZNABS[hosts.index("http://prowlarr.example:9696/1/api")]
+    assert migrated[0] == "Nyaa"
+    assert migrated[3] == "abc123"
+    assert migrated[4] == "8020"
+    assert migrated[5] == "1"
+
+    assert cfg.TORZNAB_NAME is None
+    assert cfg.TORZNAB_HOST is None
+    text = ini.read_text(encoding="utf-8").lower()
+    assert "torznab_host" not in text
+    assert "extra_torznabs" in text
+
+
+def test_legacy_torznab_incomplete_fields_warn_and_stay_unmigrated(tmp_path, monkeypatch):
+    cfg, _ini = _load_config(
+        tmp_path,
+        monkeypatch,
+        """[General]
+config_version = 18
+minimal_ini = False
+encrypt_passwords = False
+
+[Torznab]
+torznab_host = http://prowlarr.example:9696/1/api
+""",
+    )
+    warn = MagicMock()
+    monkeypatch.setattr(config_module.logger, "warn", warn)
+
+    assert cfg.read(startup=False) is cfg
+
+    assert cfg.EXTRA_TORZNABS == []
+    assert warn.called
+    assert "NOT used for searching" in warn.call_args_list[0][0][0]

--- a/tests/unit/test_config_version_migrations.py
+++ b/tests/unit/test_config_version_migrations.py
@@ -253,6 +253,38 @@ torznab_category = 8020
     assert any("reuse the provider name" in call[0][0] for call in warn.call_args_list)
 
 
+def test_legacy_torznab_name_collision_with_newznab_warns_and_stays_unmigrated(tmp_path, monkeypatch):
+    """Provider names share one namespace across newznabs and torznabs — a
+    migrated entry reusing a Newznab name would fail provider validation."""
+    cfg, _ini = _load_config(
+        tmp_path,
+        monkeypatch,
+        """[General]
+config_version = 18
+minimal_ini = False
+encrypt_passwords = False
+
+[Newznab]
+extra_newznabs = Nyaa, http://usenet.example:5000/api, False, zzz, 7030, 1, 3
+
+[Torznab]
+enable_torznab = True
+torznab_name = Nyaa
+torznab_host = http://prowlarr.example:9696/1/api
+torznab_apikey = abc123
+torznab_category = 8020
+""",
+    )
+    warn = MagicMock()
+    monkeypatch.setattr(config_module.logger, "warn", warn)
+
+    assert cfg.read(startup=False) is cfg
+
+    hosts = [entry[1] for entry in cfg.EXTRA_TORZNABS]
+    assert "http://prowlarr.example:9696/1/api" not in hosts
+    assert any("reuse the provider name" in call[0][0] for call in warn.call_args_list)
+
+
 def test_legacy_torznab_incomplete_fields_warn_and_stay_unmigrated(tmp_path, monkeypatch):
     cfg, _ini = _load_config(
         tmp_path,

--- a/tests/unit/test_config_version_migrations.py
+++ b/tests/unit/test_config_version_migrations.py
@@ -194,6 +194,65 @@ torznab_category = 8020
     assert "extra_torznabs" in text
 
 
+def test_legacy_torznab_migration_skips_reserved_provider_ids(tmp_path, monkeypatch):
+    """The migrated entry must not claim an id held by a built-in provider
+    (experimental=101, DDL=200/201) or provider validation rejects it."""
+    cfg, _ini = _load_config(
+        tmp_path,
+        monkeypatch,
+        """[General]
+config_version = 18
+minimal_ini = False
+encrypt_passwords = False
+
+[Experimental]
+experimental = True
+
+[Torznab]
+enable_torznab = True
+torznab_name = Nyaa
+torznab_host = http://prowlarr.example:9696/1/api
+torznab_apikey = abc123
+torznab_category = 8020
+""",
+    )
+    monkeypatch.setattr(comicarr, "PROVIDER_START_ID", 100, raising=False)
+
+    assert cfg.read(startup=False) is cfg
+
+    migrated = next(entry for entry in cfg.EXTRA_TORZNABS if entry[1] == "http://prowlarr.example:9696/1/api")
+    assert migrated[6] == 102  # 101 is reserved by experimental
+    assert comicarr.PROVIDER_START_ID == 102
+
+
+def test_legacy_torznab_name_collision_warns_and_stays_unmigrated(tmp_path, monkeypatch):
+    cfg, _ini = _load_config(
+        tmp_path,
+        monkeypatch,
+        """[General]
+config_version = 18
+minimal_ini = False
+encrypt_passwords = False
+
+[Torznab]
+enable_torznab = True
+extra_torznabs = Nyaa, http://other.example:9696/api, False, zzz, 8020, 1, 7
+torznab_name = Nyaa
+torznab_host = http://prowlarr.example:9696/1/api
+torznab_apikey = abc123
+torznab_category = 8020
+""",
+    )
+    warn = MagicMock()
+    monkeypatch.setattr(config_module.logger, "warn", warn)
+
+    assert cfg.read(startup=False) is cfg
+
+    hosts = [entry[1] for entry in cfg.EXTRA_TORZNABS]
+    assert "http://prowlarr.example:9696/1/api" not in hosts
+    assert any("reuse the provider name" in call[0][0] for call in warn.call_args_list)
+
+
 def test_legacy_torznab_incomplete_fields_warn_and_stay_unmigrated(tmp_path, monkeypatch):
     cfg, _ini = _load_config(
         tmp_path,

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -309,6 +309,57 @@ def test_explicit_issue_actions_dual_write_canonical_intent(monkeypatch):
     ]
 
 
+def test_update_search_settings_stores_flag_columns_in_search_readable_form(monkeypatch):
+    """AllowPacks is read as == 1 / == "1" by search.py; IgnoreType via bool()."""
+    upsert = MagicMock()
+    rows = iter(
+        [
+            {"ComicID": "160294", "AllowPacks": None, "IgnoreType": None},
+            {"ComicID": "160294", "AllowPacks": "1", "IgnoreType": 0},
+        ]
+    )
+    monkeypatch.setattr(series_service.series_queries, "get_comic_search_settings", lambda _comic_id: next(rows))
+    monkeypatch.setattr(series_service.series_queries, "update_comic_search_settings", upsert)
+
+    result = series_service.update_search_settings(_make_ctx(), "160294", allow_packs=True, ignore_type=False)
+
+    upsert.assert_called_once_with("160294", {"AllowPacks": "1", "IgnoreType": 0})
+    assert result == {"success": True, "settings": {"allow_packs": True, "ignore_type": False}}
+
+
+def test_update_search_settings_is_partial_and_rejects_unknown_series(monkeypatch):
+    upsert = MagicMock()
+    monkeypatch.setattr(
+        series_service.series_queries,
+        "get_comic_search_settings",
+        lambda comic_id: (
+            {"ComicID": "160294", "AllowPacks": "0", "IgnoreType": 1} if comic_id == "160294" else None
+        ),
+    )
+    monkeypatch.setattr(series_service.series_queries, "update_comic_search_settings", upsert)
+
+    missing = series_service.update_search_settings(_make_ctx(), "999999", allow_packs=True)
+    assert missing["success"] is False
+    upsert.assert_not_called()
+
+    empty = series_service.update_search_settings(_make_ctx(), "160294")
+    assert empty["success"] is False
+    upsert.assert_not_called()
+
+    partial = series_service.update_search_settings(_make_ctx(), "160294", ignore_type=False)
+    assert partial["success"] is True
+    upsert.assert_called_once_with("160294", {"IgnoreType": 0})
+
+
+def test_search_settings_query_upserts_lowercase_comics_table(monkeypatch):
+    upsert = MagicMock()
+    monkeypatch.setattr(series_queries.db, "upsert", upsert)
+
+    series_queries.update_comic_search_settings("160294", {"AllowPacks": "1", "IgnoreType": 1})
+
+    upsert.assert_called_once_with("comics", {"AllowPacks": "1", "IgnoreType": 1}, {"ComicID": "160294"})
+
+
 def test_preview_search_all_missing_excludes_owned_future_and_skipped(monkeypatch):
     projected = [
         series_service.project_issue_state(row, series_status="Active")


### PR DESCRIPTION
## Summary

Fixes the pack-search issue cluster reported by @Freddster — all three verified against the codebase before fixing.

### #632 — pack gate no longer requires 32P
`NZB_SEARCH()` demanded `all([ENABLE_TORRENT_SEARCH, ENABLE_32P])` before any pack release could match, blocking packs from every other torrent/Torznab provider. The gate now requires only `ENABLE_TORRENT_SEARCH`.

### #633 — AllowPacks / IgnoreType finally have a write path
The `comics.AllowPacks` and `comics.IgnoreType` columns were read extensively by `search.py` / `search_filer.py` / `rsscheck.py` but never written anywhere — so packs could never match and booktype mismatches were always fatal, for every series, in every install.

- New `PATCH /api/series/{comic_id}/search-settings` endpoint (partial update, boolean-validated) → service → `db.upsert("comics", …)`
- Series detail page grows a **Search options** section with **Allow packs** and **Ignore book type** toggles (`useUpdateSeriesSearchSettings` hook); both columns added to the series projection
- Storage matches how search reads the columns: `AllowPacks` (Text) as `"1"/"0"`, `IgnoreType` (Integer) as `1/0`
- Hardened `rsscheck.py`'s `bool(...)` truthiness on both flags — a stored `"0"` string would have read as *enabled* via the RSS temp-table path

### #631 — legacy torznab_* fields are absorbed, not silently ignored
The single-provider `[Torznab]` fields were only consumed by the `CONFIG_VERSION < 8` migration, so re-populating them on a modern config did nothing, with no warning. A new `_absorb_legacy_torznab()` runs on every config read: a complete entry is folded into `extra_torznabs` (fresh provider id, deduped by host) and the stale keys scrubbed from config.ini; an incomplete entry logs a loud warning pointing at the Settings UI.

## Caveat / follow-up

The non-DDL pack *parsing* pipeline in `search_filer.py` is partially vestigial in this fork — only DDL entries get `pack=True` today — so **Ignore book type** is the flag doing most of the work for torrent bundle matching. Full Torznab pack-range parsing (issue-range extraction + per-issue reconciliation for torrent packs) is a follow-up.

## Testing

- New unit tests: search-settings service/queries (storage form, partial update, unknown series, lowercase upsert table) and legacy-torznab absorption (complete → migrated + scrubbed, incomplete → warned + unmigrated)
- Full suite: 2305 passed
- `npm run lint` lanes all green (modern, guards, backend, generated, frontend + prettier); frontend `tsc --noEmit` clean

Fixes #631, fixes #632, fixes #633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M42w2uyDjCg6tEymhJGkzf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-series search options to allow pack releases and ignore book-type mismatches.
  * Added controls for these options on the series details page, with save-state feedback and error notifications.
  * Pack searches can now work without requiring the 32P tracker when torrent search is enabled.

* **Bug Fixes**
  * Corrected handling of disabled search settings.
  * Migrated complete legacy Torznab settings automatically, with warnings for incomplete or conflicting entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->