### PR TITLE
fix: Open Activity on the items the in-flight count uses

### DIFF
--- a/.changeset/inflight-link-shows-those-items.md
+++ b/.changeset/inflight-link-shows-those-items.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+The status bar's "N in flight" count now opens Activity on exactly those items — running searches and open download/post-processing rows — instead of a generic unfiltered Activity page.

--- a/comicarr/app/activity/queries.py
+++ b/comicarr/app/activity/queries.py
@@ -14,6 +14,8 @@ every count. These queries never aggregate ``activity_events`` for open-work
 or attention numbers — only ordered time slices of that table are allowed.
 """
 
+import json
+
 from sqlalchemy import and_, func, or_, select
 
 from comicarr import db
@@ -23,7 +25,7 @@ from comicarr.app.attention._read import list_rows as _list_attention_rows
 from comicarr.app.attention._read import unresolved_condition as _unresolved_attention_condition
 from comicarr.app.attention._serialization import serialize_groups as _serialize_attention_groups
 from comicarr.app.core.database import paginated_query
-from comicarr.app.downloads.journal import OPEN_STAGES
+from comicarr.app.downloads.journal import OPEN_STAGES, load_payload
 from comicarr.tables import acquisition_run_items, activity_events, pipeline_journal
 
 # Pagination pages *events* (not pre-grouped stories). Story grouping of 25 is
@@ -187,6 +189,115 @@ def count_open_journal_stages():
     )
     row = db.select_one(stmt)
     return int((row or {}).get("journal_count", 0) or 0)
+
+
+def _text(value):
+    if value in (None, ""):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _json_object(raw):
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    try:
+        decoded = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _run_item_label(row, payload):
+    name = _text(payload.get("comicname"))
+    number = _text(payload.get("issue_number")) or _text(payload.get("issuenumber"))
+    if name and number:
+        return "%s #%s" % (name, number)
+    if name:
+        return name
+    entity_type = _text(row.get("entity_type")) or "item"
+    entity_id = _text(row.get("entity_id"))
+    if entity_id:
+        return "%s %s" % (entity_type, entity_id)
+    return _text(row.get("command_kind")) or "search"
+
+
+def _journal_item_label(row, payload):
+    name = _text(payload.get("comicname")) or _text(payload.get("ComicName"))
+    number = _text(payload.get("issuenumber")) or _text(payload.get("Issue_Number"))
+    if name and number:
+        return "%s #%s" % (name, number)
+    if name:
+        return name
+    nzbname = _text(payload.get("nzbname")) or _text(payload.get("nzb_name")) or _text(row.get("nzbname"))
+    if nzbname:
+        return nzbname
+    issueid = _text(row.get("issueid")) or _text(payload.get("issueid"))
+    if issueid:
+        return "issue %s" % issueid
+    return _text(row.get("release_key")) or "download"
+
+
+def _shape_run_item(row):
+    payload = _json_object(row.get("payload_json"))
+    entity_type = _text(row.get("entity_type"))
+    entity_id = _text(row.get("entity_id"))
+    issueid = _text(payload.get("issueid"))
+    if issueid is None and entity_type in ("issue", "annual"):
+        issueid = entity_id
+    return {
+        "kind": "run",
+        "item_id": row.get("item_id"),
+        "run_id": row.get("run_id"),
+        "state": row.get("state"),
+        "label": _run_item_label(row, payload),
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "comicid": _text(payload.get("comicid")),
+        "issueid": issueid,
+        "command_kind": row.get("command_kind"),
+        "updated_at": row.get("updated_at"),
+    }
+
+
+def _shape_journal_item(row):
+    payload = _json_object(load_payload(row.get("payload_json")))
+    issueid = _text(row.get("issueid")) or _text(payload.get("issueid"))
+    return {
+        "kind": "journal",
+        "release_key": row.get("release_key"),
+        "stage": row.get("stage"),
+        "label": _journal_item_label(row, payload),
+        "issueid": issueid,
+        "comicid": _text(payload.get("comicid")) or _text(payload.get("ComicID")),
+        "provider": _text(row.get("provider")),
+        "updated_at": row.get("updated_date"),
+    }
+
+
+def _in_flight_sort_key(item):
+    identity = item.get("item_id") if item.get("kind") == "run" else item.get("release_key")
+    return (item.get("updated_at") or "", item.get("kind") or "", str(identity or ""))
+
+
+def list_in_flight_items():
+    """Return the same rows ``get_open_work_counts()['in_flight']`` counts.
+
+    Membership is the count predicates — accepted|running run items plus
+    OPEN_STAGES journal rows. Each item carries a stable identity (``kind``
+    plus ``item_id`` or ``release_key``) so a later cancel can target a row
+    without inventing a second list (#676 / #677).
+    """
+    run_rows = db.select_all(
+        select(acquisition_run_items).where(acquisition_run_items.c.state.in_(IN_FLIGHT_ITEM_STATES))
+    )
+    journal_rows = db.select_all(select(pipeline_journal).where(pipeline_journal.c.stage.in_(OPEN_STAGES)))
+    items = [_shape_run_item(row) for row in run_rows]
+    items.extend(_shape_journal_item(row) for row in journal_rows)
+    items.sort(key=_in_flight_sort_key, reverse=True)
+    return items
 
 
 def get_open_work_counts():

--- a/comicarr/app/activity/router.py
+++ b/comicarr/app/activity/router.py
@@ -14,6 +14,7 @@ Endpoints:
 * ``GET /api/activity/timeline`` — narrative events, newest first
 * ``GET /api/activity/band`` — needs-attention groups (R9 predicate, grouped)
 * ``GET /api/activity/status`` — derived open-work counts (never narrative)
+* ``GET /api/activity/in-flight`` — the rows that status counts as in-flight
 
 **Pagination choice:** timeline pages *events* ordered by ``created_at``.
 Story grouping (25 stories per UI page) is a client concern so the API can
@@ -86,3 +87,14 @@ def get_status():
     ``attention`` = unresolved band count. Never aggregates activity_events.
     """
     return service.get_status()
+
+
+@router.get("/in-flight", dependencies=[Depends(require_session)])
+def get_in_flight():
+    """Return the rows counted as in-flight.
+
+    Same membership as ``GET /api/activity/status`` ``in_flight``:
+    accepted|running run items plus OPEN_STAGES journal rows. Each item has a
+    stable identity (``kind`` plus ``item_id`` or ``release_key``).
+    """
+    return service.get_in_flight()

--- a/comicarr/app/activity/service.py
+++ b/comicarr/app/activity/service.py
@@ -39,3 +39,9 @@ def get_attention_band(scope_type=None, scope_id=None):
 def get_status():
     """Open-work counts for the global quiet-counts status indicator."""
     return queries.get_open_work_counts()
+
+
+def get_in_flight():
+    """Rows counted as in-flight — same membership as ``get_status()['in_flight']``."""
+    items = queries.list_in_flight_items()
+    return {"results": items, "total": len(items)}

--- a/frontend/src/hooks/useActivity.ts
+++ b/frontend/src/hooks/useActivity.ts
@@ -7,6 +7,7 @@ import {
 import { apiRequest } from "@/lib/api";
 import {
   ACTIVITY_BAND_QUERY_KEY,
+  ACTIVITY_IN_FLIGHT_QUERY_KEY,
   ACTIVITY_STATUS_QUERY_KEY,
   ACTIVITY_TIMELINE_QUERY_KEY,
 } from "@/lib/activityKeys";
@@ -91,6 +92,38 @@ interface QueueResponse {
   pagination: PaginationMeta;
 }
 
+export type InFlightRunItem = {
+  kind: "run";
+  item_id: number;
+  run_id: string;
+  state: string;
+  label: string;
+  entity_type: string;
+  entity_id: string;
+  comicid?: string | null;
+  issueid?: string | null;
+  command_kind: string;
+  updated_at: string;
+};
+
+export type InFlightJournalItem = {
+  kind: "journal";
+  release_key: string;
+  stage: string;
+  label: string;
+  issueid?: string | null;
+  comicid?: string | null;
+  provider?: string | null;
+  updated_at: string;
+};
+
+export type InFlightItem = InFlightRunItem | InFlightJournalItem;
+
+export interface InFlightPage {
+  results: InFlightItem[];
+  total: number;
+}
+
 interface RequeueDownloadResult {
   success: boolean;
   error?: string;
@@ -126,6 +159,19 @@ export function useDownloadHistory(query: ActivityQuery) {
         activityUrl("/api/downloads/history", query),
       ),
     staleTime: 30 * 1000, // 30 seconds
+  });
+}
+
+/**
+ * Derived in-flight rows — the same set GET /api/activity/status counts.
+ * Do not reuse the DDL queue as the source of truth (#676).
+ */
+export function useInFlightItems() {
+  return useQuery<InFlightPage>({
+    queryKey: ACTIVITY_IN_FLIGHT_QUERY_KEY,
+    queryFn: () => apiRequest<InFlightPage>("GET", "/api/activity/in-flight"),
+    staleTime: ACTIVITY_POLL_MS,
+    refetchInterval: ACTIVITY_POLL_MS,
   });
 }
 

