### PR TITLE
feat: safely grab interactive release candidates

### DIFF
--- a/comicarr/app/search/interactive.py
+++ b/comicarr/app/search/interactive.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import threading
+from contextlib import nullcontext
 
 from sqlalchemy import select
 
@@ -19,17 +20,24 @@ from comicarr import db, helpers, logger, search, search_filer
 from comicarr.app.common.redaction import redact_sensitive_text
 from comicarr.app.core.workers import start_background_thread
 from comicarr.app.search.interactive_sessions import (
+    InteractiveCandidateConflict,
+    claim_server_candidate,
     complete_search_session,
     create_pending_session,
+    evaluation_reconstruction,
+    finish_candidate_claim,
     read_session,
+    release_candidate_claim,
     update_search_progress,
 )
 from comicarr.app.search.providers import effective_provider_plan
 from comicarr.app.search.service import _search_route_health
+from comicarr.app.series import queries as series_queries
 from comicarr.tables import storyarcs
 
 _ENTITY_TYPES = frozenset({"issue", "annual", "story_arc_issue"})
 _WORKER_LOCK = threading.Lock()
+_GRAB_LOCK = threading.Lock()
 
 
 def _resolve_entity(entity_type, entity_id):
@@ -49,7 +57,14 @@ def _resolve_entity(entity_type, entity_id):
         series_id = row.get("ComicID")
     else:
         series_id = row.get("ComicID") or row.get("StoryArcID")
-    return {"entity_type": entity_type, "entity_id": entity_id, "series_id": series_id}, None
+    return {
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "series_id": series_id,
+        "release_date": row.get("ReleaseDate"),
+        "issue_date": row.get("IssueDate"),
+        "digital_date": row.get("DigitalDate"),
+    }, None
 
 
 def _provider_plan(ctx):
@@ -88,16 +103,24 @@ def start_search(ctx, *, actor, browser_session, entity_type, entity_id):
         for provider in plan
         if provider.blocked
     ]
-    pending = create_pending_session(
-        db.get_engine(),
-        actor=actor,
-        browser_session=browser_session,
-        entity_type=entity["entity_type"],
-        entity_id=entity["entity_id"],
-        series_id=entity["series_id"],
-        provider_total=len(plan),
-        provider_failures=initial_failures,
-    )
+    try:
+        pending = create_pending_session(
+            db.get_engine(),
+            actor=actor,
+            browser_session=browser_session,
+            entity_type=entity["entity_type"],
+            entity_id=entity["entity_id"],
+            series_id=entity["series_id"],
+            provider_total=len(plan),
+            provider_failures=initial_failures,
+        )
+    except InteractiveCandidateConflict as e:
+        return {
+            "success": False,
+            "status_code": 409,
+            "status": "conflict",
+            "error": str(e),
+        }
     try:
         start_background_thread(
             _collect,
@@ -204,3 +227,243 @@ def get_search(*, session_id, actor, browser_session):
         actor=actor,
         browser_session=browser_session,
     )
