### PR TITLE
fix: honor series content kind in workflows

### DIFF
--- a/.changeset/honest-ravens-search.md
+++ b/.changeset/honest-ravens-search.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Honor each series' stored comic or manga classification during search, refresh, and post-processing.

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -1360,7 +1360,11 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
         "DynamicComicName": dynamic_name,
         "ComicLocation": comlocation,
         "Type": "Manga",
-        "ContentType": "manga",
+        "ContentType": (
+            dbmanga["ContentType"]
+            if dbmanga is not None and dbmanga.get("ContentType") in ("comic", "manga")
+            else "manga"
+        ),
         "ReadingDirection": "rtl",
         "MetadataSource": "mangadex",
         "ExternalID": mangadex_uuid,
@@ -1529,7 +1533,11 @@ def addMangaToDB_MAL(mangaid, imported=None, calledfrom=None):
         "DynamicComicName": dynamic_name,
         "ComicLocation": comlocation,
         "Type": "Manga",
-        "ContentType": "manga",
+        "ContentType": (
+            dbmanga["ContentType"]
+            if dbmanga is not None and dbmanga.get("ContentType") in ("comic", "manga")
+            else "manga"
+        ),
         "ReadingDirection": "rtl",
         "MetadataSource": "mal",
         "ExternalID": mal_numeric_id,

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -638,10 +638,13 @@ class PostProcessor(object):
 
         self.oneoffinlist = False
 
-        # Provider-issued ids only: at this point the series row has not been
-        # loaded, so ContentType cannot participate. Legacy manga predating the
-        # prefixes take the ComicVine path here, as they always have.
-        if self.comicid is not None and series_kind.provider_of(self.comicid) in series_kind.MANGA_PROVIDERS:
+        series = None
+        if self.comicid is not None:
+            series = db.select_one(
+                select(comics.c.ComicID, comics.c.ContentType).where(comics.c.ComicID == self.comicid)
+            )
+        kind_source = series if series is not None else self.comicid
+        if self.comicid is not None and series_kind.is_manga(kind_source):
             logger.fdebug(
                 "%s Manga series detected (ComicID: %s) - branching to manga post-processing" % (module, self.comicid)
             )

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -53,6 +53,7 @@ from comicarr import (
     rsscheck,
     sabnzbd,
     search_filer,
+    series_kind,
     updater,
 )
 from comicarr.app.common.redaction import redact_sensitive_text
@@ -2627,6 +2628,7 @@ def searchforissue(
 
                 allow_packs = False
                 ComicID = result["ComicID"]
+                content_type = "comic"
                 if smode == "story_arc":
                     ComicName = result["ComicName"]
                     Comicname_filesafe = helpers.filesafe(ComicName)
@@ -2665,6 +2667,7 @@ def searchforissue(
                     ignore_booktype = False
                 else:
                     comic = db.select_one(select(comics).where(comics.c.ComicID == ComicID))
+                    content_type = "manga" if series_kind.is_manga(comic) else "comic"
                     if smode == "want_ann":
                         ComicName = result["ReleaseComicName"]
                         Comicname_filesafe = None
@@ -2732,6 +2735,7 @@ def searchforissue(
                     digitaldate=DigitalDate,
                     booktype=booktype,
                     ignore_booktype=ignore_booktype,
+                    content_type=content_type,
                 )
                 if manual is True:
                     comicarr.SEARCHLOCK.release()

--- a/comicarr/series_kind.py
+++ b/comicarr/series_kind.py
@@ -83,16 +83,16 @@ def provider_of(series: str | Mapping | None) -> SeriesProvider:
 def is_manga(series: str | Mapping | None) -> bool:
     """Return whether this Series is manga, reconciling prefix and ContentType.
 
-    A provider prefix is sufficient on its own. For rows, ``ContentType`` is
-    also honoured, so legacy manga added before the prefixes existed still
-    answer True.
+    A stored ``ContentType`` is authoritative when a row is available. Provider
+    identity is only the fallback for a bare id or a legacy row whose field is
+    absent/null. This lets an operator classify any provider's Series while
+    retaining prefix inference for old data.
     """
-    if provider_of(series) in MANGA_PROVIDERS:
-        return True
     if isinstance(series, Mapping):
         content_type = series.get("ContentType")
-        return str(content_type or "").strip().casefold() == _MANGA_CONTENT_TYPE
-    return False
+        if content_type is not None:
+            return str(content_type).strip().casefold() == _MANGA_CONTENT_TYPE
+    return provider_of(series) in MANGA_PROVIDERS
 
 
 def chapter_source_id(series: str | Mapping | None) -> str | None:

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -190,6 +190,7 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                     comics.c.ComicName,
                     comics.c.Corrected_SeriesYear,
                     comics.c.Corrected_Type,
+                    comics.c.ContentType,
                     comics.c.ComicYear,
                     comics.c.Status,
                 )
@@ -234,6 +235,7 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                             "Status": comlist["Status"],
                             "Corrected_SeriesYear": comlist["Corrected_SeriesYear"],
                             "Corrected_Type": comlist["Corrected_Type"],
+                            "ContentType": comlist["ContentType"],
                         }
                     )
 
