### PR TITLE
fix: Import NZBGet completions from the real job folder

### DIFF
--- a/.changeset/nzbget-import-real-folder.md
+++ b/.changeset/nzbget-import-real-folder.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Completed NZBGet downloads are imported from the files actually sitting in the job folder. Comicarr used to look for a file with the same name as the release inside that folder, miss the real `.cbr`/`.cbz`, and mark a successful download as failed.

--- a/comicarr/app/downloads/completed_path.py
+++ b/comicarr/app/downloads/completed_path.py
@@ -1,0 +1,74 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Resolve the file Completed Download Handling should open on disk."""
+
+from pathlib import Path
+
+from comicarr import logger
+
+_COMPLETED_ARCHIVE_SUFFIXES = (".cbr", ".cbz", ".cb7", ".cbt", ".pdf", ".zip", ".rar", ".7z")
+
+
+def _is_regular_file(path):
+    try:
+        return path.is_file()
+    except Exception as e:
+        logger.fdebug("[DOWNLOADS-CDH] Could not stat %s: %s" % (path, e))
+        return False
+
+
+def _file_size(path):
+    try:
+        return path.stat().st_size
+    except Exception as e:
+        logger.fdebug("[DOWNLOADS-CDH] Could not size %s: %s" % (path, e))
+        return -1
+
+
+def resolve_completed_download_file(location, name=None):
+    """Pick the completed-download file sitting on disk.
+
+    NZBGet's location is already the job folder; history Name is the release
+    name and is usually not a child file. SAB still reports parent + filename.
+    A missing location/name path is never treated as the file to open.
+    """
+    if not location:
+        return None
+    loc = Path(location)
+    if _is_regular_file(loc):
+        return loc
+
+    if name:
+        named = loc / name
+        if _is_regular_file(named):
+            return named
+
+    try:
+        if not loc.is_dir():
+            return None
+        children = list(loc.iterdir())
+    except Exception as e:
+        logger.fdebug("[DOWNLOADS-CDH] Could not list completed folder %s: %s" % (location, e))
+        return None
+
+    regular = []
+    archives = []
+    for child in children:
+        if not _is_regular_file(child):
+            continue
+        regular.append(child)
+        if child.suffix.lower() in _COMPLETED_ARCHIVE_SUFFIXES:
+            archives.append(child)
+
+    if archives:
+        return max(archives, key=_file_size)
+    if len(regular) == 1:
+        return regular[0]
+    return None

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -19,7 +19,6 @@ import os
 import re
 import time
 import zipfile
-from pathlib import Path
 
 import rarfile
 
@@ -27,6 +26,7 @@ import comicarr
 from comicarr import db, getcomics, logger, nzbget, process, sabnzbd
 from comicarr.app.attention import BATCH_CAP, PROBLEM_STATUS, Failure, ManualReview, record
 from comicarr.app.downloads import queries as dl_queries
+from comicarr.app.downloads.completed_path import resolve_completed_download_file
 from comicarr.app.downloads.ddl_commands import DDLCommand, DDLCommandError
 from comicarr.app.downloads.pp_commands import PostProcessCommandError, configured_roots, validate_postprocess_item
 from comicarr.downloaders import mediafire, mega, pixeldrain
@@ -2184,10 +2184,14 @@ def _cdh_monitor_owned(queue, item, nzstat, readd=False):
             comicarr.NZB_QUEUE.put(item)
     elif nzstat["status"] is True:
         if nzstat["failed"] is False:
-            fullpath = Path(nzstat["location"]) / nzstat["name"]
-            filecondition = check_file_condition(fullpath)
-            if not filecondition["status"]:
+            resolved = resolve_completed_download_file(nzstat["location"], nzstat.get("name"))
+            if resolved is None:
+                logger.warn("Unable to locate completed download file under %s" % nzstat.get("location"))
                 nzstat["failed"] = True
+            else:
+                filecondition = check_file_condition(resolved)
+                if not filecondition["status"]:
+                    nzstat["failed"] = True
         if nzstat["failed"] is False:
             logger.info("File successfully downloaded - now initiating completed downloading handling.")
         else:

--- a/tests/unit/test_cdh_completed_path.py
+++ b/tests/unit/test_cdh_completed_path.py
@@ -1,0 +1,129 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Completed-download path resolution for NZBGet/SAB CDH."""
+
+import queue as queuelib
+import zipfile
+from unittest.mock import MagicMock
+
+import comicarr
+from comicarr.app.downloads.service import (
+    _cdh_monitor_owned,
+    check_file_condition,
+    resolve_completed_download_file,
+)
+
+
+def _write_zip(path, payload=b"page"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("page.jpg", payload)
+    return path
+
+
+def test_resolve_completed_download_file_picks_archive_inside_job_folder(tmp_path):
+    job = tmp_path / "Absolute.Batman.001.2024-GetComics"
+    job.mkdir()
+    archive = _write_zip(job / "Absolute Batman 001 (2024).cbr")
+    doubled = job / job.name
+    assert not doubled.exists()
+
+    resolved = resolve_completed_download_file(str(job), job.name)
+
+    assert resolved is not None
+    assert resolved.exists()
+    assert resolved.is_file()
+    assert resolved == archive
+    assert resolved != doubled
+    condition = check_file_condition(resolved)
+    assert condition["status"] is True
+
+
+def test_resolve_completed_download_file_returns_location_when_it_is_a_file(tmp_path):
+    archive = _write_zip(tmp_path / "direct-file.cbz")
+
+    resolved = resolve_completed_download_file(str(archive), "not-a-child")
+
+    assert resolved is not None
+    assert resolved.exists()
+    assert resolved == archive
+    assert check_file_condition(resolved)["status"] is True
+
+
+def test_resolve_completed_download_file_uses_existing_location_name_child(tmp_path):
+    job = tmp_path / "sab-job"
+    job.mkdir()
+    archive = _write_zip(job / "Saga.001.cbz")
+    decoy = _write_zip(job / "extra.cbr", payload=b"x" * 4096)
+
+    resolved = resolve_completed_download_file(str(job), archive.name)
+
+    assert resolved == archive
+    assert resolved != decoy
+    assert resolved.exists()
+
+
+def test_resolve_completed_download_file_prefers_largest_archive(tmp_path):
+    job = tmp_path / "Some.Release.Name-Group"
+    job.mkdir()
+    _write_zip(job / "sample.zip", payload=b"tiny")
+    larger = _write_zip(job / "Some Release 001.cbz", payload=b"y" * 8192)
+
+    resolved = resolve_completed_download_file(str(job), job.name)
+
+    assert resolved is not None
+    assert resolved.exists()
+    assert resolved == larger
+
+
+def test_resolve_completed_download_file_falls_back_to_single_regular_file(tmp_path):
+    job = tmp_path / "Dotted.Release.Name"
+    job.mkdir()
+    only = job / "issue-without-suffix"
+    only.write_bytes(b"PK\x03\x04not-a-full-zip")
+
+    resolved = resolve_completed_download_file(str(job), job.name)
+
+    assert resolved is not None
+    assert resolved.exists()
+    assert resolved == only
+
+
+def test_cdh_monitor_owned_does_not_fail_when_name_is_not_a_child_file(tmp_path, monkeypatch):
+    job = tmp_path / "Absolute.Batman.001.2024-GetComics"
+    job.mkdir()
+    archive = _write_zip(job / "Absolute Batman 001 (2024).cbr")
+    assert not (job / job.name).exists()
+
+    fake_pp = MagicMock()
+    monkeypatch.setattr(comicarr, "PP_QUEUE", fake_pp, raising=False)
+    monkeypatch.setattr("comicarr.app.downloads.journal.read_one", lambda *a, **k: None)
+    monkeypatch.setattr("comicarr.app.downloads.journal.record_transition", lambda *a, **k: True)
+    monkeypatch.setattr("comicarr.app.downloads.journal.release_key", lambda *a, **k: "rk-test")
+
+    nzstat = {
+        "status": True,
+        "failed": False,
+        "name": job.name,
+        "location": str(job),
+        "issueid": "I1",
+        "comicid": "C1",
+        "apicall": True,
+        "download_info": {"provider": "nzb.su", "id": "nzbid-1"},
+    }
+
+    _cdh_monitor_owned(queuelib.Queue(), {"nzo_id": "nzb-1"}, nzstat)
+
+    assert nzstat["failed"] is False
+    fake_pp.put.assert_called_once()
+    queued = fake_pp.put.call_args[0][0]
+    assert queued["failed"] is False
+    assert queued["nzb_folder"] == str(job)
+    assert resolve_completed_download_file(queued["nzb_folder"], queued["nzb_name"]) == archive


### PR DESCRIPTION
## Summary
Completed NZBGet jobs are imported from the files actually sitting in the job folder. Comicarr used to look for a same-named file inside that folder, miss the real `.cbr`/`.cbz`, and mark a successful download as failed.

Fixes #674

## Test plan
- [x] `pytest tests/unit/test_cdh_completed_path.py -v`
- Complete an NZBGet job whose extracted filename differs from the release name and confirm it is imported rather than quarantined.