### PR TITLE
fix: Show Settings select labels on first paint

### DIFF
--- a/.changeset/settings-select-shows-labels.md
+++ b/.changeset/settings-select-shows-labels.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Coded Settings dropdowns (for example NZB client) now show the option name on first load. They used to show the raw stored value until you opened the menu once.

--- a/frontend/src/components/settings/SettingField.tsx
+++ b/frontend/src/components/settings/SettingField.tsx
@@ -14,6 +14,16 @@ interface SelectOption {
   label: string;
 }
 
+/** Label for a coded select value. Used so the trigger does not wait for the popup to mount. */
+export function labelForSelectValue(
+  options: SelectOption[],
+  value?: string | number,
+): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const wanted = value.toString();
+  return options.find((option) => option.value.toString() === wanted)?.label;
+}
+
 interface SettingFieldProps {
   label: string;
   value?: string | number;
@@ -127,6 +137,7 @@ export function SettingField({
 
   // Select field
   if (type === "select") {
+    const selectedLabel = labelForSelectValue(options, value);
     return (
       <div className="py-2.5">
         <Label htmlFor={fieldId} className="text-[12.5px] font-medium">
@@ -139,7 +150,9 @@ export function SettingField({
             disabled={readOnly}
           >
             <SelectTrigger id={fieldId}>
-              <SelectValue placeholder={placeholder || "Select…"} />
+              <SelectValue placeholder={placeholder || "Select…"}>
+                {selectedLabel}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               {options.map((option) => (

--- a/frontend/tests/components/SettingField.test.tsx
+++ b/frontend/tests/components/SettingField.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "../test-utils";
+import {
+  SettingField,
+  labelForSelectValue,
+} from "@/components/settings/SettingField";
+
+const NZB_CLIENT_OPTIONS = [
+  { value: "3", label: "Disabled" },
+  { value: "0", label: "SABnzbd" },
+  { value: "1", label: "NZBGet" },
+  { value: "2", label: "Blackhole" },
+];
+
+describe("labelForSelectValue", () => {
+  it("maps a coded stored value to its option label", () => {
+    expect(labelForSelectValue(NZB_CLIENT_OPTIONS, "3")).toBe("Disabled");
+    expect(labelForSelectValue(NZB_CLIENT_OPTIONS, 0)).toBe("SABnzbd");
+    expect(labelForSelectValue(NZB_CLIENT_OPTIONS, "missing")).toBeUndefined();
+  });
+});
+
+describe("SettingField select", () => {
+  it("shows the option label on first paint before the popup is opened", () => {
+    render(
+      <SettingField
+        label="NZB client"
+        type="select"
+        value="3"
+        options={NZB_CLIENT_OPTIONS}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "NZB client" });
+    expect(trigger.textContent).toContain("Disabled");
+    expect(trigger.textContent).not.toMatch(/(^|[^A-Za-z])3([^0-9]|$)/);
+  });
+});


### PR DESCRIPTION
## Summary
Coded Settings dropdowns (NZB client and the rest) showed the raw stored value (`3`) until the menu was opened once. The trigger now uses the option label from the `options` array on first paint.

Fixes #680

## Test plan
- [x] `vitest run tests/components/SettingField.test.tsx`
- Open Settings → Download clients on a fresh load and confirm NZB client shows **Disabled** / **SABnzbd** / etc., not `3`/`0`.