### PR TITLE
feat: Add the series content-kind API

### DIFF
--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -186,6 +186,16 @@ def update_comic_search_settings(comic_id, values):
     db.upsert("comics", values, {"ComicID": comic_id})
 
 
+def get_comic_content_kind(comic_id):
+    """Get the persisted provider-independent content kind for a Series."""
+    return db.select_one(select(t_comics.c.ComicID, t_comics.c.ContentType).where(t_comics.c.ComicID == comic_id))
+
+
+def update_comic_content_kind(comic_id, content_type):
+    """Atomically persist only the Series content-kind field."""
+    db.upsert("comics", {"ContentType": content_type}, {"ComicID": comic_id})
+
+
 def pause_comic(comic_id):
     """Set comic status to Paused."""
     db.upsert("comics", {"Status": "Paused"}, {"ComicID": comic_id})

--- a/comicarr/app/series/router.py
+++ b/comicarr/app/series/router.py
@@ -112,6 +112,30 @@ def update_series_search_settings(
     return result
 
 
+@router.patch("/series/{comic_id}/content-kind", dependencies=[Depends(require_session)])
+def update_series_content_kind(
+    comic_id: str,
+    request_body: dict = None,
+    ctx: AppContext = Depends(get_context),
+):
+    """Set a Series' provider-independent comic-or-manga content kind."""
+    if request_body is None:
+        request_body = {}
+
+    content_type = request_body.get("content_type")
+    if not isinstance(content_type, str) or content_type not in {"comic", "manga"}:
+        return JSONResponse(
+            status_code=400,
+            content={"detail": "content_type must be one of: comic, manga"},
+        )
+
+    result = series_service.update_content_kind(ctx, comic_id, content_type)
+    if not result["success"]:
+        status = 404 if "not found" in result.get("error", "").lower() else 400
+        return JSONResponse(status_code=status, content={"detail": result.get("error")})
+    return result
+
+
 @router.put("/series/{comic_id}/pause", dependencies=[Depends(require_session)])
 def pause_series(comic_id: str, ctx: AppContext = Depends(get_context)):
     """Pause a comic series."""

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -438,6 +438,27 @@ def update_search_settings(ctx, comic_id, allow_packs=None, ignore_type=None):
     }
 
 
+def update_content_kind(ctx, comic_id, content_type):
+    """Persist an operator-controlled comic-or-manga classification.
+
+    Content kind is deliberately independent of provider identity and legacy
+    publication ``Type``. This write therefore touches only ``ContentType``;
+    provider metadata and issue/annual rows remain unchanged.
+    """
+    if content_type not in ("comic", "manga"):
+        return {"success": False, "error": "Content kind must be comic or manga"}
+
+    existing = series_queries.get_comic_content_kind(comic_id)
+    if not existing:
+        return {"success": False, "error": "ComicID %s not found in watchlist" % comic_id}
+
+    series_queries.update_comic_content_kind(comic_id, content_type)
+    updated = series_queries.get_comic_content_kind(comic_id)
+    canonical = updated["ContentType"] if updated else content_type
+    logger.fdebug("[SERIES] Updated content kind for %s: %s" % (comic_id, canonical))
+    return {"success": True, "content_type": canonical}
+
+
 def pause_comic(ctx, comic_id):
     """Set comic status to Paused."""
     series_queries.pause_comic(comic_id)

