### PR TITLE
fix: Keep the completed folder when recovering SAB and NZBGet jobs

### DIFF
--- a/.changeset/recovery-keeps-completed-folder.md
+++ b/.changeset/recovery-keeps-completed-folder.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Restart recovery of a finished SABnzbd or NZBGet download now keeps the completed folder the downloader already reported. Comicarr used to throw away that path and then fail post-processing with "nzb_folder is required", leaving a successful download stuck after a restart.

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -377,6 +377,26 @@ def _reconstruct_anchors():
 # ---------------------------------------------------------------------------
 
 
+def _merge_completion_evidence(payload, details):
+    """Copy probe-reported completion location/name into the journal payload.
+
+    SAB/NZBGet snatch payloads have no nzb_folder (addfile returns nzo_ids
+    only). Recovery already resolved the folder via historycheck; keep it.
+    Do not invent a path the probe did not return.
+    """
+    merged = dict(payload or {})
+    details = details or {}
+    location = details.get("location")
+    if location:
+        merged["nzb_folder"] = str(location)
+    name = details.get("name")
+    if name and not merged.get("nzb_name") and not merged.get("nzbname"):
+        merged["nzb_name"] = name
+    if details.get("failed") is not None:
+        merged["failed"] = bool(details.get("failed"))
+    return merged
+
+
 def _pp_item_from_row(row, payload):
     """Reconstruct a PP_QUEUE item dict from a journal row's payload. The
     authoritative release_key is stamped as `journal_release_key` so the U4
@@ -801,12 +821,10 @@ def _resolve_row(snapshot_row, probes=None, pp_cap=None):
         return "done-check"
 
     # --- per-downloader classification (U5) -------------------------------
-    # classify() accepts an optional payload= for direct callers, but we do
-    # NOT pass it here: the recovery_classify.classify symbol is a test
-    # monkeypatch seam whose stubs take (row, probes=) only. classify's own
-    # single internal parse covers _resolve_downloader/has_done_signal; the
-    # bigger re-parse wins (item-builders, finalizer) are already threaded.
-    verdict = recovery_classify.classify(row, probes=probes)
+    # classify_details keeps historycheck location/name/failed. classify()
+    # remains the string-verdict wrapper used by existing tests.
+    details = recovery_classify.classify_details(row, probes=probes, payload=payload)
+    verdict = details.get("verdict")
 
     if verdict == recovery_classify.GONE:
         recovery_classify.apply_verdict(row, verdict)
@@ -831,6 +849,9 @@ def _resolve_row(snapshot_row, probes=None, pp_cap=None):
         # works. release_key (rkey) is authoritative and is what the PP item
         # carries as journal_release_key (the U3/U4/U6 propagated-key
         # contract — never re-derived).
+        # SAB/NZBGet snatch payloads omit nzb_folder; merge the folder the
+        # probe just resolved so PP does not fail with "nzb_folder is required".
+        payload = _merge_completion_evidence(payload, details)
         journal.record_transition(
             rkey,
             journal.DOWNLOADED,

--- a/comicarr/app/downloads/recovery_classify.py
+++ b/comicarr/app/downloads/recovery_classify.py
@@ -12,6 +12,8 @@ Per-downloader startup classification for the durable pipeline.
 
 Module boundary: this module is PURE-VERDICT — ``classify()`` returns a
 verdict (STILL/COMPLETE/GONE/UNKNOWN) and NEVER mutates the journal.
+``classify_details()`` is the same decision plus any completion evidence
+(location/name/failed) the SAB/NZBGet probe already resolved.
 journal.py owns transitions; recovery.py owns replay orchestration.
 ``apply_verdict()`` is a thin optional helper mapping a GONE verdict to an
 Attention failure record; it is a deliberate no-op for
@@ -212,10 +214,11 @@ def has_done_signal(row):
 
 
 # ---------------------------------------------------------------------------
-# Per-downloader probes. Each returns one of:
+# Per-downloader probes. Each returns either a raw state string
 #   "still" / "complete" / "absent" / "unreachable"
-# (raw client state, BEFORE the done-signal cross-check turns "absent" into
-# COMPLETE-or-GONE). Probes are injectable for tests via classify(..., probes=).
+# or a richer historycheck-shaped dict (status + optional location/name/failed).
+# Raw state is decided BEFORE the done-signal cross-check turns "absent" into
+# COMPLETE-or-GONE. Probes are injectable for tests via classify(..., probes=).
 # ---------------------------------------------------------------------------
 
 
@@ -291,7 +294,7 @@ def _sab_history_or_queue(row, payload=None):
     except Exception as e:
         logger.warn("[RECOVERY-CLASSIFY] SAB unreachable probing %s: %s" % (nzo_id, e))
         return "unreachable"
-    return _nzstat_to_raw(nzstat)
+    return nzstat
 
 
 def _nzbget_history(row, payload=None):
@@ -317,7 +320,7 @@ def _nzbget_history(row, payload=None):
     except Exception as e:
         logger.warn("[RECOVERY-CLASSIFY] NZBGet unreachable probing %s: %s" % (nzbid, e))
         return "unreachable"
-    return _nzstat_to_raw(nzstat)
+    return nzstat
 
 
 def _nzstat_to_raw(nzstat):
@@ -345,6 +348,36 @@ def _nzstat_to_raw(nzstat):
     # post-processing could not proceed. It is NOT absent; treat as complete
     # at the downloader (the PP/failure path owns it, replay must not GONE it).
     return "complete"
+
+
+_RAW_PROBE_STATES = frozenset(("still", "complete", "absent", "unreachable"))
+
+
+def _probe_evidence(raw):
+    """Normalize a probe return to (raw_state, location, name, failed).
+
+    Test probes may return a raw state string. Built-in SAB/NZBGet probes
+    (and richer test probes) may return a historycheck dict; location/name/
+    failed are kept so recovery can stamp nzb_folder instead of discarding
+    the path historycheck already resolved.
+    """
+    if isinstance(raw, str):
+        return raw, None, None, None
+    if not isinstance(raw, dict):
+        return "unreachable", None, None, None
+    location = raw.get("location")
+    name = raw.get("name")
+    failed = raw.get("failed")
+    status = raw.get("status")
+    if status in _RAW_PROBE_STATES:
+        raw_state = status
+    else:
+        raw_state = _nzstat_to_raw(raw)
+    return raw_state, location, name, failed
+
+
+def _empty_details(verdict=UNKNOWN):
+    return {"verdict": verdict, "location": None, "name": None, "failed": None}
 
 
 def _probe_nzb(row, payload=None):
@@ -458,13 +491,18 @@ def _resolve_downloader(row, payload=None):
 # ---------------------------------------------------------------------------
 
 
-def classify(row, probes=None, payload=None):
-    """Classify one open journal row. Returns one of STILL/COMPLETE/GONE/
-    UNKNOWN. PURE: never mutates the journal.
+def classify_details(row, probes=None, payload=None):
+    """Classify one open journal row and return completion evidence.
+
+    Returns ``{verdict, location, name, failed}``. ``verdict`` is one of
+    STILL/COMPLETE/GONE/UNKNOWN. ``location``/``name``/``failed`` come from a
+    richer SAB/NZBGet probe result when present; they are None when the probe
+    returned only a raw state string. PURE: never mutates the journal.
 
     `probes` (test seam): optional {downloader_type: callable(row)->raw}
     overriding the real client-query paths. `raw` is one of
-    "still"/"complete"/"absent"/"unreachable".
+    "still"/"complete"/"absent"/"unreachable", or a historycheck-shaped dict
+    with ``status`` plus optional ``location``/``name``/``failed``.
 
     `payload` (efficiency): the already-decoded payload_json dict, parsed once
     per replay row by the caller and threaded in to avoid re-parsing it for
@@ -474,7 +512,7 @@ def classify(row, probes=None, payload=None):
     their own single internal parse.
     """
     if not row:
