### PR TITLE
Persist secure interactive-search sessions

### DIFF
--- a/alembic/versions/0006_interactive_search_sessions.py
+++ b/alembic/versions/0006_interactive_search_sessions.py
@@ -1,0 +1,113 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Add bounded Interactive release search session storage.
+
+Revision ID: 0006_interactive_search_sessions
+Revises: 0005_activity_events
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0006_interactive_search_sessions"
+down_revision = "0005_activity_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    existing_tables = set(sa.inspect(bind).get_table_names())
+    if "interactive_search_sessions" not in existing_tables:
+        op.create_table(
+            "interactive_search_sessions",
+            sa.Column("session_id", sa.String(length=64), primary_key=True),
+            sa.Column("slot_digest", sa.String(length=64), nullable=False),
+            sa.Column("actor_digest", sa.String(length=64), nullable=False),
+            sa.Column("browser_digest", sa.String(length=64), nullable=False),
+            sa.Column("entity_type", sa.String(length=32), nullable=False),
+            sa.Column("entity_id", sa.String(length=255), nullable=False),
+            sa.Column("series_id", sa.String(length=255)),
+            sa.Column("state", sa.String(length=32), nullable=False),
+            sa.Column("candidate_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("created_at", sa.String(length=40), nullable=False),
+            sa.Column("updated_at", sa.String(length=40), nullable=False),
+            sa.Column("expires_at", sa.String(length=40), nullable=False),
+            sa.UniqueConstraint("slot_digest", name="uq_interactive_search_session_slot"),
+        )
+    if "interactive_search_candidates" not in existing_tables:
+        op.create_table(
+            "interactive_search_candidates",
+            sa.Column("candidate_id", sa.String(length=64), primary_key=True),
+            sa.Column("session_id", sa.String(length=64), nullable=False),
+            sa.Column("ordinal", sa.Integer(), nullable=False),
+            sa.Column("state", sa.String(length=32), nullable=False),
+            sa.Column("public_json", sa.Text(), nullable=False),
+            sa.Column("reconstruction_json", sa.Text(), nullable=False),
+            sa.Column("fingerprint", sa.String(length=64), nullable=False),
+            sa.Column("created_at", sa.String(length=40), nullable=False),
+            sa.Column("updated_at", sa.String(length=40), nullable=False),
+            sa.Column("expires_at", sa.String(length=40), nullable=False),
+            sa.UniqueConstraint(
+                "session_id",
+                "ordinal",
+                name="uq_interactive_search_candidate_ordinal",
+            ),
+        )
+
+    inspector = sa.inspect(bind)
+    session_indexes = {index["name"] for index in inspector.get_indexes("interactive_search_sessions")}
+    if "interactive_search_sessions_expiry" not in session_indexes:
+        op.create_index(
+            "interactive_search_sessions_expiry",
+            "interactive_search_sessions",
+            ["expires_at"],
+        )
+    if "interactive_search_sessions_scope" not in session_indexes:
+        op.create_index(
+            "interactive_search_sessions_scope",
+            "interactive_search_sessions",
+            ["entity_type", "entity_id"],
+        )
+    candidate_indexes = {index["name"] for index in inspector.get_indexes("interactive_search_candidates")}
+    if "interactive_search_candidates_session" not in candidate_indexes:
+        op.create_index(
+            "interactive_search_candidates_session",
+            "interactive_search_candidates",
+            ["session_id", "ordinal"],
+        )
+    if "interactive_search_candidates_expiry" not in candidate_indexes:
+        op.create_index(
+            "interactive_search_candidates_expiry",
+            "interactive_search_candidates",
+            ["expires_at"],
+        )
+
+
+def downgrade():
+    op.drop_index(
+        "interactive_search_candidates_expiry",
+        table_name="interactive_search_candidates",
+    )
+    op.drop_index(
+        "interactive_search_candidates_session",
+        table_name="interactive_search_candidates",
+    )
+    op.drop_table("interactive_search_candidates")
+    op.drop_index(
+        "interactive_search_sessions_scope",
+        table_name="interactive_search_sessions",
+    )
+    op.drop_index(
+        "interactive_search_sessions_expiry",
+        table_name="interactive_search_sessions",
+    )
+    op.drop_table("interactive_search_sessions")

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -1078,6 +1078,18 @@ def start(ctx):
                 trigger=IntervalTrigger(hours=24, minutes=0, timezone="UTC"),
             )
 
+            # Short-lived Interactive search state gets an independent bounded
+            # sweep, in addition to opportunistic cleanup on session creation.
+            from comicarr.app.search import interactive_sessions
+
+            _add_recurring_job(
+                func=interactive_sessions.run,
+                id="interactive_search_retention",
+                name=interactive_sessions.JOB_NAME,
+                next_run_time=datetime.datetime.utcnow(),
+                trigger=IntervalTrigger(hours=24, minutes=0, timezone="UTC"),
+            )
+
             # A schema failure, persistent repair fence, or explicit operator
             # override suppresses every producer/consumer that can claim or
             # hand off acquisition work. The scheduler itself still starts so

--- a/comicarr/app/core/schema.py
+++ b/comicarr/app/core/schema.py
@@ -61,6 +61,7 @@ _REVISION_INTRODUCED_TABLES = {
         }
     ),
     "0005_activity_events": frozenset({"activity_events"}),
