### PR TITLE
refactor: explain release candidate matching

### DIFF
--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -22,17 +22,191 @@ import datetime
 import email.utils
 import re
 import time
+from dataclasses import dataclass, field
 from wsgiref.handlers import format_date_time
 
 import comicarr
 from comicarr import filechecker, helpers, logger, search
+
+_REASON_DEFINITIONS = {
+    "accepted.issue": ("Accepted issue match", False, "accepted"),
+    "accepted.pack": ("Accepted pack match", False, "accepted"),
+    "ignored.search_word": ("Contains a configured ignored word", True, "rejected"),
+    "rejected.size_below_min": ("Below the configured minimum size", True, "rejected"),
+    "rejected.size_above_max": ("Above the configured maximum size", True, "rejected"),
+    "rejected.cover_only": ("Looks like a cover-only release", True, "rejected"),
+    "invalid.pubdate_missing": ("Provider did not supply a publication date", False, "invalid"),
+    "invalid.reference_date_missing": ("Tracked item has no usable reference date", False, "invalid"),
+    "invalid.pubdate_unparseable": ("Provider publication date could not be parsed", False, "invalid"),
+    "rejected.before_reference_date": ("Published before the tracked item", True, "rejected"),
+    "error.matcher_exception": ("Title matcher failed", False, "error"),
+    "rejected.series_mismatch": ("Series title does not match", True, "rejected"),
+    "rejected.alternate_series": ("Matched only an alternate series name", True, "rejected"),
+    "rejected.book_type": ("Publication format does not match", True, "rejected"),
+    "rejected.unparseable_title": ("Release title could not be parsed", True, "rejected"),
+    "rejected.year_mismatch": ("Series year does not match", True, "rejected"),
+    "rejected.volume_mismatch": ("Series volume does not match", True, "rejected"),
+    "rejected.pack_issue_absent": ("Pack does not contain the tracked item", True, "rejected"),
+    "error.pack_lookup_exception": ("Pack contents could not be evaluated", False, "error"),
+    "rejected.issue_mismatch": ("Issue or chapter number does not match", True, "rejected"),
+    "blocked.duplicate": ("Duplicate candidate was suppressed", False, "blocked"),
+    "error.evaluation_exception": ("Candidate evaluation failed", False, "error"),
+}
+
+
+class _EntryRejected(Exception):
+    def __init__(self, reason_code):
+        super().__init__(reason_code)
+        self.reason_code = reason_code
+
+
+@dataclass(frozen=True)
+class _AcceptedMatch:
+    legacy_match: dict
+    match_kind: str
+
+
+@dataclass
+class ReleaseCandidateEvaluation:
+    """One sanitized provider candidate plus its structured match verdict.
+
+    ``legacy_match`` and ``exception`` stay server-side. ``as_dict`` is the
+    credential-safe representation intended for later interactive-search APIs.
+    """
+
+    candidate: dict
+    verdict: dict
+    legacy_match: dict | None = field(default=None, repr=False)
+    exception: Exception | None = field(default=None, repr=False)
+
+    def as_dict(self):
+        return {"candidate": dict(self.candidate), "verdict": dict(self.verdict)}
 
 
 class search_check(object):
     def __init__(self):
         pass
 