-        return UNKNOWN
+        return _empty_details(UNKNOWN)
     if payload is None:
         payload = journal.load_payload(row.get("payload_json"))
     rkey = row.get("release_key")
@@ -485,29 +523,35 @@ def classify(row, probes=None, payload=None):
             "[RECOVERY-CLASSIFY] No probe for downloader_type=%r (release_key=%s) "
             "— UNKNOWN, journal left unchanged." % (downloader, rkey)
         )
-        return UNKNOWN
+        return _empty_details(UNKNOWN)
 
     try:
         raw = probe(row)
     except Exception as e:
         # A probe blowing up is treated as a transient outage — NEVER a GONE.
         logger.warn("[RECOVERY-CLASSIFY] probe raised for %s (%s) — UNKNOWN: %s" % (rkey, downloader, e))
-        return UNKNOWN
+        return _empty_details(UNKNOWN)
 
-    if raw == "still":
+    raw_state, location, name, failed = _probe_evidence(raw)
+    details = {"verdict": UNKNOWN, "location": location, "name": name, "failed": failed}
+
+    if raw_state == "still":
         logger.fdebug("[RECOVERY-CLASSIFY] %s -> still (in client)" % rkey)
-        return STILL
-    if raw == "complete":
+        details["verdict"] = STILL
+        return details
+    if raw_state == "complete":
         logger.fdebug("[RECOVERY-CLASSIFY] %s -> complete (done at downloader)" % rkey)