--- a/frontend/src/lib/activityKeys.ts
+++ b/frontend/src/lib/activityKeys.ts
@@ -10,6 +10,7 @@
 export const ACTIVITY_TIMELINE_QUERY_KEY = ["activity", "timeline"] as const;
 export const ACTIVITY_BAND_QUERY_KEY = ["activity", "band"] as const;
 export const ACTIVITY_STATUS_QUERY_KEY = ["activity", "status"] as const;
+export const ACTIVITY_IN_FLIGHT_QUERY_KEY = ["activity", "in-flight"] as const;
 
 /**
  * Every key a narrated event stales: the narrative feed plus the derived
@@ -20,4 +21,5 @@ export const ACTIVITY_INVALIDATION_KEYS: readonly (readonly string[])[] = [
   ACTIVITY_TIMELINE_QUERY_KEY,
   ACTIVITY_BAND_QUERY_KEY,
   ACTIVITY_STATUS_QUERY_KEY,
+  ACTIVITY_IN_FLIGHT_QUERY_KEY,
 ];

--- a/frontend/src/lib/activityStatus.ts
+++ b/frontend/src/lib/activityStatus.ts
@@ -56,7 +56,8 @@ function apiText(s: ActivityStatusSnapshot): string {
 
 /**
  * Compose the quiet-count status line and segment roles.
- * Attention segment only when K > 0. Activity/idle/attention/unreachable link to /activity.
+ * Attention segment only when K > 0. In-flight links to
+ * `/activity?state=in_flight`; idle/unreachable stay on `/activity`.
  */
 export function formatQuietStatus(s: ActivityStatusSnapshot): QuietStatusMeta {
   const segments: StatusSegment[] = [];
@@ -84,7 +85,7 @@ export function formatQuietStatus(s: ActivityStatusSnapshot): QuietStatusMeta {
       segments.push({
         role: "activity",
         text: `${s.inFlight} in flight`,
-        href: "/activity",
+        href: "/activity?state=in_flight",
       });
     } else {
       segments.push({

--- a/frontend/src/lib/mockData.ts
+++ b/frontend/src/lib/mockData.ts
@@ -658,6 +658,36 @@ export function mockApiResponse(
     // Quiet-count inputs for AppStatusBar (Variant A). Fixture: light open work.
     return { in_flight: 2, recovery_pending: 1, attention: 0 };
   }
+  if (m === "GET" && url === "/api/activity/in-flight") {
+    return {
+      results: [
+        {
+          kind: "run",
+          item_id: 1,
+          run_id: "run-1",
+          state: "running",
+          label: "Saga #1",
+          entity_type: "issue",
+          entity_id: "iss-1",
+          comicid: "absolute-flash",
+          issueid: "iss-1",
+          command_kind: "search_issue",
+          updated_at: "2026-07-10 10:01:00",
+        },
+        {
+          kind: "journal",
+          release_key: "open-pp",
+          stage: "post_processing",
+          label: "Invincible #12",
+          issueid: "iss-10",
+          comicid: "invincible",
+          provider: "DDL",
+          updated_at: "2026-07-10 12:00:00",
+        },
+      ],
+      total: 2,
+    };
+  }
   if (m === "GET" && url === "/api/dashboard/library") {
     return dashboardLibraryPayload();
   }

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -232,7 +232,7 @@ function inFlightKindLabel(item: InFlightItem): string {
 
 function inFlightStateLabel(item: InFlightItem): string {
   if (item.kind === "run") return item.state;
-  return item.stage.replaceAll("_", " ");
+  return (item.stage || "").replace(/_/g, " ");
 }
 
 function InFlightView() {

--- a/frontend/src/pages/ActivityPage.tsx
+++ b/frontend/src/pages/ActivityPage.tsx
@@ -9,8 +9,10 @@ import { RefreshCw } from "lucide-react";
 import {
   useDownloadHistory,
   useDownloadQueue,
+  useInFlightItems,
   useRequeueDownload,
   type HistoryItem,
+  type InFlightItem,
   type QueueItem,
 } from "@/hooks/useActivity";
 import { useDebounce } from "@/hooks/use-debounce";
@@ -34,7 +36,7 @@ import PageHeader, { Tab, TabRow } from "@/components/layout/PageHeader";
 import { useToast } from "@/components/ui/toast";
 import type { PaginationMeta } from "@/types";
 
-type ActivityView = "timeline" | "queue" | "history";
+type ActivityView = "timeline" | "in_flight" | "queue" | "history";
 const PAGE_SIZE = 25;
 
 function statusPillMeta(status: string) {
@@ -115,9 +117,14 @@ export default function ActivityPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const rawView = searchParams.get("view");
   // Timeline is the default landing tab (#429 / #486). Queue keeps working via
-  // ?view=queue; history via ?view=history.
+  // ?view=queue; history via ?view=history. The status bar's in-flight count
+  // lands on ?state=in_flight — a different dataset than the timeline (#676).
   const currentView: ActivityView =
-    rawView === "history" || rawView === "queue" ? rawView : "timeline";
+    searchParams.get("state") === "in_flight"
+      ? "in_flight"
+      : rawView === "history" || rawView === "queue"
+        ? rawView
+        : "timeline";
 
   const scope_type = searchParams.get("scope_type");
   const scope_id = searchParams.get("scope_id");
@@ -125,8 +132,14 @@ export default function ActivityPage() {
   const setView = (view: ActivityView) => {
     setSearchParams((current) => {
       const next = new URLSearchParams(current);
-      if (view === "timeline") next.delete("view");
-      else next.set("view", view);
+      if (view === "in_flight") {
+        next.delete("view");
+        next.set("state", "in_flight");
+      } else {
+        next.delete("state");
+        if (view === "timeline") next.delete("view");
+        else next.set("view", view);
+      }
       return next;
     });
   };
@@ -134,9 +147,11 @@ export default function ActivityPage() {
   const meta =
     currentView === "timeline"
       ? "what Comicarr has been doing"
-      : currentView === "queue"
-        ? "live direct downloads"
-        : "download history";
+      : currentView === "in_flight"
+        ? "running searches and open download rows"
+        : currentView === "queue"
+          ? "live direct downloads"
+          : "download history";
 
   return (
     <div className="page-transition flex h-full min-h-0 flex-col">
@@ -147,6 +162,11 @@ export default function ActivityPage() {
           active={currentView === "timeline"}
           label="Timeline"
           onClick={() => setView("timeline")}
+        />
+        <Tab
+          active={currentView === "in_flight"}
+          label="In flight"
+          onClick={() => setView("in_flight")}
         />
         <Tab
           active={currentView === "queue"}
@@ -164,10 +184,143 @@ export default function ActivityPage() {
         {currentView === "timeline" && (
           <TimelineView scope_type={scope_type} scope_id={scope_id} />
         )}
+        {currentView === "in_flight" && <InFlightView />}
         {currentView === "queue" && <QueueView />}
         {currentView === "history" && <HistoryView />}
       </div>
     </div>
+  );
+}
+
+function inFlightRowId(item: InFlightItem): string {
+  return item.kind === "run"
+    ? `run:${item.item_id}`
+    : `journal:${item.release_key}`;
+}
+
+function inFlightHref(item: InFlightItem): string | null {
+  if (item.comicid && item.issueid) {
+    return `/library/${encodeURIComponent(item.comicid)}/issue/${encodeURIComponent(item.issueid)}`;
+  }
+  if (item.comicid) {
+    return `/library/${encodeURIComponent(item.comicid)}`;
+  }
+  return null;
+}
+
+function inFlightKindLabel(item: InFlightItem): string {
+  if (item.kind === "run") {
+    const command = (item.command_kind || "").toLowerCase();
+    if (command.includes("refresh")) return "Refreshing";
+    return "Searching";
+  }
+  switch (item.stage) {
+    case "reserved":
+      return "Reserved";
+    case "snatched":
+      return "Snatched";
+    case "downloaded":
+      return "Downloaded";
+    case "post_processing":
+      return "Post-processing";
+    case "moved":
+      return "Moving";
+    default:
+      return item.stage || "In flight";
+  }
+}
+
+function inFlightStateLabel(item: InFlightItem): string {
+  if (item.kind === "run") return item.state;
+  return item.stage.replaceAll("_", " ");
+}
+
+function InFlightView() {
+  const inflight = useInFlightItems();
+  const items = inflight.data?.results ?? [];
+  const hardError = !inflight.data ? inflight.error : null;
+
+  if (inflight.isLoading && !inflight.data) {
+    return <LoadingRows />;
+  }
+
+  if (hardError) {
+    return (
+      <div className="px-5 py-4">
+        <ErrorDisplay
+          error={hardError}
+          title="Unable to load in-flight work"
+          onRetry={() => void inflight.refetch()}
+        />
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="px-5 py-10">
+        <EmptyState
+          variant="custom"
+          eyebrow="IN FLIGHT · EMPTY"
+          title="Nothing in flight"
+          description="Running searches and open download or post-processing rows appear here — the same items the status bar counts."
+          action={{ label: "Back to timeline", to: "/activity" }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <ul
+      className="flex-1 min-h-0 overflow-auto divide-y divide-border"
+      aria-label="In-flight items"
+    >
+      {items.map((item) => {
+        const href = inFlightHref(item);
+        return (
+          <li
+            key={inFlightRowId(item)}
+            className="flex items-start gap-3 px-5 py-2.5"
+            data-kind={item.kind}
+            data-item-id={
+              item.kind === "run" ? String(item.item_id) : item.release_key
+            }
+          >
+            <span
+              className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full"
+              style={{ background: "var(--status-active)" }}
+              aria-hidden
+            />
+            <div className="min-w-0 flex-1">
+              <div className="text-[13px]">
+                {href ? (
+                  <Link
+                    to={href}
+                    className="font-medium hover:text-[var(--primary)]"
+                  >
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span className="font-medium">{item.label}</span>
+                )}
+              </div>
+              <div className="font-mono text-[11px] text-muted-foreground">
+                {inFlightKindLabel(item)}
+                <span className="mx-1.5">·</span>
+                {inFlightStateLabel(item)}
+                {item.kind === "journal" && item.provider ? (
+                  <>
+                    <span className="mx-1.5">·</span>
+                    {item.provider}
+                  </>
+                ) : null}
+              </div>
+            </div>
+            <RelativeTime value={item.updated_at} />
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 

--- a/frontend/tests/components/AppStatusBar.test.tsx
+++ b/frontend/tests/components/AppStatusBar.test.tsx
@@ -32,9 +32,9 @@ describe("AppStatusBar", () => {
     expect(screen.queryByText("production")).toBeNull();
     expect(screen.queryByText("healthy")).toBeNull();
 
-    // Activity segment links to /activity; library/api do not.
+    // In-flight count links to the items it counts; library/api do not.
     const activityLink = screen.getByRole("link", { name: "2 in flight" });
-    expect(activityLink.getAttribute("href")).toBe("/activity");
+    expect(activityLink.getAttribute("href")).toBe("/activity?state=in_flight");
     expect(screen.queryByRole("link", { name: /10 series/ })).toBeNull();
     expect(screen.queryByRole("link", { name: /online/ })).toBeNull();
 

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -145,6 +145,37 @@ export const handlers = [
     HttpResponse.json({ in_flight: 2, attention: 0 }),
   ),
 
+  http.get("/api/activity/in-flight", () =>
+    HttpResponse.json({
+      results: [
+        {
+          kind: "run",
+          item_id: 1,
+          run_id: "run-1",
+          state: "running",
+          label: "Saga #1",
+          entity_type: "issue",
+          entity_id: "iss-1",
+          comicid: "42",
+          issueid: "iss-1",
+          command_kind: "search_issue",
+          updated_at: "2026-07-10 10:01:00",
+        },
+        {
+          kind: "journal",
+          release_key: "open-pp",
+          stage: "post_processing",
+          label: "Invincible #12",
+          issueid: "iss-10",
+          comicid: "7",
+          provider: "DDL",
+          updated_at: "2026-07-10 12:00:00",
+        },
+      ],
+      total: 2,
+    }),
+  ),
+
   // Needs-attention groups (dashboard §3.2 / Activity Center band). Default
   // empty so a page that mounts the band never invents trouble.
   http.get("/api/attention", () =>

--- a/frontend/tests/pages/ActivityPage.test.tsx
+++ b/frontend/tests/pages/ActivityPage.test.tsx
@@ -395,6 +395,84 @@ describe("ActivityPage", () => {
     });
   });
 
+  it("renders the in-flight items from the dedicated endpoint when state=in_flight", async () => {
+    let inFlightCalls = 0;
+    let timelineCalls = 0;
+    server.use(
+      http.get("/api/activity/in-flight", () => {
+        inFlightCalls += 1;
+        return HttpResponse.json({
+          results: [
+            {
+              kind: "run",
+              item_id: 11,
+              run_id: "run-1",
+              state: "running",
+              label: "Saga #1",
+              entity_type: "issue",
+              entity_id: "iss-1",
+              comicid: "42",
+              issueid: "iss-1",
+              command_kind: "search_issue",
+              updated_at: "2026-07-10 10:01:00",
+            },
+            {
+              kind: "journal",
+              release_key: "open-pp",
+              stage: "post_processing",
+              label: "Invincible #12",
+              issueid: "iss-10",
+              comicid: "7",
+              provider: "DDL",
+              updated_at: "2026-07-10 12:00:00",
+            },
+          ],
+          total: 2,
+        });
+      }),
+      http.get("/api/activity/timeline", () => {
+        timelineCalls += 1;
+        return HttpResponse.json({
+          results: [],
+          total: 0,
+          limit: 100,
+          offset: 0,
+          has_more: false,
+        });
+      }),
+      http.get("/api/downloads/queue", () =>
+        HttpResponse.json({
+          queue: [queueItem],
+          pagination: { total: 1, limit: 25, offset: 0, has_more: false },
+        }),
+      ),
+    );
+
+    render(<ActivityPage />, {
+      route: "/activity?state=in_flight",
+      useMemoryRouter: true,
+    });
+
+    expect(await screen.findByText("Saga #1")).toBeTruthy();
+    expect(screen.getByText("Invincible #12")).toBeTruthy();
+    expect(screen.getByText(/searching/i)).toBeTruthy();
+    expect(screen.getByText(/post-processing/i)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "In flight" }).getAttribute(
+        "aria-pressed",
+      ),
+    ).toBe("true");
+
+    // Same set as the status-bar count — not the timeline and not the DDL queue.
+    expect(screen.queryByText("Nothing has happened yet")).toBeNull();
+    expect(screen.queryByText("Absolute Flash")).toBeNull();
+    expect(
+      screen.queryByRole("textbox", { name: "Filter queue activity" }),
+    ).toBeNull();
+    expect(inFlightCalls).toBeGreaterThan(0);
+    expect(timelineCalls).toBe(0);
+  });
+
   it("uses the shared table for history with newest-first defaults", async () => {
     let historyRequest: URL | undefined;
     server.use(

--- a/frontend/tests/unit/lib/activityLive.test.ts
+++ b/frontend/tests/unit/lib/activityLive.test.ts
@@ -58,6 +58,7 @@ describe("invalidation contract", () => {
       ["activity", "timeline"],
       ["activity", "band"],
       ["activity", "status"],
+      ["activity", "in-flight"],
     ]);
   });
 

--- a/frontend/tests/unit/lib/activityStatus.test.ts
+++ b/frontend/tests/unit/lib/activityStatus.test.ts
@@ -32,7 +32,7 @@ describe("formatQuietStatus", () => {
     const meta = formatQuietStatus(snap({ inFlight: 5 }));
     expect(meta.line).toBe("library: 412 series · api: online · 5 in flight");
     expect(meta.segments.find((s) => s.role === "activity")?.href).toBe(
-      "/activity",
+      "/activity?state=in_flight",
     );
   });
 

--- a/frontend/tests/unit/useServerEvents.test.tsx
+++ b/frontend/tests/unit/useServerEvents.test.tsx
@@ -144,6 +144,7 @@ describe("coalesced invalidation", () => {
       "activity/timeline",
       "activity/band",
       "activity/status",
+      "activity/in-flight",
       "wanted",
     ]);
   });
@@ -173,6 +174,7 @@ describe("coalesced invalidation", () => {
       "activity/timeline",
       "activity/band",
       "activity/status",
+      "activity/in-flight",
       "series",
       "series/42",
       "wanted",
@@ -220,6 +222,7 @@ describe("coalesced invalidation", () => {
       "activity/timeline",
       "activity/band",
       "activity/status",
+      "activity/in-flight",
     ]);
   });
 

--- a/tests/unit/test_activity_read_apis.py
+++ b/tests/unit/test_activity_read_apis.py
@@ -568,93 +568,133 @@ def test_reason_phrase_matches_on_base_token(activity_db):
 # ---------------------------------------------------------------------------
 
 
+def _seed_open_work_count_fixtures(conn):
+    """2 accepted|running run items + 1 OPEN_STAGES journal (+ terminal noise)."""
+    conn.execute(
+        insert(activity_events),
+        [
+            _event(activity="search", status="started", subject_type="run", subject_id="r1"),
+            _event(activity="grab", status="failed", subject_type="issue", subject_id="iss-1"),
+        ],
+    )
+    conn.execute(
+        insert(acquisition_run_items),
+        [
+            {
+                "run_id": "run-1",
+                "command_kind": "search_issue",
+                "entity_type": "issue",
+                "entity_id": "iss-1",
+                "state": "accepted",
+                "dispatch_state": "pending",
+                "queue_priority": "routine",
+                "attempt_count": 0,
+                "created_at": "2026-07-10 10:00:00",
+                "updated_at": "2026-07-10 10:00:00",
+            },
+            {
+                "run_id": "run-1",
+                "command_kind": "search_issue",
+                "entity_type": "issue",
+                "entity_id": "iss-2",
+                "state": "running",
+                "dispatch_state": "accepted",
+                "queue_priority": "routine",
+                "attempt_count": 1,
+                "created_at": "2026-07-10 10:00:00",
+                "updated_at": "2026-07-10 10:01:00",
+            },
+            {
+                "run_id": "run-1",
+                "command_kind": "search_issue",
+                "entity_type": "issue",
+                "entity_id": "iss-3",
+                "state": "succeeded",
+                "dispatch_state": "accepted",
+                "queue_priority": "routine",
+                "attempt_count": 1,
+                "created_at": "2026-07-10 10:00:00",
+                "updated_at": "2026-07-10 10:02:00",
+                "completed_at": "2026-07-10 10:02:00",
+            },
+        ],
+    )
+    conn.execute(
+        insert(pipeline_journal),
+        [
+            _journal(
+                release_key="open-pp",
+                stage="post_processing",
+                stage_rank=30,
+                status=None,
+                issueid="iss-10",
+            ),
+            _journal(
+                release_key="done",
+                stage="post_processed",
+                stage_rank=50,
+                status=None,
+                issueid="iss-11",
+            ),
+            _journal(release_key="need-attn", stage="failed", status=None, issueid="iss-12"),
+            _journal(
+                release_key="resolved",
+                stage="failed",
+                status="ignored",
+                issueid="iss-13",
+            ),
+        ],
+    )
+
+
 def test_open_work_counts_from_ledgers_not_narrative(activity_db):
     """Authority rule: never aggregate activity_events for counts."""
     from comicarr.app.activity import queries
 
     with activity_db.begin() as conn:
-        # Narrative noise — must not affect counts
-        conn.execute(
-            insert(activity_events),
-            [
-                _event(activity="search", status="started", subject_type="run", subject_id="r1"),
-                _event(activity="grab", status="failed", subject_type="issue", subject_id="iss-1"),
-            ],
-        )
-        conn.execute(
-            insert(acquisition_run_items),
-            [
-                {
-                    "run_id": "run-1",
-                    "command_kind": "search_issue",
-                    "entity_type": "issue",
-                    "entity_id": "iss-1",
-                    "state": "accepted",
-                    "dispatch_state": "pending",
-                    "queue_priority": "routine",
-                    "attempt_count": 0,
-                    "created_at": "2026-07-10 10:00:00",
-                    "updated_at": "2026-07-10 10:00:00",
-                },
-                {
-                    "run_id": "run-1",
-                    "command_kind": "search_issue",
-                    "entity_type": "issue",
-                    "entity_id": "iss-2",
-                    "state": "running",
-                    "dispatch_state": "accepted",
-                    "queue_priority": "routine",
-                    "attempt_count": 1,
-                    "created_at": "2026-07-10 10:00:00",
-                    "updated_at": "2026-07-10 10:01:00",
-                },
-                {
-                    "run_id": "run-1",
-                    "command_kind": "search_issue",
-                    "entity_type": "issue",
-                    "entity_id": "iss-3",
-                    "state": "succeeded",
-                    "dispatch_state": "accepted",
-                    "queue_priority": "routine",
-                    "attempt_count": 1,
-                    "created_at": "2026-07-10 10:00:00",
-                    "updated_at": "2026-07-10 10:02:00",
-                    "completed_at": "2026-07-10 10:02:00",
-                },
-            ],
-        )
-        conn.execute(
-            insert(pipeline_journal),
-            [
-                _journal(
-                    release_key="open-pp",
-                    stage="post_processing",
-                    stage_rank=30,
-                    status=None,
-                    issueid="iss-10",
-                ),
-                _journal(
-                    release_key="done",
-                    stage="post_processed",
-                    stage_rank=50,
-                    status=None,
-                    issueid="iss-11",
-                ),
-                _journal(release_key="need-attn", stage="failed", status=None, issueid="iss-12"),
-                _journal(
-                    release_key="resolved",
-                    stage="failed",
-                    status="ignored",
-                    issueid="iss-13",
-                ),
-            ],
-        )
+        _seed_open_work_count_fixtures(conn)
 
     counts = queries.get_open_work_counts()
     # 2 in-flight run items + 1 open journal stage
     assert counts["in_flight"] == 3
     assert counts["attention"] == 1
     assert "activity_events" not in counts
+
+
+def test_list_in_flight_items_matches_open_work_count_rows(activity_db):
+    """The listed rows are exactly the rows the in-flight count uses (#676)."""
+    from comicarr.app.activity import queries
+
+    with activity_db.begin() as conn:
+        _seed_open_work_count_fixtures(conn)
+
+    items = queries.list_in_flight_items()
+    counts = queries.get_open_work_counts()
+    assert len(items) == counts["in_flight"] == 3
+
+    by_identity = {}
+    for item in items:
+        if item["kind"] == "run":
+            by_identity[("run", item["entity_id"])] = item
+        else:
+            by_identity[("journal", item["release_key"])] = item
+
+    assert set(by_identity) == {
+        ("run", "iss-1"),
+        ("run", "iss-2"),
+        ("journal", "open-pp"),
+    }
+    accepted = by_identity[("run", "iss-1")]
+    assert accepted["state"] == "accepted"
+    assert accepted["run_id"] == "run-1"
+    assert accepted["item_id"] is not None
+    assert accepted["entity_type"] == "issue"
+    running = by_identity[("run", "iss-2")]
+    assert running["state"] == "running"
+    assert running["item_id"] != accepted["item_id"]
+    journal = by_identity[("journal", "open-pp")]
+    assert journal["stage"] == "post_processing"
+    assert journal["issueid"] == "iss-10"
 
 
 def test_open_work_idle_when_ledgers_empty(activity_db):
@@ -698,6 +738,9 @@ def test_service_timeline_and_status_shapes(activity_db):
     assert status["in_flight"] == 0
     assert status["attention"] == 1
 
+    inflight = service.get_in_flight()
+    assert inflight == {"results": [], "total": 0}
+
 
 def test_band_endpoint_collapses_a_production_shaped_pile(activity_db):
     """The wire shape the frontend types mirror, at the volume that broke it.
@@ -723,9 +766,7 @@ def test_band_endpoint_collapses_a_production_shaped_pile(activity_db):
                 stage="manual_review",
                 stage_rank=55,
                 fail_reason="downloaded_invalid_artifact_command:PostProcessCommandError",
-                payload_json=json.dumps(
-                    {"comicid": "18839", "comicname": "Looney Tunes", "issuenumber": str(index)}
-                ),
+                payload_json=json.dumps({"comicid": "18839", "comicname": "Looney Tunes", "issuenumber": str(index)}),
             )
         )
     for index in range(226):
@@ -736,9 +777,7 @@ def test_band_endpoint_collapses_a_production_shaped_pile(activity_db):
                 stage="manual_review",
                 stage_rank=55,
                 fail_reason="postprocess_error:OperationalError",
-                payload_json=json.dumps(
-                    {"comicid": "s%d" % (index % 38), "comicname": "Series %d" % (index % 38)}
-                ),
+                payload_json=json.dumps({"comicid": "s%d" % (index % 38), "comicname": "Series %d" % (index % 38)}),
             )
         )
 
@@ -786,6 +825,36 @@ def test_band_endpoint_collapses_a_production_shaped_pile(activity_db):
         assert status.json()["attention_members"] == 399
 
 
+def test_in_flight_endpoint_returns_same_rows_as_count(activity_db):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from comicarr.app.activity.router import router
+    from comicarr.app.core.security import require_session
+
+    with activity_db.begin() as conn:
+        _seed_open_work_count_fixtures(conn)
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_session] = lambda: "operator"
+
+    with TestClient(app) as client:
+        response = client.get("/api/activity/in-flight")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 3
+        assert len(body["results"]) == 3
+        identities = {(item["kind"], item.get("entity_id") or item.get("release_key")) for item in body["results"]}
+        assert identities == {
+            ("run", "iss-1"),
+            ("run", "iss-2"),
+            ("journal", "open-pp"),
+        }
+        status = client.get("/api/activity/status")
+        assert status.json()["in_flight"] == body["total"]
+
+
 def test_router_registers_session_protected_routes():
     """Auth class matches other operator APIs (require_session dependency)."""
     from comicarr.app.activity.router import router
@@ -795,6 +864,7 @@ def test_router_registers_session_protected_routes():
     assert "/api/activity/timeline" in paths
     assert "/api/activity/band" in paths
     assert "/api/activity/status" in paths
+    assert "/api/activity/in-flight" in paths
 
     for route in router.routes:
         deps = getattr(route, "dependencies", None) or []


### PR DESCRIPTION
## Summary
The status bar's "N in flight" count now opens Activity on exactly those items — running searches and open download/post-processing rows — instead of a generic unfiltered Activity page.

Fixes #676

## Test plan
- [x] `pytest tests/unit/test_activity_read_apis.py::test_in_flight_endpoint_returns_same_rows_as_count`
- [x] `vitest run tests/unit/lib/activityStatus.test.ts tests/components/AppStatusBar.test.tsx tests/pages/ActivityPage.test.tsx`
- Click "N in flight" in the status bar and confirm the In flight tab lists the same items as the count.