+    @staticmethod
+    def _entry_value(entry, key, default=None):
+        try:
+            return entry.get(key, default)
+        except AttributeError:
+            try:
+                return entry[key]
+            except Exception:
+                return default
+
+    def _normalized_candidate(self, entry, is_info):
+        info = is_info or {}
+        nzbprov = str(info.get("nzbprov") or self._entry_value(entry, "site") or "Unknown")
+        provider_stat = info.get("provider_stat") or {}
+        provider_type = str(provider_stat.get("type") or "").lower()
+        newznab_host = info.get("newznab_host")
+        torznab_host = info.get("torznab_host")
+
+        if newznab_host:
+            provider = str(newznab_host[0] or "Newznab")
+        elif torznab_host:
+            provider = str(torznab_host[0] or "Torznab")
+        else:
+            provider = nzbprov
+
+        if "ddl" in nzbprov.lower():
+            source_kind = "ddl"
+        elif provider_type in ("newznab", "usenet") or "newznab" in nzbprov.lower():
+            source_kind = "usenet"
+        elif provider_type in ("torznab", "torrent") or "torrent" in nzbprov.lower() or nzbprov == "32P":
+            source_kind = "torrent"
+        else:
+            source_kind = "unknown"
+
+        provider_lower = provider.lower()
+        if any(marker in provider_lower for marker in ("://", "@", "?", "apikey=", "token=")):
+            provider = {
+                "ddl": "Direct-download provider",
+                "torrent": "Torrent provider",
+                "usenet": "Usenet provider",
+            }.get(source_kind, "Search provider")
+
+        raw_size = self._entry_value(entry, "length")
+        if raw_size in (None, "", "0", 0):
+            raw_size = self._entry_value(entry, "size")
+        try:
+            size_bytes = int(raw_size)
+        except (TypeError, ValueError):
+            try:
+                size_bytes = helpers.human2bytes(str(raw_size))
+            except (AssertionError, TypeError, ValueError):
+                size_bytes = None
+
+        metrics = {}
+        for key in ("seeders", "peers", "leechers", "grabs", "files"):
+            value = self._entry_value(entry, key)
+            if value not in (None, ""):
+                try:
+                    metrics[key] = int(value)
+                except (TypeError, ValueError):
+                    continue
+
+        return {
+            "title": str(self._entry_value(entry, "title") or "Untitled release"),
+            "provider": provider,
+            "source_kind": source_kind,
+            "published_at": self._entry_value(entry, "updated") or self._entry_value(entry, "pubdate"),
+            "size_bytes": size_bytes,
+            "pack": bool(self._entry_value(entry, "pack", False)),
+            "metrics": metrics,
+        }
+
+    @staticmethod
+    def _verdict(reason_code, match_kind="none"):
+        message, overrideable, status = _REASON_DEFINITIONS[reason_code]
+        return {
+            "status": status,
+            "accepted": status == "accepted",
+            "overrideable": overrideable,
+            "reason_code": reason_code,
+            "reasons": [{"code": reason_code, "message": message}],
+            "match_kind": match_kind,
+        }
+
+    def evaluate_entry(self, entry, is_info=None):
+        """Evaluate one raw provider entry without exposing provider secrets."""
+
+        candidate = self._normalized_candidate(entry, is_info)
+        try:
+            accepted = self._match_entry(entry, is_info)
+        except _EntryRejected as rejection:
+            return ReleaseCandidateEvaluation(candidate, self._verdict(rejection.reason_code))
+        except Exception as e:
+            return ReleaseCandidateEvaluation(
+                candidate,
+                self._verdict("error.evaluation_exception"),
+                exception=e,
+            )
+
+        reason_code = "accepted.pack" if accepted.match_kind == "pack" else "accepted.issue"
+        return ReleaseCandidateEvaluation(
+            candidate,
+            self._verdict(reason_code, match_kind=accepted.match_kind),
+            legacy_match=accepted.legacy_match,
+        )
+
+    def evaluate_entries(self, entries, is_info=None):
+        """Return one evaluation per raw provider entry, in provider order."""
+
+        return [self.evaluate_entry(entry, is_info) for entry in entries]
+
     def _process_entry(self, entry, is_info):
+        """Compatibility adapter for existing automatic-search callers."""
+
+        evaluation = self.evaluate_entry(entry, is_info)
+        if evaluation.exception is not None:
+            raise evaluation.exception
+        return evaluation.legacy_match
+
+    def _match_entry(self, entry, is_info):
         if is_info:
             ComicName = is_info["ComicName"]
             nzbprov = is_info["nzbprov"]
@@ -122,7 +296,7 @@ class search_check(object):
                 "[IGNORE_SEARCH_WORDS] %s exists within the search result (%s). Ignoring this result."
                 % (ignored, ComicTitle)
             )
-            return None
+            raise _EntryRejected("ignored.search_word")
 
         comsize_m = 0
         if nzbprov != "dognzb":
@@ -171,19 +345,19 @@ class search_check(object):
                         logger.fdebug("comparing Min threshold %s .. to .. nzb %s" % (conv_minsize, comsize_b))
                         if int(conv_minsize) > int(comsize_b):
                             logger.fdebug("Failure to meet the Minimum size threshold - skipping")
-                            return None
+                            raise _EntryRejected("rejected.size_below_min")
                     if comicarr.CONFIG.USE_MAXSIZE:
                         conv_maxsize = helpers.human2bytes(comicarr.CONFIG.MAXSIZE + "M")
                         logger.fdebug("comparing Max threshold %s .. to .. nzb %s" % (conv_maxsize, comsize_b))
                         if int(comsize_b) > int(conv_maxsize):
                             logger.fdebug("Failure to meet the Maximium size threshold - skipping")
-                            return None
+                            raise _EntryRejected("rejected.size_above_max")
 
         if comicarr.CONFIG.IGNORE_COVERS is True:
             cvrchk = re.sub(r"[\s\s+\_\.]", "", entry["title"]).lower()
             if any(["coversonly" in cvrchk, "coveronly" in cvrchk]):
                 logger.fdebug("Cover(s) only detected. Ignoring result.")
-                return None
+                raise _EntryRejected("rejected.cover_only")
 
         # ---- date constaints.
         # if the posting date is prior to the publication date,
@@ -199,7 +373,7 @@ class search_check(object):
                     pubdate = entry["pubdate"]
                 except Exception as e:
                     logger.fdebug("Invalid date found. Unable to continue - skipping result. Error returned: %s" % e)
-                    return None
+                    raise _EntryRejected("invalid.pubdate_missing")
 
         if UseFuzzy == "1":
             logger.fdebug("Year has been fuzzied for this series, ignoring store date comparison entirely.")
@@ -215,7 +389,7 @@ class search_check(object):
                         " probably should refresh the series or wait for CV"
                         " to correct the data"
                     )
-                    return None
+                    raise _EntryRejected("invalid.reference_date_missing")
                 else:
                     stdate = IssueDate
                 logger.fdebug("issue date used is : %s" % stdate)