+
+
+def _same_candidate_identity(stored, current):
+    keys = (
+        "provider_config_id",
+        "provider_type",
+        "provider_name",
+        "source_kind",
+        "provider_item_digest",
+        "pack",
+    )
+    if any(str(stored.get(key)) != str(current.get(key)) for key in keys):
+        return False
+    stored_id = stored.get("provider_item_id")
+    return stored_id in (None, "") or str(stored_id) == str(current.get("provider_item_id"))
+
+
+def _revalidate_candidate(entity, *, override_reason=None):
+    evaluations = []
+
+    def on_evaluations(values):
+        evaluations.extend(values)
+
+    override = search_filer.interactive_candidate_override(override_reason) if override_reason else nullcontext()
+    with (
+        _WORKER_LOCK,
+        override,
+        search_filer.interactive_collection(
+            on_evaluations=on_evaluations,
+            on_provider_complete=lambda _provider: None,
+            on_provider_failure=lambda _provider, _code, _detail: None,
+        ),
+    ):
+        result = search.searchforissue(
+            issueid=entity["entity_id"],
+            manual=True,
+            entity_type=entity["entity_type"] if entity["entity_type"] != "story_arc_issue" else None,
+        )
+    return evaluations, result
+
+
+def _verification_info(match, entity_type):
+    return {
+        "foundc": {"status": False},
+        "nzbprov": match["nzbprov"],
+        "RSS": "no",
+        "ComicName": match["ComicName"],
+        "ComicID": match["ComicID"],
+        "IssueID": match["IssueID"],
+        "IssueNumber": match["IssueNumber"],
+        "ComicYear": match["comyear"],
+        "SARC": match.get("SARC"),
+        "IssueArcID": match.get("IssueArcID"),
+        "oneoff": match.get("oneoff", False),
+        "smode": {
+            "issue": "want",
+            "annual": "want_ann",
+            "story_arc_issue": "story_arc",
+        }[entity_type],
+    }
+
+
+def _candidate_eligibility(entity):
+    candidate = series_queries.get_search_candidate_state(
+        entity["entity_id"],
+        entity_type=entity["entity_type"],
+    )
+    if candidate is None:
+        return {"status": False, "reason": "tracked item no longer exists"}
+    return search.searchforissue_checker(
+        entity["entity_id"],
+        entity.get("release_date"),
+        entity.get("issue_date"),
+        entity.get("digital_date"),
+        {
+            "candidate": candidate,
+            "entity_type": entity["entity_type"],
+        },
+    )
+
+
+def _release_with_error(engine, candidate, *, error, status_code=409, code="candidate_changed"):
+    release_candidate_claim(engine, candidate=candidate)
+    return {
+        "success": False,
+        "status_code": status_code,
+        "status": "blocked",
+        "code": code,
+        "error": error,
+    }
+
+
+def grab_candidate(
+    ctx,
+    *,
+    session_id,
+    candidate_id,
+    actor,
+    browser_session,
+    override=False,
+):
+    """Re-find, revalidate, and journal-handoff one owned release candidate."""
+
+    engine = db.get_engine()
+    with _GRAB_LOCK:
+        claim = claim_server_candidate(
+            engine,
+            session_id=session_id,
+            candidate_id=candidate_id,
+            actor=actor,
+            browser_session=browser_session,
+        )
+        if not claim["claimed"]:
+            outcome = dict(claim.get("outcome") or {"status": claim["state"]})
+            outcome.update({"success": claim["state"] == "submitted", "idempotent": True})
+            return outcome
+
+        candidate = claim["candidate"]
+        public = candidate["public"]
+        verdict = public.get("verdict") or {}
+        if not verdict.get("accepted"):
+            if not verdict.get("overrideable"):
+                return _release_with_error(
+                    engine,
+                    candidate,
+                    error="Release candidate cannot be overridden",
+                )
+            if not override:
+                return _release_with_error(
+                    engine,
+                    candidate,
+                    error="Release candidate requires an explicit override",
+                    code="override_required",
+                )
+            override_reason = verdict.get("reason_code")
+        else:
+            override_reason = None
+
+        entity, error = _resolve_entity(candidate["entity_type"], candidate["entity_id"])
+        if error:
+            return _release_with_error(engine, candidate, error=error["error"], status_code=error["status_code"])
+
+        eligibility = _candidate_eligibility(entity)
+        if not eligibility.get("status"):
+            return _release_with_error(
+                engine,
+                candidate,
+                error="Tracked item is no longer eligible for acquisition",
+                code="item_not_eligible",
+            )
+
+        route_health = _search_route_health(ctx)
+        if not route_health.get("success"):
+            return _release_with_error(
+                engine,
+                candidate,
+                error=route_health.get("error") or "No complete acquisition route is ready",
+                code="route_unavailable",
+            )
+        if not any(not provider.blocked for provider in _provider_plan(ctx)):
+            return _release_with_error(
+                engine,
+                candidate,
+                error="No enabled search provider is currently available",
+                code="provider_unavailable",
+            )
+
+        try:
+            evaluations, search_result = _revalidate_candidate(entity, override_reason=override_reason)
+        except Exception as e:
+            logger.error("[INTERACTIVE-GRAB] Candidate revalidation failed: %s" % redact_sensitive_text(e))
+            return _release_with_error(
+                engine,
+                candidate,
+                error="Release candidate could not be revalidated",
+                status_code=502,
+                code="revalidation_failed",
+            )
+        if isinstance(search_result, dict) and search_result.get("status") == "IN PROGRESS":
+            return _release_with_error(
+                engine,
+                candidate,
+                error="Another search is already running",
+                code="search_busy",
+            )
+
+        matches = [
+            evaluation
+            for evaluation in evaluations
+            if _same_candidate_identity(
+                candidate["reconstruction"],
+                evaluation_reconstruction(evaluation),
+            )
+        ]
+        if len(matches) != 1 or matches[0].legacy_match is None:
+            return _release_with_error(
+                engine,
+                candidate,
+                error="Release candidate is no longer uniquely available under the current provider configuration",
+                code="candidate_changed",
+            )
+
+        match = dict(matches[0].legacy_match)
+        match["downloadit"] = True
+        info = _verification_info(match, entity["entity_type"])
+        try:
+            result = search.verification([match], info)
+        except Exception as e:
+            logger.error("[INTERACTIVE-GRAB] Handoff outcome is ambiguous: %s" % redact_sensitive_text(e))
+            outcome = {
+                "status": "manual_review",
+                "candidate_id": candidate_id,
+                "code": "handoff_outcome_ambiguous",
+                "error": "Handoff outcome requires manual review",
+                "status_code": 500,
+            }
+            finish_candidate_claim(engine, candidate=candidate, state="manual_review", outcome=outcome)
+            return dict(outcome, success=False)
+
+        found = (result or {}).get("foundc") or {}
+        handoff = found.get("info") or {}
+        if not found.get("status"):
+            outcome = {
+                "status": "failed",
+                "candidate_id": candidate_id,
+                "code": "handoff_rejected",
+                "error": "Release handoff was not accepted",
+                "status_code": 502,
+            }
+            finish_candidate_claim(engine, candidate=candidate, state="failed", outcome=outcome)
+            return dict(outcome, success=False)
+
+        outcome = {
+            "status": "submitted",
+            "candidate_id": candidate_id,
+            "journal_release_key": handoff.get("journal_release_key"),
+            "journal_managed": bool(handoff.get("journal_managed")),
+        }
+        outcome = finish_candidate_claim(engine, candidate=candidate, state="submitted", outcome=outcome)
+        return dict(outcome, success=True, idempotent=False)

--- a/comicarr/app/search/interactive_sessions.py
+++ b/comicarr/app/search/interactive_sessions.py
@@ -26,7 +26,7 @@ import secrets
 import threading
 from collections.abc import Mapping, Sequence
 
-from sqlalchemy import delete, insert, select, update
+from sqlalchemy import delete, exists, insert, select, update
 
 from comicarr import logger
 from comicarr.app.common.redaction import redact_sensitive_text
@@ -38,6 +38,7 @@ MAX_CANDIDATES = 200
 MAX_SESSION_BYTES = 512 * 1024
 MAX_RECORD_BYTES = 64 * 1024
 CLEANUP_BATCH_SIZE = 500
+CLAIM_LEASE_SECONDS = 60 * 60
 JOB_ID = "interactive_search_retention"
 JOB_NAME = "Interactive Search Retention"
 