-        return COMPLETE
-    if raw == "unreachable":
+        details["verdict"] = COMPLETE
+        return details
+    if raw_state == "unreachable":
         # Transient outage / API unreachable. Leave the journal stage
         # UNCHANGED — reclassified next startup. NEVER write failed here.
         logger.warn(
             "[RECOVERY-CLASSIFY] %s -> UNKNOWN (downloader API unreachable / "
             "transient) — journal stage left unchanged." % rkey
         )
-        return UNKNOWN
+        details["verdict"] = UNKNOWN
+        return details
 
     # raw == "absent". Ambiguous, NOT authoritatively gone. Cross-check the
     # done-signals (history-eviction guard) BEFORE classifying GONE.
@@ -516,14 +560,26 @@ def classify(row, probes=None, payload=None):
             "[RECOVERY-CLASSIFY] %s absent in client BUT done-signal present "
             "(history likely evicted while down) -> complete, NOT gone." % rkey
         )
-        return COMPLETE
+        details["verdict"] = COMPLETE
+        return details
 
     # Absent AND no done-signal AND client reachable ⇒ authoritatively GONE.
     logger.warn(
         "[RECOVERY-CLASSIFY] %s absent from a reachable client with NO "
         "done-signal -> GONE (will be marked failed, payload retained)." % rkey
     )