+    "0006_interactive_search_sessions": frozenset({"interactive_search_sessions", "interactive_search_candidates"}),
 }
 _READINGLIST_TO_STORYARCS_COLUMNS = (
     "StoryArcID",

--- a/comicarr/app/search/interactive_sessions.py
+++ b/comicarr/app/search/interactive_sessions.py
@@ -1,0 +1,454 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Bounded, browser-owned persistence for Interactive release search.
+
+The browser receives only opaque ids and the matcher's sanitized public
+projection.  The server-side reconstruction record is a deliberately narrow
+allowlist: it can identify the current provider configuration and candidate,
+but cannot replay a request by itself and never stores credentials or URLs.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import hmac
+import json
+import re
+import secrets
+import threading
+from collections.abc import Mapping, Sequence
+
+from sqlalchemy import delete, insert, select, update
+
+from comicarr import logger
+from comicarr.app.common.redaction import redact_sensitive_text
+from comicarr.db import get_engine
+from comicarr.tables import interactive_search_candidates, interactive_search_sessions
+
+SESSION_TTL_SECONDS = 10 * 60
+MAX_CANDIDATES = 200
+MAX_SESSION_BYTES = 512 * 1024
+MAX_RECORD_BYTES = 64 * 1024
+CLEANUP_BATCH_SIZE = 500
+JOB_ID = "interactive_search_retention"
+JOB_NAME = "Interactive Search Retention"
+
+_ENTITY_TYPES = frozenset({"issue", "annual", "story_arc_issue"})
+_SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,254}$")
+_SAFE_PROVIDER_TYPE = re.compile(r"^[a-z0-9_-]{1,32}$")
+_URL_PATTERN = re.compile(r"(?i)https?://[^\s]+")
+_CREATE_LOCK = threading.Lock()
+
+
+class InteractiveSearchSessionError(RuntimeError):
+    """Base class for safe Interactive release search persistence errors."""
+
+
+class InteractiveSearchAuthorizationError(InteractiveSearchSessionError):
+    """An opaque session is unavailable to the authenticated browser."""
+
+
+class InteractiveSearchExpired(InteractiveSearchAuthorizationError):
+    """The authenticated browser's Interactive search session expired."""
+
+
+class InteractiveSearchLimitError(InteractiveSearchSessionError):
+    """A session exceeded its fixed candidate or serialized-size bound."""
+
+
+def _now(value=None):
+    value = value or datetime.datetime.now(datetime.timezone.utc)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def _digest(value):
+    return hashlib.sha256(str(value).encode("utf-8", "replace")).hexdigest()
+
+
+def _slot_digest(actor, browser_session, entity_type, entity_id):
+    return _digest("\0".join((str(actor), _digest(browser_session), entity_type, entity_id)))
+
+
+def _bounded_json(value, *, label):
+    try:
+        encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    except (TypeError, ValueError) as e:
+        raise InteractiveSearchSessionError("%s is not serializable" % label) from e
+    if len(encoded.encode("utf-8")) > MAX_RECORD_BYTES:
+        raise InteractiveSearchLimitError("%s exceeds the per-record storage limit" % label)
+    return encoded
+
+
+def _decode_object(value, *, label):
+    try:
+        decoded = json.loads(value)
+    except (TypeError, ValueError) as e:
+        raise InteractiveSearchSessionError("stored %s is malformed" % label) from e
+    if not isinstance(decoded, dict):
+        raise InteractiveSearchSessionError("stored %s is malformed" % label)
+    return decoded
+
+
+def _sanitize_public(value):
+    """Recursively redact credential syntax and entire URLs from public data."""
+
+    if isinstance(value, Mapping):
+        return {str(key): _sanitize_public(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_sanitize_public(item) for item in value]
+    if isinstance(value, str):
+        return _URL_PATTERN.sub("[redacted URL]", redact_sensitive_text(value))[:4096]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return _sanitize_public(str(value))
+
+
+def _safe_identifier(value):
+    if value is None or isinstance(value, (dict, list, tuple, set)):
+        return None
+    candidate = str(value).strip()
+    if not _SAFE_IDENTIFIER.fullmatch(candidate):
+        return None
+    if any(marker in candidate.lower() for marker in ("apikey", "api_key", "password", "passkey", "token")):
+        return None
+    return candidate
+
+
+def _entry_value(entry, key):
+    try:
+        return entry.get(key)
+    except AttributeError:
+        try:
+            return entry[key]
+        except Exception:
+            return None
+
+
+def _candidate_reconstruction(evaluation, public):
+    """Build the credential-free server reconstruction allowlist."""
+
+    legacy = getattr(evaluation, "legacy_match", None) or {}
+    hint = getattr(evaluation, "reconstruction_hint", None) or {}
+    hint = hint if isinstance(hint, dict) else {}
+    provider_stat = legacy.get("provider_stat") if isinstance(legacy, dict) else None
+    provider_stat = provider_stat if isinstance(provider_stat, dict) else {}
+    entry = legacy.get("entry") if isinstance(legacy, dict) else None
+    raw_identity = None
+    if isinstance(legacy, dict):
+        raw_identity = legacy.get("nzbid")
+    if raw_identity in (None, ""):
+        raw_identity = _entry_value(entry, "id")
+    if raw_identity in (None, "") and isinstance(legacy, dict):
+        raw_identity = legacy.get("link")
+    if raw_identity in (None, ""):
+        raw_identity = hint.get("provider_item_id")
+
+    provider_type = str(provider_stat.get("type") or hint.get("provider_type") or "").lower()
+    if not _SAFE_PROVIDER_TYPE.fullmatch(provider_type):
+        provider_type = "unknown"
+    provider_config_id = provider_stat.get("id")
+    if provider_config_id is None:
+        provider_config_id = hint.get("provider_config_id")
+    if not isinstance(provider_config_id, int):
+        provider_config_id = _safe_identifier(provider_config_id)
+
+    candidate = public.get("candidate") or {}
+    verdict = public.get("verdict") or {}
+    reconstruction = {
+        "provider_config_id": provider_config_id,
+        "provider_type": provider_type,
+        "provider_name": str(candidate.get("provider") or "Search provider")[:255],
+        "source_kind": str(candidate.get("source_kind") or "unknown")[:32],
+        "provider_item_id": _safe_identifier(raw_identity),
+        "provider_item_digest": _digest(raw_identity or ""),
+        "match_kind": str(verdict.get("match_kind") or "none")[:32],
+        "pack": bool(candidate.get("pack")),
+    }
+    # The digest is useful when an unsafe identity must be re-found under the
+    # current provider config; it is not reversible and grants no access.
+    return reconstruction
+
+
+def _evaluation_record(evaluation, ordinal, expires_at, created_at):
+    public = _sanitize_public(evaluation.as_dict())
+    if not isinstance(public, dict) or not isinstance(public.get("candidate"), dict):
+        raise InteractiveSearchSessionError("release candidate public projection is malformed")
+    if not isinstance(public.get("verdict"), dict):
+        raise InteractiveSearchSessionError("release candidate verdict is malformed")
+    reconstruction = _candidate_reconstruction(evaluation, public)
+    public_json = _bounded_json(public, label="release candidate public projection")
+    reconstruction_json = _bounded_json(reconstruction, label="release candidate reconstruction")
+    fingerprint = _digest(public_json + "\0" + reconstruction_json)
+    verdict = public["verdict"]
+    available = bool(verdict.get("accepted") or verdict.get("overrideable"))
+    return {
+        "candidate_id": secrets.token_urlsafe(24),
+        "ordinal": ordinal,
+        "state": "available" if available else "unavailable",
+        "public_json": public_json,
+        "reconstruction_json": reconstruction_json,
+        "fingerprint": fingerprint,
+        "created_at": created_at,
+        "updated_at": created_at,
+        "expires_at": expires_at,
+    }
+
+
+def _validate_owner(actor, browser_session):
+    if actor in (None, "") or browser_session in (None, ""):
+        raise ValueError("interactive search requires an authenticated browser session")
+
+
+def create_session(
+    engine,
+    *,
+    actor,
+    browser_session,
+    entity_type,
+    entity_id,
+    evaluations: Sequence,
+    series_id=None,
+    now=None,
+    ttl_seconds=SESSION_TTL_SECONDS,
+):
+    """Replace one actor/browser/item slot with a bounded ready session.
+
+    Replacement and candidate insertion share one transaction, so readers see
+    either the previous complete session or the new complete session.  A new
+    opaque id invalidates every URL from the superseded search.
+    """
+
+    _validate_owner(actor, browser_session)
+    entity_type = str(entity_type)
+    entity_id = str(entity_id or "")
+    if entity_type not in _ENTITY_TYPES or not entity_id or len(entity_id) > 255:
+        raise ValueError("interactive search requires a supported tracked item")
+    if len(evaluations) > MAX_CANDIDATES:
+        raise InteractiveSearchLimitError("interactive search candidate count exceeds %s" % MAX_CANDIDATES)
+    if not 1 <= int(ttl_seconds) <= SESSION_TTL_SECONDS:
+        raise ValueError("interactive search TTL must be between 1 and %s seconds" % SESSION_TTL_SECONDS)
+
+    created = _now(now)
+    created_at = created.isoformat()
+    expires_at = (created + datetime.timedelta(seconds=int(ttl_seconds))).isoformat()
+    records = [
+        _evaluation_record(evaluation, ordinal, expires_at, created_at)
+        for ordinal, evaluation in enumerate(evaluations)
+    ]
+    total_bytes = sum(
+        len(record["public_json"].encode("utf-8")) + len(record["reconstruction_json"].encode("utf-8"))
+        for record in records
+    )
+    if total_bytes > MAX_SESSION_BYTES:
+        raise InteractiveSearchLimitError("interactive search session exceeds the storage limit")
+
+    opaque_id = secrets.token_urlsafe(24)
+    slot = _slot_digest(actor, browser_session, entity_type, entity_id)
+    session_values = {
+        "session_id": opaque_id,
+        "slot_digest": slot,
+        "actor_digest": _digest(actor),
+        "browser_digest": _digest(browser_session),
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "series_id": str(series_id)[:255] if series_id not in (None, "") else None,
+        "state": "ready",
+        "candidate_count": len(records),
+        "created_at": created_at,
+        "updated_at": created_at,
+        "expires_at": expires_at,
+    }
+
+    # Comicarr runs one application process by default. The lock closes the
+    # absent-row race inside that process; the unique slot remains the durable
+    # backstop if deployment topology changes.
+    with _CREATE_LOCK:
+        purge_expired_sessions(engine, now=created)
+        with engine.begin() as conn:
+            previous_id = conn.execute(
+                select(interactive_search_sessions.c.session_id).where(
+                    interactive_search_sessions.c.slot_digest == slot
+                )
+            ).scalar_one_or_none()
+            if previous_id is None:
+                conn.execute(insert(interactive_search_sessions).values(**session_values))
+            else:
+                conn.execute(
+                    delete(interactive_search_candidates).where(
+                        interactive_search_candidates.c.session_id == previous_id
+                    )
+                )
+                conn.execute(
+                    update(interactive_search_sessions)
+                    .where(interactive_search_sessions.c.slot_digest == slot)
+                    .values(**session_values)
+                )
+            if records:
+                conn.execute(
+                    insert(interactive_search_candidates),
+                    [dict(record, session_id=opaque_id) for record in records],
+                )
+        return read_session(
+            engine,
+            session_id=opaque_id,
+            actor=actor,
+            browser_session=browser_session,
+            now=created,
+        )
+
+
+def _authorized_row(engine, *, session_id, actor, browser_session, now):
+    _validate_owner(actor, browser_session)
+    with engine.connect() as conn:
+        row = (
+            conn.execute(
+                select(interactive_search_sessions).where(interactive_search_sessions.c.session_id == str(session_id))
+            )
+            .mappings()
+            .first()
+        )
+    if row is None:
+        raise InteractiveSearchAuthorizationError("interactive search session is not available to this browser")
+    if not hmac.compare_digest(str(row["actor_digest"]), _digest(actor)):
+        raise InteractiveSearchAuthorizationError("interactive search session is not available to this browser")
+    if not hmac.compare_digest(str(row["browser_digest"]), _digest(browser_session)):
+        raise InteractiveSearchAuthorizationError("interactive search session is not available to this browser")
+    if _now(now) >= _now(datetime.datetime.fromisoformat(row["expires_at"])):
+        raise InteractiveSearchExpired("interactive search session expired")
+    return dict(row)
+
+
+def read_session(engine, *, session_id, actor, browser_session, now=None):
+    """Return only the opaque id and sanitized candidate projections."""
+
+    row = _authorized_row(
+        engine,
+        session_id=session_id,
+        actor=actor,
+        browser_session=browser_session,
+        now=now,
+    )
+    with engine.connect() as conn:
+        candidate_rows = (
+            conn.execute(
+                select(interactive_search_candidates)
+                .where(interactive_search_candidates.c.session_id == row["session_id"])
+                .order_by(interactive_search_candidates.c.ordinal)
+            )
+            .mappings()
+            .all()
+        )
+    candidates = []
+    for candidate_row in candidate_rows:
+        public = _decode_object(candidate_row["public_json"], label="release candidate projection")
+        public["candidate_id"] = candidate_row["candidate_id"]
+        public["state"] = candidate_row["state"]
+        candidates.append(public)
+    return {
+        "session_id": row["session_id"],
+        "entity_type": row["entity_type"],
+        "entity_id": row["entity_id"],
+        "series_id": row["series_id"],
+        "state": row["state"],
+        "candidate_count": row["candidate_count"],
+        "created_at": row["created_at"],
+        "expires_at": row["expires_at"],
+        "candidates": candidates,
+    }
+
+
+def read_server_candidate(
+    engine,
+    *,
+    session_id,
+    candidate_id,
+    actor,
+    browser_session,
+    now=None,
+):
+    """Authorize one candidate and return its private reconstruction record.
+
+    This is a server-only seam for the later safe-grab ticket. HTTP responses
+    must continue to use :func:`read_session`.
+    """
+
+    session = _authorized_row(
+        engine,
+        session_id=session_id,
+        actor=actor,
+        browser_session=browser_session,
+        now=now,
+    )
+    with engine.connect() as conn:
+        row = (
+            conn.execute(
+                select(interactive_search_candidates)
+                .where(interactive_search_candidates.c.session_id == session["session_id"])
+                .where(interactive_search_candidates.c.candidate_id == str(candidate_id))
+            )
+            .mappings()
+            .first()
+        )
+    if row is None:
+        raise InteractiveSearchAuthorizationError("release candidate is not available to this browser")
+    return {
+        "candidate_id": row["candidate_id"],
+        "session_id": row["session_id"],
+        "state": row["state"],
+        "fingerprint": row["fingerprint"],
+        "public": _decode_object(row["public_json"], label="release candidate projection"),
+        "reconstruction": _decode_object(
+            row["reconstruction_json"],
+            label="release candidate reconstruction",
+        ),
+    }
+
+
+def purge_expired_sessions(engine, *, now=None, batch_size=CLEANUP_BATCH_SIZE):
+    """Delete at most one bounded batch of expired sessions and candidates."""
+
+    limit = max(1, min(int(batch_size), CLEANUP_BATCH_SIZE))
+    cutoff = _now(now).isoformat()
+    with engine.begin() as conn:
+        session_ids = list(
+            conn.execute(
+                select(interactive_search_sessions.c.session_id)
+                .where(interactive_search_sessions.c.expires_at <= cutoff)
+                .order_by(interactive_search_sessions.c.expires_at)
+                .limit(limit)
+            ).scalars()
+        )
+        if not session_ids:
+            return {"sessions": 0, "candidates": 0}
+        candidates = conn.execute(
+            delete(interactive_search_candidates).where(interactive_search_candidates.c.session_id.in_(session_ids))
+        ).rowcount
+        sessions = conn.execute(
+            delete(interactive_search_sessions).where(interactive_search_sessions.c.session_id.in_(session_ids))
+        ).rowcount
+    return {"sessions": sessions or 0, "candidates": candidates or 0}
+
+
+def run():
+    """APScheduler entry point for the bounded daily expiry sweep."""
+
+    try:
+        summary = purge_expired_sessions(get_engine())
+    except Exception as e:
+        logger.error("[INTERACTIVE-SEARCH-RETENTION] Purge failed: %s" % e)
+        raise
+    logger.fdebug(
+        "[INTERACTIVE-SEARCH-RETENTION] Deleted %s sessions and %s candidates"
+        % (summary["sessions"], summary["candidates"])
+    )
+    return summary

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -77,6 +77,7 @@ SCHEDULER_JOB_NAMES = {
     "ddl_health": "DDL Health Check",
     "ledger_retention": "Ledger Retention",
     "activity_retention": "Activity Event Retention",
+    "interactive_search_retention": "Interactive Search Retention",
 }
 
 SETUP_PERSISTENCE_ERROR = "Failed to persist initial credentials"

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -78,6 +78,7 @@ class ReleaseCandidateEvaluation:
     verdict: dict
     legacy_match: dict | None = field(default=None, repr=False)
     exception: Exception | None = field(default=None, repr=False)
+    reconstruction_hint: dict | None = field(default=None, repr=False)
 
     def as_dict(self):
         return {"candidate": dict(self.candidate), "verdict": dict(self.verdict)}
@@ -171,19 +172,46 @@ class search_check(object):
             "match_kind": match_kind,
         }
 