@@ -248,7 +422,7 @@ class search_check(object):
                         "Unable to parse posting date from provider result set"
                         " for : %s. Error returned: %s" % (entry["title"], e)
                     )
-                    return None
+                    raise _EntryRejected("invalid.pubdate_unparseable")
 
             if all([digitaldate != "0000-00-00", digitaldate is not None]):
                 i = 0
@@ -317,7 +491,7 @@ class search_check(object):
                         "%s is before store date of %s. Ignoring search result"
                         " as this is not the right issue." % (pubdate, stdate)
                     )
-                    return None
+                    raise _EntryRejected("rejected.before_reference_date")
                 else:
                     logger.fdebug("[CONV] %s is after store date of %s" % (pubdate, stdate))
             except Exception:
@@ -331,7 +505,7 @@ class search_check(object):
                         "%s is before store date of %s. Ignoring search result"
                         " as this is not the right issue." % (pubdate, stdate)
                     )
-                    return None
+                    raise _EntryRejected("rejected.before_reference_date")
                 else:
                     logger.fdebug("[INT] %s is after store date of %s" % (pubdate, stdate))
         # -- end size constaints.
@@ -401,12 +575,12 @@ class search_check(object):
                 filecomic = fcomic.matchIT(parsed_comic)
             except Exception as e:
                 logger.error("[PARSE-ERROR]: %s" % e)
-                return None
+                raise _EntryRejected("error.matcher_exception")
             else:
                 logger.fdebug("match_check: %s" % filecomic)
                 if filecomic["process_status"] == "fail":
                     logger.fdebug("%s was not a match to %s (%s)" % (cleantitle, ComicName, SeriesYear))
-                    return None
+                    raise _EntryRejected("rejected.series_mismatch")
                 elif filecomic["process_status"] == "alt_match":
                     # if it's an alternate series match, we'll retain each value
                     # until the search has compeletely run, compiling matches.
@@ -425,10 +599,10 @@ class search_check(object):
                 "Booktypes do not match. Looking for %s, this is a %s."
                 " Ignoring this result." % (booktype, parsed_comic["booktype"])
             )
-            return None
+            raise _EntryRejected("rejected.book_type")
         else:
             logger.fdebug("Unable to parse name properly: %s. Ignoring this result" % parsed_comic)
-            return None
+            raise _EntryRejected("rejected.unparseable_title")
 
         # adjust for covers only by removing them entirely...
         vers4year = "no"
@@ -547,7 +721,7 @@ class search_check(object):
             yearmatch = True
 
         if yearmatch is False and pack is False:
-            return None
+            raise _EntryRejected("rejected.year_mismatch")
 
         annualize = False
         if "annual" in ComicName.lower():
@@ -658,7 +832,7 @@ class search_check(object):
                     )
                 else:
                     logger.fdebug("Versions wrong. Ignoring possible match.")
-                    return None
+                    raise _EntryRejected("rejected.volume_mismatch")
 
         downloadit = False
 
@@ -676,10 +850,12 @@ class search_check(object):
                         logger.info("Issue Number %s exists within pack. Continuing." % IssueNumber)
                     else:
                         logger.fdebug("Issue Number %s does NOT exist within this pack. Skipping" % IssueNumber)
-                        return None
+                        raise _EntryRejected("rejected.pack_issue_absent")
+            except _EntryRejected:
+                raise
             except Exception as e:
                 logger.error("Unable to identify pack range for %s. Error returned: %s" % (entry["title"], e))
-                return None
+                raise _EntryRejected("error.pack_lookup_exception")
             # pack support.
             nowrite = False
             if "DDL" in nzbprov:
@@ -721,38 +897,42 @@ class search_check(object):
                     if torznab_host is not None:
                         tprov = torznab_host[0]
 
-                return {
-                    "ComicName": ComicName,
-                    "ComicID": ComicID,
-                    "IssueID": IssueID,
-                    "ComicVolume": ComicVersion,
-                    "IssueNumber": IssueNumber,
-                    "IssueDate": IssueDate,
-                    "comyear": comyear,
-                    "pack": True,
-                    "pack_numbers": pack_issuelist,
-                    "pack_issuelist": issueid_info,
-                    "modcomicname": entry["title"],
-                    "oneoff": oneoff,
-                    "nzbprov": nzbprov,
-                    "nzbtitle": entry["title"],
-                    "nzbid": nzbid,
-                    "provider": tprov,
-                    "link": entry["link"],
-                    "pubdate": pubdate,
-                    "size": comsize_m,
-                    "tmpprov": tmpprov,
-                    "kind": kind,
-                    "SARC": SARC,
-                    "booktype": booktype,
-                    "IssueArcID": IssueArcID,
-                    "newznab": newznab_host,
-                    "torznab": torznab_host,
-                    "downloadit": downloadit,
-                    "ComicTitle": ComicTitle,
-                    "entry": entry,
-                    "provider_stat": provider_stat,
-                }
+                return _AcceptedMatch(
+                    {
+                        "ComicName": ComicName,
+                        "ComicID": ComicID,
+                        "IssueID": IssueID,
+                        "ComicVolume": ComicVersion,
+                        "IssueNumber": IssueNumber,
+                        "IssueDate": IssueDate,
+                        "comyear": comyear,
+                        "pack": True,
+                        "pack_numbers": pack_issuelist,
+                        "pack_issuelist": issueid_info,
+                        "modcomicname": entry["title"],
+                        "oneoff": oneoff,
+                        "nzbprov": nzbprov,
+                        "nzbtitle": entry["title"],
+                        "nzbid": nzbid,
+                        "provider": tprov,
+                        "link": entry["link"],
+                        "pubdate": pubdate,
+                        "size": comsize_m,
+                        "tmpprov": tmpprov,
+                        "kind": kind,
+                        "SARC": SARC,
+                        "booktype": booktype,
+                        "IssueArcID": IssueArcID,
+                        "newznab": newznab_host,
+                        "torznab": torznab_host,
+                        "downloadit": downloadit,
+                        "ComicTitle": ComicTitle,
+                        "entry": entry,
+                        "provider_stat": provider_stat,
+                    },
+                    "pack",
+                )
+            raise _EntryRejected("blocked.duplicate")
         else:
             if filecomic["process_status"] == "match":
                 if cmloopit != 4:
@@ -922,43 +1102,49 @@ class search_check(object):
                             if torznab_host is not None:
                                 tprov = torznab_host[0]
 
-                        return {
-                            "ComicName": ComicName,
-                            "ComicID": ComicID,
-                            "IssueID": IssueID,
-                            "ComicVolume": ComicVersion,
-                            "IssueNumber": IssueNumber,
-                            "IssueDate": IssueDate,
-                            "comyear": cyear,
-                            "pack": False,
-                            "pack_numbers": None,
-                            "pack_issuelist": None,
-                            "modcomicname": modcomicname,
-                            "oneoff": oneoff,
-                            "nzbprov": nzbprov,
-                            "provider": tprov,
-                            "nzbtitle": entry["title"],
-                            "nzbid": nzbid,
-                            "link": entry["link"],
-                            "pubdate": pubdate,
-                            "size": comsize_m,
-                            "tmpprov": tmpprov,
-                            "kind": kind,
-                            "booktype": booktype,
-                            "SARC": SARC,
-                            "IssueArcID": IssueArcID,
-                            "newznab": newznab_host,
-                            "torznab": torznab_host,
-                            "downloadit": downloadit,
-                            "ComicTitle": ComicTitle,
-                            "entry": entry,
-                            "provider_stat": provider_stat,
-                        }
+                        return _AcceptedMatch(
+                            {
+                                "ComicName": ComicName,
+                                "ComicID": ComicID,
+                                "IssueID": IssueID,
+                                "ComicVolume": ComicVersion,
+                                "IssueNumber": IssueNumber,
+                                "IssueDate": IssueDate,
+                                "comyear": cyear,
+                                "pack": False,
+                                "pack_numbers": None,
+                                "pack_issuelist": None,
+                                "modcomicname": modcomicname,
+                                "oneoff": oneoff,
+                                "nzbprov": nzbprov,
+                                "provider": tprov,
+                                "nzbtitle": entry["title"],
+                                "nzbid": nzbid,
+                                "link": entry["link"],
+                                "pubdate": pubdate,
+                                "size": comsize_m,
+                                "tmpprov": tmpprov,
+                                "kind": kind,
+                                "booktype": booktype,
+                                "SARC": SARC,
+                                "IssueArcID": IssueArcID,
+                                "newznab": newznab_host,
+                                "torznab": torznab_host,
+                                "downloadit": downloadit,
+                                "ComicTitle": ComicTitle,
+                                "entry": entry,
+                                "provider_stat": provider_stat,
+                            },
+                            "alternate" if alt_match else "standard",
+                        )
+                    raise _EntryRejected("blocked.duplicate")
                 else:
                     # log2file = log2file + "issues don't match.." + "\n"
                     downloadit = False
                     # foundc['status'] = False
-        return None
+        if alt_match:
+            raise _EntryRejected("rejected.alternate_series")
+        raise _EntryRejected("rejected.issue_mismatch")
 
     def checker(self, entries, is_info=None):
         comicarr.COMICINFO = []

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -373,7 +373,7 @@ class search_check(object):
                     pubdate = entry["pubdate"]
                 except Exception as e:
                     logger.fdebug("Invalid date found. Unable to continue - skipping result. Error returned: %s" % e)
-                    raise _EntryRejected("invalid.pubdate_missing")
+                    raise _EntryRejected("invalid.pubdate_missing") from e
 
         if UseFuzzy == "1":
             logger.fdebug("Year has been fuzzied for this series, ignoring store date comparison entirely.")
@@ -422,7 +422,7 @@ class search_check(object):
                         "Unable to parse posting date from provider result set"
                         " for : %s. Error returned: %s" % (entry["title"], e)
                     )
-                    raise _EntryRejected("invalid.pubdate_unparseable")
+                    raise _EntryRejected("invalid.pubdate_unparseable") from e
 
             if all([digitaldate != "0000-00-00", digitaldate is not None]):
                 i = 0
