### PR TITLE
docs: define interactive release search language

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,18 @@ Who issued a Series' identifier: ComicVine, MangaDex (`md-` prefix), or MyAnimeL
 
 The MangaDex UUID a manga Series polls for new chapters. MangaDex Series carry it in their ComicID; MyAnimeList Series supply metadata from MAL but keep the chapter source in `MangaDexID`, and have none until it is resolved.
 
+## Release candidate
+
+A provider result considered for acquiring one tracked issue, chapter, annual, or story-arc item. Its match verdict explains whether automatic search would accept it, whether an operator may override that decision, and every reason for rejection.
+
+_Avoid_: Search result, NZB result, torrent result
+
+## Interactive release search
+
+An operator-initiated review of release candidates for one tracked acquisition item, followed optionally by a deliberate manual grab. It is distinct from metadata search, which finds a Series to add to the library.
+
+_Avoid_: Manual search, interactive search
+
 ## Log level
 
 Comicarr's single verbosity dial, named by the severity it admits: `0` warning, `1` info, `2` debug. Level `0` means warnings and errors, not silence, which is why it is never called "quiet" — `--quiet` and `--verbose` are flag spellings, not level names.


### PR DESCRIPTION
## Summary
- define Release candidate as the provider result reviewed for one tracked acquisition item
- distinguish Interactive release search from metadata search for adding a Series
- record the canonical terms selected while charting [Wayfinder: Interactive release search](https://github.com/frankieramirez/comicarr/issues/651)

## Validation
- `npm run lint`

No changeset: domain glossary only.