+    def _reconstruction_hint(self, entry, is_info):
+        """Retain only the raw identity inputs needed for safe persistence.
+
+        The persistence service still validates and hashes these values before
+        writing them. Keeping this hint private lets overrideable rejections be
+        found again even though they never produce an accepted legacy match.
+        """
+
+        info = is_info or {}
+        provider_stat = info.get("provider_stat") or {}
+        if not isinstance(provider_stat, dict):
+            provider_stat = {}
+        raw_identity = self._entry_value(entry, "id")
+        if raw_identity in (None, ""):
+            raw_identity = self._entry_value(entry, "link")
+        return {
+            "provider_config_id": provider_stat.get("id"),
+            "provider_type": provider_stat.get("type"),
+            "provider_item_id": raw_identity,
+        }
+
     def evaluate_entry(self, entry, is_info=None):
         """Evaluate one raw provider entry without exposing provider secrets."""
 
         candidate = self._normalized_candidate(entry, is_info)
+        reconstruction_hint = self._reconstruction_hint(entry, is_info)
         try:
             accepted = self._match_entry(entry, is_info)
         except _EntryRejected as rejection:
-            return ReleaseCandidateEvaluation(candidate, self._verdict(rejection.reason_code))
+            return ReleaseCandidateEvaluation(
+                candidate,
+                self._verdict(rejection.reason_code),
+                reconstruction_hint=reconstruction_hint,
+            )
         except Exception as e:
             return ReleaseCandidateEvaluation(
                 candidate,
                 self._verdict("error.evaluation_exception"),
                 exception=e,
+                reconstruction_hint=reconstruction_hint,
             )
 
         reason_code = "accepted.pack" if accepted.match_kind == "pack" else "accepted.issue"
