### PR TITLE
feat: Add Interactive Search on series and story-arc issue rows

### DIFF
--- a/.changeset/series-issue-interactive-search.md
+++ b/.changeset/series-issue-interactive-search.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Each issue on a series page (and the matching annual and story-arc rows) now has an Interactive Search action that opens the release picker for that issue, so you do not have to leave the page and find it again under Releases.

--- a/frontend/src/components/releases/ReleaseReviewSheet.tsx
+++ b/frontend/src/components/releases/ReleaseReviewSheet.tsx
@@ -34,11 +34,11 @@ import { getErrorMessage } from "@/lib/api";
 import type {
   InteractiveGrabResult,
   InteractiveReleaseCandidate,
-  UpcomingIssue,
+  ReleaseReviewIssue,
 } from "@/types";
 
 interface ReleaseReviewSheetProps {
-  issue: UpcomingIssue | null;
+  issue: ReleaseReviewIssue | null;
   sessionId: string | null;
   startPending: boolean;
   startError: unknown;
@@ -164,7 +164,7 @@ function IssueContext({
   issue,
   expiresAt,
 }: {
-  issue: UpcomingIssue;
+  issue: ReleaseReviewIssue;
   expiresAt?: string;
 }) {
   const number = issue.IssueNumber ?? issue.Issue_Number ?? "—";

--- a/frontend/src/components/storyarcs/ArcIssueTable.tsx
+++ b/frontend/src/components/storyarcs/ArcIssueTable.tsx
@@ -12,6 +12,8 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/toast";
+import { ReleaseReviewSheet } from "@/components/releases/ReleaseReviewSheet";
+import { useInteractiveReview } from "@/hooks/useInteractiveSearch";
 import { useSetArcIssueStatus, useDelArcIssue } from "@/hooks/useStoryArcs";
 import type { ArcIssue, ArcIssueStatus } from "@/types";
 
@@ -39,6 +41,7 @@ export default function ArcIssueTable({
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const { addToast } = useToast();
+  const { startReview, reviewSheetProps } = useInteractiveReview();
 
   const setStatusMutation = useSetArcIssueStatus(storyArcId);
   const delIssueMutation = useDelArcIssue();
@@ -173,6 +176,28 @@ export default function ArcIssueTable({
                         role="menu"
                         className="absolute right-0 top-full mt-1 z-50 min-w-[10rem] rounded-md border border-card-border bg-card shadow-lg p-1"
                       >
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className="flex items-center gap-2 w-full px-3 py-1.5 text-sm rounded-sm hover:bg-muted transition-colors text-left"
+                          onClick={() => {
+                            setOpenMenuId(null);
+                            void startReview(
+                              {
+                                IssueNumber: issue.IssueNumber,
+                                ComicName: issue.ComicName,
+                                Status: issue.Status,
+                              },
+                              {
+                                entityType: "story_arc_issue",
+                                entityId: issue.IssueArcID,
+                              },
+                            );
+                          }}
+                        >
+                          <Search className="w-4 h-4" />
+                          Interactive Search
+                        </button>
                         {issue.Status === "Read" ? (
                           <button
                             className="flex items-center gap-2 w-full px-3 py-1.5 text-sm rounded-sm hover:bg-muted transition-colors text-left"
@@ -264,6 +289,7 @@ export default function ArcIssueTable({
           ))}
         </tbody>
       </table>
+      <ReleaseReviewSheet {...reviewSheetProps} />
     </div>
   );
 }

--- a/frontend/src/hooks/useInteractiveSearch.ts
+++ b/frontend/src/hooks/useInteractiveSearch.ts
@@ -1,11 +1,17 @@
+import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useToast } from "@/components/ui/toast";
 import { apiRequest } from "@/lib/api";
-import type { InteractiveGrabResult, InteractiveSearchSession } from "@/types";
+import type {
+  InteractiveGrabResult,
+  InteractiveSearchSession,
+  ReleaseReviewIssue,
+} from "@/types";
 
 const INTERACTIVE_POLL_MS = 2_000;
 const ACTIVE_STATES = new Set(["queued", "running"]);
 
-interface StartInteractiveSearchInput {
+export interface StartInteractiveSearchInput {
   entityType: "issue" | "annual" | "story_arc_issue";
   entityId: string;
 }
@@ -62,7 +68,69 @@ export function useGrabInteractiveCandidate() {
         queryClient.invalidateQueries({ queryKey: ["upcoming"] }),
         queryClient.invalidateQueries({ queryKey: ["wanted"] }),
         queryClient.invalidateQueries({ queryKey: ["activity"] }),
+        queryClient.invalidateQueries({ queryKey: ["series"] }),
+        queryClient.invalidateQueries({ queryKey: ["storyArcs"] }),
       ]);
     },
   });
+}
+
+export function useInteractiveReview() {
+  const startInteractiveSearch = useStartInteractiveSearch();
+  const { addToast } = useToast();
+  const [reviewIssue, setReviewIssue] = useState<ReleaseReviewIssue | null>(
+    null,
+  );
+  const [reviewSessionId, setReviewSessionId] = useState<string | null>(null);
+  const [reviewTarget, setReviewTarget] =
+    useState<StartInteractiveSearchInput | null>(null);
+
+  const startReview = async (
+    issue: ReleaseReviewIssue,
+    target: StartInteractiveSearchInput,
+  ) => {
+    if (!target.entityId) return;
+    setReviewIssue(issue);
+    setReviewTarget(target);
+    setReviewSessionId(null);
+    startInteractiveSearch.reset();
+    try {
+      const session = await startInteractiveSearch.mutateAsync(target);
+      setReviewSessionId(session.session_id);
+    } catch {
+      // The sheet owns the actionable error and retry affordance.
+    }
+  };
+
+  const closeReview = () => {
+    setReviewIssue(null);
+    setReviewSessionId(null);
+    setReviewTarget(null);
+    startInteractiveSearch.reset();
+  };
+
+  return {
+    startReview,
+    reviewSheetProps: {
+      issue: reviewIssue,
+      sessionId: reviewSessionId,
+      startPending: startInteractiveSearch.isPending,
+      startError: startInteractiveSearch.error,
+      onRetry: () =>
+        reviewIssue && reviewTarget
+          ? void startReview(reviewIssue, reviewTarget)
+          : undefined,
+      onClose: closeReview,
+      onGrabbed: (result: InteractiveGrabResult) => {
+        addToast({
+          type: "success",
+          title: result.idempotent ? "Grab already started" : "Grab started",
+          message: result.idempotent
+            ? "Comicarr returned the existing handoff outcome."
+            : "The selected release was handed to the configured download route.",
+        });
+        closeReview();
+      },
+    },
+  };
 }

