### PR TITLE
fix: Search the Newznab categories you configured

### DIFF
--- a/.changeset/newznab-categories-actually-searched.md
+++ b/.changeset/newznab-categories-actually-searched.md
@@ -1,0 +1,11 @@
+---
+"comicarr": patch
+---
+
+The Newznab categories you set are now the categories Comicarr searches. Whatever you typed into **Settings → Search → Categories** was being folded into a legacy field that also carries the indexer's RSS user ID, and the searcher could not tell the two apart — so it fell back to its built-in comics category on every Usenet query, and the Settings page displayed the value you entered as though it were in use. Restricting or widening your categories had no effect, and no error said so.
+
+The RSS user ID now has its own field beside Categories, so each means one thing. Existing indexers are re-read on upgrade: if the box shows fewer categories than you remember typing, that is the part that was actually reaching your indexer, and you can now correct it. Newly added indexers default to `7030` (Books/Comics) instead of `5030`, which is a TV category and was never right for this application.
+
+Two related fixes to how providers are stored. An indexer whose *verify TLS* or *enabled* field was written as `True`/`False` rather than `1`/`0` — the shape produced when a legacy `torznab_*` block is absorbed, and present in some configs inherited from Mylar3 — was reported as enabled on the Acquisition tab while the searcher skipped it entirely, or took the search down with an error when it tried to read the TLS setting. Both fields are now normalised wherever configuration is read or written, so every part of Comicarr agrees on what a provider is set to. And an absorbed `torznab_*` entry now verifies TLS certificates by default rather than silently arriving with verification off.
+
+Finally, the log messages about inert `torznab_*` fields no longer point you at a Settings UI that cannot edit Torznab providers. They now name `extra_torznabs` under `[Torznab]` in `config.ini` and show the entry format.

--- a/comicarr/app/config/registry.py
+++ b/comicarr/app/config/registry.py
@@ -407,7 +407,11 @@ _KEYS: tuple[ConfigKey, ...] = (
     ConfigKey("TORZNAB_HOST", str, "Torznab", None),
     ConfigKey("TORZNAB_APIKEY", str, "Torznab", None),
     ConfigKey("TORZNAB_CATEGORY", str, "Torznab", None),
-    ConfigKey("TORZNAB_VERIFY", bool, "Torznab", False),
+    # Verify TLS by default. This value is only ever read to seed the verify
+    # field of a legacy torznab_* entry being absorbed into extra_torznabs, and
+    # an absorbed entry inherits every other field from the operator -- so a
+    # False here silently downgraded a provider they never chose to downgrade.
+    ConfigKey("TORZNAB_VERIFY", bool, "Torznab", True),
     ConfigKey("EXPERIMENTAL", bool, "Experimental", False),
     ConfigKey("ALTEXPERIMENTAL", bool, "Experimental", False),
     ConfigKey("TAB_ENABLE", bool, "Tablet", False),

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -352,6 +352,37 @@ def _http_origin(value):
     return scheme, hostname, port
 
 
+DEFAULT_NEWZNAB_RSS_UID = "1"
+
+
+def split_newznab_category_field(value):
+    """Split a Newznab category field into its RSS uid and its category list.
+
+    Field 5 of a Newznab record is ``uid#categories``: the uid is the ``i=``
+    parameter of the indexer's RSS URL, and everything after the first ``#`` is
+    the category list. A value with no ``#`` is a uid on its own, which is why
+    a bare ``7030`` typed into the Settings Categories box was stored as a uid
+    and searched nothing -- the categories the operator asked for were dropped
+    on the floor with no error. Returned as ``(uid, categories)`` with the
+    category separator normalised to a comma for display.
+
+    Torznab records have no uid; field 5 there is the category list alone.
+    """
+    uid, separator, categories = str(value or "").partition("#")
+    if not separator:
+        return uid, ""
+    return uid, categories.replace("#", ",")
+
+
+def join_newznab_category_field(uid, categories):
+    """Rebuild the stored ``uid#categories`` field from its two halves."""
+    uid = str(uid or "").strip() or DEFAULT_NEWZNAB_RSS_UID
+    categories = str(categories or "").strip().replace(",", "#")
+    # A uid on its own, rather than a trailing '#', so the search path falls
+    # back to its built-in category instead of querying `cat=` empty.
+    return "%s#%s" % (uid, categories) if categories else uid
+
+
 def _safe_provider_projection(config, provider_type):
     """Build the credential-free provider projection returned by the API."""
     attr_name = "EXTRA_NEWZNABS" if provider_type == "newznab" else "EXTRA_TORZNABS"
@@ -368,6 +399,10 @@ def _safe_provider_projection(config, provider_type):
             "enabled": str(entry[5]).lower() in {"1", "true", "yes", "on"},
             "api_key_set": _secret_is_configured(entry[3]),
         }