@@ -62,6 +63,10 @@ class InteractiveSearchExpired(InteractiveSearchAuthorizationError):
 
 class InteractiveSearchLimitError(InteractiveSearchSessionError):
     """A session exceeded its fixed candidate or serialized-size bound."""
+
+
+class InteractiveCandidateConflict(InteractiveSearchSessionError):
+    """A selected candidate cannot start another handoff."""
 
 
 def _now(value=None):
@@ -143,16 +148,16 @@ def _candidate_reconstruction(evaluation, public):
     provider_stat = legacy.get("provider_stat") if isinstance(legacy, dict) else None
     provider_stat = provider_stat if isinstance(provider_stat, dict) else {}
     entry = legacy.get("entry") if isinstance(legacy, dict) else None
-    raw_identity = None
-    if isinstance(legacy, dict):
-        raw_identity = legacy.get("nzbid")
+    # The pre-match provider identity is stable across accepted and overridden
+    # evaluations. A generated legacy nzbid may instead derive from a link and
+    # change merely because the same rejection was explicitly overridden.
+    raw_identity = hint.get("provider_item_id")
     if raw_identity in (None, ""):
         raw_identity = _entry_value(entry, "id")
     if raw_identity in (None, "") and isinstance(legacy, dict):
+        raw_identity = legacy.get("nzbid")
+    if raw_identity in (None, "") and isinstance(legacy, dict):
         raw_identity = legacy.get("link")
-    if raw_identity in (None, ""):
-        raw_identity = hint.get("provider_item_id")
-
     provider_type = str(provider_stat.get("type") or hint.get("provider_type") or "").lower()
     if not _SAFE_PROVIDER_TYPE.fullmatch(provider_type):
         provider_type = "unknown"
@@ -177,6 +182,13 @@ def _candidate_reconstruction(evaluation, public):
     # The digest is useful when an unsafe identity must be re-found under the
     # current provider config; it is not reversible and grants no access.
     return reconstruction
+
+
+def evaluation_reconstruction(evaluation):
+    """Return the same safe identity projection used by persisted candidates."""
+
+    public = _sanitize_public(evaluation.as_dict())
+    return _candidate_reconstruction(evaluation, public)
 
 
 def _evaluation_record(evaluation, ordinal, expires_at, created_at):