--- a/frontend/src/pages/ReleasesPage.tsx
+++ b/frontend/src/pages/ReleasesPage.tsx
@@ -24,7 +24,7 @@ import { useTableState } from "@/components/data-table/useTableState";
 import ErrorDisplay from "@/components/ui/ErrorDisplay";
 import EmptyState from "@/components/ui/EmptyState";
 import { ReleaseReviewSheet } from "@/components/releases/ReleaseReviewSheet";
-import { useStartInteractiveSearch } from "@/hooks/useInteractiveSearch";
+import { useInteractiveReview } from "@/hooks/useInteractiveSearch";
 import type { UpcomingIssue } from "@/types";
 
 interface WeeklyIssue {
@@ -281,26 +281,15 @@ function MyReleasesView() {
   const bulkQueueMutation = useBulkQueueIssues();
   const bulkUnqueueMutation = useBulkUnqueueIssues();
   const { addToast } = useToast();
-  const startInteractiveSearch = useStartInteractiveSearch();
-  const [reviewIssue, setReviewIssue] = useState<UpcomingIssue | null>(null);
-  const [reviewSessionId, setReviewSessionId] = useState<string | null>(null);
+  const { startReview, reviewSheetProps } = useInteractiveReview();
 
-  const startReview = async (issue: UpcomingIssue) => {
-    setReviewIssue(issue);
-    setReviewSessionId(null);
-    startInteractiveSearch.reset();
-    try {
-      const session = await startInteractiveSearch.mutateAsync({
-        entityType: issue.annual ? "annual" : "issue",
-        entityId: issue.IssueID,
-      });
-      setReviewSessionId(session.session_id);
-    } catch {
-      // The sheet owns the actionable error and retry affordance.
-    }
-  };
+  const startIssueReview = (issue: UpcomingIssue) =>
+    startReview(issue, {
+      entityType: issue.annual ? "annual" : "issue",
+      entityId: issue.IssueID,
+    });
 
-  const columns = useUpcomingColumns((issue) => void startReview(issue));
+  const columns = useUpcomingColumns((issue) => void startIssueReview(issue));
   // Unpaginated: the whole week renders at once, so `pagination` is omitted
   // and the hook holds no page state (#360).
   const { table, selectedIds, clearSelection } = useTableState({
@@ -500,32 +489,7 @@ function MyReleasesView() {
         onClear={clearSelection}
         isLoading={bulkQueueMutation.isPending || bulkUnqueueMutation.isPending}
       />
-      <ReleaseReviewSheet
-        issue={reviewIssue}
-        sessionId={reviewSessionId}
-        startPending={startInteractiveSearch.isPending}
-        startError={startInteractiveSearch.error}
-        onRetry={() =>
-          reviewIssue ? void startReview(reviewIssue) : undefined
-        }
-        onClose={() => {
-          setReviewIssue(null);
-          setReviewSessionId(null);
-          startInteractiveSearch.reset();
-        }}
-        onGrabbed={(result) => {
-          addToast({
-            type: "success",
-            title: result.idempotent ? "Grab already started" : "Grab started",
-            message: result.idempotent
-              ? "Comicarr returned the existing handoff outcome."
-              : "The selected release was handed to the configured download route.",
-          });
-          setReviewIssue(null);
-          setReviewSessionId(null);
-          startInteractiveSearch.reset();
-        }}
-      />
+      <ReleaseReviewSheet {...reviewSheetProps} />
     </div>
   );
 }

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/components/ui/dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useToast } from "@/components/ui/toast";
+import { ReleaseReviewSheet } from "@/components/releases/ReleaseReviewSheet";
+import { useInteractiveReview } from "@/hooks/useInteractiveSearch";
 import {
   useConfirmSearchMissing,
   useDeleteSeries,
@@ -39,6 +41,7 @@ import {
 import type {
   ComicOrManga,
   Issue,
+  ReleaseReviewIssue,
   SearchMissingPreview,
   SearchMissingResult,
   ContentType,
@@ -146,6 +149,30 @@ function pluralize(count: number, singular: string): string {
   return `${count} ${singular}${count === 1 ? "" : "s"}`;
 }
 
+const ISSUE_GRID_COLS =
+  "grid-cols-[54px_42px_minmax(220px,1fr)_130px_110px_190px_36px]";
+
+function toReleaseReviewIssue(
+  issue: Issue,
+  seriesName: string,
+): ReleaseReviewIssue {
+  return {
+    IssueNumber: issue.number ?? issue.Issue_Number,
+    Issue_Number: issue.Issue_Number,
+    ComicName: issue.ComicName ?? issue.comicName ?? seriesName,
+    Status: issue.Status ?? issue.status,
+    annual: Boolean(issue.annual),
+  };
+}
+
+function interactiveSearchLabel(issue: Issue): string {
+  const issueName = issue.name ?? issue.IssueName;
+  const issueNumber = issue.number ?? issue.Issue_Number;
+  const fallback =
+    `${issue.annual ? "Annual" : "Issue"} ${issueNumber ?? ""}`.trim();
+  return `Interactive Search for ${issueName || fallback}`;
+}
+
 export default function SeriesDetailPage() {
   const { comicId } = useParams<{ comicId: string }>();
   const navigate = useNavigate();
@@ -170,6 +197,7 @@ export default function SeriesDetailPage() {
   const retrySearchRun = useRetrySearchRun();
   const searchSettingsMutation = useUpdateSeriesSearchSettings();
   const contentKindMutation = useUpdateSeriesContentKind();
+  const { startReview, reviewSheetProps } = useInteractiveReview();
 
   const fetchSearchPreview = async () => {
     setPreview(null);
@@ -774,7 +802,7 @@ export default function SeriesDetailPage() {
       <div className="flex-1 min-h-0 overflow-auto">
         <div className="min-w-[720px]">
           <div
-            className="sticky top-0 z-10 grid grid-cols-[54px_42px_minmax(220px,1fr)_130px_110px_190px] gap-3 border-b px-5 py-2 font-mono text-[10px] uppercase tracking-[0.1em]"
+            className={`sticky top-0 z-10 grid ${ISSUE_GRID_COLS} gap-3 border-b px-5 py-2 font-mono text-[10px] uppercase tracking-[0.1em]`}
             style={{
               borderColor: "var(--border)",
               color: "var(--text-muted)",
@@ -787,6 +815,7 @@ export default function SeriesDetailPage() {
             <div>arc</div>
             <div>date</div>
             <div>state</div>
+            <div className="sr-only">search</div>
           </div>
 
           {filteredIssues.length === 0 ? (
@@ -812,7 +841,7 @@ export default function SeriesDetailPage() {
               return (
                 <div
                   key={`${issue.annual ? "annual" : "issue"}-${issueId}`}
-                  className="grid grid-cols-[54px_42px_minmax(220px,1fr)_130px_110px_190px] items-center gap-3 border-b px-5 py-2 text-[12px]"
+                  className={`grid ${ISSUE_GRID_COLS} items-center gap-3 border-b px-5 py-2 text-[12px]`}
                   style={{ borderColor: "var(--border)" }}
                 >
                   <div>
@@ -866,6 +895,27 @@ export default function SeriesDetailPage() {
                         intent: {separateIntent}
                       </span>
                     )}
+                  </div>
+                  <div className="flex justify-end">
+                    <button
+                      type="button"
+                      className="inline-flex size-7 items-center justify-center rounded-[5px] transition-colors hover:bg-secondary/50"
+                      style={{ color: "var(--muted-foreground)" }}
+                      aria-label={interactiveSearchLabel(issue)}
+                      title="Interactive Search"
+                      disabled={!issueId}
+                      onClick={() =>
+                        void startReview(
+                          toReleaseReviewIssue(issue, comic.ComicName),
+                          {
+                            entityType: issue.annual ? "annual" : "issue",
+                            entityId: String(issueId ?? ""),
+                          },
+                        )
+                      }
+                    >
+                      <Search className="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
                   </div>
                 </div>
               );
@@ -1116,6 +1166,7 @@ export default function SeriesDetailPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      <ReleaseReviewSheet {...reviewSheetProps} />
     </div>
   );
 }

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -350,6 +350,16 @@ export interface UpcomingIssue extends Omit<Issue, "Status"> {
   Store_Date?: string;
 }
 
+/** Fields the interactive-search review sheet actually renders. */
+export interface ReleaseReviewIssue {
+  IssueNumber?: string | null;
+  Issue_Number?: string | null;
+  ComicName?: string | null;
+  ReleaseComicName?: string | null;
+  Status?: string | null;
+  annual?: boolean;
+}
+
 export interface InteractiveVerdictReason {
   code: string;
   message: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,6 +40,7 @@ export type {
   WantedAcquisitionAnnotation,
   WantedIssue,
   UpcomingIssue,
+  ReleaseReviewIssue,
   InteractiveVerdictReason,
   InteractiveReleaseCandidate,
   InteractiveProviderFailure,

--- a/frontend/tests/components/ArcIssueTable.test.tsx
+++ b/frontend/tests/components/ArcIssueTable.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/server";
+import { render, screen } from "../test-utils";
+import ArcIssueTable from "@/components/storyarcs/ArcIssueTable";
+import type { ArcIssue } from "@/types";
+
+const arcIssue: ArcIssue = {
+  IssueArcID: "arc-issue-9",
+  ReadingOrder: 1,
+  ComicID: "comic-1",
+  ComicName: "Absolute Batman",
+  IssueNumber: "9",
+  IssueID: "issue-9",
+  Status: "Wanted",
+  IssueDate: "2026-08-12",
+  IssueName: "Ready to search",
+  IssuePublisher: "DC Comics",
+  Location: null,
+};
+
+describe("ArcIssueTable", () => {
+  it("starts Interactive Search for a story-arc issue in place", async () => {
+    let searchBody: unknown;
+    server.use(
+      http.post("/api/search/interactive", async ({ request }) => {
+        searchBody = await request.json();
+        return HttpResponse.json({
+          session_id: "session-arc",
+          entity_type: "story_arc_issue",
+          entity_id: "arc-issue-9",
+          series_id: "comic-1",
+          state: "complete",
+          candidate_count: 0,
+          progress: {
+            provider_total: 0,
+            provider_completed: 0,
+            current_provider: null,
+          },
+          provider_failures: [],
+          created_at: "2026-08-12T04:00:00Z",
+          expires_at: "2026-08-12T04:10:00Z",
+          candidates: [],
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    render(<ArcIssueTable issues={[arcIssue]} storyArcId="arc-1" />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Actions for Absolute Batman #9",
+      }),
+    );
+    await user.click(
+      screen.getByRole("menuitem", { name: "Interactive Search" }),
+    );
+
+    await waitFor(() => {
+      expect(searchBody).toEqual({
+        entity_type: "story_arc_issue",
+        entity_id: "arc-issue-9",
+      });
+    });
+    expect(
+      await screen.findByRole("heading", { name: "Review releases" }),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -347,6 +347,50 @@ export const handlers = [
     return HttpResponse.json({ success: true });
   }),
 
+  http.post("/api/search/interactive", async ({ request }) => {
+    const body = (await request.json()) as {
+      entity_type?: string;
+      entity_id?: string;
+    };
+    return HttpResponse.json({
+      session_id: "session-test",
+      entity_type: body.entity_type ?? "issue",
+      entity_id: body.entity_id ?? "",
+      series_id: null,
+      state: "complete",
+      candidate_count: 0,
+      progress: {
+        provider_total: 0,
+        provider_completed: 0,
+        current_provider: null,
+      },
+      provider_failures: [],
+      created_at: "2026-08-12T04:00:00Z",
+      expires_at: "2026-08-12T04:10:00Z",
+      candidates: [],
+    });
+  }),
+
+  http.get("/api/search/interactive/:sessionId", ({ params }) => {
+    return HttpResponse.json({
+      session_id: params.sessionId,
+      entity_type: "issue",
+      entity_id: "wanted",
+      series_id: null,
+      state: "complete",
+      candidate_count: 0,
+      progress: {
+        provider_total: 0,
+        provider_completed: 0,
+        current_provider: null,
+      },
+      provider_failures: [],
+      created_at: "2026-08-12T04:00:00Z",
+      expires_at: "2026-08-12T04:10:00Z",
+      candidates: [],
+    });
+  }),
+
   // -------------------------------------------------------------------------
   // Config endpoints
   // -------------------------------------------------------------------------

--- a/frontend/tests/pages/SeriesDetailPage.test.tsx
+++ b/frontend/tests/pages/SeriesDetailPage.test.tsx
@@ -571,4 +571,94 @@ describe("SeriesDetailPage", () => {
         .getAttribute("href"),
     ).toBe("/settings?section=search");
   });
+
+  it("starts Interactive Search for a series issue in place", async () => {
+    let searchBody: unknown;
+    server.use(
+      http.post("/api/search/interactive", async ({ request }) => {
+        searchBody = await request.json();
+        return HttpResponse.json({
+          session_id: "session-issue",
+          entity_type: "issue",
+          entity_id: "wanted",
+          series_id: "1",
+          state: "complete",
+          candidate_count: 0,
+          progress: {
+            provider_total: 0,
+            provider_completed: 0,
+            current_provider: null,
+          },
+          provider_failures: [],
+          created_at: "2026-08-12T04:00:00Z",
+          expires_at: "2026-08-12T04:10:00Z",
+          candidates: [],
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderDetail();
+
+    await screen.findByText("Ready to search");
+    await user.click(
+      screen.getByRole("button", {
+        name: "Interactive Search for Ready to search",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(searchBody).toEqual({
+        entity_type: "issue",
+        entity_id: "wanted",
+      });
+    });
+    expect(
+      await screen.findByRole("heading", { name: "Review releases" }),
+    ).toBeTruthy();
+  });
+
+  it("starts Interactive Search for an annual in place", async () => {
+    let searchBody: unknown;
+    server.use(
+      http.post("/api/search/interactive", async ({ request }) => {
+        searchBody = await request.json();
+        return HttpResponse.json({
+          session_id: "session-annual",
+          entity_type: "annual",
+          entity_id: "annual-1",
+          series_id: "1",
+          state: "complete",
+          candidate_count: 0,
+          progress: {
+            provider_total: 0,
+            provider_completed: 0,
+            current_provider: null,
+          },
+          provider_failures: [],
+          created_at: "2026-08-12T04:00:00Z",
+          expires_at: "2026-08-12T04:10:00Z",
+          candidates: [],
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderDetail();
+
+    await screen.findByText("Annual event");
+    await user.click(
+      screen.getByRole("button", {
+        name: "Interactive Search for Annual event",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(searchBody).toEqual({
+        entity_type: "annual",
+        entity_id: "annual-1",
+      });
+    });
+    expect(
+      await screen.findByRole("heading", { name: "Review releases" }),
+    ).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
Each issue on a series page (and the matching annual and story-arc rows) now has an Interactive Search action that opens the release picker for that issue, so you do not have to leave the page and find it again under Releases.

Fixes #675

## Test plan
- [x] `vitest run tests/pages/SeriesDetailPage.test.tsx tests/components/ArcIssueTable.test.tsx`
- On a series page, click Interactive Search on an issue and an annual.
- On a story-arc page, use the row menu Interactive Search action.