@@ -494,6 +494,8 @@ class search_check(object):
                     raise _EntryRejected("rejected.before_reference_date")
                 else:
                     logger.fdebug("[CONV] %s is after store date of %s" % (pubdate, stdate))
+            except _EntryRejected:
+                raise
             except Exception:
                 # if the above fails, drop down to the integer compare method
                 # as a failsafe.
@@ -505,7 +507,7 @@ class search_check(object):
                         "%s is before store date of %s. Ignoring search result"
                         " as this is not the right issue." % (pubdate, stdate)
                     )
-                    raise _EntryRejected("rejected.before_reference_date")
+                    raise _EntryRejected("rejected.before_reference_date") from None
                 else:
                     logger.fdebug("[INT] %s is after store date of %s" % (pubdate, stdate))
         # -- end size constaints.
@@ -575,7 +577,7 @@ class search_check(object):
                 filecomic = fcomic.matchIT(parsed_comic)
             except Exception as e:
                 logger.error("[PARSE-ERROR]: %s" % e)
-                raise _EntryRejected("error.matcher_exception")
+                raise _EntryRejected("error.matcher_exception") from e
             else:
                 logger.fdebug("match_check: %s" % filecomic)
                 if filecomic["process_status"] == "fail":
@@ -855,12 +857,15 @@ class search_check(object):
                 raise
             except Exception as e:
                 logger.error("Unable to identify pack range for %s. Error returned: %s" % (entry["title"], e))
-                raise _EntryRejected("error.pack_lookup_exception")
+                raise _EntryRejected("error.pack_lookup_exception") from e
             # pack support.
             nowrite = False
             if "DDL" in nzbprov:
-                if "getcomics" in entry["link"]:
-                    nzbid = entry["id"]
+                if "GetComics" in nzbprov and RSS == "yes":
+                    entry["id"] = entry["link"]
+                    entry["link"] = "https://getcomics.info/?p=" + str(entry["id"])
+                    entry["filename"] = entry["title"]
+                nzbid = entry["id"]
             else:
                 nzbid = search.generate_id(provider_stat, entry["link"], ComicName)
             if all([manual is not True, alt_match is False]):
@@ -1135,7 +1140,7 @@ class search_check(object):
                                 "entry": entry,
                                 "provider_stat": provider_stat,
                             },
-                            "alternate" if alt_match else "standard",
+                            "standard",
                         )
                     raise _EntryRejected("blocked.duplicate")
                 else:

--- a/tests/unit/test_search_filer.py
+++ b/tests/unit/test_search_filer.py
@@ -1,0 +1,394 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import comicarr
+from comicarr import search_filer
+
+
+def _config(**overrides):
+    values = {
+        "IGNORE_SEARCH_WORDS": [],
+        "USE_MINSIZE": False,
+        "MINSIZE": "10",
+        "USE_MAXSIZE": False,
+        "MAXSIZE": "1000",
+        "IGNORE_COVERS": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _info(**overrides):
+    values = {
+        "ComicName": "Example Series",
+        "nzbprov": "experimental",
+        "RSS": "no",
+        "UseFuzzy": "1",
+        "StoreDate": "2024-01-01",
+        "IssueDate": "2024-01-01",
+        "digitaldate": "0000-00-00",
+        "booktype": "Print",
+        "ignore_booktype": False,
+        "SeriesYear": "2024",
+        "ComicVersion": None,
+        "IssDateFix": "no",
+        "ComicYear": "2024",
+        "IssueID": "issue-1",
+        "ComicID": "comic-1",
+        "IssueNumber": "1",
+        "manual": True,
+        "newznab_host": None,
+        "torznab_host": None,
+        "oneoff": False,
+        "tmpprov": "Experimental",
+        "SARC": None,
+        "IssueArcID": None,
+        "cmloopit": 3,
+        "findcomiciss": "1",
+        "intIss": 1000,
+        "chktpb": 0,
+        "provider_stat": {"type": "experimental", "id": 1, "active": True, "hits": 0},
+    }
+    values.update(overrides)
+    return values
+
+
+def _entry(**overrides):
+    values = {
+        "title": "Example Series 001 (2024)",
+        "link": "https://indexer.test/download?apikey=super-secret",
+        "pubdate": "Wed, 10 Jan 2024 12:00:00 +0000",
+        "length": "104857600",
+        "site": "experimental",
+        "id": "provider-item-1",
+        "pack": False,
+        "seeders": "7",
+        "peers": "2",
+    }
+    values.update(overrides)
+    return values
+
+
+def _parsed(**overrides):
+    values = {
+        "parse_status": "success",
+        "booktype": "issue",
+        "series_volume": None,
+        "issue_year": "2024",
+        "issue_number": "1",
+    }
+    values.update(overrides)
+    return values
+
+
+def _matched(**overrides):
+    values = {
+        "process_status": "match",
+        "justthedigits": "1",
+        "booktype": "issue",
+    }
+    values.update(overrides)
+    return values
+
+
+@pytest.fixture(autouse=True)
+def _matcher_environment(monkeypatch):
+    monkeypatch.setattr(comicarr, "CONFIG", _config())
+    monkeypatch.setattr(comicarr, "COMICINFO", [])
+    monkeypatch.setattr(search_filer.search, "generate_id", lambda _provider, identity, _name: str(identity))
+    _install_parser(monkeypatch)
+
+
+def _install_parser(monkeypatch, *, parsed=None, matched=None, match_error=None):
+    parsed_result = parsed or _parsed()
+    matched_result = matched or _matched()
+
+    class FakeFileChecker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def listFiles(self):
+            return parsed_result
+
+        def matchIT(self, _parsed_result):
+            if match_error is not None:
+                raise match_error
+            return matched_result
+
+        def dynamic_replace(self, _series):
+            return {"mod_seriesname": "Example Series"}
+
+    monkeypatch.setattr(search_filer.filechecker, "FileChecker", FakeFileChecker)
+
+
+def _reason(evaluation):
+    return evaluation.verdict["reason_code"]
+
+
+def test_accepted_candidate_is_normalized_and_credential_safe():
+    evaluation = search_filer.search_check().evaluate_entry(_entry(), _info())
+
+    assert evaluation.verdict == {
+        "status": "accepted",
+        "accepted": True,
+        "overrideable": False,
+        "reason_code": "accepted.issue",
+        "reasons": [{"code": "accepted.issue", "message": "Accepted issue match"}],
+        "match_kind": "standard",
+    }
+    assert evaluation.candidate == {
+        "title": "Example Series 001 (2024)",
+        "provider": "experimental",
+        "source_kind": "unknown",
+        "published_at": "Wed, 10 Jan 2024 12:00:00 +0000",
+        "size_bytes": 104857600,
+        "pack": False,
+        "metrics": {"seeders": 7, "peers": 2},
+    }
+    assert evaluation.legacy_match["link"].endswith("super-secret")
+    assert "super-secret" not in str(evaluation.as_dict())
+    assert "link" not in evaluation.as_dict()["candidate"]
+    assert "provider_stat" not in evaluation.as_dict()["candidate"]
+
+
+def test_provider_display_cannot_expose_a_credential_bearing_endpoint():
+    secret = "provider-config-secret"
+    info = _info(
+        nzbprov="dognzb",
+        newznab_host=(f"https://user:{secret}@indexer.test?apikey={secret}", "endpoint", "1", secret),
+        provider_stat={"type": "newznab", "api_key": secret},
+    )
+
+    evaluation = search_filer.search_check().evaluate_entry(_entry(), info)
+    public = evaluation.as_dict()
+
+    assert public["candidate"]["provider"] == "Usenet provider"
+    assert secret not in str(public)
+
+
+@pytest.mark.parametrize(
+    ("config", "entry", "info", "reason_code", "overrideable"),
+    [
+        (
+            _config(IGNORE_SEARCH_WORDS=["repack"]),
+            _entry(title="Example Series 001 REPACK"),
+            _info(),
+            "ignored.search_word",
+            True,
+        ),
+        (_config(USE_MINSIZE=True, MINSIZE="200"), _entry(), _info(), "rejected.size_below_min", True),
+        (_config(USE_MAXSIZE=True, MAXSIZE="50"), _entry(), _info(), "rejected.size_above_max", True),
+        (
+            _config(IGNORE_COVERS=True),
+            _entry(title="Example Series 001 Covers Only"),
+            _info(),
+            "rejected.cover_only",
+            True,
+        ),
+        (
+            _config(),
+            {key: value for key, value in _entry().items() if key != "pubdate"},
+            _info(nzbprov="dognzb", provider_stat={"type": "newznab"}),
+            "invalid.pubdate_missing",
+            False,
+        ),
+        (
+            _config(),
+            _entry(),
+            _info(UseFuzzy="0", StoreDate="0000-00-00", IssueDate="0000-00-00"),
+            "invalid.reference_date_missing",
+            False,
+        ),
+        (
+            _config(),
+            _entry(pubdate="not-a-date"),
+            _info(UseFuzzy="0"),
+            "invalid.pubdate_unparseable",
+            False,
+        ),
+        (
+            _config(),
+            _entry(pubdate="Wed, 10 Jan 2024 12:00:00 +0000"),
+            _info(UseFuzzy="0", StoreDate="2024-02-01", IssueDate="2024-02-01", digitaldate=None),
+            "rejected.before_reference_date",
+            True,
+        ),
+    ],
+)
+def test_early_rejection_reasons_are_stable(monkeypatch, config, entry, info, reason_code, overrideable):
+    monkeypatch.setattr(comicarr, "CONFIG", config)
+
+    evaluation = search_filer.search_check().evaluate_entry(entry, info)
+
+    assert _reason(evaluation) == reason_code
+    assert evaluation.verdict["accepted"] is False
+    assert evaluation.verdict["overrideable"] is overrideable
+    assert evaluation.legacy_match is None
+
+
+@pytest.mark.parametrize(
+    ("parsed", "matched", "match_error", "info", "reason_code"),
+    [
+        (_parsed(), _matched(), RuntimeError("parser broke"), _info(), "error.matcher_exception"),
+        (_parsed(), _matched(process_status="fail"), None, _info(), "rejected.series_mismatch"),
+        (_parsed(booktype="TPB"), _matched(), None, _info(), "rejected.book_type"),
+        (_parsed(parse_status="fail"), _matched(), None, _info(booktype="issue"), "rejected.unparseable_title"),
+        (_parsed(issue_year="2023"), _matched(), None, _info(UseFuzzy="0"), "rejected.year_mismatch"),
+        (
+            _parsed(series_volume="v2"),
+            _matched(),
+            None,
+            _info(ComicVersion="v1"),
+            "rejected.volume_mismatch",
+        ),
+        (_parsed(), _matched(justthedigits="2"), None, _info(), "rejected.issue_mismatch"),
+    ],
+)
+def test_matcher_rejection_reasons_are_stable(
+    monkeypatch,
+    parsed,
+    matched,
+    match_error,
+    info,
+    reason_code,
+):
+    _install_parser(monkeypatch, parsed=parsed, matched=matched, match_error=match_error)
+
+    evaluation = search_filer.search_check().evaluate_entry(_entry(), info)
+
+    assert _reason(evaluation) == reason_code
+    assert evaluation.verdict["status"] == ("error" if reason_code.startswith("error.") else "rejected")
+
+
+def _pack_entry(**overrides):
+    values = _entry(
+        title="Example Series 001-010 (2024)",
+        site="DDL(GetComics)",
+        filename="Example Series 001-010 (2024)",
+        series="Example Series",
+        gc_booktype="issue",
+        issues=["1", "2", "3"],
+        year="2024",
+        pack=True,
+        size="100M",
+        link="https://getcomics.info/post/123",
+    )
+    values.update(overrides)
+    return values
+
+
+def test_pack_candidate_and_pack_failure_reasons(monkeypatch):
+    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args: {"valid": True, "issues": []})
+    info = _info(nzbprov="DDL(GetComics)", tmpprov="DDL(GetComics)")
+
+    accepted = search_filer.search_check().evaluate_entry(_pack_entry(), info)
+    assert _reason(accepted) == "accepted.pack"
+    assert accepted.verdict["match_kind"] == "pack"
+    assert accepted.candidate["source_kind"] == "ddl"
+
+    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args: {"valid": False})
+    absent = search_filer.search_check().evaluate_entry(_pack_entry(), info)
+    assert _reason(absent) == "rejected.pack_issue_absent"
+
+    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", MagicMock(side_effect=RuntimeError("lookup failed")))
+    failed = search_filer.search_check().evaluate_entry(_pack_entry(), info)
+    assert _reason(failed) == "error.pack_lookup_exception"
+
+
+def test_alternate_match_is_explainable_and_remains_filtered(monkeypatch):
+    _install_parser(monkeypatch, matched=_matched(process_status="alt_match"))
+    evaluation = search_filer.search_check().evaluate_entry(_entry(), _info(manual=False))
+
+    assert _reason(evaluation) == "rejected.alternate_series"
+    assert evaluation.verdict["overrideable"] is True
+    assert evaluation.legacy_match is None
+
+
+def test_duplicate_candidate_is_blocked(monkeypatch):
+    checker = search_filer.search_check()
+    info = _info(manual=True)
+    first = checker._process_entry(_entry(), info)
+    comicarr.COMICINFO.append(first)
+
+    duplicate = checker.evaluate_entry(_entry(), info)
+
+    assert _reason(duplicate) == "blocked.duplicate"
+    assert duplicate.verdict["overrideable"] is False
+
+
+def test_unexpected_evaluator_error_is_structured_but_legacy_adapter_reraises():
+    checker = search_filer.search_check()
+    malformed = {"title": "Example Series 001"}
+
+    evaluation = checker.evaluate_entry(malformed, _info())
+    assert _reason(evaluation) == "error.evaluation_exception"
+    assert evaluation.exception is not None
+
+    with pytest.raises(type(evaluation.exception)):
+        checker._process_entry(malformed, _info())
+
+
+def test_evaluate_entries_returns_one_ordered_evaluation_per_raw_entry(monkeypatch):
+    monkeypatch.setattr(comicarr, "CONFIG", _config(IGNORE_SEARCH_WORDS=["repack"]))
+    entries = [
+        _entry(id="accepted"),
+        _entry(id="ignored", title="Example Series 001 REPACK"),
+        {"title": "Malformed provider entry"},
+    ]
+
+    evaluations = search_filer.search_check().evaluate_entries(entries, _info())
+
+    assert [_reason(evaluation) for evaluation in evaluations] == [
+        "accepted.issue",
+        "ignored.search_word",
+        "error.evaluation_exception",
+    ]
+
+
+def test_automatic_adapter_preserves_legacy_shape_and_download_flag():
+    match = search_filer.search_check()._process_entry(_entry(), _info(manual=False))
+
+    assert match["downloadit"] is True
+    assert match["pack"] is False
+    assert "verdict" not in match
+    assert "candidate" not in match
+
+
+def test_checker_keeps_only_legacy_matches_and_populates_global(monkeypatch):
+    checker = search_filer.search_check()
+    entries = [_entry(id="one"), _entry(id="ignored", title="Example Series REPACK"), _entry(id="two", link="two")]
+    monkeypatch.setattr(comicarr, "CONFIG", _config(IGNORE_SEARCH_WORDS=["repack"]))
+
+    matches = checker.checker(entries, _info())
+
+    assert [match["entry"]["id"] for match in matches] == ["one", "two"]
+    assert comicarr.COMICINFO == matches
+
+
+def test_first_result_preserves_preference_and_last_fallback(monkeypatch):
+    checker = search_filer.search_check()
+    candidates = [
+        {"pack": True, "name": "first-pack"},
+        {"pack": True, "name": "last-pack"},
+        {"pack": False, "name": "preferred-issue"},
+    ]
+    process = MagicMock(side_effect=candidates)
+    monkeypatch.setattr(checker, "_process_entry", process)
+
+    assert checker.check_for_first_result([1, 2, 3], {}, prefer_pack=False)["name"] == "preferred-issue"
+    assert process.call_count == 3
+
+    process.reset_mock(side_effect=True)
+    process.side_effect = candidates[:2]
+    assert checker.check_for_first_result([1, 2], {}, prefer_pack=False)["name"] == "last-pack"