@@ -291,6 +303,18 @@ def create_session(
             if previous_id is None:
                 conn.execute(insert(interactive_search_sessions).values(**session_values))
             else:
+                active_claim = conn.execute(
+                    select(interactive_search_candidates.c.candidate_id)
+                    .where(interactive_search_candidates.c.session_id == previous_id)
+                    .where(interactive_search_candidates.c.state == "submitting")
+                    .where(
+                        interactive_search_candidates.c.updated_at
+                        > (created - datetime.timedelta(seconds=CLAIM_LEASE_SECONDS)).isoformat()
+                    )
+                    .limit(1)
+                ).scalar_one_or_none()
+                if active_claim is not None:
+                    raise InteractiveCandidateConflict("release candidate handoff is already in progress")
                 conn.execute(
                     delete(interactive_search_candidates).where(
                         interactive_search_candidates.c.session_id == previous_id
@@ -573,16 +597,154 @@ def read_server_candidate(
     }
 
 
+def claim_server_candidate(
+    engine,
+    *,
+    session_id,
+    candidate_id,
+    actor,
+    browser_session,
+    now=None,
+):
+    """Atomically claim one available candidate for server-side handoff.
+
+    Terminal outcomes are returned verbatim to make browser retries
+    idempotent. An in-progress claim is never stolen: the download journal is
+    the cross-process side-effect boundary, while this state prevents normal
+    concurrent requests from reaching it twice.
+    """
+
+    session = _authorized_row(
+        engine,
+        session_id=session_id,
+        actor=actor,
+        browser_session=browser_session,
+        now=now,
+    )
+    timestamp = _now(now).isoformat()
+    with engine.begin() as conn:
+        row = (
+            conn.execute(
+                select(interactive_search_candidates)
+                .where(interactive_search_candidates.c.session_id == session["session_id"])
+                .where(interactive_search_candidates.c.candidate_id == str(candidate_id))
+            )
+            .mappings()
+            .first()
+        )
+        if row is None:
+            raise InteractiveSearchAuthorizationError("release candidate is not available to this browser")
+        reconstruction = _decode_object(
+            row["reconstruction_json"],
+            label="release candidate reconstruction",
+        )
+        if row["state"] in {"submitted", "failed", "manual_review"}:
+            candidate = _server_candidate(row, reconstruction)
+            candidate["entity_type"] = session["entity_type"]
+            candidate["entity_id"] = session["entity_id"]
+            return {
+                "claimed": False,
+                "state": row["state"],
+                "outcome": reconstruction.get("selection_outcome"),
+                "candidate": candidate,
+            }
+        if row["state"] == "submitting":
+            raise InteractiveCandidateConflict("release candidate handoff is already in progress")
+        if row["state"] != "available":
+            raise InteractiveCandidateConflict("release candidate is not available for handoff")
+        result = conn.execute(
+            update(interactive_search_candidates)
+            .where(interactive_search_candidates.c.candidate_id == row["candidate_id"])
+            .where(interactive_search_candidates.c.session_id == session["session_id"])
+            .where(interactive_search_candidates.c.state == "available")
+            .where(interactive_search_candidates.c.expires_at > timestamp)
+            .values(state="submitting", updated_at=timestamp)
+        )
+        if not result.rowcount:
+            raise InteractiveCandidateConflict("release candidate handoff is already in progress")
+    candidate = _server_candidate(row, reconstruction)
+    candidate["state"] = "submitting"
+    candidate["entity_type"] = session["entity_type"]
+    candidate["entity_id"] = session["entity_id"]
+    return {"claimed": True, "state": "submitting", "outcome": None, "candidate": candidate}
+
+
+def _server_candidate(row, reconstruction):
+    return {
+        "candidate_id": row["candidate_id"],
+        "session_id": row["session_id"],
+        "state": row["state"],
+        "fingerprint": row["fingerprint"],
+        "public": _decode_object(row["public_json"], label="release candidate projection"),
+        "reconstruction": reconstruction,
+    }
+
+
+def finish_candidate_claim(engine, *, candidate, state, outcome, now=None):
+    """Persist one bounded terminal handoff outcome using the claim CAS."""
+
+    if state not in {"submitted", "failed", "manual_review"}:
+        raise ValueError("unsupported release candidate outcome")
+    reconstruction = dict(candidate["reconstruction"])
+    reconstruction["selection_outcome"] = _sanitize_public(outcome)
+    encoded = _bounded_json(reconstruction, label="release candidate handoff outcome")
+    with engine.begin() as conn:
+        result = conn.execute(
+            update(interactive_search_candidates)
+            .where(interactive_search_candidates.c.candidate_id == candidate["candidate_id"])
+            .where(interactive_search_candidates.c.session_id == candidate["session_id"])
+            .where(interactive_search_candidates.c.fingerprint == candidate["fingerprint"])
+            .where(interactive_search_candidates.c.state == "submitting")
+            .values(
+                state=state,
+                reconstruction_json=encoded,
+                updated_at=_now(now).isoformat(),
+            )
+        )
+    if not result.rowcount:
+        raise InteractiveCandidateConflict("release candidate claim changed before completion")
+    return reconstruction["selection_outcome"]
+
+
+def release_candidate_claim(engine, *, candidate, now=None):
+    """Release a claim after a deterministic pre-handoff validation failure."""
+
+    reconstruction = dict(candidate["reconstruction"])
+    reconstruction.pop("selection_outcome", None)
+    with engine.begin() as conn:
+        result = conn.execute(
+            update(interactive_search_candidates)
+            .where(interactive_search_candidates.c.candidate_id == candidate["candidate_id"])
+            .where(interactive_search_candidates.c.session_id == candidate["session_id"])
+            .where(interactive_search_candidates.c.fingerprint == candidate["fingerprint"])
+            .where(interactive_search_candidates.c.state == "submitting")
+            .values(
+                state="available",
+                reconstruction_json=_bounded_json(reconstruction, label="release candidate reconstruction"),
+                updated_at=_now(now).isoformat(),
+            )
+        )
+    return bool(result.rowcount)
+
+
 def purge_expired_sessions(engine, *, now=None, batch_size=CLEANUP_BATCH_SIZE):
     """Delete at most one bounded batch of expired sessions and candidates."""
 
     limit = max(1, min(int(batch_size), CLEANUP_BATCH_SIZE))
     cutoff = _now(now).isoformat()
+    claim_cutoff = (_now(now) - datetime.timedelta(seconds=CLAIM_LEASE_SECONDS)).isoformat()
+    active_claim = exists(
+        select(interactive_search_candidates.c.candidate_id)
+        .where(interactive_search_candidates.c.session_id == interactive_search_sessions.c.session_id)
+        .where(interactive_search_candidates.c.state == "submitting")
+        .where(interactive_search_candidates.c.updated_at > claim_cutoff)
+    )
     with engine.begin() as conn:
         session_ids = list(
             conn.execute(
                 select(interactive_search_sessions.c.session_id)
                 .where(interactive_search_sessions.c.expires_at <= cutoff)
+                .where(~active_claim)
                 .order_by(interactive_search_sessions.c.expires_at)
                 .limit(limit)
             ).scalars()

--- a/comicarr/app/search/router.py
+++ b/comicarr/app/search/router.py
@@ -21,6 +21,7 @@ from comicarr.app.core.security import COOKIE_NAME, require_session
 from comicarr.app.search import interactive as interactive_search
 from comicarr.app.search import service as search_service
 from comicarr.app.search.interactive_sessions import (
+    InteractiveCandidateConflict,
     InteractiveSearchAuthorizationError,
     InteractiveSearchExpired,
 )
@@ -214,6 +215,45 @@ def poll_interactive_search(
         return JSONResponse(status_code=410, content={"detail": str(e), "status": "expired"})
     except InteractiveSearchAuthorizationError:
         return JSONResponse(status_code=404, content={"detail": "Interactive search session not found"})
+
+
+@router.post(
+    "/interactive/{session_id}/candidates/{candidate_id}/grab",
+    dependencies=[Depends(require_session)],
+)
+async def grab_interactive_candidate(
+    session_id: str,
+    candidate_id: str,
+    request: Request,
+    username: str = Depends(require_session),
+    ctx: AppContext = Depends(get_context),
+):
+    """Safely hand off one owned, freshly revalidated release candidate."""
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+    try:
+        result = interactive_search.grab_candidate(
+            ctx,
+            session_id=session_id,
+            candidate_id=candidate_id,
+            actor=username,
+            browser_session=_session_identity(request, username),
+            override=body.get("override") is True,
+        )
+    except InteractiveSearchExpired as e:
+        return JSONResponse(status_code=410, content={"detail": str(e), "status": "expired"})
+    except InteractiveSearchAuthorizationError:
+        return JSONResponse(status_code=404, content={"detail": "Release candidate not found"})
+    except InteractiveCandidateConflict as e:
+        return JSONResponse(status_code=409, content={"detail": str(e), "status": "conflict"})
+    if result.get("success") is False:
+        return JSONResponse(status_code=int(result.pop("status_code", 409)), content=result)
+    return result
 
 
 @router.get("/runs/{run_id}", dependencies=[Depends(require_session)])

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -87,6 +87,35 @@ class ReleaseCandidateEvaluation:
 
 
 _INTERACTIVE_COLLECTOR = contextvars.ContextVar("interactive_release_collector", default=None)
+_INTERACTIVE_OVERRIDE = contextvars.ContextVar("interactive_release_override", default=None)
+
+
+@contextmanager
+def interactive_candidate_override(reason_code):
+    """Override exactly one matcher rejection during server-side revalidation.
+
+    Only reasons already classified as overrideable may enter this context.
+    Every other matcher guard continues to fail closed, so selecting a rejected
+    candidate never bypasses unrelated safety checks.
+    """
+
+    definition = _REASON_DEFINITIONS.get(str(reason_code))
+    if definition is None or not definition[1]:
+        raise ValueError("release candidate rejection is not overrideable")
+    token = _INTERACTIVE_OVERRIDE.set(str(reason_code))
+    try:
+        yield
+    finally:
+        _INTERACTIVE_OVERRIDE.reset(token)
+
+
+def _reject(reason_code, *, cause=None):
+    if _INTERACTIVE_OVERRIDE.get() == reason_code:
+        return
+    rejection = _EntryRejected(reason_code)
+    if cause is not None:
+        raise rejection from cause
+    raise rejection
 
 
 @contextmanager
@@ -359,7 +388,7 @@ class search_check(object):
                 "[IGNORE_SEARCH_WORDS] %s exists within the search result (%s). Ignoring this result."
                 % (ignored, ComicTitle)
             )
-            raise _EntryRejected("ignored.search_word")
+            _reject("ignored.search_word")
 
         comsize_m = 0
         if nzbprov != "dognzb":
@@ -408,19 +437,19 @@ class search_check(object):
                         logger.fdebug("comparing Min threshold %s .. to .. nzb %s" % (conv_minsize, comsize_b))
                         if int(conv_minsize) > int(comsize_b):
                             logger.fdebug("Failure to meet the Minimum size threshold - skipping")
-                            raise _EntryRejected("rejected.size_below_min")
+                            _reject("rejected.size_below_min")
                     if comicarr.CONFIG.USE_MAXSIZE:
                         conv_maxsize = helpers.human2bytes(comicarr.CONFIG.MAXSIZE + "M")
                         logger.fdebug("comparing Max threshold %s .. to .. nzb %s" % (conv_maxsize, comsize_b))
                         if int(comsize_b) > int(conv_maxsize):
                             logger.fdebug("Failure to meet the Maximium size threshold - skipping")
-                            raise _EntryRejected("rejected.size_above_max")
+                            _reject("rejected.size_above_max")
 
         if comicarr.CONFIG.IGNORE_COVERS is True:
             cvrchk = re.sub(r"[\s\s+\_\.]", "", entry["title"]).lower()
             if any(["coversonly" in cvrchk, "coveronly" in cvrchk]):
                 logger.fdebug("Cover(s) only detected. Ignoring result.")
-                raise _EntryRejected("rejected.cover_only")
+                _reject("rejected.cover_only")
 
         # ---- date constaints.
         # if the posting date is prior to the publication date,
@@ -436,7 +465,7 @@ class search_check(object):
                     pubdate = entry["pubdate"]
                 except Exception as e:
                     logger.fdebug("Invalid date found. Unable to continue - skipping result. Error returned: %s" % e)
-                    raise _EntryRejected("invalid.pubdate_missing") from e
+                    _reject("invalid.pubdate_missing", cause=e)
 
         if UseFuzzy == "1":
             logger.fdebug("Year has been fuzzied for this series, ignoring store date comparison entirely.")
@@ -452,7 +481,7 @@ class search_check(object):
                         " probably should refresh the series or wait for CV"
                         " to correct the data"
                     )
-                    raise _EntryRejected("invalid.reference_date_missing")
+                    _reject("invalid.reference_date_missing")
                 else:
                     stdate = IssueDate
                 logger.fdebug("issue date used is : %s" % stdate)
@@ -485,7 +514,7 @@ class search_check(object):
                         "Unable to parse posting date from provider result set"
                         " for : %s. Error returned: %s" % (entry["title"], e)
                     )
-                    raise _EntryRejected("invalid.pubdate_unparseable") from e
+                    _reject("invalid.pubdate_unparseable", cause=e)
 
             if all([digitaldate != "0000-00-00", digitaldate is not None]):
                 i = 0
@@ -554,7 +583,7 @@ class search_check(object):
                         "%s is before store date of %s. Ignoring search result"
                         " as this is not the right issue." % (pubdate, stdate)
                     )
-                    raise _EntryRejected("rejected.before_reference_date")
+                    _reject("rejected.before_reference_date")
                 else:
                     logger.fdebug("[CONV] %s is after store date of %s" % (pubdate, stdate))
             except _EntryRejected:
@@ -570,7 +599,7 @@ class search_check(object):
                         "%s is before store date of %s. Ignoring search result"
                         " as this is not the right issue." % (pubdate, stdate)
                     )