@@ -247,6 +249,7 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                     comics.c.ComicYear,
                     comics.c.Corrected_SeriesYear,
                     comics.c.Corrected_Type,
+                    comics.c.ContentType,
                     comics.c.Status,
                 )
                 .where((comics.c.Status == "Active") | (comics.c.Status == "Loading"))
@@ -262,6 +265,7 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
                 comics.c.ComicYear,
                 comics.c.Corrected_SeriesYear,
                 comics.c.Corrected_Type,
+                comics.c.ContentType,
                 comics.c.LastUpdated,
                 comics.c.Status,
             )
@@ -331,8 +335,11 @@ def dbUpdate(ComicIDList=None, calledfrom=None, sched=False):
             lastupdated = datetime.datetime.strptime(comic["LastUpdated"], "%Y-%m-%d %H:%M:%S").strftime("%Y-%m-%d")
 
         mismatch = "no"
-        if series_kind.provider_of(ComicID) in series_kind.MANGA_PROVIDERS:
-            # Manga (MangaDex/MAL) refreshes entirely through the manga importer.
+        if series_kind.provider_of(ComicID) in series_kind.MANGA_PROVIDERS or series_kind.is_manga(comic):
+            # Provider-backed manga imports and series classified as manga both
+            # avoid ComicVine's issuedata reconciliation. addComictoDB still
+            # owns provider dispatch, while ContentType extends this safe path
+            # to manga whose metadata provider is ComicVine.
             # The CV_ONETIMER reconciliation below deletes issue rows and expects
             # CV issuedata that the manga add functions do not return, so route
             # these series around it and re-match files via forceRescan.

--- a/tests/unit/test_mal_prefix_drift.py
+++ b/tests/unit/test_mal_prefix_drift.py
@@ -56,7 +56,11 @@ class TestPostProcessingRoutesBothProviders:
     def test_manga_ids_reach_the_manga_path(self, comicid):
         pp = _make_pp(comicid)
 
-        with patch.object(pp, "_process_manga", return_value=None) as process_manga:
+        with (
+            patch.object(pp, "_process_manga", return_value=None) as process_manga,
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
+            mock_db.select_one.return_value = {"ComicID": comicid, "ContentType": "manga"}
             pp.Process()
 
         process_manga.assert_called_once()

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -144,7 +144,11 @@ class TestMangaBranchDetection:
             comicid="md-abc123",
             apicall=True,
         )
