### PR TITLE
fix: Let the Logs console use available width

### DIFF
--- a/.changeset/logs-console-uses-width.md
+++ b/.changeset/logs-console-uses-width.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+The Settings → Logs console now uses the available page width and wraps long lines, so debug output no longer requires sideways scrolling in a narrow centered column.

--- a/frontend/src/components/settings/LogsTab.tsx
+++ b/frontend/src/components/settings/LogsTab.tsx
@@ -256,7 +256,7 @@ export function LogsTab({ config, formData, onChange }: LogsTabProps) {
         </div>
       ) : (
         <pre
-          className="max-h-[min(62vh,640px)] overflow-auto rounded-[6px] border p-3 font-mono text-[11.5px] leading-[1.45] whitespace-pre"
+          className="max-h-[min(62vh,640px)] overflow-auto rounded-[6px] border p-3 font-mono text-[11.5px] leading-[1.45] whitespace-pre-wrap break-words"
           style={{
             borderColor: "var(--border)",
             background: "color-mix(in oklab, var(--card) 70%, black)",

--- a/frontend/src/lib/settingsPanel.ts
+++ b/frontend/src/lib/settingsPanel.ts
@@ -1,0 +1,27 @@
+/**
+ * Settings-page layout helpers. Pure composition; no React, no I/O.
+ *
+ * Lives outside SettingsPage.tsx so the page module exports only its
+ * component (react-refresh/only-export-components).
+ */
+
+export type SectionId =
+  | "general"
+  | "interface"
+  | "api"
+  | "search"
+  | "acquisition"
+  | "media"
+  | "notifications"
+  | "clients"
+  | "ai"
+  | "logs"
+  | "about";
+
+/** Logs use the full content pane; other tabs stay a readable centered column. */
+export function settingsPanelClassName(section: SectionId): string {
+  const padding = "px-4 py-5 md:px-6 md:py-6 mx-auto pb-24";
+  return section === "logs"
+    ? `${padding} w-full max-w-none`
+    : `${padding} max-w-4xl`;
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -19,25 +19,13 @@ import PageHeader from "@/components/layout/PageHeader";
 import { prepareConfigSaveData } from "@/lib/configSave";
 import { formatAppVersion } from "@/lib/version";
 import { httpOrigin } from "@/lib/httpOrigin";
+import { settingsPanelClassName, type SectionId } from "@/lib/settingsPanel";
 import type { Config } from "@/types";
 import type {
   ReadableConfig,
   SettingsFormData,
   WritableConfig,
 } from "@/types/config.generated";
-
-type SectionId =
-  | "general"
-  | "interface"
-  | "api"
-  | "search"
-  | "acquisition"
-  | "media"
-  | "notifications"
-  | "clients"
-  | "ai"
-  | "logs"
-  | "about";
 
 const SECTIONS: { id: SectionId; label: string }[] = [
   { id: "general", label: "General" },
@@ -56,14 +44,6 @@ const SECTIONS: { id: SectionId; label: string }[] = [
 ];
 
 const SECTION_IDS = new Set(SECTIONS.map((s) => s.id));
-
-/** Logs use the full content pane; other tabs stay a readable centered column. */
-export function settingsPanelClassName(section: SectionId): string {
-  const padding = "px-4 py-5 md:px-6 md:py-6 mx-auto pb-24";
-  return section === "logs"
-    ? `${padding} w-full max-w-none`
-    : `${padding} max-w-4xl`;
-}
 
 function parseSectionParam(raw: string | null): SectionId | null {
   if (!raw) return null;

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -57,6 +57,14 @@ const SECTIONS: { id: SectionId; label: string }[] = [
 
 const SECTION_IDS = new Set(SECTIONS.map((s) => s.id));
 
+/** Logs use the full content pane; other tabs stay a readable centered column. */
+export function settingsPanelClassName(section: SectionId): string {
+  const padding = "px-4 py-5 md:px-6 md:py-6 mx-auto pb-24";
+  return section === "logs"
+    ? `${padding} w-full max-w-none`
+    : `${padding} max-w-4xl`;
+}
+
 function parseSectionParam(raw: string | null): SectionId | null {
   if (!raw) return null;
   return SECTION_IDS.has(raw as SectionId) ? (raw as SectionId) : null;
@@ -385,7 +393,7 @@ export default function SettingsPage() {
 
         {/* Content panel */}
         <div className="overflow-auto min-w-0">
-          <div className="px-4 py-5 md:px-6 md:py-6 max-w-4xl mx-auto pb-24">
+          <div className={settingsPanelClassName(section)}>
             {section === "general" && <GeneralTab {...tabProps} />}
             {section === "interface" && <InterfaceTab {...tabProps} />}
             {section === "api" && <ApiTab {...apiTabProps} />}

--- a/frontend/tests/components/LogsTab.test.tsx
+++ b/frontend/tests/components/LogsTab.test.tsx
@@ -82,11 +82,21 @@ describe("LogsTab", () => {
   });
 
   it("wraps long log lines instead of forcing horizontal scroll", async () => {
-    stubLogs(LINES, UNPINNED);
+    const unbrokenToken = `/config/cache/${"a".repeat(200)}.cbz`;
+    stubLogs(
+      [
+        ...LINES,
+        `11-Aug-2026 14:31:40 - DEBUG   :: comicarr.postprocessor : Thread-7 : scanned ${unbrokenToken}`,
+      ],
+      UNPINNED,
+    );
     renderTab();
 
     const consoleBox = await screen.findByText(/pool open/);
-    expect(consoleBox.closest("pre")?.className).toContain("whitespace-pre-wrap");
+    const pre = consoleBox.closest("pre");
+    expect(pre?.textContent).toContain(unbrokenToken);
+    expect(pre?.className).toContain("whitespace-pre-wrap");
+    expect(pre?.className).toContain("break-words");
   });
 
   it("says nothing extra when the config file is the top of the chain", async () => {

--- a/frontend/tests/components/LogsTab.test.tsx
+++ b/frontend/tests/components/LogsTab.test.tsx
@@ -81,6 +81,14 @@ describe("LogsTab", () => {
     expect(screen.getByText(/refused/)).toBeTruthy();
   });
 
+  it("wraps long log lines instead of forcing horizontal scroll", async () => {
+    stubLogs(LINES, UNPINNED);
+    renderTab();
+
+    const consoleBox = await screen.findByText(/pool open/);
+    expect(consoleBox.closest("pre")?.className).toContain("whitespace-pre-wrap");
+  });
+
   it("says nothing extra when the config file is the top of the chain", async () => {
     stubLogs(LINES, UNPINNED);
     renderTab();

--- a/frontend/tests/pages/SettingsPage.test.ts
+++ b/frontend/tests/pages/SettingsPage.test.ts
@@ -6,13 +6,20 @@ import { server } from "../mocks/server";
 import { render, screen, waitFor } from "../test-utils";
 import { prepareConfigSaveData } from "@/lib/configSave";
 import { formatAppVersion } from "@/lib/version";
-import SettingsPage from "@/pages/SettingsPage";
+import SettingsPage, { settingsPanelClassName } from "@/pages/SettingsPage";
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe("settings configuration", () => {
+  it("widens the Logs panel and keeps other tabs in a readable column", () => {
+    expect(settingsPanelClassName("logs")).toContain("max-w-none");
+    expect(settingsPanelClassName("logs")).not.toContain("max-w-4xl");
+    expect(settingsPanelClassName("general")).toContain("max-w-4xl");
+    expect(settingsPanelClassName("clients")).toContain("max-w-4xl");
+  });
+
   it.each([
     ["disabled client with empty host", 3, ""],
     ["non-SAB client with legacy-invalid host", 1, "sab host without scheme"],

--- a/frontend/tests/pages/SettingsPage.test.ts
+++ b/frontend/tests/pages/SettingsPage.test.ts
@@ -6,7 +6,8 @@ import { server } from "../mocks/server";
 import { render, screen, waitFor } from "../test-utils";
 import { prepareConfigSaveData } from "@/lib/configSave";
 import { formatAppVersion } from "@/lib/version";
-import SettingsPage, { settingsPanelClassName } from "@/pages/SettingsPage";
+import SettingsPage from "@/pages/SettingsPage";
+import { settingsPanelClassName } from "@/lib/settingsPanel";
 
 afterEach(() => {
   vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary
Settings → Logs was trapped in the same `max-w-4xl` column as the other tabs, and log lines used `whitespace-pre` so anything longer than the box required sideways scrolling. The Logs tab now uses the full content pane and wraps long lines.

Fixes #679

## Test plan
- [x] `vitest run tests/pages/SettingsPage.test.ts tests/components/LogsTab.test.tsx`
- Open Settings → Logs on a wide viewport, set Debug, and confirm long lines wrap inside the console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - The Settings → Logs console now uses the available page width.
  - Long log lines and words wrap automatically, reducing the need for horizontal scrolling.
  - Other Settings tabs retain their centered, readable-width layout.
  - Existing log filtering, refreshing, copying, and error handling remain unchanged.

- **Tests**
  - Added coverage to verify log wrapping and tab-specific panel widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->