-                    raise _EntryRejected("rejected.before_reference_date") from None
+                    _reject("rejected.before_reference_date")
                 else:
                     logger.fdebug("[INT] %s is after store date of %s" % (pubdate, stdate))
         # -- end size constaints.
@@ -640,12 +669,12 @@ class search_check(object):
                 filecomic = fcomic.matchIT(parsed_comic)
             except Exception as e:
                 logger.error("[PARSE-ERROR]: %s" % e)
-                raise _EntryRejected("error.matcher_exception") from e
+                _reject("error.matcher_exception", cause=e)
             else:
                 logger.fdebug("match_check: %s" % filecomic)
                 if filecomic["process_status"] == "fail":
                     logger.fdebug("%s was not a match to %s (%s)" % (cleantitle, ComicName, SeriesYear))
-                    raise _EntryRejected("rejected.series_mismatch")
+                    _reject("rejected.series_mismatch")
                 elif filecomic["process_status"] == "alt_match":
                     # if it's an alternate series match, we'll retain each value
                     # until the search has compeletely run, compiling matches.
@@ -664,10 +693,10 @@ class search_check(object):
                 "Booktypes do not match. Looking for %s, this is a %s."
                 " Ignoring this result." % (booktype, parsed_comic["booktype"])
             )
-            raise _EntryRejected("rejected.book_type")
+            _reject("rejected.book_type")
         else:
             logger.fdebug("Unable to parse name properly: %s. Ignoring this result" % parsed_comic)