@@ -191,6 +219,7 @@ class search_check(object):
             candidate,
             self._verdict(reason_code, match_kind=accepted.match_kind),
             legacy_match=accepted.legacy_match,
+            reconstruction_hint=reconstruction_hint,
         )
 
     def evaluate_entries(self, entries, is_info=None):

--- a/comicarr/tables.py
+++ b/comicarr/tables.py
@@ -870,6 +870,48 @@ acquisition_search_previews = Table(
     UniqueConstraint("token_digest", name="uq_acquisition_search_preview_token"),
 )
 
+# An Interactive release search session is authenticated browser-owned state,
+# not a serialized provider response.  The public candidate projection and the
+# credential-free reconstruction allowlist live separately on the candidate
+# row; raw links, provider tuples, cookies, and API credentials are forbidden.
+interactive_search_sessions = Table(
+    "interactive_search_sessions",
+    metadata,
+    Column("session_id", String(64), primary_key=True),
+    Column("slot_digest", String(64), nullable=False),
+    Column("actor_digest", String(64), nullable=False),
+    Column("browser_digest", String(64), nullable=False),
+    Column("entity_type", String(32), nullable=False),
+    Column("entity_id", String(255), nullable=False),
+    Column("series_id", String(255)),
+    Column("state", String(32), nullable=False),
+    Column("candidate_count", Integer, nullable=False, server_default="0"),
+    Column("created_at", String(40), nullable=False),
+    Column("updated_at", String(40), nullable=False),
+    Column("expires_at", String(40), nullable=False),
+    UniqueConstraint("slot_digest", name="uq_interactive_search_session_slot"),
+)
+
+interactive_search_candidates = Table(
+    "interactive_search_candidates",
+    metadata,
+    Column("candidate_id", String(64), primary_key=True),
+    Column("session_id", String(64), nullable=False),
+    Column("ordinal", Integer, nullable=False),
+    Column("state", String(32), nullable=False),
+    Column("public_json", Text, nullable=False),
+    Column("reconstruction_json", Text, nullable=False),
+    Column("fingerprint", String(64), nullable=False),
+    Column("created_at", String(40), nullable=False),
+    Column("updated_at", String(40), nullable=False),
+    Column("expires_at", String(40), nullable=False),
+    UniqueConstraint(
+        "session_id",
+        "ordinal",
+        name="uq_interactive_search_candidate_ordinal",
+    ),
+)
+
 # Migration completion is not enough to resume acquisition. This one-row
 # durable control records the operator-visible reconciliation gate across
 # container restarts.