-        with patch.object(pp, "_process_manga", return_value=None) as mock_pm:
+        with (
+            patch.object(pp, "_process_manga", return_value=None) as mock_pm,
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
+            mock_db.select_one.return_value = {"ComicID": "md-abc123", "ContentType": "manga"}
             pp.Process()
             mock_pm.assert_called_once()
 
@@ -169,6 +173,44 @@ class TestMangaBranchDetection:
             except Exception:
                 pass
             mock_pm.assert_not_called()
+
+    def test_comicvine_manga_row_triggers_manga_branch(self):
+        pp, _mock_queue = _make_pp(
+            nzb_name="Solo Leveling v01.cbz",
+            nzb_folder="/tmp/downloads",
+            comicid="134064",
+            apicall=True,
+        )
+        with (
+            patch.object(pp, "_process_manga", return_value=None) as mock_pm,
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
+            mock_db.select_one.return_value = {"ComicID": "134064", "ContentType": "manga"}
+            pp.Process()
+
+        mock_pm.assert_called_once()
+
+    def test_explicit_comic_kind_overrides_mangadex_prefix(self):
+        pp, _mock_queue = _make_pp(
+            nzb_name="Example 001.cbz",
+            nzb_folder="/tmp/downloads",
+            comicid="md-example",
+            issueid="issue-1",
+            apicall=True,
+        )
+        with (
+            patch.object(pp, "_process_manga") as mock_pm,
+            patch("comicarr.postprocessor.filechecker") as mock_fc,
+            patch("comicarr.postprocessor.db") as mock_db,
+        ):
+            mock_db.select_one.return_value = {"ComicID": "md-example", "ContentType": "comic"}
+            mock_fc.FileChecker.return_value.listFiles.return_value = {"comiccount": 0, "comiclist": []}
+            try:
+                pp.Process()
+            except Exception:
+                pass
+
+        mock_pm.assert_not_called()
 
     def test_none_comicid_skips_manga_branch(self):
         """When comicid is None, manga branch should be skipped."""

--- a/tests/unit/test_manga_refresh_regressions.py
+++ b/tests/unit/test_manga_refresh_regressions.py
@@ -62,6 +62,7 @@ class TestDbUpdateMangaShortCircuit:
                     "ComicID": "mal-161890",
                     "ComicName": "Test Manga",
                     "ComicYear": "2020",
+                    "ContentType": "manga",
                     "Status": "Active",
                     "LastUpdated": None,
                 },
@@ -86,6 +87,67 @@ class TestDbUpdateMangaShortCircuit:
         mock_rescan.assert_called_once_with("mal-161890")
         mock_emit.assert_called()
         assert mock_emit.call_args[0][:2] == ("refresh", "succeeded")
+
+    def test_comicvine_manga_refresh_uses_manga_aware_rescan_path(self, monkeypatch):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(
+                comics.insert(),
+                {
+                    "ComicID": "134064",
+                    "ComicName": "Solo Leveling",
+                    "ComicYear": "2022",
+                    "ContentType": "manga",
+                    "Type": "Print",
+                    "Status": "Active",
+                    "LastUpdated": None,
+                },
+            )
+
+        monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(comicarr, "IMPORTLOCK", False, raising=False)
+        monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(CV_ONLY=True, CV_ONETIMER=1), raising=False)
+        mock_add = MagicMock(return_value={"status": "complete", "comicid": "134064"})
+        mock_rescan = MagicMock()
+        monkeypatch.setattr(comicarr.importer, "addComictoDB", mock_add)
+        monkeypatch.setattr(updater, "forceRescan", mock_rescan)
+        monkeypatch.setattr("comicarr.app.activity.producers.emit_series_activity", MagicMock())
+
+        updater.dbUpdate(["134064"], calledfrom="refresh")
+
+        mock_add.assert_called_once_with("134064", "no")
+        mock_rescan.assert_called_once_with("134064")
+
+    def test_mangadex_comic_refresh_still_uses_provider_safe_path(self, monkeypatch):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(
+                comics.insert(),
+                {
+                    "ComicID": "md-example",
+                    "ComicName": "Example Series",
+                    "ComicYear": "2022",
+                    "ContentType": "comic",
+                    "Status": "Active",
+                    "LastUpdated": None,
+                },
+            )
+
+        monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(comicarr, "IMPORTLOCK", False, raising=False)
+        monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace(CV_ONLY=True, CV_ONETIMER=1), raising=False)
+        mock_add = MagicMock(return_value={"status": "complete", "comicid": "md-example"})
+        mock_rescan = MagicMock()
+        monkeypatch.setattr(comicarr.importer, "addComictoDB", mock_add)
+        monkeypatch.setattr(updater, "forceRescan", mock_rescan)
+        monkeypatch.setattr("comicarr.app.activity.producers.emit_series_activity", MagicMock())
+
+        updater.dbUpdate(["md-example"], calledfrom="refresh")
+
+        mock_add.assert_called_once_with("md-example", "no")
+        mock_rescan.assert_called_once_with("md-example")
 
 
 class TestForceRescanNullIssueDate:
@@ -425,6 +487,60 @@ class TestMangaRefreshPreservesLibraryState:
         assert row["IssueName"] == "Romance Dawn"
 
 
+class TestMangaRefreshPreservesContentKind:
+    @pytest.mark.parametrize(
+        ("provider", "stored_kind", "expected_kind"),
+        [
+            ("mangadex", "comic", "comic"),
+            ("myanimelist", "comic", "comic"),
+            ("mangadex", None, "manga"),
+            ("myanimelist", None, "manga"),
+        ],
+    )
+    def test_refresh_preserves_explicit_kind_and_fills_legacy_null(
+        self, monkeypatch, provider, stored_kind, expected_kind
+    ):
+        engine = create_engine("sqlite://")
+        metadata.create_all(engine)
+        comic_id = "md-uuid-1" if provider == "mangadex" else "mal-13"
+        with engine.begin() as conn:
+            conn.execute(
+                comics.insert(),
+                {
+                    "ComicID": comic_id,
+                    "ComicName": "One Piece",
+                    "ComicYear": "1997",
+                    "ContentType": stored_kind,
+                    "Status": "Active",
+                },
+            )
+
+        monkeypatch.setattr(importer.db, "get_engine", lambda: engine)
+        monkeypatch.setattr(comicarr, "COMICSORT", None, raising=False)
+        monkeypatch.setattr(
+            comicarr,
+            "CONFIG",
+            SimpleNamespace(CREATE_FOLDERS=False, FOLDER_FORMAT="$Series ($Year)"),
+            raising=False,
+        )
+        monkeypatch.setattr("comicarr.config.get_manga_destination", lambda: None)
+        monkeypatch.setattr(importer.helpers, "getImage", lambda *a, **k: {"status": "failed"})
+        monkeypatch.setattr(importer, "_populate_manga_chapters", lambda *a, **k: None)
+        monkeypatch.setattr(importer.helpers, "ComicSort", lambda **k: None)
+
+        if provider == "mangadex":
+            monkeypatch.setattr("comicarr.mangadex.get_manga_details", lambda _id: _mal_details())
+            importer.addMangaToDB(comic_id)
+        else:
+            monkeypatch.setattr("comicarr.myanimelist.get_manga_details", lambda _id: _mal_details())
+            monkeypatch.setattr("comicarr.mangadex.find_by_mal_id", lambda *a, **k: "uuid-1")
+            importer.addMangaToDB_MAL(comic_id)
+
+        with engine.connect() as conn:
+            row = conn.execute(select(comics).where(comics.c.ComicID == comic_id)).mappings().one()
+        assert row["ContentType"] == expected_kind
+
+
 class TestMangaRefreshForceRescanErrors:
     """#4: forceRescan exceptions must not report Refresh success."""
 
@@ -438,6 +554,7 @@ class TestMangaRefreshForceRescanErrors:
                     "ComicID": "mal-161890",
                     "ComicName": "Test Manga",
                     "ComicYear": "2020",
+                    "ContentType": "manga",
                     "Status": "Active",
                     "LastUpdated": None,
                 },