-            raise _EntryRejected("rejected.unparseable_title")
+            _reject("rejected.unparseable_title")
 
         # adjust for covers only by removing them entirely...
         vers4year = "no"
@@ -786,7 +815,7 @@ class search_check(object):
             yearmatch = True
 
         if yearmatch is False and pack is False:
-            raise _EntryRejected("rejected.year_mismatch")
+            _reject("rejected.year_mismatch")
 
         annualize = False
         if "annual" in ComicName.lower():
@@ -897,7 +926,7 @@ class search_check(object):
                     )
                 else:
                     logger.fdebug("Versions wrong. Ignoring possible match.")
-                    raise _EntryRejected("rejected.volume_mismatch")
+                    _reject("rejected.volume_mismatch")
 
         downloadit = False
 
@@ -915,12 +944,12 @@ class search_check(object):
                         logger.info("Issue Number %s exists within pack. Continuing." % IssueNumber)
                     else:
                         logger.fdebug("Issue Number %s does NOT exist within this pack. Skipping" % IssueNumber)
-                        raise _EntryRejected("rejected.pack_issue_absent")
+                        _reject("rejected.pack_issue_absent")
             except _EntryRejected:
                 raise
             except Exception as e:
                 logger.error("Unable to identify pack range for %s. Error returned: %s" % (entry["title"], e))
-                raise _EntryRejected("error.pack_lookup_exception") from e
+                _reject("error.pack_lookup_exception", cause=e)
             # pack support.
             nowrite = False
             if "DDL" in nzbprov:
@@ -1000,7 +1029,7 @@ class search_check(object):
                     },
                     "pack",
                 )
-            raise _EntryRejected("blocked.duplicate")
+            _reject("blocked.duplicate")
         else:
             if filecomic["process_status"] == "match":
                 if cmloopit != 4:
@@ -1205,14 +1234,14 @@ class search_check(object):
                             },
                             "standard",
                         )
-                    raise _EntryRejected("blocked.duplicate")
+                    _reject("blocked.duplicate")
                 else:
                     # log2file = log2file + "issues don't match.." + "\n"
                     downloadit = False
                     # foundc['status'] = False
         if alt_match:
-            raise _EntryRejected("rejected.alternate_series")
-        raise _EntryRejected("rejected.issue_mismatch")
+            _reject("rejected.alternate_series")
+        _reject("rejected.issue_mismatch")
 
     def checker(self, entries, is_info=None):
         comicarr.COMICINFO = []

--- a/tests/unit/test_interactive_search_api.py
+++ b/tests/unit/test_interactive_search_api.py
@@ -20,7 +20,7 @@ import comicarr
 from comicarr.app.core.context import AppContext, get_context
 from comicarr.app.core.security import COOKIE_NAME, require_session
 from comicarr.app.search import interactive
-from comicarr.app.search.interactive_sessions import read_session
+from comicarr.app.search.interactive_sessions import create_session, read_session
 from comicarr.app.search.router import router
 from comicarr.search_filer import ReleaseCandidateEvaluation
 from comicarr.tables import interactive_search_sessions, metadata
@@ -84,6 +84,43 @@ def _evaluation(title="Candidate"):
     )
 
 
+def _handoff_evaluation(title="Candidate"):
+    evaluation = _evaluation(title)
+    evaluation.legacy_match = {
+        "ComicName": "Example",
+        "ComicID": "series-1",
+        "IssueID": "tracked-1",
+        "ComicVolume": None,
+        "IssueNumber": "1",
+        "IssueDate": "2026-08-11",
+        "comyear": "2026",
+        "pack": False,
+        "pack_numbers": None,
+        "pack_issuelist": None,
+        "modcomicname": "Example",
+        "oneoff": False,
+        "nzbprov": "DDL(GetComics)",
+        "provider": "DDL(GetComics)",
+        "nzbtitle": title,
+        "nzbid": "item-1",
+        "link": "https://provider.invalid/private",
+        "pubdate": None,
+        "size": None,
+        "tmpprov": "DDL(GetComics)",
+        "kind": "ddl",
+        "SARC": None,
+        "booktype": "Print",
+        "IssueArcID": None,
+        "newznab": None,
+        "torznab": None,
+        "downloadit": False,
+        "ComicTitle": title,
+        "entry": {"id": "item-1", "link": "https://provider.invalid/private"},
+        "provider_stat": {"id": 200, "type": "ddl", "active": True, "hits": 0},
+    }
+    return evaluation
+
+
 @pytest.fixture
 def api_client():
     app = FastAPI()