+        if provider_type == "newznab":
+            rss_uid, categories = split_newznab_category_field(entry[4])
+            row["rss_uid"] = rss_uid
+            row["categories"] = categories
         if len(entry) >= 7:
             try:
                 row["id"] = int(entry[6])
@@ -590,12 +625,21 @@ def update_providers(ctx, provider_data):
                 credential = old[3]
             if old is not None and host == _safe_provider_host(old[1]):
                 host = old[1]
+            categories = str(row.get("categories") or "").replace(",", "#")
+            if provider_type == "newznab":
+                # Keep the uid the operator is already using when the client
+                # does not send one back, so editing categories cannot silently
+                # repoint the indexer's RSS feed at a different user.
+                rss_uid = row.get("rss_uid")
+                if rss_uid in (None, ""):
+                    rss_uid = split_newznab_category_field(old[4])[0] if old is not None and len(old) >= 5 else None
+                categories = join_newznab_category_field(rss_uid, row.get("categories"))
             normalized_row = [
                 row.get("name", ""),
                 host,
                 "1" if row.get("verify") else "0",
                 credential or "",
-                str(row.get("categories") or "").replace(",", "#"),
+                categories,
                 "1" if row.get("enabled") else "0",
             ]
             provider_id = (

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -370,14 +370,25 @@ def split_newznab_category_field(value):
     """
     uid, separator, categories = str(value or "").partition("#")
     if not separator:
-        return uid, ""
-    return uid, categories.replace("#", ",")
+        return uid.strip(), ""
+    return uid.strip(), ",".join(normalize_category_list(categories, "#"))
+
+
+def normalize_category_list(value, separator=","):
+    """Return the category ids in ``value`` with blanks and padding removed.
+
+    `7030, 7020` typed into Settings used to be stored with the space intact
+    and would have reached the indexer as `cat=7030, 7020`. It never showed
+    because the categories were not reaching the searcher at all; now that they
+    are, the field has to survive the way operators actually type a list.
+    """
+    return [part.strip() for part in str(value or "").split(separator) if part.strip()]
 
 
 def join_newznab_category_field(uid, categories):
     """Rebuild the stored ``uid#categories`` field from its two halves."""
     uid = str(uid or "").strip() or DEFAULT_NEWZNAB_RSS_UID
-    categories = str(categories or "").strip().replace(",", "#")
+    categories = "#".join(normalize_category_list(categories))
     # A uid on its own, rather than a trailing '#', so the search path falls
     # back to its built-in category instead of querying `cat=` empty.
     return "%s#%s" % (uid, categories) if categories else uid
@@ -395,7 +406,7 @@ def _safe_provider_projection(config, provider_type):
             "name": str(entry[0] or ""),
             "host": _safe_provider_host(entry[1]),
             "verify": str(entry[2]).lower() in {"1", "true", "yes", "on"},
-            "categories": str(entry[4] or "").replace("#", ","),
+            "categories": ",".join(normalize_category_list(entry[4], "#")),
             "enabled": str(entry[5]).lower() in {"1", "true", "yes", "on"},
             "api_key_set": _secret_is_configured(entry[3]),
         }
@@ -625,7 +636,7 @@ def update_providers(ctx, provider_data):
                 credential = old[3]
             if old is not None and host == _safe_provider_host(old[1]):
                 host = old[1]
-            categories = str(row.get("categories") or "").replace(",", "#")
+            categories = "#".join(normalize_category_list(row.get("categories")))
             if provider_type == "newznab":
                 # Keep the uid the operator is already using when the client
                 # does not send one back, so editing categories cannot silently

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -46,6 +46,12 @@ _PROVIDER_EXTRA_FIELDS = ("EXTRA_NEWZNABS", "EXTRA_TORZNABS")
 _PROVIDER_EXTRA_WIDTHS = (6, 7)
 _PROVIDER_CREDENTIAL_INDEX = 3
 _PROVIDER_BOOLEAN_VALUES = {"0", "1", "false", "true", "no", "yes", "off", "on"}