--- a/tests/unit/test_manga_search.py
+++ b/tests/unit/test_manga_search.py
@@ -5,9 +5,12 @@ Tests cover _build_manga_search_terms() which generates NZB/torrent-provider
 query variations for manga chapters and volumes.
 """
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+import comicarr
 
 
 # Patch the logger so _build_manga_search_terms can be imported without
@@ -161,3 +164,86 @@ class TestBuildMangaSearchTermsEdgeCases:
         volume_idx = terms.index("Series v05")
         assert combined_idx < chapter_idx
         assert combined_idx < volume_idx
+
+
+class TestSeriesContentKindSearchHandoff:
+    @pytest.mark.parametrize(
+        ("comic_id", "stored_kind", "expected_kind"),
+        (
+            ("134064", "manga", "manga"),
+            ("md-example", "comic", "comic"),
+        ),
+    )
+    def test_search_init_receives_authoritative_series_kind(
+        self,
+        monkeypatch,
+        comic_id,
+        stored_kind,
+        expected_kind,
+    ):
+        from comicarr import search
+
+        monkeypatch.setattr(
+            comicarr,
+            "CONFIG",
+            SimpleNamespace(
+                EXTRA_NEWZNABS=[],
+                EXTRA_TORZNABS=[],
+                ENABLE_DDL=False,
+                ENABLE_GETCOMICS=False,
+                ENABLE_EXTERNAL_SERVER=False,
+                EXPERIMENTAL=True,
+                NEWZNAB=False,
+                ENABLE_TORRENT_SEARCH=False,
+                ENABLE_TORRENTS=False,
+            ),
+        )
+        search_lock = MagicMock()
+        search_lock.locked.return_value = False
+        monkeypatch.setattr(comicarr, "SEARCHLOCK", search_lock)
+        monkeypatch.setattr(
+            search,
+            "_search_source_for_issue",
+            MagicMock(
+                return_value=(
+                    {
+                        "ComicID": comic_id,
+                        "IssueID": "issue-1",
+                        "Issue_Number": "1",
+                        "IssueDate": "2026-01-01",
+                        "ReleaseDate": "2026-01-01",
+                        "DigitalDate": "2026-01-01",
+                    },
+                    "want",
+                    False,
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            search.db,
+            "select_one",
+            MagicMock(
+                return_value={
+                    "ComicID": comic_id,
+                    "ComicName": "Example Series",
+                    "ComicName_Filesafe": "Example_Series",
+                    "ComicYear": "2026",
+                    "ComicPublisher": "Example",
+                    "AlternateSearch": None,
+                    "UseFuzzy": None,
+                    "ComicVersion": None,
+                    "TorrentID_32P": None,
+                    "Type": "Print",
+                    "Corrected_Type": None,
+                    "IgnoreType": 0,
+                    "AllowPacks": 0,
+                    "ContentType": stored_kind,
+                }
+            ),
+        )
+        search_init = MagicMock(return_value=({"status": False}, None))
+        monkeypatch.setattr(search, "search_init", search_init)
+
+        search.searchforissue("issue-1", manual=True)
+
+        assert search_init.call_args.kwargs["content_type"] == expected_kind

--- a/tests/unit/test_postprocess_input_resolution.py
+++ b/tests/unit/test_postprocess_input_resolution.py
@@ -47,7 +47,9 @@ def _run(processor, config, *, use_sab=0, use_nzbget=0):
         patch.object(comicarr, "USE_SABNZBD", use_sab),
         patch.object(comicarr, "USE_NZBGET", use_nzbget),
         patch.object(processor, "_process_manga", return_value="manga") as manga,
+        patch("comicarr.postprocessor.db") as mock_db,
     ):
+        mock_db.select_one.return_value = {"ComicID": "md-saga", "ContentType": "manga"}
         result = processor.Process()
     return result, manga
 

--- a/tests/unit/test_series_kind.py
+++ b/tests/unit/test_series_kind.py
@@ -72,6 +72,14 @@ class TestIsManga:
     def test_a_comic_row_is_not_manga(self):
         assert is_manga({"ComicID": "999", "ContentType": "comic"}) is False
 
+    @pytest.mark.parametrize("series_id", ("md-uuid-1", "mal-161890"))
+    def test_an_explicit_comic_kind_overrides_a_manga_provider(self, series_id):
+        assert is_manga({"ComicID": series_id, "ContentType": "comic"}) is False
+
+    @pytest.mark.parametrize("series_id", ("md-uuid-1", "mal-161890"))
+    def test_a_null_kind_falls_back_to_the_provider(self, series_id):
+        assert is_manga({"ComicID": series_id, "ContentType": None}) is True
+
     def test_a_row_with_neither_signal_is_not_manga(self):
         assert is_manga({"ComicID": "999"}) is False
 


### PR DESCRIPTION
## Summary
- make stored `ContentType` authoritative over provider prefixes when a series row is available
- pass content kind into search and use it for refresh and post-processing behavior
- preserve explicit operator classification during MangaDex and MyAnimeList refreshes
- retain provider-based refresh mechanics and chapter-source routing

## Validation
- `uv run pytest tests/unit -q` (2336 passed)
- `npm run lint`
- focused content-kind regressions (112 passed after final provider-routing guard)

Resolves #644