### PR TITLE
feat: Add View on ComicVine, MangaDex, and MyAnimeList links

### DIFF
--- a/.changeset/series-view-on-provider.md
+++ b/.changeset/series-view-on-provider.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+The series page now has a "View on ComicVine", "View on MangaDex", or "View on MyAnimeList" link for the catalog that issued the series. MyAnimeList series also get a MangaDex link when that chapter source is known.

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -44,6 +44,7 @@ COMICS_COLUMNS = [
     t_comics.c.ContentType.label("ContentType"),
     t_comics.c.AllowPacks.label("AllowPacks"),
     t_comics.c.IgnoreType.label("IgnoreType"),
+    t_comics.c.MangaDexID.label("MangaDexID"),
 ]
 
 ISSUES_COLUMNS = [

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -323,12 +323,14 @@ def get_comic_detail(ctx, comic_id):
         series_location=series_location,
     )
     summary = _issue_summary(projected_issues + projected_annuals)
+    comic_row = comic[0] if comic else None
 
     return {
         "comic": comic,
         "issues": projected_issues,
         "annuals": projected_annuals,
         "summary": summary,
+        "providerLinks": series_kind.provider_page_links(comic_row) if comic_row else [],
     }
 
 

--- a/comicarr/series_kind.py
+++ b/comicarr/series_kind.py
@@ -146,7 +146,7 @@ def add_prefix(raw_id: str | None, provider: SeriesProvider) -> str:
 _PROVIDER_PAGE = {
     SeriesProvider.COMICVINE: (
         "ComicVine",
-        "https://comicvine.gamespot.com/-/{id}/",
+        "https://comicvine.gamespot.com/volume/4050-{id}/",
     ),
     SeriesProvider.MANGADEX: ("MangaDex", "https://mangadex.org/title/{id}"),
     SeriesProvider.MYANIMELIST: (
@@ -154,6 +154,15 @@ _PROVIDER_PAGE = {
         "https://myanimelist.net/manga/{id}",
     ),
 }
+
+_COMICVINE_VOLUME_PREFIX = "4050-"
+
+
+def _catalog_id(series_id: str, provider: SeriesProvider) -> str:
+    """Native id for a catalog URL — ComicVine volume ids must not keep 4050-."""
+    if provider is SeriesProvider.COMICVINE and series_id.startswith(_COMICVINE_VOLUME_PREFIX):
+        return series_id[len(_COMICVINE_VOLUME_PREFIX) :]
+    return series_id
 
 
 def provider_page_links(series: str | Mapping | None) -> list[dict[str, str]]:
@@ -172,7 +181,7 @@ def provider_page_links(series: str | Mapping | None) -> list[dict[str, str]]:
             {
                 "provider": provider.value,
                 "label": label,
-                "url": template.format(id=native_id),
+                "url": template.format(id=_catalog_id(native_id, provider)),
             }
         )
     if provider_of(series) is SeriesProvider.MYANIMELIST:

--- a/comicarr/series_kind.py
+++ b/comicarr/series_kind.py
@@ -141,3 +141,49 @@ def add_prefix(raw_id: str | None, provider: SeriesProvider) -> str:
     if prefix is None:
         return raw_id
     return "%s%s" % (prefix, raw_id)
+
+
+_PROVIDER_PAGE = {
+    SeriesProvider.COMICVINE: (
+        "ComicVine",
+        "https://comicvine.gamespot.com/-/{id}/",
+    ),
+    SeriesProvider.MANGADEX: ("MangaDex", "https://mangadex.org/title/{id}"),
+    SeriesProvider.MYANIMELIST: (
+        "MyAnimeList",
+        "https://myanimelist.net/manga/{id}",
+    ),
+}
+
+
+def provider_page_links(series: str | Mapping | None) -> list[dict[str, str]]:
+    """Return outbound catalog links for this Series.
+
+    Always includes the issuing provider when a native id is present. A
+    MyAnimeList Series also includes its MangaDex chapter source when
+    ``MangaDexID`` is set — MAL is metadata, MangaDex is chapters.
+    """
+    links: list[dict[str, str]] = []
+    native_id = strip_prefix(_series_id_of(series))
+    if native_id:
+        provider = provider_of(series)
+        label, template = _PROVIDER_PAGE[provider]
+        links.append(
+            {
+                "provider": provider.value,
+                "label": label,
+                "url": template.format(id=native_id),
+            }
+        )
+    if provider_of(series) is SeriesProvider.MYANIMELIST:
+        mangadex_id = chapter_source_id(series)
+        if mangadex_id:
+            label, template = _PROVIDER_PAGE[SeriesProvider.MANGADEX]
+            links.append(
+                {
+                    "provider": SeriesProvider.MANGADEX.value,
+                    "label": label,
+                    "url": template.format(id=mangadex_id),
+                }
+            )
+    return links

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   Activity,
+  ExternalLink,
   MoreHorizontal,
   Pause,
   Play,