@@ -135,6 +172,29 @@ def test_poll_endpoint_never_exposes_private_reconstruction(api_client, monkeypa
 
     assert response.status_code == 200
     assert "reconstruction" not in response.text
+
+
+def test_grab_endpoint_binds_owner_and_explicit_override(api_client, monkeypatch):
+    captured = {}
+
+    def grab(_ctx, **kwargs):
+        captured.update(kwargs)
+        return {"success": True, "status": "submitted"}
+
+    monkeypatch.setattr(interactive, "grab_candidate", grab)
+    response = api_client.post(
+        "/api/search/interactive/session-1/candidates/candidate-1/grab",
+        json={"override": True},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "session_id": "session-1",
+        "candidate_id": "candidate-1",
+        "actor": "alice",
+        "browser_session": "browser-cookie",
+        "override": True,
+    }
 
 
 @pytest.mark.parametrize(
@@ -321,3 +381,164 @@ def test_worker_failure_is_terminal_and_credential_safe(engine, monkeypatch):
     assert row["state"] == "failed"
     assert "secret" not in row["provider_failures_json"]
     assert "https://" not in row["provider_failures_json"]
+
+
+def test_grab_refinds_exact_candidate_handoffs_once_and_replays(engine, monkeypatch):
+    created = create_session(
+        engine,
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="issue",
+        entity_id="tracked-1",
+        series_id="series-1",
+        evaluations=[_handoff_evaluation()],
+    )
+    candidate_id = created["candidates"][0]["candidate_id"]
+    monkeypatch.setattr(
+        interactive,
+        "_resolve_entity",
+        lambda entity_type, entity_id: (
+            {"entity_type": entity_type, "entity_id": entity_id, "series_id": "series-1"},
+            None,
+        ),
+    )
+    monkeypatch.setattr(interactive, "_candidate_eligibility", lambda _entity: {"status": True})
+    searches = []
+
+    def manual_search(**kwargs):
+        searches.append(kwargs)
+        interactive.search_filer._INTERACTIVE_COLLECTOR.get()["evaluations"]([_handoff_evaluation()])
+        return []
+
+    monkeypatch.setattr(interactive.search, "searchforissue", manual_search)
+    handoffs = []
+
+    def verify(matches, info):
+        handoffs.append((matches, info))
+        info["foundc"] = {
+            "status": True,
+            "info": {"journal_release_key": "release-1", "journal_managed": True},
+        }
+        return info
+
+    monkeypatch.setattr(interactive.search, "verification", verify)
+    kwargs = {
+        "session_id": created["session_id"],
+        "candidate_id": candidate_id,
+        "actor": "alice",
+        "browser_session": "browser-cookie",
+    }
+
+    first = interactive.grab_candidate(AppContext(config=_config()), **kwargs)
+    replay = interactive.grab_candidate(AppContext(config=_config()), **kwargs)
+
+    assert first == {
+        "status": "submitted",
+        "candidate_id": candidate_id,
+        "journal_release_key": "release-1",
+        "journal_managed": True,
+        "success": True,
+        "idempotent": False,
+    }
+    assert replay["success"] is True
+    assert replay["idempotent"] is True
+    assert len(searches) == 1
+    assert len(handoffs) == 1
+    assert handoffs[0][0][0]["downloadit"] is True
+
+
+def test_grab_fails_closed_when_candidate_identity_changes(engine, monkeypatch):
+    created = create_session(
+        engine,
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="issue",
+        entity_id="tracked-1",
+        evaluations=[_handoff_evaluation()],
+    )
+    monkeypatch.setattr(
+        interactive,
+        "_resolve_entity",
+        lambda entity_type, entity_id: (
+            {"entity_type": entity_type, "entity_id": entity_id, "series_id": "series-1"},
+            None,
+        ),
+    )
+    monkeypatch.setattr(interactive, "_candidate_eligibility", lambda _entity: {"status": True})
+
+    def changed_search(**_kwargs):
+        changed = _handoff_evaluation()
+        changed.legacy_match["nzbid"] = "different-item"
+        changed.reconstruction_hint["provider_item_id"] = "different-item"
+        interactive.search_filer._INTERACTIVE_COLLECTOR.get()["evaluations"]([changed])
+        return []
+
+    monkeypatch.setattr(interactive.search, "searchforissue", changed_search)
+    result = interactive.grab_candidate(
+        AppContext(config=_config()),
+        session_id=created["session_id"],
+        candidate_id=created["candidates"][0]["candidate_id"],
+        actor="alice",
+        browser_session="browser-cookie",
+    )
+
+    assert result["success"] is False
+    assert result["code"] == "candidate_changed"
+
+
+def test_grab_requires_and_revalidates_explicit_candidate_override(engine, monkeypatch):
+    rejected = _evaluation("Candidate REPACK")
+    rejected.verdict.update(
+        {
+            "status": "rejected",
+            "accepted": False,
+            "overrideable": True,
+            "reason_code": "ignored.search_word",
+            "match_kind": "none",
+        }
+    )
+    created = create_session(
+        engine,
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="issue",
+        entity_id="tracked-1",
+        evaluations=[rejected],
+    )
+    candidate_id = created["candidates"][0]["candidate_id"]
+    monkeypatch.setattr(
+        interactive,
+        "_resolve_entity",
+        lambda entity_type, entity_id: (
+            {"entity_type": entity_type, "entity_id": entity_id, "series_id": "series-1"},
+            None,
+        ),
+    )
+    monkeypatch.setattr(interactive, "_candidate_eligibility", lambda _entity: {"status": True})
+    kwargs = {
+        "session_id": created["session_id"],
+        "candidate_id": candidate_id,
+        "actor": "alice",
+        "browser_session": "browser-cookie",
+    }
+
+    required = interactive.grab_candidate(AppContext(config=_config()), **kwargs)
+    assert required["code"] == "override_required"
+
+    reasons = []
+
+    def revalidate(_entity, *, override_reason=None):
+        reasons.append(override_reason)
+        return [_handoff_evaluation("Candidate REPACK")], []
+
+    monkeypatch.setattr(interactive, "_revalidate_candidate", revalidate)
+
+    def verify(_matches, info):
+        info["foundc"] = {"status": True, "info": {"journal_release_key": "release-override"}}
+        return info
+
+    monkeypatch.setattr(interactive.search, "verification", verify)
+    result = interactive.grab_candidate(AppContext(config=_config()), override=True, **kwargs)
+
+    assert result["status"] == "submitted"
+    assert reasons == ["ignored.search_word"]

--- a/tests/unit/test_interactive_search_sessions.py
+++ b/tests/unit/test_interactive_search_sessions.py
@@ -17,13 +17,17 @@ import pytest
 from sqlalchemy import create_engine, func, select
 
 from comicarr.app.search.interactive_sessions import (
+    CLAIM_LEASE_SECONDS,
     JOB_ID,
     JOB_NAME,
     MAX_CANDIDATES,
+    InteractiveCandidateConflict,
     InteractiveSearchAuthorizationError,
     InteractiveSearchExpired,
     InteractiveSearchLimitError,
+    claim_server_candidate,
     create_session,
+    finish_candidate_claim,
     purge_expired_sessions,
     read_server_candidate,
     read_session,
@@ -293,6 +297,75 @@ def test_session_survives_service_restart_boundary(engine):
     )
 
     assert loaded == created
+
+
+def test_candidate_claim_is_atomic_and_terminal_outcome_replays(engine):
+    created = _create(engine)
+    candidate_id = created["candidates"][0]["candidate_id"]
+
+    claimed = claim_server_candidate(
+        engine,
+        session_id=created["session_id"],
+        candidate_id=candidate_id,
+        actor="alice",
+        browser_session="raw-session-cookie",
+        now=NOW,
+    )
+    assert claimed["claimed"] is True
+    assert claimed["candidate"]["entity_id"] == "issue-125"
+
+    outcome = finish_candidate_claim(
+        engine,
+        candidate=claimed["candidate"],
+        state="submitted",
+        outcome={"status": "submitted", "journal_release_key": "release-1"},
+        now=NOW,
+    )
+    replay = claim_server_candidate(
+        engine,
+        session_id=created["session_id"],
+        candidate_id=candidate_id,
+        actor="alice",
+        browser_session="raw-session-cookie",
+        now=NOW,
+    )
+
+    assert replay["claimed"] is False
+    assert replay["state"] == "submitted"
+    assert replay["outcome"] == outcome
+    assert (
+        read_session(
+            engine,
+            session_id=created["session_id"],
+            actor="alice",
+            browser_session="raw-session-cookie",
+            now=NOW,
+        )["candidates"][0]["state"]
+        == "submitted"
+    )
+
+
+def test_active_claim_blocks_replacement_and_expiry_cleanup_until_lease_ends(engine):
+    created = _create(engine, ttl_seconds=1)
+    claim_server_candidate(
+        engine,
+        session_id=created["session_id"],
+        candidate_id=created["candidates"][0]["candidate_id"],
+        actor="alice",
+        browser_session="raw-session-cookie",
+        now=NOW,
+    )
+
+    with pytest.raises(InteractiveCandidateConflict, match="already in progress"):
+        _create(engine, now=NOW + datetime.timedelta(seconds=2))
+    assert purge_expired_sessions(engine, now=NOW + datetime.timedelta(minutes=10)) == {
+        "sessions": 0,
+        "candidates": 0,
+    }
+    assert purge_expired_sessions(
+        engine,
+        now=NOW + datetime.timedelta(seconds=CLAIM_LEASE_SECONDS + 1),
+    ) == {"sessions": 1, "candidates": 1}
 
 
 def test_candidate_and_record_limits_fail_before_any_write(engine):

--- a/tests/unit/test_search_filer.py
+++ b/tests/unit/test_search_filer.py
@@ -180,6 +180,22 @@ def test_overrideable_rejection_retains_private_provider_identity_hint(monkeypat
     assert "reconstruction_hint" not in evaluation.as_dict()
 
 
+def test_candidate_override_revalidates_exactly_one_overrideable_reason(monkeypatch):
+    monkeypatch.setattr(comicarr, "CONFIG", _config(IGNORE_SEARCH_WORDS=["repack"]))
+    checker = search_filer.search_check()
+    entry = _entry(title="Example Series 001 REPACK")
+
+    with search_filer.interactive_candidate_override("ignored.search_word"):
+        evaluation = checker.evaluate_entry(entry, _info())
+
+    assert evaluation.verdict["accepted"] is True
+    assert evaluation.legacy_match["ComicTitle"] == "Example Series 001 REPACK"
+
+    with pytest.raises(ValueError, match="not overrideable"):
+        with search_filer.interactive_candidate_override("blocked.duplicate"):
+            pass
+
+
 def test_interactive_collection_disables_first_result_shortcut(monkeypatch):
     monkeypatch.setattr(comicarr, "CONFIG", _config(IGNORE_SEARCH_WORDS=["repack"]))
     collected = []


### PR DESCRIPTION
Closes #655\n\nAdds an authenticated candidate-selection endpoint that atomically claims an owned candidate, revalidates item eligibility and current provider/route configuration, re-finds the exact provider release, supports explicit single-reason overrides, and submits through the existing journal-aware handoff. Terminal outcomes replay idempotently, while active claims are protected from session replacement and retention cleanup by a bounded lease.\n\nValidation:\n- uv run npm run lint\n- uv run pytest tests/unit -qq (2398 passed)\n- uv run pytest tests/integration -q (14 passed; 8 dialect cases require DATABASE_URL; 1 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to claim and grab interactive search candidates for submission.
  * Added support for controlled overrides when eligible candidates are rejected for specific reasons.
  * Interactive results now retain release, issue, and digital dates.
* **Bug Fixes**
  * Prevented conflicting or outdated candidate submissions.
  * Improved handling of expired sessions and repeated grab attempts.
  * Added clearer outcomes for successful, failed, released, and manual-review submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->