--- a/tests/unit/test_search_filer.py
+++ b/tests/unit/test_search_filer.py
@@ -220,7 +220,12 @@ def test_provider_display_cannot_expose_a_credential_bearing_endpoint():
         (
             _config(),
             _entry(pubdate="Wed, 10 Jan 2024 12:00:00 +0000"),
-            _info(UseFuzzy="0", StoreDate="2024-02-01", IssueDate="2024-02-01", digitaldate=None),
+            _info(
+                UseFuzzy="0",
+                StoreDate="2024-02-01",
+                IssueDate="2024-02-01",
+                digitaldate="2024-02-01",
+            ),
             "rejected.before_reference_date",
             True,
         ),
@@ -235,6 +240,23 @@ def test_early_rejection_reasons_are_stable(monkeypatch, config, entry, info, re
     assert evaluation.verdict["accepted"] is False
     assert evaluation.verdict["overrideable"] is overrideable
     assert evaluation.legacy_match is None
+
+
+def test_datetime_rejection_does_not_fall_through_to_disagreeing_integer_comparison(monkeypatch):
+    integer_times = iter([300, 1706659200, 100, 1706659200, 100])
+    monkeypatch.setattr(search_filer.time, "mktime", lambda _value: next(integer_times))
+
+    evaluation = search_filer.search_check().evaluate_entry(
+        _entry(pubdate="Wed, 10 Jan 2024 12:00:00 +0000"),
+        _info(
+            UseFuzzy="0",
+            StoreDate="2024-02-01",
+            IssueDate="2024-02-01",
+            digitaldate="2024-02-01",
+        ),
+    )
+
+    assert _reason(evaluation) == "rejected.before_reference_date"
 
 
 @pytest.mark.parametrize(
@@ -304,6 +326,16 @@ def test_pack_candidate_and_pack_failure_reasons(monkeypatch):
     monkeypatch.setattr(search_filer.helpers, "issue_find_ids", MagicMock(side_effect=RuntimeError("lookup failed")))
     failed = search_filer.search_check().evaluate_entry(_pack_entry(), info)
     assert _reason(failed) == "error.pack_lookup_exception"
+
+
+def test_rss_getcomics_pack_uses_post_id_as_nzbid(monkeypatch):
+    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args: {"valid": True, "issues": []})
+    info = _info(nzbprov="DDL(GetComics)", tmpprov="DDL(GetComics)", RSS="yes")
+
+    evaluation = search_filer.search_check().evaluate_entry(_pack_entry(link=123), info)
+
+    assert evaluation.legacy_match["nzbid"] == 123
+    assert evaluation.legacy_match["link"] == "https://getcomics.info/?p=123"
 
 
 def test_alternate_match_is_explainable_and_remains_filtered(monkeypatch):


### PR DESCRIPTION
## Summary
- add one sanitized `ReleaseCandidateEvaluation` per raw provider entry
- classify accepted, rejected, invalid, blocked, and error outcomes with stable reason codes and overrideability
- retain legacy match payloads only server-side while excluding links and provider configuration from the public representation
- preserve existing automatic `checker()` and first-result behavior through a compatibility adapter
- add focused coverage for all matcher outcome families, packs, duplicates, unexpected errors, ordering, credential safety, and legacy behavior

## Validation
- `uv run pytest tests/unit -q` (2362 passed)
- `npm run lint`
- `coderabbit review --agent -t uncommitted --base main` (0 findings)

No changeset: this PR establishes an internal matching/evaluation seam without exposing a user-facing API or UI.

Resolves #652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured search-result evaluations with clear outcomes for accepted, duplicate, alternate-series, and issue-mismatch results.
  - Added support for evaluating individual results or batches of results.
  - Search results now provide safer, sanitized candidate information and standardized rejection reasons.

- **Bug Fixes**
  - Improved handling of matching errors and unexpected failures without interrupting searches.
  - Preserved compatibility with existing automatic search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->