-    return GONE
+    details["verdict"] = GONE
+    return details
+
+
+def classify(row, probes=None, payload=None):
+    """Classify one open journal row. Returns one of STILL/COMPLETE/GONE/
+    UNKNOWN. PURE: never mutates the journal.
+
+    Thin wrapper over :func:`classify_details` so existing callers and tests
+    keep receiving the same verdict strings.
+    """
+    return classify_details(row, probes=probes, payload=payload)["verdict"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_recovery_classify.py
+++ b/tests/unit/test_recovery_classify.py
@@ -103,6 +103,19 @@ def test_sab_in_history_complete_is_complete():
     assert recovery_classify.classify(row, probes=_probe("complete")) == recovery_classify.COMPLETE
 
 
+def test_string_complete_probe_still_classifies_complete_without_inventing_folder():
+    """Existing test-seam contract: a string-only probe returning "complete"
+    still classifies COMPLETE. Recovery must not invent a folder the probe
+    did not return."""
+    row = _insert_journal("I2s|sab|nzb2s", journal.SNATCHED, issueid="I2s", provider="sab", downloader_type="nzb")
+    probes = _probe("complete")
+    assert recovery_classify.classify(row, probes=probes) == recovery_classify.COMPLETE
+    details = recovery_classify.classify_details(row, probes=probes)
+    assert details["verdict"] == recovery_classify.COMPLETE
+    assert details["location"] is None
+    assert details["name"] is None
+
+
 def test_sab_absent_no_done_signal_reachable_is_gone():
     """Absent AND no done-signal (issue not post-processed, nzblog present)
     AND client reachable ⇒ GONE."""
@@ -371,6 +384,49 @@ def test_sab_real_historycheck_status_true_maps_complete():
     )
     with patch("comicarr.sabnzbd.SABnzbd.historycheck", return_value={"status": True, "failed": False}):
         assert recovery_classify.classify(row) == recovery_classify.COMPLETE
+
+
+def test_sab_historycheck_keeps_completion_location():
+    """Built-in SAB probe must not collapse historycheck to the string
+    "complete" and drop the folder it already resolved."""
+    location = "/downloads/Spawn.344"
+    nzb_name = "Spawn.344.cbz"
+    row = _insert_journal(
+        "S1loc|sab|n",
+        journal.SNATCHED,
+        issueid="S1loc",
+        provider="sab",
+        downloader_type="sabnzbd",
+        payload={
+            "comicid": "C1",
+            "route": "sabnzbd",
+            "nzo_id": "nzoSpawn",
+            "nzb_name": nzb_name,
+            "download_info": {"nzo_id": "nzoSpawn"},
+        },
+    )
+    nzstat = {"status": True, "location": location, "name": nzb_name, "failed": False}
+    with patch("comicarr.sabnzbd.SABnzbd.historycheck", return_value=nzstat):
+        details = recovery_classify.classify_details(row)
+        assert recovery_classify.classify(row) == recovery_classify.COMPLETE
+    assert details["verdict"] == recovery_classify.COMPLETE
+    assert details["location"] == location
+    assert details["name"] == nzb_name
+    assert details["failed"] is False
+
+
+def test_dict_probe_with_location_classifies_complete_and_keeps_folder():
+    """Richer injectable probes (historycheck-shaped dicts) are accepted
+    without breaking the string-returning test seam."""
+    location = "/downloads/Spawn.344"
+    nzb_name = "Spawn.344.cbz"
+    row = _insert_journal("S1dict|sab|n", journal.SNATCHED, issueid="S1dict", provider="sab", downloader_type="nzb")
+    probes = _probe({"status": True, "location": location, "name": nzb_name, "failed": False})
+    details = recovery_classify.classify_details(row, probes=probes)
+    assert details["verdict"] == recovery_classify.COMPLETE
+    assert details["location"] == location
+    assert details["name"] == nzb_name
+    assert recovery_classify.classify(row, probes=probes) == recovery_classify.COMPLETE
 
 
 def test_sab_real_historycheck_status_false_is_absent_then_gone():

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -154,6 +154,68 @@ def test_replay_does_not_acquire_init_lock(queues):
 # ---------------------------------------------------------------------------
 
 
