### PR TITLE
Verify and document series content kind

### DIFF
--- a/.changeset/honest-ravens-search.md
+++ b/.changeset/honest-ravens-search.md
@@ -2,4 +2,4 @@
 "comicarr": patch
 ---
 
-Honor each series' stored comic or manga classification during search, refresh, and post-processing.
+Let operators classify any series as comic or manga from its detail page, independent of metadata provider. Honor that stored classification during search, refresh, and post-processing.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ python3 Comicarr.py --nolaunch
 
 ## Configuration
 
+### Series content kind
+
+Open a series and use **Catalog this as** to choose **Comic** or **Manga**.
+This classification is independent of the metadata provider, so a series added
+from ComicVine can still use manga chapter labels and matching rules. The
+choice applies to future search, refresh, and post-processing behavior; it does
+not change the provider or rewrite existing files and issue history.
+
 ### Interactive release search
 
 Open **Releases**, stay on the **Mine** tab, and choose **Review releases** for

--- a/frontend/tests/e2e/series-content-kind.smoke.spec.ts
+++ b/frontend/tests/e2e/series-content-kind.smoke.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "@playwright/test";
+
+test("operator can classify a ComicVine series as manga", async ({ page }) => {
+  let contentType = "comic";
+  let updateBody: unknown;
+
+  await page.route("**/api/series/160294", async (route, request) => {
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+
+    await route.fulfill({
+      contentType: "application/json",
+      json: {
+        comic: {
+          ComicID: "160294",
+          ComicName: "Solo Leveling",
+          ComicYear: "2024",
+          ComicPublisher: "Yen Press",
+          Status: "Active",
+          ContentType: contentType,
+        },
+        issues: [],
+        annuals: [],
+      },
+    });
+  });
+  await page.route(
+    "**/api/series/160294/content-kind",
+    async (route, request) => {
+      updateBody = request.postDataJSON();
+      contentType = "manga";
+      await route.fulfill({
+        contentType: "application/json",
+        json: { success: true, content_type: "manga" },
+      });
+    },
+  );
+
+  await page.goto("/series/160294");
+
+  await expect(
+    page.getByRole("heading", { name: "Solo Leveling" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/Metadata still comes from ComicVine/),
+  ).toBeVisible();
+  await expect(page.getByRole("radio", { name: "Comic" })).toHaveAttribute(
+    "aria-checked",
+    "true",
+  );
+
+  await page.getByRole("radio", { name: "Manga" }).click();
+
+  await expect.poll(() => updateBody).toEqual({ content_type: "manga" });
+  await expect(page.getByText("Content kind updated")).toBeVisible();
+  await expect(page.getByRole("radio", { name: "Manga" })).toHaveAttribute(
+    "aria-checked",
+    "true",
+  );
+  await expect(page.getByText(/Use manga chapter labels/)).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- document the provider-independent Comic/Manga series control
- expand the existing patch changeset to cover the operator-facing editor
- add a Chromium smoke test for reclassifying a ComicVine series as manga

## Validation
- `uv run pytest tests/unit -q` (2,398 passed)
- `npm run test:run` (437 passed)
- `uv run npm run lint`
- `npm run typecheck`
- `npm run build`
- `uv run npm --prefix frontend run test:e2e -- --project=chromium tests/e2e/series-content-kind.smoke.spec.ts` (2 passed including auth setup)

Closes #646
Closes #637