--- a/tests/unit/test_series_content_kind_api.py
+++ b/tests/unit/test_series_content_kind_api.py
@@ -1,0 +1,71 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""HTTP-boundary tests for the per-series content-kind contract."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from comicarr.app.series import router as series_router
+
+
+def _response_body(response):
+    return json.loads(response.body)
+
+
+@pytest.mark.parametrize(
+    "request_body",
+    [
+        None,
+        {},
+        {"content_type": None},
+        {"content_type": 1},
+        {"content_type": True},
+        {"content_type": "Comic"},
+        {"content_type": " manga "},
+        {"content_type": "print"},
+    ],
+)
+def test_content_kind_route_rejects_every_value_outside_strict_wire_enum(monkeypatch, request_body):
+    update = MagicMock()
+    monkeypatch.setattr(series_router.series_service, "update_content_kind", update)
+
+    response = series_router.update_series_content_kind("160294", request_body, SimpleNamespace())
+
+    assert response.status_code == 400
+    assert _response_body(response) == {"detail": "content_type must be one of: comic, manga"}
+    update.assert_not_called()
+
+
+@pytest.mark.parametrize("content_type", ["comic", "manga"])
+def test_content_kind_route_accepts_enum_and_returns_service_result(monkeypatch, content_type):
+    update = MagicMock(return_value={"success": True, "content_type": content_type})
+    monkeypatch.setattr(series_router.series_service, "update_content_kind", update)
+    ctx = SimpleNamespace()
+
+    response = series_router.update_series_content_kind("160294", {"content_type": content_type}, ctx)
+
+    assert response == {"success": True, "content_type": content_type}
+    update.assert_called_once_with(ctx, "160294", content_type)
+
+
+def test_content_kind_route_maps_unknown_series_to_404(monkeypatch):
+    monkeypatch.setattr(
+        series_router.series_service,
+        "update_content_kind",
+        lambda *_args: {"success": False, "error": "ComicID missing not found in watchlist"},
+    )
+
+    response = series_router.update_series_content_kind("missing", {"content_type": "manga"}, SimpleNamespace())
+
+    assert response.status_code == 404
+    assert _response_body(response) == {"detail": "ComicID missing not found in watchlist"}

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -332,9 +332,7 @@ def test_update_search_settings_is_partial_and_rejects_unknown_series(monkeypatc
     monkeypatch.setattr(
         series_service.series_queries,
         "get_comic_search_settings",
-        lambda comic_id: (
-            {"ComicID": "160294", "AllowPacks": "0", "IgnoreType": 1} if comic_id == "160294" else None
-        ),
+        lambda comic_id: {"ComicID": "160294", "AllowPacks": "0", "IgnoreType": 1} if comic_id == "160294" else None,
     )
     monkeypatch.setattr(series_service.series_queries, "update_comic_search_settings", upsert)
 
@@ -358,6 +356,44 @@ def test_search_settings_query_upserts_lowercase_comics_table(monkeypatch):
     series_queries.update_comic_search_settings("160294", {"AllowPacks": "1", "IgnoreType": 1})
 
     upsert.assert_called_once_with("comics", {"AllowPacks": "1", "IgnoreType": 1}, {"ComicID": "160294"})
+
+
+@pytest.mark.parametrize("content_type", ["comic", "manga"])
+def test_update_content_kind_persists_and_returns_canonical_value(monkeypatch, content_type):
+    update = MagicMock()
+    rows = iter(
+        [
+            {"ComicID": "160294", "ContentType": "comic"},
+            {"ComicID": "160294", "ContentType": content_type},
+        ]
+    )
+    monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
+    monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
+
+    result = series_service.update_content_kind(_make_ctx(), "160294", content_type)
+
+    update.assert_called_once_with("160294", content_type)
+    assert result == {"success": True, "content_type": content_type}
+
+
+def test_update_content_kind_rejects_unknown_series_without_writing(monkeypatch):
+    update = MagicMock()
+    monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: None)
+    monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
+
+    result = series_service.update_content_kind(_make_ctx(), "missing", "manga")
+
+    assert result == {"success": False, "error": "ComicID missing not found in watchlist"}
+    update.assert_not_called()
+
+
+def test_content_kind_query_updates_only_content_type(monkeypatch):
+    upsert = MagicMock()
+    monkeypatch.setattr(series_queries.db, "upsert", upsert)
+
+    series_queries.update_comic_content_kind("160294", "manga")
+
+    upsert.assert_called_once_with("comics", {"ContentType": "manga"}, {"ComicID": "160294"})
 
 
 def test_preview_search_all_missing_excludes_owned_future_and_skipped(monkeypatch):


### PR DESCRIPTION
## Summary

- add strict `PATCH /api/series/{comic_id}/content-kind` accepting only lowercase `comic` or `manga`
- persist only `comics.ContentType`, leaving provider identity and issue/annual history untouched
- return the canonical post-write value and map unknown series to 404
- add focused router, service, and query-boundary tests

Part of #639. Resolves #643.

## Validation

- `uv run pytest tests/unit -q` — 2,323 passed
- `npm run lint` with the locked virtualenv on PATH — passed
- focused red/green proof: 15 failures before implementation; 59 focused tests pass after