### PR TITLE
Ship the series content-kind editor

### DIFF
--- a/frontend/src/components/series/SeriesContentKind.tsx
+++ b/frontend/src/components/series/SeriesContentKind.tsx
@@ -1,0 +1,95 @@
+import { LoaderCircle } from "lucide-react";
+import type { ContentType } from "@/types";
+
+const KIND_COPY: Record<ContentType, { label: string; description: string }> = {
+  comic: {
+    label: "Comic",
+    description: "Use comic issue labels and matching rules.",
+  },
+  manga: {
+    label: "Manga",
+    description: "Use manga chapter labels and matching rules.",
+  },
+};
+
+interface SeriesContentKindProps {
+  value: ContentType;
+  provider: string;
+  pending: boolean;
+  onChange: (value: ContentType) => void;
+}
+
+export function SeriesContentKind({
+  value,
+  provider,
+  pending,
+  onChange,
+}: SeriesContentKindProps) {
+  return (
+    <section
+      className="mb-3.5 max-w-[640px] rounded-[6px] border p-3"
+      style={{
+        borderColor: "var(--border)",
+        background: "color-mix(in oklab, var(--primary) 4%, var(--background))",
+      }}
+      aria-labelledby="content-kind-title"
+    >
+      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px] sm:items-center">
+        <div>
+          <div id="content-kind-title" className="text-[12px] font-semibold">
+            Catalog this as
+          </div>
+          <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+            {KIND_COPY[value].description} Metadata still comes from {provider}.
+          </p>
+          <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
+            Future labels and matching follow this choice. Existing files and
+            issue history stay unchanged.
+          </p>
+        </div>
+        <div
+          role="radiogroup"
+          aria-label="Content kind"
+          aria-busy={pending}
+          className="relative grid grid-cols-2 rounded-[5px] border border-border bg-background p-0.5"
+        >
+          {(Object.keys(KIND_COPY) as ContentType[]).map((kind) => {
+            const active = value === kind;
+            return (
+              <button
+                key={kind}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                disabled={pending}
+                onClick={() => onChange(kind)}
+                onKeyDown={(event) => {
+                  if (event.key !== "ArrowLeft" && event.key !== "ArrowRight")
+                    return;
+                  event.preventDefault();
+                  onChange(kind === "comic" ? "manga" : "comic");
+                }}
+                className={`rounded-[3px] px-3 py-2 font-mono text-[12px] transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-wait disabled:opacity-70 ${
+                  active
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground"
+                }`}
+              >
+                {KIND_COPY[kind].label}
+              </button>
+            );
+          })}
+          {pending ? (
+            <span className="pointer-events-none absolute inset-0 grid place-items-center rounded-[3px] bg-background/70">
+              <LoaderCircle
+                className="size-4 animate-spin motion-reduce:animate-none"
+                aria-hidden="true"
+              />
+              <span className="sr-only">Saving content kind</span>
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/hooks/useSeries.ts
+++ b/frontend/src/hooks/useSeries.ts
@@ -9,6 +9,7 @@ import {
 import { apiRequest } from "@/lib/api";
 import type {
   Comic,
+  ContentType,
   SearchMissingConfirmationInput,
   SearchMissingPreview,
   SearchMissingResult,
@@ -179,6 +180,32 @@ export interface SeriesSearchSettingsInput {
   comicId: string;
   allowPacks?: boolean;
   ignoreType?: boolean;
+}
+
+export interface SeriesContentKindInput {
+  comicId: string;
+  contentType: ContentType;
+}
+
+export function useUpdateSeriesContentKind(): UseMutationResult<
+  { success: boolean; content_type: ContentType },
+  Error,
+  SeriesContentKindInput
+> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ comicId, contentType }) =>
+      apiRequest<{ success: boolean; content_type: ContentType }>(
+        "PATCH",
+        `/api/series/${comicId}/content-kind`,
+        { content_type: contentType },
+      ),
+    onSuccess: (_, { comicId }) => {
+      queryClient.invalidateQueries({ queryKey: ["series"] });
+      queryClient.invalidateQueries({ queryKey: ["series", comicId] });
+    },
+  });
 }
 
 /**

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   Trash2,
 } from "lucide-react";
 import StatusBadge from "@/components/StatusBadge";
+import { SeriesContentKind } from "@/components/series/SeriesContentKind";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -33,12 +34,14 @@ import {
   useSearchRun,
   useSeriesDetail,
   useUpdateSeriesSearchSettings,
+  useUpdateSeriesContentKind,
 } from "@/hooks/useSeries";
 import type {
   ComicOrManga,
   Issue,
   SearchMissingPreview,
   SearchMissingResult,
+  ContentType,
 } from "@/types";
 import { displayComicDate, pickComicDate } from "@/lib/format";
 
@@ -166,6 +169,7 @@ export default function SeriesDetailPage() {
   const searchRun = useSearchRun(searchRunId);
   const retrySearchRun = useRetrySearchRun();
   const searchSettingsMutation = useUpdateSeriesSearchSettings();
+  const contentKindMutation = useUpdateSeriesContentKind();
 
   const fetchSearchPreview = async () => {
     setPreview(null);
@@ -330,6 +334,17 @@ export default function SeriesDetailPage() {
     comic.ContentType === "manga" ||
     comicId?.startsWith("md-") ||
     comicId?.startsWith("mal-");
+  const contentKind: ContentType = isManga ? "manga" : "comic";
+  const provider = comicId?.startsWith("md-")
+    ? "MangaDex"
+    : comicId?.startsWith("mal-")
+      ? "MyAnimeList"
+      : "ComicVine";
+  const providerCode = comicId?.startsWith("md-")
+    ? "md"
+    : comicId?.startsWith("mal-")
+      ? "mal"
+      : "cv";
   const slug = (comic.ComicName || "").toLowerCase().replace(/\s+/g, "-");
   const filteredIssues = allIssues.filter((issue) => {
     if (filter === "have") return isIssueOwned(issue);
@@ -374,6 +389,27 @@ export default function SeriesDetailPage() {
     }
   };
 
+  const handleContentKindChange = async (nextKind: ContentType) => {
+    if (!comicId || nextKind === contentKind) return;
+    try {
+      await contentKindMutation.mutateAsync({
+        comicId,
+        contentType: nextKind,
+      });
+      addToast({
+        type: "success",
+        title: "Content kind updated",
+        description: `This series now uses ${nextKind} labels and matching rules.`,
+      });
+    } catch {
+      addToast({
+        type: "error",
+        title: "Content kind not updated",
+        description: "Comicarr could not save this classification. Try again.",
+      });
+    }
+  };
+
   const handleDelete = async () => {
     if (!comicId) return;
     try {
@@ -410,7 +446,7 @@ export default function SeriesDetailPage() {
           {slug}
         </span>
         <span className="ml-auto hidden shrink-0 sm:inline">
-          cv:{comic.ComicID} ·{" "}
+          {providerCode}:{comic.ComicID} ·{" "}
           {comic.LatestDate ? `last sync ${comic.LatestDate}` : "unsynced"}
         </span>
       </div>
@@ -484,6 +520,13 @@ export default function SeriesDetailPage() {
               {comic.Description}
             </p>
           )}
+
+          <SeriesContentKind
+            value={contentKind}
+            provider={provider}
+            pending={contentKindMutation.isPending}
+            onChange={(nextKind) => void handleContentKindChange(nextKind)}
+          />
 
           <div className="flex flex-wrap items-center gap-2">
             <button

--- a/frontend/tests/pages/SeriesDetailPage.test.tsx
+++ b/frontend/tests/pages/SeriesDetailPage.test.tsx
@@ -216,6 +216,70 @@ describe("SeriesDetailPage", () => {
     expect(screen.queryByLabelText("Needs attention")).toBeNull();
   });
 
+  it("persists a provider-independent content kind and refreshes the series", async () => {
+    let contentType = "comic";
+    let payload: unknown;
+    let detailReads = 0;
+    server.use(
+      http.get("/api/series/1", () => {
+        detailReads += 1;
+        return HttpResponse.json({
+          comic: {
+            ComicID: "1",
+            ComicName: "Absolute Batman",
+            ComicYear: "2024",
+            ComicPublisher: "DC Comics",
+            Status: "Active",
+            ContentType: contentType,
+          },
+          issues: canonicalIssues,
+          annuals: [annual],
+        });
+      }),
+      http.patch("/api/series/1/content-kind", async ({ request }) => {
+        payload = await request.json();
+        contentType = "manga";
+        return HttpResponse.json({ success: true, content_type: "manga" });
+      }),
+    );
+    const user = userEvent.setup();
+    renderDetail();
+
+    expect(
+      await screen.findByText(/Metadata still comes from ComicVine/),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/Existing files and issue history stay unchanged/),
+    ).toBeTruthy();
+    screen.getByRole("radio", { name: "Comic" }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    await waitFor(() => expect(payload).toEqual({ content_type: "manga" }));
+    await waitFor(() => expect(detailReads).toBeGreaterThan(1));
+    expect(await screen.findByText("Content kind updated")).toBeTruthy();
+    expect(
+      screen.getByRole("radio", { name: "Manga" }).getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(screen.getByText(/Use manga chapter labels/)).toBeTruthy();
+  });
+
+  it("keeps the current kind and reports an API failure", async () => {
+    server.use(
+      http.patch("/api/series/1/content-kind", () =>
+        HttpResponse.json({ detail: "save failed" }, { status: 500 }),
+      ),
+    );
+    const user = userEvent.setup();
+    renderDetail();
+
+    await user.click(await screen.findByRole("radio", { name: "Manga" }));
+
+    expect(await screen.findByText("Content kind not updated")).toBeTruthy();
+    expect(
+      screen.getByRole("radio", { name: "Comic" }).getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
   it("uses the canonical summary and shows annuals, evidence, and intent separately", async () => {
     const user = userEvent.setup();
     renderDetail();


### PR DESCRIPTION
## Summary
- add the accepted Comic/Manga control to series details
- keep provider identity separate and explain prospective-only effects
- refresh series caches and report success or failure
- cover keyboard access, persistence, cache refresh, and error handling

## Validation
- `npm run test:run` (437 passed)
- `uv run npm run lint`
- `npm run typecheck`
- `npm run build`

Closes #645