@@ -511,6 +512,24 @@ export default function SeriesDetailPage() {
           <h1 className="mb-2 text-[28px] font-bold leading-tight tracking-[-0.02em]">
             {comic.ComicName}
           </h1>
+
+          {seriesData.providerLinks && seriesData.providerLinks.length > 0 ? (
+            <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
+              {seriesData.providerLinks.map((link) => (
+                <a
+                  key={`${link.provider}-${link.url}`}
+                  href={link.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-[12px] font-medium hover:underline"
+                  style={{ color: "var(--primary)" }}
+                >
+                  View on {link.label}
+                  <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                </a>
+              ))}
+            </div>
+          ) : null}
 
           {comic.Description && (
             <p

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -419,12 +419,20 @@ export interface InteractiveGrabResult {
   error?: string;
 }
 
+/** Outbound catalog page for the series' metadata (and chapter) provider. */
+export interface ProviderPageLink {
+  provider: string;
+  label: string;
+  url: string;
+}
+
 /** Series detail response (includes issues) */
 export interface SeriesDetail {
   comic: Comic[] | Comic;
   issues: Issue[];
   annuals?: Issue[];
   summary?: SeriesIssueSummary;
+  providerLinks?: ProviderPageLink[];
 }
 
 /** Content type for comic/manga distinction */

--- a/frontend/tests/pages/SeriesDetailPage.test.tsx
+++ b/frontend/tests/pages/SeriesDetailPage.test.tsx
@@ -179,6 +179,13 @@ describe("SeriesDetailPage", () => {
           },
           issues: canonicalIssues,
           annuals: [annual],
+          providerLinks: [
+            {
+              provider: "comicvine",
+              label: "ComicVine",
+              url: "https://comicvine.gamespot.com/-/1/",
+            },
+          ],
           summary: {
             total: 10,
             issues: 9,
@@ -199,6 +206,51 @@ describe("SeriesDetailPage", () => {
         }),
       ),
     );
+  });
+
+  it("links out to the series page on its metadata provider", async () => {
+    renderDetail();
+    const link = await screen.findByRole("link", { name: "View on ComicVine" });
+    expect(link.getAttribute("href")).toBe(
+      "https://comicvine.gamespot.com/-/1/",
+    );
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("shows MyAnimeList and MangaDex when both ids exist", async () => {
+    server.use(
+      http.get("/api/series/1", () =>
+        HttpResponse.json({
+          comic: {
+            ComicID: "mal-161890",
+            ComicName: "Absolute Batman",
+            Status: "Active",
+          },
+          issues: canonicalIssues,
+          providerLinks: [
+            {
+              provider: "myanimelist",
+              label: "MyAnimeList",
+              url: "https://myanimelist.net/manga/161890",
+            },
+            {
+              provider: "mangadex",
+              label: "MangaDex",
+              url: "https://mangadex.org/title/uuid-2",
+            },
+          ],
+        }),
+      ),
+    );
+    renderDetail();
+    expect(
+      (await screen.findByRole("link", { name: "View on MyAnimeList" })).getAttribute(
+        "href",
+      ),
+    ).toBe("https://myanimelist.net/manga/161890");
+    expect(
+      screen.getByRole("link", { name: "View on MangaDex" }).getAttribute("href"),
+    ).toBe("https://mangadex.org/title/uuid-2");
   });
 
   it("deep-links to scoped Activity without embedding a feed", async () => {

--- a/frontend/tests/pages/SeriesDetailPage.test.tsx
+++ b/frontend/tests/pages/SeriesDetailPage.test.tsx
@@ -183,7 +183,7 @@ describe("SeriesDetailPage", () => {
             {
               provider: "comicvine",
               label: "ComicVine",
-              url: "https://comicvine.gamespot.com/-/1/",
+              url: "https://comicvine.gamespot.com/volume/4050-1/",
             },
           ],
           summary: {
@@ -212,7 +212,7 @@ describe("SeriesDetailPage", () => {
     renderDetail();
     const link = await screen.findByRole("link", { name: "View on ComicVine" });
     expect(link.getAttribute("href")).toBe(
-      "https://comicvine.gamespot.com/-/1/",
+      "https://comicvine.gamespot.com/volume/4050-1/",
     );
     expect(link.getAttribute("target")).toBe("_blank");
   });

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -199,7 +199,7 @@ def test_get_comic_detail_returns_backend_summary_for_issues_and_null_deleted_an
         {
             "provider": "comicvine",
             "label": "ComicVine",
-            "url": "https://comicvine.gamespot.com/-/160294/",
+            "url": "https://comicvine.gamespot.com/volume/4050-160294/",
         }
     ]
 

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -175,7 +175,7 @@ def test_get_comic_detail_returns_backend_summary_for_issues_and_null_deleted_an
     monkeypatch.setattr(
         series_service.series_queries,
         "get_comic",
-        lambda _comic_id: [{"Status": "Active", "ComicLocation": str(series_root)}],
+        lambda _comic_id: [{"ComicID": "160294", "Status": "Active", "ComicLocation": str(series_root)}],
     )
     monkeypatch.setattr(
         series_service.series_queries,
@@ -195,6 +195,13 @@ def test_get_comic_detail_returns_backend_summary_for_issues_and_null_deleted_an
     assert result["summary"]["issues"] == 1
     assert result["summary"]["annuals"] == 1
     assert result["annuals"][0]["annual"] is True
+    assert result["providerLinks"] == [
+        {
+            "provider": "comicvine",
+            "label": "ComicVine",
+            "url": "https://comicvine.gamespot.com/-/160294/",
+        }
+    ]
 
 
 def test_get_annuals_keeps_legacy_null_deleted_rows(monkeypatch):

--- a/tests/unit/test_series_kind.py
+++ b/tests/unit/test_series_kind.py
@@ -23,6 +23,7 @@ from comicarr.series_kind import (
     chapter_source_id,
     is_manga,
     provider_of,
+    provider_page_links,
     strip_prefix,
 )
 
@@ -115,6 +116,50 @@ class TestChapterSourceId:
     def test_a_comicvine_series_has_no_mangadex_chapter_source(self):
         assert chapter_source_id("12345") is None
         assert chapter_source_id({"ComicID": "999", "ContentType": "manga"}) is None
+
+
+class TestProviderPageLinks:
+    def test_comicvine_id_builds_the_volume_page(self):
+        assert provider_page_links("160294") == [
+            {
+                "provider": "comicvine",
+                "label": "ComicVine",
+                "url": "https://comicvine.gamespot.com/-/160294/",
+            }
+        ]
+
+    def test_mangadex_id_builds_the_title_page(self):
+        assert provider_page_links("md-uuid-1") == [
+            {
+                "provider": "mangadex",
+                "label": "MangaDex",
+                "url": "https://mangadex.org/title/uuid-1",
+            }
+        ]
+
+    def test_mal_series_includes_mangadex_when_both_ids_exist(self):
+        links = provider_page_links({"ComicID": "mal-161890", "MangaDexID": "md-uuid-2"})
+        assert links == [
+            {
+                "provider": "myanimelist",
+                "label": "MyAnimeList",
+                "url": "https://myanimelist.net/manga/161890",
+            },
+            {
+                "provider": "mangadex",
+                "label": "MangaDex",
+                "url": "https://mangadex.org/title/uuid-2",
+            },
+        ]
+
+    def test_mal_without_mangadex_id_is_only_myanimelist(self):
+        assert provider_page_links("mal-161890") == [
+            {
+                "provider": "myanimelist",
+                "label": "MyAnimeList",
+                "url": "https://myanimelist.net/manga/161890",
+            }
+        ]
 
 
 class TestPrefixes:

--- a/tests/unit/test_series_kind.py
+++ b/tests/unit/test_series_kind.py
@@ -120,13 +120,20 @@ class TestChapterSourceId:
 
 class TestProviderPageLinks:
     def test_comicvine_id_builds_the_volume_page(self):
-        assert provider_page_links("160294") == [
+        links = provider_page_links("160294")
+        assert links == [
             {
                 "provider": "comicvine",
                 "label": "ComicVine",
-                "url": "https://comicvine.gamespot.com/-/160294/",
+                "url": "https://comicvine.gamespot.com/volume/4050-160294/",
             }
         ]
+        assert "volume/4050-160294" in links[0]["url"]
+        assert "/-/" not in links[0]["url"]
+
+    def test_comicvine_volume_prefix_is_not_doubled(self):
+        links = provider_page_links("4050-160294")
+        assert links[0]["url"] == "https://comicvine.gamespot.com/volume/4050-160294/"
 
     def test_mangadex_id_builds_the_title_page(self):
         assert provider_page_links("md-uuid-1") == [


### PR DESCRIPTION
## Summary
The series detail page now links out to the catalog that issued the series. MyAnimeList series also get a MangaDex link when that chapter source is recorded.

Fixes #678

## Test plan
- [x] `pytest tests/unit/test_series_kind.py tests/unit/test_series_domain.py`
- [x] `vitest run tests/pages/SeriesDetailPage.test.tsx`
- Open a ComicVine series and click **View on ComicVine**.
- Open a MAL series with a MangaDex id and confirm both links.