@@ -1131,6 +1173,24 @@ Index(
 )
 Index("acq_search_preview_series_state", acquisition_search_previews.c.series_id, acquisition_search_previews.c.state)
 Index("acq_search_preview_run", acquisition_search_previews.c.run_id)
+Index(
+    "interactive_search_sessions_expiry",
+    interactive_search_sessions.c.expires_at,
+)
+Index(
+    "interactive_search_sessions_scope",
+    interactive_search_sessions.c.entity_type,
+    interactive_search_sessions.c.entity_id,
+)
+Index(
+    "interactive_search_candidates_session",
+    interactive_search_candidates.c.session_id,
+    interactive_search_candidates.c.ordinal,
+)
+Index(
+    "interactive_search_candidates_expiry",
+    interactive_search_candidates.c.expires_at,
+)
 Index("acq_reconciliation_state", acquisition_reconciliation.c.state)
 Index("acq_canary_permit_state", acquisition_canary_permits.c.state, acquisition_canary_permits.c.expires_at)
 Index("acq_canary_permit_release", acquisition_canary_permits.c.release_key)
@@ -1216,6 +1276,8 @@ TABLE_MAP = {
     "acquisition_runs": acquisition_runs,
     "acquisition_run_items": acquisition_run_items,
     "acquisition_search_previews": acquisition_search_previews,
+    "interactive_search_sessions": interactive_search_sessions,
+    "interactive_search_candidates": interactive_search_candidates,
     "acquisition_reconciliation": acquisition_reconciliation,
     "acquisition_canary_permits": acquisition_canary_permits,
     "acquisition_maintenance": acquisition_maintenance,

--- a/tests/integration/test_schema_migration_dialects.py
+++ b/tests/integration/test_schema_migration_dialects.py
@@ -92,9 +92,9 @@ def test_fresh_database_uses_application_runner_and_is_idempotent():
     try:
         _reset_database(engine)
 
-        assert upgrade_database(engine) == "0005_activity_events"
-        assert upgrade_database(engine) == "0005_activity_events"
-        assert current_revision(engine) == "0005_activity_events"
+        assert upgrade_database(engine) == "0006_interactive_search_sessions"
+        assert upgrade_database(engine) == "0006_interactive_search_sessions"
+        assert current_revision(engine) == "0006_interactive_search_sessions"
         assert set(metadata.tables).issubset(set(inspect(engine).get_table_names()))
     finally:
         engine.dispose()
@@ -177,9 +177,9 @@ def test_legacy_adoption_preserves_data_and_is_idempotent_across_dialects():
         _reset_database(engine)
         _build_legacy_fixture(engine)
 
-        assert upgrade_database(engine) == "0005_activity_events"
-        assert upgrade_database(engine) == "0005_activity_events"
-        assert current_revision(engine) == "0005_activity_events"
+        assert upgrade_database(engine) == "0006_interactive_search_sessions"
+        assert upgrade_database(engine) == "0006_interactive_search_sessions"
+        assert current_revision(engine) == "0006_interactive_search_sessions"
 
         table_names = set(inspect(engine).get_table_names())
         assert "readinglist" not in table_names

--- a/tests/unit/test_ai_library_chat.py
+++ b/tests/unit/test_ai_library_chat.py
@@ -61,7 +61,7 @@ def production_chat_db(tmp_path, monkeypatch):
         conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
         conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
         conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0002_legacy_adoption')"))
-    assert upgrade_database(engine) == "0005_activity_events"
+    assert upgrade_database(engine) == "0006_interactive_search_sessions"
     yield tmp_path
     db.shutdown_engine()
 

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -79,7 +79,7 @@ def test_migrate_deduplicates_unique_keys_across_batches(tmp_path, capsys):
     target_engine = create_engine(_sqlite_url(target_path))
     with target_engine.connect() as conn:
         rows = conn.execute(text("SELECT ComicID, ComicName FROM comics ORDER BY rowid")).mappings().all()
-    assert current_revision(target_engine) == "0005_activity_events"
+    assert current_revision(target_engine) == "0006_interactive_search_sessions"
     target_engine.dispose()
 
     assert rows == [
@@ -120,7 +120,7 @@ def test_migrate_deduplicates_composite_keys_with_empty_components(tmp_path, cap
             .mappings()
             .all()
         )
-    assert current_revision(target_engine) == "0005_activity_events"
+    assert current_revision(target_engine) == "0006_interactive_search_sessions"
     target_engine.dispose()
 
     assert rows == [

--- a/tests/unit/test_interactive_search_sessions.py
+++ b/tests/unit/test_interactive_search_sessions.py
@@ -1,0 +1,313 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Security and lifecycle contracts for Interactive search persistence."""
+
+import datetime
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from sqlalchemy import create_engine, func, select
+
+from comicarr.app.search.interactive_sessions import (
+    JOB_ID,
+    JOB_NAME,
+    MAX_CANDIDATES,
+    InteractiveSearchAuthorizationError,
+    InteractiveSearchExpired,
+    InteractiveSearchLimitError,
+    create_session,
+    purge_expired_sessions,
+    read_server_candidate,
+    read_session,
+)
+from comicarr.app.system import service as system_service
+from comicarr.search_filer import ReleaseCandidateEvaluation
+from comicarr.tables import interactive_search_candidates, interactive_search_sessions, metadata
+
+NOW = datetime.datetime(2026, 8, 11, 15, 0, tzinfo=datetime.timezone.utc)
+
+
+def _evaluation(
+    title="Batman 125 (2022)",
+    *,
+    accepted=True,
+    overrideable=False,
+    legacy_match=None,
+    reconstruction_hint=None,
+):
+    return ReleaseCandidateEvaluation(
+        candidate={
+            "title": title,
+            "provider": "Indexer",
+            "source_kind": "usenet",
+            "published_at": "2026-08-11T12:00:00+00:00",
+            "size_bytes": 42,
+            "pack": False,
+            "metrics": {"grabs": 8},
+        },
+        verdict={
+            "status": "accepted" if accepted else "rejected",
+            "accepted": accepted,
+            "overrideable": overrideable,
+            "reason_code": "accepted.issue" if accepted else "rejected.wrong_issue",
+            "reasons": [{"code": "test", "message": "Stable test verdict"}],
+            "match_kind": "issue" if accepted else "none",
+        },
+        legacy_match=legacy_match,
+        reconstruction_hint=reconstruction_hint,
+    )
+
+
+@pytest.fixture
+def engine(tmp_path):
+    value = create_engine("sqlite:///%s" % (tmp_path / "interactive-search.db"))
+    metadata.create_all(value)
+    yield value
+    value.dispose()
+
+
+def _create(engine, evaluations=None, **overrides):
+    values = {
+        "actor": "alice",
+        "browser_session": "raw-session-cookie",
+        "entity_type": "issue",
+        "entity_id": "issue-125",
+        "series_id": "series-batman",
+        "evaluations": [_evaluation()] if evaluations is None else evaluations,
+        "now": NOW,
+    }
+    values.update(overrides)
+    return create_session(engine, **values)
+
+
+def test_session_is_opaque_ordered_and_public_only(engine):
+    result = _create(
+        engine,
+        [
+            _evaluation("first"),
+            _evaluation("second", accepted=False, overrideable=True),
+            _evaluation("third", accepted=False),
+        ],
+    )
+
+    assert result["candidate_count"] == 3
+    assert [item["candidate"]["title"] for item in result["candidates"]] == ["first", "second", "third"]
+    assert [item["state"] for item in result["candidates"]] == ["available", "available", "unavailable"]
+    assert result["session_id"] not in {"issue-125", "series-batman", "raw-session-cookie"}
+    assert all("reconstruction" not in item for item in result["candidates"])
+    assert all(item["candidate_id"] not in item["candidate"]["title"] for item in result["candidates"])
+
+
+def test_overrideable_rejection_keeps_credential_free_reconstruction_identity(engine):
+    result = _create(
+        engine,
+        [
+            _evaluation(
+                accepted=False,
+                overrideable=True,
+                reconstruction_hint={
+                    "provider_config_id": 42,
+                    "provider_type": "torznab",
+                    "provider_item_id": "torrent-item-7",
+                },
+            )
+        ],
+    )
+
+    private = read_server_candidate(
+        engine,
+        session_id=result["session_id"],
+        candidate_id=result["candidates"][0]["candidate_id"],
+        actor="alice",
+        browser_session="raw-session-cookie",
+        now=NOW,
+    )
+    assert private["state"] == "available"
+    assert private["reconstruction"]["provider_config_id"] == 42
+    assert private["reconstruction"]["provider_type"] == "torznab"
+    assert private["reconstruction"]["provider_item_id"] == "torrent-item-7"
+
+
+def test_persisted_rows_never_contain_credentials_urls_or_raw_cookie(engine):
+    secret = "super-secret-api-key"
+    raw_url = "https://user:password@example.invalid/download?apikey=%s" % secret
+    evaluation = _evaluation(
+        raw_url,
+        legacy_match={
+            "link": raw_url,
+            "nzbid": raw_url,
+            "entry": {"id": raw_url, "download": raw_url},
+            "provider_stat": {
+                "id": 17,
+                "type": "newznab",
+                "apikey": secret,
+                "host": raw_url,
+            },
+        },
+    )
+    evaluation.candidate["provider"] = raw_url
+
+    result = _create(engine, [evaluation])
+    with engine.connect() as conn:
+        session_row = dict(conn.execute(select(interactive_search_sessions)).mappings().one())
+        candidate_row = dict(conn.execute(select(interactive_search_candidates)).mappings().one())
+    persisted = json.dumps({"session": session_row, "candidate": candidate_row}, sort_keys=True)
+
+    assert secret not in persisted
+    assert raw_url not in persisted
+    assert "raw-session-cookie" not in persisted
+    assert "alice" not in persisted
+    assert "password" not in persisted
+    assert "apikey" not in persisted
+    assert result["candidates"][0]["candidate"]["title"] == "[redacted URL]"
+
+    private = read_server_candidate(
+        engine,
+        session_id=result["session_id"],
+        candidate_id=result["candidates"][0]["candidate_id"],
+        actor="alice",
+        browser_session="raw-session-cookie",
+        now=NOW,
+    )
+    assert set(private["reconstruction"]) == {
+        "provider_config_id",
+        "provider_type",
+        "provider_name",
+        "source_kind",
+        "provider_item_id",
+        "provider_item_digest",
+        "match_kind",
+        "pack",
+    }
+    assert private["reconstruction"]["provider_config_id"] == 17
+    assert private["reconstruction"]["provider_item_id"] is None
+    assert private["reconstruction"]["provider_name"] == "[redacted URL]"
+    assert private["reconstruction"]["provider_type"] == "newznab"
+    assert len(private["reconstruction"]["provider_item_digest"]) == 64
+
+
+@pytest.mark.parametrize(
+    ("actor", "browser_session"),
+    [("mallory", "raw-session-cookie"), ("alice", "different-cookie")],
+)
+def test_session_requires_both_actor_and_browser_ownership(engine, actor, browser_session):
+    result = _create(engine)
+
+    with pytest.raises(InteractiveSearchAuthorizationError, match="not available"):
+        read_session(
+            engine,
+            session_id=result["session_id"],
+            actor=actor,
+            browser_session=browser_session,
+            now=NOW,
+        )
+
+
+def test_latest_creation_supersedes_one_actor_browser_item_slot(engine):
+    first = _create(engine, [_evaluation("first")])
+    second = _create(engine, [_evaluation("second")])
+    other_item = _create(engine, [_evaluation("other")], entity_id="issue-126")
+
+    assert first["session_id"] != second["session_id"]
+    with pytest.raises(InteractiveSearchAuthorizationError, match="not available"):
+        read_session(
+            engine,
+            session_id=first["session_id"],
+            actor="alice",
+            browser_session="raw-session-cookie",
+            now=NOW,
+        )
+    assert (
+        read_session(
+            engine,
+            session_id=second["session_id"],
+            actor="alice",
+            browser_session="raw-session-cookie",
+            now=NOW,
+        )["candidates"][0]["candidate"]["title"]
+        == "second"
+    )
+    assert other_item["entity_id"] == "issue-126"
+    with engine.connect() as conn:
+        assert conn.execute(select(func.count()).select_from(interactive_search_sessions)).scalar_one() == 2
+        assert conn.execute(select(func.count()).select_from(interactive_search_candidates)).scalar_one() == 2
+
+
+def test_concurrent_replacements_both_return_and_leave_one_complete_slot(engine):
+    def create(title):
+        return _create(engine, [_evaluation(title)])
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(create, ("first", "second")))
+
+    assert len({result["session_id"] for result in results}) == 2
+    with engine.connect() as conn:
+        sessions = conn.execute(select(interactive_search_sessions)).mappings().all()
+        candidates = conn.execute(select(interactive_search_candidates)).mappings().all()
+    assert len(sessions) == 1
+    assert len(candidates) == 1
+    assert candidates[0]["session_id"] == sessions[0]["session_id"]
+    assert sessions[0]["candidate_count"] == 1
+
+
+def test_expiry_fails_closed_and_cleanup_is_bounded(engine):
+    first = _create(engine, entity_id="issue-expired-1", ttl_seconds=1)
+    _create(engine, entity_id="issue-expired-2", ttl_seconds=1)
+
+    after_expiry = NOW + datetime.timedelta(seconds=2)
+    with pytest.raises(InteractiveSearchExpired, match="expired"):
+        read_session(
+            engine,
+            session_id=first["session_id"],
+            actor="alice",
+            browser_session="raw-session-cookie",
+            now=after_expiry,
+        )
+
+    assert purge_expired_sessions(engine, now=after_expiry, batch_size=1) == {
+        "sessions": 1,
+        "candidates": 1,
+    }
+    with engine.connect() as conn:
+        assert conn.execute(select(func.count()).select_from(interactive_search_sessions)).scalar_one() == 1
+    assert purge_expired_sessions(engine, now=after_expiry) == {"sessions": 1, "candidates": 1}
+
+
+def test_session_survives_service_restart_boundary(engine):
+    created = _create(engine)
+
+    loaded = read_session(
+        engine,
+        session_id=created["session_id"],
+        actor="alice",
+        browser_session="raw-session-cookie",
+        now=NOW + datetime.timedelta(seconds=30),
+    )
+
+    assert loaded == created
+
+
+def test_candidate_and_record_limits_fail_before_any_write(engine):
+    with pytest.raises(InteractiveSearchLimitError, match="candidate count"):
+        _create(engine, [_evaluation()] * (MAX_CANDIDATES + 1))
+    oversized = _evaluation()
+    oversized.candidate["metrics"] = {"metric-%s" % index: index for index in range(10_000)}
+    with pytest.raises(InteractiveSearchLimitError, match="per-record"):
+        _create(engine, [oversized])
+
+    with engine.connect() as conn:
+        assert conn.execute(select(func.count()).select_from(interactive_search_sessions)).scalar_one() == 0
+        assert conn.execute(select(func.count()).select_from(interactive_search_candidates)).scalar_one() == 0
+
+
+def test_scheduler_job_name_matches_retention_service():
+    assert JOB_ID == "interactive_search_retention"
+    assert system_service.SCHEDULER_JOB_NAMES[JOB_ID] == JOB_NAME

--- a/tests/unit/test_scheduler_configuration.py
+++ b/tests/unit/test_scheduler_configuration.py
@@ -38,6 +38,7 @@ _RECURRING_JOB_IDS = {
     "ddl_health",
     "ledger_retention",
     "activity_retention",
+    "interactive_search_retention",
 }
 
 

--- a/tests/unit/test_schema_migrations.py
+++ b/tests/unit/test_schema_migrations.py
@@ -196,8 +196,8 @@ def test_upgrade_database_accepts_a_known_prior_comicarr_revision(tmp_path):
         conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
         conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0001_baseline')"))
 
-    assert upgrade_database(engine) == "0005_activity_events"
-    assert current_revision(engine) == "0005_activity_events"
+    assert upgrade_database(engine) == "0006_interactive_search_sessions"
+    assert current_revision(engine) == "0006_interactive_search_sessions"
 
 
 def test_upgrade_database_accepts_pre_chat_revision_without_library_chat_tables(tmp_path):
@@ -218,8 +218,8 @@ def test_upgrade_database_accepts_pre_chat_revision_without_library_chat_tables(
 
     assert "ai_chat_threads" not in set(inspect(engine).get_table_names())
     assert classify_database(engine) is DatabaseState.VERSIONED
-    assert upgrade_database(engine) == "0005_activity_events"
-    assert current_revision(engine) == "0005_activity_events"
+    assert upgrade_database(engine) == "0006_interactive_search_sessions"
+    assert current_revision(engine) == "0006_interactive_search_sessions"
     assert {"ai_chat_threads", "ai_chat_messages", "ai_chat_attachments"}.issubset(
         set(inspect(engine).get_table_names())
     )
@@ -252,8 +252,8 @@ def test_upgrade_database_accepts_pre_activity_revision_without_activity_events(
 
     assert "activity_events" not in set(inspect(engine).get_table_names())
     assert classify_database(engine) is DatabaseState.VERSIONED
-    assert upgrade_database(engine) == "0005_activity_events"
-    assert current_revision(engine) == "0005_activity_events"
+    assert upgrade_database(engine) == "0006_interactive_search_sessions"
+    assert current_revision(engine) == "0006_interactive_search_sessions"
     assert "activity_events" in set(inspect(engine).get_table_names())
 
     activity_indexes = {index["name"] for index in inspect(engine).get_indexes("activity_events")}
@@ -277,6 +277,73 @@ def test_head_revision_still_requires_activity_events(tmp_path):
 
     with pytest.raises(MigrationStateError, match="missing tables required by its Comicarr revision"):
         upgrade_database(engine)
+
+
+def test_upgrade_accepts_pre_interactive_revision_without_session_tables(tmp_path):
+    engine = create_engine("sqlite:///%s" % (tmp_path / "pre-interactive-version.db"))
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE interactive_search_candidates"))
+        conn.execute(text("DROP TABLE interactive_search_sessions"))
+        conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(64) NOT NULL)"))
+        conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0005_activity_events')"))
+
+    assert classify_database(engine) is DatabaseState.VERSIONED
+    assert upgrade_database(engine) == "0006_interactive_search_sessions"
+    assert {"interactive_search_sessions", "interactive_search_candidates"}.issubset(
+        set(inspect(engine).get_table_names())
+    )
+
+
+def test_head_revision_requires_interactive_search_session_tables(tmp_path):
+    engine = create_engine("sqlite:///%s" % (tmp_path / "head-missing-interactive.db"))
+    metadata.create_all(engine)
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE interactive_search_candidates"))
+        conn.execute(text("DROP TABLE interactive_search_sessions"))
+        conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
+        conn.execute(text("CREATE TABLE alembic_version (version_num VARCHAR(64) NOT NULL)"))
+        conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0006_interactive_search_sessions')"))
+
+    with pytest.raises(MigrationStateError, match="missing tables required by its Comicarr revision"):
+        upgrade_database(engine)
+
+
+def test_interactive_search_tables_match_security_contract():
+    sessions = metadata.tables["interactive_search_sessions"]
+    candidates = metadata.tables["interactive_search_candidates"]
+
+    assert list(sessions.c.keys()) == [
+        "session_id",
+        "slot_digest",
+        "actor_digest",
+        "browser_digest",
+        "entity_type",
+        "entity_id",
+        "series_id",
+        "state",
+        "candidate_count",
+        "created_at",
+        "updated_at",
+        "expires_at",
+    ]
+    assert list(candidates.c.keys()) == [
+        "candidate_id",
+        "session_id",
+        "ordinal",
+        "state",
+        "public_json",
+        "reconstruction_json",
+        "fingerprint",
+        "created_at",
+        "updated_at",
+        "expires_at",
+    ]
+    assert sessions.c.session_id.primary_key
+    assert candidates.c.candidate_id.primary_key
+    assert not {"cookie", "credential", "url", "link", "payload"}.intersection(sessions.c.keys())
+    assert not {"cookie", "credential", "url", "link", "payload"}.intersection(candidates.c.keys())
 
 
 def test_activity_events_table_matches_field_contract():
@@ -321,7 +388,7 @@ def test_upgrade_creates_pipeline_journal_stage_index_when_missing(tmp_path):
         conn.execute(text("INSERT INTO alembic_version(version_num) VALUES ('0003_library_chat')"))
 
     assert "pipeline_journal_stage" not in {index["name"] for index in inspect(engine).get_indexes("pipeline_journal")}
-    assert upgrade_database(engine) == "0005_activity_events"
+    assert upgrade_database(engine) == "0006_interactive_search_sessions"
     assert "pipeline_journal_stage" in {index["name"] for index in inspect(engine).get_indexes("pipeline_journal")}
 
 
@@ -339,7 +406,7 @@ def test_upgrade_database_builds_a_fresh_database_to_the_single_head(tmp_path):
 
     revision = upgrade_database(engine)
 
-    assert revision == "0005_activity_events"
+    assert revision == "0006_interactive_search_sessions"
     assert set(metadata.tables).issubset(set(inspect(engine).get_table_names()))
 
 
@@ -347,7 +414,7 @@ def test_head_includes_ledger_retention_indexes(tmp_path):
     """#478: four retention indexes land at head; pipeline_journal_stage stays."""
 
     engine = create_engine("sqlite:///%s" % (tmp_path / "retention-indexes.db"))
-    assert upgrade_database(engine) == "0005_activity_events"
+    assert upgrade_database(engine) == "0006_interactive_search_sessions"
 
     inspector = inspect(engine)
     expected = {
@@ -382,7 +449,7 @@ def test_upgrade_from_library_chat_creates_missing_retention_indexes(tmp_path):
         for index_name in retention_indexes:
             conn.execute(text("DROP INDEX IF EXISTS %s" % index_name))
 
-    assert upgrade_database(engine) == "0005_activity_events"
+    assert upgrade_database(engine) == "0006_interactive_search_sessions"
     inspector = inspect(engine)
     for table_name, index_name in (
         ("acquisition_run_items", "acquisition_run_items_state_completed"),
@@ -401,8 +468,8 @@ def test_upgrade_database_stamps_only_a_verified_legacy_database(tmp_path):
     with engine.begin() as conn:
         conn.execute(text("INSERT INTO mylar_info(DatabaseVersion) VALUES (0)"))
 
-    assert upgrade_database(engine) == "0005_activity_events"
-    assert current_revision(engine) == "0005_activity_events"
+    assert upgrade_database(engine) == "0006_interactive_search_sessions"
+    assert current_revision(engine) == "0006_interactive_search_sessions"
 
 
 def test_upgrade_database_never_stamps_an_unknown_database(tmp_path):

--- a/tests/unit/test_search_filer.py
+++ b/tests/unit/test_search_filer.py
@@ -160,6 +160,24 @@ def test_accepted_candidate_is_normalized_and_credential_safe():
     assert "super-secret" not in str(evaluation.as_dict())
     assert "link" not in evaluation.as_dict()["candidate"]
     assert "provider_stat" not in evaluation.as_dict()["candidate"]
+    assert "reconstruction_hint" not in evaluation.as_dict()
+
+
+def test_overrideable_rejection_retains_private_provider_identity_hint(monkeypatch):
+    monkeypatch.setattr(comicarr, "CONFIG", _config(IGNORE_SEARCH_WORDS=["repack"]))
+    evaluation = search_filer.search_check().evaluate_entry(
+        _entry(title="Example Series 001 REPACK"),
+        _info(provider_stat={"type": "newznab", "id": 19, "api_key": "secret"}),
+    )
+
+    assert evaluation.verdict["overrideable"] is True
+    assert evaluation.reconstruction_hint == {
+        "provider_config_id": 19,
+        "provider_type": "newznab",
+        "provider_item_id": "provider-item-1",
+    }
+    assert "secret" not in str(evaluation.reconstruction_hint)
+    assert "reconstruction_hint" not in evaluation.as_dict()
 
 
 def test_provider_display_cannot_expose_a_credential_bearing_endpoint():


### PR DESCRIPTION
## Summary
- add bounded, opaque Interactive release search session and candidate persistence
- bind sessions to actor and browser digests with atomic latest-session supersession
- persist only sanitized public projections and allowlisted provider reconstruction identities
- add opportunistic and scheduled expiry cleanup plus Alembic migration coverage

## Validation
- npm run lint
- uv run pytest tests/unit -q (2,377 passed)
- focused session/migration/search/scheduler suite (103 passed)

Closes #658