+_PROVIDER_BOOLEAN_TRUE = {"1", "true", "yes", "on"}
+# Verify-TLS and enabled. Both are read as `bool(int(field))` by the search
+# path and compared against the literal "1" by the enabled filters, so a field
+# spelled any other legal way is a crash or a silent skip -- see
+# _canonical_provider_boolean.
+_PROVIDER_BOOLEAN_INDEXES = (2, 5)
 
 
 def config_transaction_lock():
@@ -59,6 +65,22 @@ def config_transaction_lock():
     bug waiting to happen.
     """
     return _CONFIG_TRANSACTION_LOCK
+
+
+def _canonical_provider_boolean(value):
+    """Return a provider boolean field as the only spelling every reader agrees on.
+
+    `_PROVIDER_BOOLEAN_VALUES` accepts eight spellings, but the consumers do
+    not. `search.py` and `rsscheck.py` read verify as `bool(int(field))`, which
+    raises `ValueError` on `"True"`; the enabled filters in `search.py` compare
+    against the literal `"1"` while `health.py` and the providers API accept
+    `true`/`yes`/`on`. So an entry stored as `True` was reported enabled by the
+    Acquisition tab and skipped by the searcher -- and one stored with a
+    non-numeric verify took the search down. Both fields are normalised here,
+    at the single boundary every reader and writer passes through, so tolerance
+    at the edge cannot become disagreement in the middle.
+    """
+    return "1" if str(value).strip().lower() in _PROVIDER_BOOLEAN_TRUE else "0"
 
 
 def _provider_entry_is_structurally_valid(entry):
@@ -103,7 +125,10 @@ def parse_provider_extras(value, config_version=15):
     for entry in entries:
         if not isinstance(entry, (list, tuple)) or not _provider_entry_is_structurally_valid(entry):
             raise ValueError("Provider entries must contain six or seven fields")
-        parsed.append(tuple(entry))
+        values = list(entry)
+        for index in _PROVIDER_BOOLEAN_INDEXES:
+            values[index] = _canonical_provider_boolean(values[index])
+        parsed.append(tuple(values))
     return parsed
 
 
@@ -578,8 +603,9 @@ class Config(object):
         if missing:
             logger.warn(
                 "[CONFIG] Legacy torznab_* fields under [Torznab] are set but incomplete "
-                "(missing: %s) and are NOT used for searching. Configure the provider via "
-                "the Settings UI (extra_torznabs) instead. Ignoring the legacy entry."
+                "(missing: %s) and are NOT used for searching. Complete them, or add the "
+                "provider to extra_torznabs under [Torznab] in config.ini as "
+                "'Name, https://host/api, 1, apikey, 7030, 1'. Ignoring the legacy entry."
                 % ", ".join("torznab_%s" % m for m in missing)
             )
             return
@@ -604,7 +630,7 @@ class Config(object):
             logger.warn(
                 "[CONFIG] Legacy torznab_* fields under [Torznab] reuse the provider name "
                 "'%s' and are NOT used for searching. Rename or remove the legacy fields, or "
-                "configure the provider via the Settings UI (extra_torznabs) instead." % legacy["name"]
+                "edit the existing entry in extra_torznabs under [Torznab] in config.ini." % legacy["name"]
             )
             return
 
@@ -619,17 +645,20 @@ class Config(object):
             (
                 legacy["name"],
                 legacy["host"],
-                self.TORZNAB_VERIFY,
+                # Canonical "1"/"0", not the raw bool: serialised it would
+                # reach the next startup as "True", and the search path reads
+                # this field as bool(int(field)).
+                _canonical_provider_boolean(self.TORZNAB_VERIFY),
                 legacy["apikey"],
                 legacy["category"],
-                str(int(bool(self.ENABLE_TORZNAB))),
+                _canonical_provider_boolean(self.ENABLE_TORZNAB),
                 candidate_id,
             )
         )
         logger.info(
             "[CONFIG] Migrated legacy torznab_* fields under [Torznab] into extra_torznabs "
             "as provider '%s' (%s). The legacy single-provider fields are no longer read; "
-            "manage this provider via the Settings UI from now on." % (legacy["name"], legacy["host"])
+            "manage this provider through extra_torznabs from now on." % (legacy["name"], legacy["host"])
         )
         _scrub()
 
@@ -2456,13 +2485,17 @@ class Config(object):
                 ex = extra_torznabs
 
             for x in ex:
+                # Field 5 is passed through exactly as stored. It used to be
+                # rewritten here -- '#' to ',', then the leading ',' back to
+                # '#' -- which left the runtime value in a shape none of its
+                # readers expected: `search.py` tests for '#' to decide whether
+                # a category was configured at all, so a stored `1#7030`
+                # arrived as `1,7030`, failed that test, and every Newznab
+                # search silently fell back to the built-in 7030. Only a value
+                # that already began with '#' survived the round trip. One
+                # storage contract now, read the same way by search.py,
+                # rsscheck.py, and the providers API.
                 x_cat = x[4]
-                if x_cat:
-                    if "#" in x_cat:
-                        x_t = x[4].split("#")
-                        x_cat = ",".join(x_t)
-                        if x_cat[0] == ",":
-                            x_cat = re.sub(",", "#", x_cat, 1)
                 try:
                     if cnt == 0:
                         x_newzcat.append((x[0], x[1], x[2], x[3], x_cat, x[5], int(x[6])))

--- a/frontend/src/components/settings/SearchTab.tsx
+++ b/frontend/src/components/settings/SearchTab.tsx
@@ -104,7 +104,12 @@ function NewznabProviderForm({
         name: "",
         host: "",
         verify: true,
-        categories: "5030",
+        // 7030 is Books/Comics in the standard Newznab category numbering.
+        // The old 5030 default was a TV category — harmless while categories
+        // were being discarded before reaching the search, and wrong now that
+        // they are not.
+        categories: "7030",
+        rss_uid: "1",
         enabled: true,
         api_key_set: false,
         api_key: "",
@@ -265,13 +270,37 @@ function NewznabProviderForm({
                       id={`indexer-categories-${suffix}`}
                       className="mt-1.5"
                       value={provider.categories}
-                      placeholder="5030"
+                      placeholder="7030"
                       onChange={(event) =>
                         updateProvider(index, {
                           categories: event.target.value,
                         })
                       }
                     />
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      Newznab category IDs, comma-separated. 7030 is
+                      Books/Comics.
+                    </p>
+                  </div>
+                  <div>
+                    <Label htmlFor={`indexer-rss-uid-${suffix}`}>
+                      RSS user ID
+                    </Label>
+                    <Input
+                      id={`indexer-rss-uid-${suffix}`}
+                      className="mt-1.5"
+                      value={provider.rss_uid ?? ""}
+                      placeholder="1"
+                      onChange={(event) =>
+                        updateProvider(index, {
+                          rss_uid: event.target.value,
+                        })
+                      }
+                    />
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      The <code>i=</code> parameter of this indexer&rsquo;s RSS
+                      URL. Leave as 1 unless your indexer says otherwise.
+                    </p>
                   </div>
                 </div>
                 <div className="mt-3 grid gap-2 sm:grid-cols-2">

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -26,6 +26,12 @@ export interface NewznabProvider {
   enabled: boolean;
   api_key_set: boolean;
   api_key?: string;
+  /**
+   * The `i=` parameter of the indexer's RSS URL. Stored joined to the
+   * categories as `uid#categories`, split apart by the API so the categories
+   * field means categories. Newznab only — Torznab records have no uid.
+   */
+  rss_uid?: string;
 }
 
 export interface ProviderConfigResponse {

--- a/frontend/tests/pages/SettingsPage.test.ts
+++ b/frontend/tests/pages/SettingsPage.test.ts
@@ -225,6 +225,61 @@ describe("settings configuration", () => {
     );
   });
 
+  it("edits Newznab categories and the RSS user ID as separate fields", async () => {
+    let saved: unknown = null;
+    server.use(
+      http.get("/api/config/providers", () =>
+        HttpResponse.json({
+          newznab: {
+            enabled: true,
+            providers: [
+              {
+                id: 101,
+                name: "Indexer",
+                host: "https://indexer.test",
+                verify: true,
+                // Server-side split of the stored `42#7030` field. The uid
+                // used to be folded into the Categories box, where editing
+                // categories quietly rewrote it.
+                categories: "7030",
+                rss_uid: "42",
+                enabled: true,
+                api_key_set: true,
+              },
+            ],
+          },
+        }),
+      ),
+      http.put("/api/config/providers", async ({ request }) => {
+        saved = await request.json();
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    const user = userEvent.setup();
+
+    render(createElement(SettingsPage));
+    await screen.findByText("Settings");
+    await user.click(screen.getAllByRole("button", { name: "Search" })[0]);
+
+    const categories = await screen.findByLabelText("Categories");
+    expect((categories as HTMLInputElement).value).toBe("7030");
+    expect(
+      (screen.getByLabelText("RSS user ID") as HTMLInputElement).value,
+    ).toBe("42");
+
+    await user.clear(categories);
+    await user.type(categories, "7030,7020");
+    await user.click(screen.getByRole("button", { name: "Save indexers" }));
+
+    await waitFor(() => expect(saved).not.toBeNull());
+    expect(saved).toMatchObject({
+      type: "newznab",
+      providers: [
+        expect.objectContaining({ categories: "7030,7020", rss_uid: "42" }),
+      ],
+    });
+  });
+
   it("requires a replacement indexer key when its server changes", async () => {
     let saved: unknown = null;
     server.use(

--- a/tests/unit/test_config_version_migrations.py
+++ b/tests/unit/test_config_version_migrations.py
@@ -306,3 +306,75 @@ torznab_host = http://prowlarr.example:9696/1/api
     assert cfg.EXTRA_TORZNABS == []
     assert warn.called
     assert "NOT used for searching" in warn.call_args_list[0][0][0]
+
+
+def test_legacy_torznab_absorption_verifies_tls_and_stores_canonical_booleans(tmp_path, monkeypatch):
+    """An absorbed entry inherits the operator's fields, not a silent downgrade.
+
+    `TORZNAB_VERIFY` used to default to False, so a legacy entry that said
+    nothing about TLS was migrated with verification off. The raw bool was also
+    written straight through, reaching the next startup as the string "True" --
+    which `search.py` reads as `bool(int(field))` and dies on.
+    """
+    cfg, ini = _load_config(
+        tmp_path,
+        monkeypatch,
+        """[General]
+config_version = 18
+minimal_ini = False
+encrypt_passwords = False
+
+[Torznab]
+enable_torznab = True
+torznab_name = Nyaa
+torznab_host = http://prowlarr.example:9696/1/api
+torznab_apikey = abc123
+torznab_category = 8020
+""",
+    )
+
+    assert cfg.read(startup=False) is cfg
+
+    migrated = next(entry for entry in cfg.EXTRA_TORZNABS if entry[1] == "http://prowlarr.example:9696/1/api")
+    assert migrated[2] == "1"
+    assert migrated[5] == "1"
+
+    # The written config must reread into the same canonical form, because
+    # that is the shape the searcher sees on every run after the first.
+    reread = configparser.ConfigParser()
+    reread.read(ini)
+    entries = config_module.parse_provider_extras(reread.get("Torznab", "extra_torznabs"))
+    assert entries[0][2] == "1"
+    assert bool(int(entries[0][2])) is True
+
+
+def test_stored_newznab_categories_reach_runtime_unmangled(tmp_path, monkeypatch):
+    """get_extras no longer rewrites the category field on its way to runtime.
+
+    It used to turn `1#7030` into `1,7030`, which `search.py` reads as "no
+    category configured" -- so every Newznab search fell back to the built-in
+    7030 no matter what the operator asked for.
+    """
+    cfg, _ini = _load_config(
+        tmp_path,
+        monkeypatch,
+        """[General]
+config_version = 18
+minimal_ini = False
+encrypt_passwords = False
+
+[Newznab]
+newznab = True
+extra_newznabs = Indexer, https://indexer.example/api, 1, abc123, 1#7030#7020, 1, 3
+
+[Torznab]
+extra_torznabs =
+""",
+    )
+
+    assert cfg.read(startup=False) is cfg
+
+    assert cfg.EXTRA_NEWZNABS[0][4] == "1#7030#7020"
+    uid, _, categories = cfg.EXTRA_NEWZNABS[0][4].partition("#")
+    assert uid == "1"
+    assert categories.replace("#", ",") == "7030,7020"

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -926,6 +926,26 @@ class TestConfigService:
         assert persisted[4] == "1#7030#7020"
         assert system_service.split_newznab_category_field(persisted[4]) == ("1", "7030,7020")
 
+    def test_category_lists_tolerate_the_spacing_operators_type(self):
+        """`7030, 7020` must not reach the indexer as `cat=7030, 7020`."""
+        ctx = _make_test_ctx()
+        ctx.config.EXTRA_TORZNABS = []
+        providers = [
+            {
+                "name": "Prowlarr",
+                "host": "https://prowlarr.test/1/api",
+                "verify": True,
+                "api_key": "secret",
+                "categories": " 7030, 7020 ,",
+                "enabled": True,
+            }
+        ]
+
+        assert system_service.update_providers(ctx, {"type": "torznab", "providers": providers})["success"] is True
+
+        persisted = ctx.config.apply_transaction.call_args.args[0]["EXTRA_TORZNABS"][0]
+        assert persisted[4] == "7030#7020"
+
     def test_newznab_edit_preserves_an_existing_rss_uid(self):
         """Editing categories cannot repoint the RSS feed at another user."""
         ctx = _make_test_ctx()

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -810,7 +810,12 @@ class TestConfigService:
 
         provider = result["newznab"]["providers"][0]
         assert provider["host"] == "https://indexer.test:8443/api"
-        assert provider["categories"] == "5030,7000"
+        # `5030#7000` is the stored `uid#categories` form, so the categories
+        # are 7000 alone -- which is what the searcher queries. Reporting
+        # "5030,7000" here was the projection agreeing with the operator's
+        # intent instead of with the search.
+        assert provider["rss_uid"] == "5030"
+        assert provider["categories"] == "7000"
         assert provider["api_key_set"] is True
         assert "secret" not in str(result)
         assert "user:pass" not in str(result)
@@ -888,10 +893,97 @@ class TestConfigService:
                 "host": "https://new.test",
                 "verify": True,
                 "categories": "5030",
+                "rss_uid": "1",
                 "enabled": True,
                 "api_key_set": True,
             }
         ]
+
+    def test_newznab_categories_survive_a_settings_round_trip(self):
+        """What the operator types into Categories is what gets stored.
+
+        The Categories box used to write straight into the `uid#categories`
+        field, so `7030,7020` was stored as `7030#7020` -- read back as uid
+        7030 with 7020 as the only category, and displayed as though both were
+        in use. The uid now has its own field and the categories are the
+        categories.
+        """
+        ctx = _make_test_ctx()
+        providers = [
+            {
+                "name": "Indexer",
+                "host": "https://indexer.test",
+                "verify": True,
+                "api_key": "secret",
+                "categories": "7030,7020",
+                "enabled": True,
+            }
+        ]
+
+        assert system_service.update_providers(ctx, {"type": "newznab", "providers": providers})["success"] is True
+
+        persisted = ctx.config.apply_transaction.call_args.args[0]["EXTRA_NEWZNABS"][0]
+        assert persisted[4] == "1#7030#7020"
+        assert system_service.split_newznab_category_field(persisted[4]) == ("1", "7030,7020")
+
+    def test_newznab_edit_preserves_an_existing_rss_uid(self):
+        """Editing categories cannot repoint the RSS feed at another user."""
+        ctx = _make_test_ctx()
+        ctx.config.EXTRA_NEWZNABS = [("Indexer", "https://indexer.test", "1", "secret", "42#7030", "1", 101)]
+        providers = [
+            {
+                "id": 101,
+                "name": "Indexer",
+                "host": "https://indexer.test",
+                "verify": True,
+                "categories": "7030,7020",
+                "enabled": True,
+            }
+        ]
+
+        assert system_service.update_providers(ctx, {"type": "newznab", "providers": providers})["success"] is True
+
+        persisted = ctx.config.apply_transaction.call_args.args[0]["EXTRA_NEWZNABS"][0]
+        assert persisted[4] == "42#7030#7020"
+
+    def test_newznab_without_categories_stores_the_uid_alone(self):
+        """A trailing '#' would query `cat=` empty instead of the default."""
+        ctx = _make_test_ctx()
+        providers = [
+            {
+                "name": "Indexer",
+                "host": "https://indexer.test",
+                "verify": True,
+                "api_key": "secret",
+                "categories": "",
+                "enabled": True,
+            }
+        ]
+
+        assert system_service.update_providers(ctx, {"type": "newznab", "providers": providers})["success"] is True
+
+        persisted = ctx.config.apply_transaction.call_args.args[0]["EXTRA_NEWZNABS"][0]
+        assert persisted[4] == "1"
+
+    def test_torznab_categories_have_no_uid_prefix(self):
+        """Only Newznab carries the legacy uid; Torznab field 5 is categories."""
+        ctx = _make_test_ctx()
+        ctx.config.EXTRA_TORZNABS = []
+        providers = [
+            {
+                "name": "Prowlarr",
+                "host": "https://prowlarr.test/1/api",
+                "verify": True,
+                "api_key": "secret",
+                "categories": "7030,8020",
+                "enabled": True,
+            }
+        ]
+
+        assert system_service.update_providers(ctx, {"type": "torznab", "providers": providers})["success"] is True
+
+        persisted = ctx.config.apply_transaction.call_args.args[0]["EXTRA_TORZNABS"][0]
+        assert persisted[4] == "7030#8020"
 
     def test_update_providers_requires_new_key_when_origin_changes(self):
         ctx = _make_test_ctx()
@@ -1600,6 +1692,48 @@ class TestConfigTransactions:
         assert len(parsed) == entry_count
         assert all(len(entry) == entry_width for entry in parsed)
         assert [entry[3] for entry in parsed] == [f"secret-{index}" for index in range(entry_count)]
+
+    @pytest.mark.parametrize(
+        ("stored", "expected"),
+        (
+            ("1", "1"),
+            ("True", "1"),
+            ("true", "1"),
+            ("Yes", "1"),
+            ("on", "1"),
+            ("0", "0"),
+            ("False", "0"),
+            ("no", "0"),
+            ("off", "0"),
+        ),
+    )
+    def test_provider_booleans_are_canonicalized_on_parse(self, stored, expected):
+        """Verify and enabled reach every reader as "1"/"0", never "True".
+
+        `search.py` reads verify as `bool(int(field))` and filters enabled with
+        `field == "1"`, so a legal-but-uncanonical spelling was a crash on one
+        field and a silent skip on the other.
+        """
+        from comicarr import config as config_module
+
+        parsed = config_module.parse_provider_extras(
+            ", ".join(["Indexer", "https://indexer.test", stored, "secret", "5030", stored])
+        )
+
+        assert parsed[0][2] == expected
+        assert parsed[0][5] == expected
+        assert bool(int(parsed[0][2])) is (expected == "1")
+
+    def test_canonicalized_booleans_survive_serialization(self):
+        """A round trip cannot reintroduce a spelling the search path rejects."""
+        from comicarr import config as config_module
+
+        serialized = config_module.serialize_provider_extras(
+            [("Indexer", "https://indexer.test", True, "secret", "5030", "True", 201)]
+        )
+
+        assert ", 1, secret, 5030, 1, " in serialized
+        assert config_module.parse_provider_extras(serialized)[0][2] == "1"
 
     def test_config_read_encrypts_plaintext_provider_before_projection(self, tmp_path, monkeypatch):
         from comicarr import config as config_module


### PR DESCRIPTION
Three follow-ups surfaced while documenting Torznab configuration for #668 (docs PR: frankieramirez/comicarr-docs#9). All three were verified against the code before fixing.

## 1 — Newznab categories never reached the searcher

Field 5 of a Newznab record is `uid#categories`: the uid is the `i=` parameter of the indexer's RSS URL, the rest is the category list. The Settings **Categories** box wrote straight into that field, mapping commas to `#` — so `7030,7020` was stored as `7030#7020`, which reads as uid `7030` with `7020` as the only category.

It got worse on the way to runtime. `get_extras()` rewrote the field — `#` to `,`, then a leading `,` back to `#` — and `search.py` decides whether *any* category was configured by testing for `#`:

```python
if "#" in newznab_host[4].rstrip():
    catstart = newznab_host[4].find("#")
    category_newznab = re.sub("#", ",", newznab_host[4][catstart + 1:]).strip()
else:
    category_newznab = "7030"
```

A stored `1#7030` arrived as `1,7030`, failed that test, and fell through to the built-in `7030`. **Every Newznab search used 7030 regardless of configuration**, unless the stored value already began with `#` — the one shape that survived the round trip. `rsscheck.py` was getting `1,7030` as the RSS uid at the same time.

Fixed by removing the rewrite so the storage contract is read the same way by `search.py`, `rsscheck.py`, and the providers API, and by giving the uid its own field in Settings so the Categories box means categories:

| | Before | After |
| --- | --- | --- |
| Typed `7030,7020` | stored `7030#7020`, searched `7030` (default) | stored `1#7030#7020`, searches `7030,7020` |
| Displayed back as | `7030,7020` — a claim the search did not honour | `7030,7020`, with RSS user ID `1` beside it |
| New indexer default | `5030` — a **TV** category | `7030` — Books/Comics |

Existing indexers are re-read on upgrade. If the box now shows fewer categories than you remember typing, that is the part that was actually reaching your indexer; the rest was being discarded. Editing categories can no longer repoint the RSS feed at a different user — the existing uid is preserved when the client does not send one.

## 2 — Provider booleans were tolerated at the edge and disagreed on in the middle

`_PROVIDER_BOOLEAN_VALUES` accepts eight spellings for the *verify TLS* and *enabled* fields. The consumers do not:

| Reader | Verify | Enabled |
| --- | --- | --- |
| `search.py` | `bool(int(field))` — **`ValueError` on `"True"`** | `field == "1"` |
| `rsscheck.py` | `bool(int(field))` | `str(field) == "1"` |
| `health.py`, providers API | — | accepts `true` / `yes` / `on` |

So an entry stored as `True` was reported **enabled on the Acquisition tab and skipped by the searcher** — the health surface claiming a route was ready while nothing was querying it. A non-numeric verify took the search down outright.

Both fields are now canonicalised to `"1"`/`"0"` in `parse_provider_extras`, the single boundary every reader and writer passes through, so edge tolerance cannot become disagreement downstream.

**This shape was reachable.** The legacy-torznab absorption added in #635 passed `self.TORZNAB_VERIFY` through as a raw Python bool; it serialised to `"True"` and came back as `"True"` on the next startup. So an absorbed provider worked once and then broke every subsequent search. It now writes `"1"`/`"0"` at the append site too.

## 3 — `TORZNAB_VERIFY` defaulted to False

That value exists only to seed the verify field of an absorbed `torznab_*` entry. Every other field of such an entry comes from the operator — so a `False` here silently downgraded TLS verification on a provider nobody chose to downgrade. Now `True`.

## Also

The absorption's log messages told operators to "configure the provider via the Settings UI (`extra_torznabs`)". There is no Torznab editor — Settings → Search edits Newznab only, so anyone following that message found nothing. They now name `extra_torznabs` under `[Torznab]` in `config.ini` and show the entry format inline.

## Testing

New tests: Newznab category round-trip through the providers service, uid preservation on edit, uid-alone storage when categories are cleared, Torznab's lack of a uid prefix, boolean canonicalisation across all eight spellings and through serialisation, absorbed-entry verify defaults and reread, unmangled runtime categories, and the new Settings field end to end.

Two existing tests changed and both encoded the bug: one asserted the projection reported `5030,7000` for a stored `5030#7000` — the projection agreeing with the operator's intent rather than with the search — and the other predates `rss_uid`.

- `uv run pytest tests/unit` — 2414 passed
- `npm run test:run` (frontend) — 438 passed
- `npm run typecheck` — clean
- `npm run lint` — all lanes green (modern, guards, backend, generated, frontend + prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QjqbhfDFmmMeBvn5Pqbk4z



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a separate RSS user ID field for Newznab indexers.
  - New indexers now default to category `7030`, with updated guidance for category configuration.
- **Bug Fixes**
  - Editing Newznab categories now preserves the RSS user ID.
  - Stored category values retain their formatting and multiple categories.
  - Legacy Torznab settings now use consistent boolean values and enable TLS verification by default.
  - Updated guidance clarifies which Torznab configuration fields are inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->