### PR TITLE
Verify interactive release-search workflow

### DIFF
--- a/.changeset/quiet-pandas-review.md
+++ b/.changeset/quiet-pandas-review.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Add issue-scoped interactive release search with explainable candidates and deliberate, safely revalidated grabs.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Comicarr is a modernized fork of [Mylar3](https://github.com/mylar3/mylar3), reb
 
 - **Modern React 19 Frontend** — Fast, responsive UI with dark/light themes and system preference detection
 - **Automated Downloads** — Monitor series and automatically grab new issues
+- **Interactive Release Search** — Review every provider candidate and its match verdict before deliberately grabbing a release
 - **Library Management** — Scan existing collections, identify missing issues, interactive import matching
 - **Multiple Download Clients** — NZB (SABnzbd, NZBGet) and torrent (qBittorrent, Deluge, Transmission, rTorrent, uTorrent)
 - **Direct Downloads** — Mega, MediaFire, and Pixeldrain support
@@ -145,6 +146,21 @@ python3 Comicarr.py --nolaunch
 5. Open `http://localhost:8090`
 
 ## Configuration
+
+### Interactive release search
+
+Open **Releases**, stay on the **Mine** tab, and choose **Review releases** for
+a Wanted issue. Comicarr searches the configured providers and opens a review
+sheet with each release candidate's source, age, size, availability, and match
+reasons. Provider failures remain visible even when other providers return
+results.
+
+Selecting **Review grab** opens a final confirmation before Comicarr hands the
+release to the configured download route. Candidates rejected only by an
+operator-overridable match rule require an additional acknowledgement. Comicarr
+never lets this workflow bypass an expired session, missing provider result,
+duplicate or in-flight acquisition, unavailable download route, or ownership
+check.
 
 ### First-run setup
 

--- a/frontend/tests/e2e/acquisition.smoke.spec.ts
+++ b/frontend/tests/e2e/acquisition.smoke.spec.ts
@@ -112,3 +112,131 @@ test("acquisition mutations require the session-bound confirmation inputs", asyn
     }),
   );
 });
+
+test("wanted releases support an explainable interactive grab", async ({
+  page,
+}) => {
+  let grabBody: unknown;
+
+  await page.route("**/api/upcoming**", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      json: [
+        {
+          IssueID: "issue-e2e",
+          ComicID: "comic-e2e",
+          ComicName: "Absolute Batman",
+          IssueNumber: "19",
+          Issue_Number: "19",
+          IssueDate: "2026-08-12",
+          Status: "Wanted",
+        },
+      ],
+    });
+  });
+  await page.route("**/api/search/interactive**", async (route, request) => {
+    const path = new URL(request.url()).pathname;
+
+    if (request.method() === "POST" && path.endsWith("/interactive")) {
+      await route.fulfill({
+        contentType: "application/json",
+        status: 202,
+        json: {
+          session_id: "session-e2e",
+          state: "queued",
+          candidates: [],
+          progress: {
+            provider_total: 1,
+            provider_completed: 0,
+            current_provider: null,
+          },
+          provider_failures: [],
+        },
+      });
+      return;
+    }
+
+    if (request.method() === "GET" && path.endsWith("/session-e2e")) {
+      await route.fulfill({
+        contentType: "application/json",
+        json: {
+          session_id: "session-e2e",
+          entity_type: "issue",
+          entity_id: "issue-e2e",
+          series_id: "comic-e2e",
+          state: "complete",
+          candidate_count: 1,
+          progress: {
+            provider_total: 1,
+            provider_completed: 1,
+            current_provider: null,
+          },
+          provider_failures: [],
+          created_at: "2026-08-12T04:00:00Z",
+          expires_at: "2026-08-12T04:10:00Z",
+          candidates: [
+            {
+              candidate_id: "candidate-e2e",
+              state: "available",
+              candidate: {
+                title: "Absolute Batman 019 (2026) (Digital)",
+                provider: "Indexer",
+                source_kind: "usenet",
+                published_at: "2026-08-12T04:00:00Z",
+                size_bytes: 98000000,
+                pack: false,
+                metrics: { grabs: 8 },
+              },
+              verdict: {
+                status: "accepted",
+                accepted: true,
+                overrideable: false,
+                reason_code: "accepted.issue",
+                reasons: [
+                  {
+                    code: "accepted.issue",
+                    message: "Issue, year, and volume match",
+                  },
+                ],
+                match_kind: "standard",
+              },
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    if (request.method() === "POST" && path.endsWith("/grab")) {
+      grabBody = request.postDataJSON();
+      await route.fulfill({
+        contentType: "application/json",
+        json: {
+          success: true,
+          status: "submitted",
+          candidate_id: "candidate-e2e",
+        },
+      });
+      return;
+    }
+
+    await route.fallback();
+  });
+
+  await page.goto("/releases");
+  await page.getByRole("button", { name: "Review releases" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Review releases" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Absolute Batman 019 (2026) (Digital)"),
+  ).toBeVisible();
+  await expect(page.getByText("Issue, year, and volume match")).toBeVisible();
+
+  await page.getByRole("button", { name: "Review grab" }).click();
+  await page.getByRole("button", { name: "Confirm grab" }).click();
+
+  await expect.poll(() => grabBody).toEqual({ override: false });
+  await expect(page.getByText("Grab started")).toBeVisible();
+});


### PR DESCRIPTION
Closes #657
Closes #638

## Summary
- document the operator-facing interactive release-search workflow and safety boundaries
- add the required release changeset
- add a Chromium smoke flow covering wanted row → explained candidate → confirmed safe grab

## Verification
- `uv run npm run lint`
- `uv run pytest tests/unit -q` (2,398 passed)
- `cd frontend && npm run test:run` (435 passed)
- `cd frontend && COMICARR_E2E_PYTHON=.venv/bin/python npx playwright test tests/e2e/acquisition.smoke.spec.ts --project=chromium-smoke` (4 passed)
- `cd frontend && npm run build`