+def test_complete_sab_recovery_keeps_historycheck_folder(queues, tmp_path, monkeypatch):
+    """A snatched SAB row has nzo_id/nzb_name but no nzb_folder (addfile only
+    returns nzo_ids). Historycheck already resolved the completed folder;
+    recovery must keep that path on the PP item instead of raising
+    PostProcessCommandError("nzb_folder is required")."""
+    sab_root = tmp_path / "sab-complete"
+    sab_root.mkdir()
+    completed = sab_root / "Spawn.344"
+    completed.mkdir()
+    monkeypatch.setattr(comicarr.CONFIG, "SAB_DIRECTORY", str(sab_root), raising=False)
+
+    nzb_name = "Spawn.344.cbz"
+    history = {
+        "status": True,
+        "location": str(completed),
+        "name": nzb_name,
+        "failed": False,
+    }
+    rkey = journal.release_key("681", "nzb.su", nzbname=nzb_name)
+    with get_engine().begin() as conn:
+        conn.execute(nzblog.insert().values(IssueID="681", PROVIDER="nzb.su"))
+        conn.execute(issues.insert().values(IssueID="681", Status="Snatched"))
+    payload = {
+        "issueid": "681",
+        "comicid": "C681",
+        "provider": "nzb.su",
+        "route": "sabnzbd",
+        "nzo_id": "SABnzbd_nzo_spawn344",
+        "nzb_name": nzb_name,
+        "download_info": {"provider": "nzb.su", "nzo_id": "SABnzbd_nzo_spawn344"},
+    }
+    assert "nzb_folder" not in payload
+    _insert_journal(
+        rkey,
+        journal.SNATCHED,
+        payload=payload,
+        issueid="681",
+        provider="nzb.su",
+        downloader_type="sabnzbd",
+    )
+
+    import comicarr.sabnzbd as sabnzbd_mod
+
+    monkeypatch.setattr(sabnzbd_mod.SABnzbd, "historycheck", lambda self, nzbinfo, **k: history)
+
+    action = recovery._resolve_row(journal.read_one(rkey))
+    assert action == "complete-pp-enqueued"
+
+    items = _drain(queues["pp"])
+    assert len(items) == 1
+    assert items[0]["nzb_folder"] == history["location"]
+    assert items[0]["nzb_name"] == nzb_name
+    assert items[0]["journal_release_key"] == rkey
+
+    persisted = journal.load_payload(journal.read_one(rkey)["payload_json"])
+    assert persisted["nzb_folder"] == history["location"]
+    row_after = journal.read_one(rkey)
+    assert row_after["stage"] == journal.DOWNLOADED
+    assert row_after.get("fail_reason") != "downloaded_invalid_artifact_command:PostProcessCommandError"
+    assert row_after.get("fail_reason") in (None, "")
+
+
 def test_complete_enqueues_pp_with_stamped_key(queues, tmp_path):
     rkey = journal.release_key("10", "nzb.su", nzbname="A.cbz")
     with get_engine().begin() as conn:
@@ -714,16 +776,16 @@ def test_one_bad_row_skipped_loop_continues_and_is_rerunnable(queues, monkeypatc
         downloader_type="nzb",
     )
 
-    real_classify = recovery_classify.classify
+    real_details = recovery_classify.classify_details
     fail_once = {"done": False}
 
-    def _classify(row, probes=None):
+    def _classify_details(row, probes=None, payload=None):
         if row.get("release_key") == bad and not fail_once["done"]:
             fail_once["done"] = True
             raise RuntimeError("boom: simulated bad row")
-        return real_classify(row, probes=probes)
+        return real_details(row, probes=probes, payload=payload)
 
-    monkeypatch.setattr(recovery_classify, "classify", _classify)
+    monkeypatch.setattr(recovery_classify, "classify_details", _classify_details)
     summary = recovery.replay_pipeline(probes=_probe("complete"))
     # Good row still processed despite the bad row raising.
     pp = _drain(queues["pp"])


### PR DESCRIPTION
## Summary
Restart recovery of a finished SABnzbd or NZBGet download now keeps the completed folder the downloader already reported. Comicarr used to throw that path away and then fail post-processing with "nzb_folder is required".

Fixes #681

## Test plan
- [x] `pytest tests/unit/test_recovery_replay.py::test_complete_sab_recovery_keeps_historycheck_folder tests/unit/test_recovery_classify.py`
- Restart Comicarr with a snatched SAB/NZBGet row whose history still has a completed location, and confirm post-processing starts instead of `PostProcessCommandError: nzb_folder is required`.