### PR TITLE
refactor: Own the Search provider record in one module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,18 @@ An operator-initiated review of release candidates for one tracked acquisition i
 
 _Avoid_: Manual search, interactive search
 
+## Search provider
+
+A configured acquisition source Comicarr queries for release candidates: a Newznab or Torznab indexer, a DDL site, a torrent site, or the experimental source. Distinct from a Series provider, which answers who issued a Series' identifier — a Search provider answers where releases are found.
+
+_Avoid_: Indexer (as the umbrella term), provider (unqualified where either meaning could apply)
+
+## Acquisition route
+
+The delivery channel a Search provider serves: `ddl`, `nzb`, or `torrent`. Every Search provider serves exactly one route. Route readiness — whether Comicarr can currently acquire through a channel end to end, including its downstream client — is a property of the route, not of any one provider.
+
+_Avoid_: Search route, download method
+
 ## Needs attention
 
 The work queue of unresolved, actionable acquisition obligations that Comicarr cannot finish without operator information, authority, or judgment. It excludes trouble Comicarr can reconcile itself.

--- a/comicarr/app/search/health.py
+++ b/comicarr/app/search/health.py
@@ -18,6 +18,7 @@ import time
 import comicarr
 from comicarr import db
 from comicarr.app.search import queries
+from comicarr.app.search.provider_config import provider_enabled
 from comicarr.app.search.providers import effective_provider_plan, enabled_provider_entries, ordered_provider_names
 from comicarr.db import get_engine
 
@@ -302,9 +303,7 @@ def build_route_readiness(
             if route == "nzb":
                 raw_providers = list(getattr(config, "EXTRA_NEWZNABS", None) or [])
                 valid_providers = [row for row in raw_providers if isinstance(row, (list, tuple)) and len(row) >= 6]
-                enabled_providers = [
-                    row for row in valid_providers if str(row[5]).lower() in {"1", "true", "yes", "on"}
-                ]
+                enabled_providers = [row for row in valid_providers if provider_enabled(row)]
                 downloader = int(getattr(config, "NZB_DOWNLOADER", 3) or 0)
                 if downloader == 3:
                     reason = "downloader_disabled"

--- a/comicarr/app/search/provider_config.py
+++ b/comicarr/app/search/provider_config.py
@@ -1,0 +1,248 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""The Search provider record and the legacy INI codec that stores it.
+
+A configured Newznab or Torznab Search provider is persisted as a flat
+positional tuple inside one comma-joined INI option (``extra_newznabs`` /
+``extra_torznabs``).  Every fact about that encoding lives here and only
+here: the legal widths, which fields are booleans and how they must be
+spelled, which field is the Fernet-encrypted credential, and how field 4
+packs ``rss_uid#categories`` for Newznab but a bare category list for
+Torznab.  Callers work with :class:`SearchProvider` and ask by name;
+``config.py`` calls the codec at its load/store choke points and is the
+only module that still needs the raw tuple shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+PROVIDER_EXTRA_FIELDS = ("EXTRA_NEWZNABS", "EXTRA_TORZNABS")
+PROVIDER_EXTRA_WIDTHS = (6, 7)
+PROVIDER_CREDENTIAL_INDEX = 3
+_PROVIDER_BOOLEAN_VALUES = {"0", "1", "false", "true", "no", "yes", "off", "on"}
+_PROVIDER_BOOLEAN_TRUE = {"1", "true", "yes", "on"}
+# Verify-TLS and enabled. Both are read as `bool(int(field))` by the search
+# path and compared against the literal "1" by the enabled filters, so a field
+# spelled any other legal way is a crash or a silent skip -- see
+# canonical_provider_boolean.
+PROVIDER_BOOLEAN_INDEXES = (2, 5)
+
+DEFAULT_NEWZNAB_RSS_UID = "1"
+
+
+def canonical_provider_boolean(value):
+    """Return a provider boolean field as the only spelling every reader agrees on.
+
+    `_PROVIDER_BOOLEAN_VALUES` accepts eight spellings, but the consumers do
+    not. `search.py` and `rsscheck.py` read verify as `bool(int(field))`, which
+    raises `ValueError` on `"True"`; the enabled filters in `search.py` compare
+    against the literal `"1"` while `health.py` and the providers API accept
+    `true`/`yes`/`on`. So an entry stored as `True` was reported enabled by the
+    Acquisition tab and skipped by the searcher -- and one stored with a
+    non-numeric verify took the search down. Both fields are normalised here,
+    at the single boundary every reader and writer passes through, so tolerance
+    at the edge cannot become disagreement in the middle.
+    """
+    return "1" if str(value).strip().lower() in _PROVIDER_BOOLEAN_TRUE else "0"
+
+
+def provider_boolean(value) -> bool:
+    """Read a provider boolean field, tolerating every historical spelling."""
+    return str(value).strip().lower() in _PROVIDER_BOOLEAN_TRUE
+
+
+def provider_enabled(entry) -> bool:
+    """The one enabled test for a raw provider tuple."""
+    try:
+        return provider_boolean(entry[5])
+    except (IndexError, TypeError):
+        return False
+
+
+def _provider_entry_is_structurally_valid(entry):
+    """Distinguish historical six- and seven-field provider records safely."""
+    if len(entry) not in PROVIDER_EXTRA_WIDTHS:
+        return False
+    if str(entry[2]).strip().lower() not in _PROVIDER_BOOLEAN_VALUES:
+        return False
+    if str(entry[5]).strip().lower() not in _PROVIDER_BOOLEAN_VALUES:
+        return False
+    if len(entry) == 7:
+        try:
+            int(entry[6])
+        except (TypeError, ValueError):
+            return False
+    return True
+
+
+def parse_provider_extras(value, config_version=15):
+    """Parse provider extras without assuming one historical tuple width."""
+    if value in (None, "", "None"):
+        return []
+
+    if isinstance(value, (list, tuple)):
+        entries = value
+    elif isinstance(value, str):
+        parts = value.split(", ")
+        candidates = []
+        for width in PROVIDER_EXTRA_WIDTHS:
+            if len(parts) % width:
+                continue
+            candidate = [parts[index : index + width] for index in range(0, len(parts), width)]
+            if all(_provider_entry_is_structurally_valid(entry) for entry in candidate):
+                candidates.append(candidate)
+        if len(candidates) != 1:
+            raise ValueError("Provider configuration has an invalid field count")
+        entries = candidates[0]
+    else:
+        raise ValueError("Provider configuration must be a list of entries")
+
+    parsed = []
+    for entry in entries:
+        if not isinstance(entry, (list, tuple)) or not _provider_entry_is_structurally_valid(entry):
+            raise ValueError("Provider entries must contain six or seven fields")
+        values = list(entry)
+        for index in PROVIDER_BOOLEAN_INDEXES:
+            values[index] = canonical_provider_boolean(values[index])
+        parsed.append(tuple(values))
+    return parsed
+
+
+def serialize_provider_extras(entries):
+    """Serialize validated provider entries using the legacy flat INI format."""
+    flattened = []
+    for entry in parse_provider_extras(entries):
+        for index, value in enumerate(entry):
+            field = "" if value is None else str(value)
+            if index == 4:
+                field = field.replace(",", "#")
+            elif ", " in field:
+                raise ValueError("Provider fields cannot contain the INI delimiter")
+            flattened.append(field)
+    return ", ".join(flattened)
+
+
+def normalize_category_list(value, separator=","):
+    """Return the category ids in ``value`` with blanks and padding removed.
+
+    `7030, 7020` typed into Settings used to be stored with the space intact
+    and would have reached the indexer as `cat=7030, 7020`. It never showed
+    because the categories were not reaching the searcher at all; now that they
+    are, the field has to survive the way operators actually type a list.
+    """
+    return [part.strip() for part in str(value or "").split(separator) if part.strip()]
+
+
+def split_newznab_category_field(value):
+    """Split a Newznab category field into its RSS uid and its category list.
+
+    Field 5 of a Newznab record is ``uid#categories``: the uid is the ``i=``
+    parameter of the indexer's RSS URL, and everything after the first ``#`` is
+    the category list. A value with no ``#`` is a uid on its own, which is why
+    a bare ``7030`` typed into the Settings Categories box was stored as a uid
+    and searched nothing -- the categories the operator asked for were dropped
+    on the floor with no error. Returned as ``(uid, categories)`` with the
+    category separator normalised to a comma for display.
+
+    Torznab records have no uid; field 5 there is the category list alone.
+    """
+    uid, separator, categories = str(value or "").partition("#")
+    if not separator:
+        return uid.strip(), ""
+    return uid.strip(), ",".join(normalize_category_list(categories, "#"))
+
+
+def join_newznab_category_field(uid, categories):
+    """Rebuild the stored ``uid#categories`` field from its two halves."""
+    uid = str(uid or "").strip() or DEFAULT_NEWZNAB_RSS_UID
+    categories = "#".join(normalize_category_list(categories))
+    # A uid on its own, rather than a trailing '#', so the search path falls
+    # back to its built-in category instead of querying `cat=` empty.
+    return "%s#%s" % (uid, categories) if categories else uid
+
+
+@dataclass(frozen=True)
+class SearchProvider:
+    """One configured Newznab or Torznab Search provider, fields by name.
+
+    ``rss_uid`` is a Newznab concept only -- Torznab stores a bare category
+    list in the same packed field, so a Torznab record always carries
+    ``rss_uid=None``.  ``id`` is ``None`` only for legacy six-field rows that
+    have never been persisted since ids were introduced.
+    """
+
+    kind: str  # "newznab" | "torznab"
+    name: str
+    host: str
+    verify: bool
+    api_key: str
+    categories: tuple[str, ...]
+    enabled: bool
+    rss_uid: str | None = None
+    id: int | None = None
+
+    @classmethod
+    def from_entry(cls, kind, entry) -> "SearchProvider":
+        """Build a record from one raw legacy tuple (six or seven fields)."""
+        if kind not in ("newznab", "torznab"):
+            raise ValueError("Unknown search provider kind: %s" % kind)
+        if not isinstance(entry, (list, tuple)) or not _provider_entry_is_structurally_valid(entry):
+            raise ValueError("Provider entries must contain six or seven fields")
+        if kind == "newznab":
+            rss_uid, categories = split_newznab_category_field(entry[4])
+            category_ids = tuple(normalize_category_list(categories))
+        else:
+            rss_uid = None
+            category_ids = tuple(normalize_category_list(entry[4], "#"))
+        provider_id = None
+        if len(entry) == 7:
+            provider_id = int(entry[6])
+        return cls(
+            kind=kind,
+            name=str(entry[0] or ""),
+            host=str(entry[1] or ""),
+            verify=provider_boolean(entry[2]),
+            api_key="" if entry[3] in (None, "None") else str(entry[3]),
+            categories=category_ids,
+            enabled=provider_boolean(entry[5]),
+            rss_uid=rss_uid,
+            id=provider_id,
+        )
+
+    def to_entry(self) -> tuple:
+        """Render the exact legacy tuple the INI codec and search path consume."""
+        if self.kind == "newznab":
+            category_field = join_newznab_category_field(self.rss_uid, ",".join(self.categories))
+        else:
+            category_field = "#".join(self.categories)
+        entry = [
+            self.name,
+            self.host,
+            canonical_provider_boolean(self.verify),
+            self.api_key,
+            category_field,
+            canonical_provider_boolean(self.enabled),
+        ]
+        if self.id is not None:
+            entry.append(self.id)
+        return tuple(entry)
+
+
+def providers_from_config(config, kind) -> list[SearchProvider]:
+    """Read the configured Search providers of one kind as records."""
+    attr_name = "EXTRA_NEWZNABS" if kind == "newznab" else "EXTRA_TORZNABS"
+    records = []
+    for entry in getattr(config, attr_name, None) or []:
+        try:
+            records.append(SearchProvider.from_entry(kind, entry))
+        except (TypeError, ValueError):
+            continue
+    return records

--- a/comicarr/app/search/providers.py
+++ b/comicarr/app/search/providers.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Callable, Iterable
 
+from comicarr.app.search.provider_config import provider_enabled
+
 
 @dataclass(frozen=True)
 class ProviderCandidate:
@@ -35,9 +37,9 @@ class ProviderCandidate:
 def enabled_provider_entries(entries: Iterable[object]):
     for entry in entries or []:
         try:
-            if str(entry[5]) == "1":
+            if provider_enabled(entry):
                 yield tuple(entry)
-        except (IndexError, TypeError):
+        except TypeError:
             continue
 
 

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -59,6 +59,11 @@ from comicarr.app.config.registry import (
 )
 from comicarr.app.core.security import LoginRateLimiter
 from comicarr.app.core.workers import start_background_thread
+from comicarr.app.search.provider_config import (
+    SearchProvider,
+    normalize_category_list,
+    providers_from_config,
+)
 from comicarr.tables import comics, jobhistory, storyarcs
 
 # Shared rate limiter instance for authentication endpoints.
@@ -352,73 +357,23 @@ def _http_origin(value):
     return scheme, hostname, port
 
 
-DEFAULT_NEWZNAB_RSS_UID = "1"
-
-
-def split_newznab_category_field(value):
-    """Split a Newznab category field into its RSS uid and its category list.
-
-    Field 5 of a Newznab record is ``uid#categories``: the uid is the ``i=``
-    parameter of the indexer's RSS URL, and everything after the first ``#`` is
-    the category list. A value with no ``#`` is a uid on its own, which is why
-    a bare ``7030`` typed into the Settings Categories box was stored as a uid
-    and searched nothing -- the categories the operator asked for were dropped
-    on the floor with no error. Returned as ``(uid, categories)`` with the
-    category separator normalised to a comma for display.
-
-    Torznab records have no uid; field 5 there is the category list alone.
-    """
-    uid, separator, categories = str(value or "").partition("#")
-    if not separator:
-        return uid.strip(), ""
-    return uid.strip(), ",".join(normalize_category_list(categories, "#"))
-
-
-def normalize_category_list(value, separator=","):
-    """Return the category ids in ``value`` with blanks and padding removed.
-
-    `7030, 7020` typed into Settings used to be stored with the space intact
-    and would have reached the indexer as `cat=7030, 7020`. It never showed
-    because the categories were not reaching the searcher at all; now that they
-    are, the field has to survive the way operators actually type a list.
-    """
-    return [part.strip() for part in str(value or "").split(separator) if part.strip()]
-
-
-def join_newznab_category_field(uid, categories):
-    """Rebuild the stored ``uid#categories`` field from its two halves."""
-    uid = str(uid or "").strip() or DEFAULT_NEWZNAB_RSS_UID
-    categories = "#".join(normalize_category_list(categories))
-    # A uid on its own, rather than a trailing '#', so the search path falls
-    # back to its built-in category instead of querying `cat=` empty.
-    return "%s#%s" % (uid, categories) if categories else uid
-
-
 def _safe_provider_projection(config, provider_type):
     """Build the credential-free provider projection returned by the API."""
-    attr_name = "EXTRA_NEWZNABS" if provider_type == "newznab" else "EXTRA_TORZNABS"
     enabled_key = "NEWZNAB" if provider_type == "newznab" else "ENABLE_TORZNAB"
     rows = []
-    for entry in getattr(config, attr_name, None) or []:
-        if not isinstance(entry, (list, tuple)) or len(entry) < 6:
-            continue
+    for provider in providers_from_config(config, provider_type):
         row = {
-            "name": str(entry[0] or ""),
-            "host": _safe_provider_host(entry[1]),
-            "verify": str(entry[2]).lower() in {"1", "true", "yes", "on"},
-            "categories": ",".join(normalize_category_list(entry[4], "#")),
-            "enabled": str(entry[5]).lower() in {"1", "true", "yes", "on"},
-            "api_key_set": _secret_is_configured(entry[3]),
+            "name": provider.name,
+            "host": _safe_provider_host(provider.host),
+            "verify": provider.verify,
+            "categories": ",".join(provider.categories),
+            "enabled": provider.enabled,
+            "api_key_set": _secret_is_configured(provider.api_key),
         }
         if provider_type == "newznab":
-            rss_uid, categories = split_newznab_category_field(entry[4])
-            row["rss_uid"] = rss_uid
-            row["categories"] = categories
-        if len(entry) >= 7:
-            try:
-                row["id"] = int(entry[6])
-            except (TypeError, ValueError):
-                pass
+            row["rss_uid"] = provider.rss_uid
+        if provider.id is not None:
+            row["id"] = provider.id
         rows.append(row)
     return {"enabled": bool(getattr(config, enabled_key, False)), "providers": rows}
 
@@ -608,13 +563,9 @@ def update_providers(ctx, provider_data):
 
     config_key = "EXTRA_NEWZNABS" if provider_type == "newznab" else "EXTRA_TORZNABS"
     if object_payload:
-        existing = getattr(ctx.config, config_key, []) or []
-        by_id = {str(row[6]): row for row in existing if isinstance(row, (list, tuple)) and len(row) >= 7}
-        by_identity = {
-            (str(row[0]), _safe_provider_host(row[1])): row
-            for row in existing
-            if isinstance(row, (list, tuple)) and len(row) >= 6
-        }
+        existing = providers_from_config(ctx.config, provider_type)
+        by_id = {str(record.id): record for record in existing if record.id is not None}
+        by_identity = {(record.name, _safe_provider_host(record.host)): record for record in existing}
         normalized = []
         for row in providers:
             if not isinstance(row, dict):
@@ -627,38 +578,36 @@ def update_providers(ctx, provider_data):
             new_origin = _http_origin(host)
             if new_origin is None:
                 return {"success": False, "error": "Provider URL must use HTTP or HTTPS"}
-            if credential in (None, "") and old is not None and _secret_is_configured(old[3]):
-                if _http_origin(old[1]) != new_origin:
+            if credential in (None, "") and old is not None and _secret_is_configured(old.api_key):
+                if _http_origin(old.host) != new_origin:
                     return {
                         "success": False,
                         "error": "A new API key is required when changing a provider origin",
                     }
-                credential = old[3]
-            if old is not None and host == _safe_provider_host(old[1]):
-                host = old[1]
-            categories = "#".join(normalize_category_list(row.get("categories")))
+                credential = old.api_key
+            if old is not None and host == _safe_provider_host(old.host):
+                host = old.host
+            rss_uid = None
             if provider_type == "newznab":
                 # Keep the uid the operator is already using when the client
                 # does not send one back, so editing categories cannot silently
                 # repoint the indexer's RSS feed at a different user.
                 rss_uid = row.get("rss_uid")
                 if rss_uid in (None, ""):
-                    rss_uid = split_newznab_category_field(old[4])[0] if old is not None and len(old) >= 5 else None
-                categories = join_newznab_category_field(rss_uid, row.get("categories"))
-            normalized_row = [
-                row.get("name", ""),
-                host,
-                "1" if row.get("verify") else "0",
-                credential or "",
-                categories,
-                "1" if row.get("enabled") else "0",
-            ]
-            provider_id = (
-                row.get("id") if row.get("id") is not None else (old[6] if old is not None and len(old) >= 7 else None)
+                    rss_uid = old.rss_uid if old is not None else None
+            provider_id = row.get("id") if row.get("id") is not None else (old.id if old is not None else None)
+            record = SearchProvider(
+                kind=provider_type,
+                name=row.get("name", ""),
+                host=host,
+                verify=bool(row.get("verify")),
+                api_key=credential or "",
+                categories=tuple(normalize_category_list(row.get("categories"))),
+                enabled=bool(row.get("enabled")),
+                rss_uid=rss_uid,
+                id=provider_id,
             )
-            if provider_id is not None:
-                normalized_row.append(provider_id)
-            normalized.append(normalized_row)
+            normalized.append(list(record.to_entry()))
         providers = normalized
     try:
         ctx.config.validate_provider_extra_value(config_key, providers)

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -37,21 +37,19 @@ import comicarr
 from comicarr import db, encrypted, filechecker, helpers, logger, maintenance
 from comicarr.app.config.log_level import record_startup_argument, resolve_startup_log_level
 from comicarr.app.config.registry import as_legacy_definitions
+from comicarr.app.search import provider_config
 
 config = configparser.ConfigParser()
 _CONFIG_TRANSACTION_LOCK = threading.RLock()
 _CONFIG_TEMP_PREFIX = ".comicarr-config-"
 _CONFIG_TEMP_SUFFIX = ".tmp"
-_PROVIDER_EXTRA_FIELDS = ("EXTRA_NEWZNABS", "EXTRA_TORZNABS")
-_PROVIDER_EXTRA_WIDTHS = (6, 7)
-_PROVIDER_CREDENTIAL_INDEX = 3
-_PROVIDER_BOOLEAN_VALUES = {"0", "1", "false", "true", "no", "yes", "off", "on"}
-_PROVIDER_BOOLEAN_TRUE = {"1", "true", "yes", "on"}
-# Verify-TLS and enabled. Both are read as `bool(int(field))` by the search
-# path and compared against the literal "1" by the enabled filters, so a field
-# spelled any other legal way is a crash or a silent skip -- see
-# _canonical_provider_boolean.
-_PROVIDER_BOOLEAN_INDEXES = (2, 5)
+# The provider tuple codec is owned by the Search provider module; config.py
+# only calls it at the INI load/store choke points.
+_PROVIDER_EXTRA_FIELDS = provider_config.PROVIDER_EXTRA_FIELDS
+_PROVIDER_CREDENTIAL_INDEX = provider_config.PROVIDER_CREDENTIAL_INDEX
+_canonical_provider_boolean = provider_config.canonical_provider_boolean
+parse_provider_extras = provider_config.parse_provider_extras
+serialize_provider_extras = provider_config.serialize_provider_extras
 
 
 def config_transaction_lock():
@@ -65,85 +63,6 @@ def config_transaction_lock():
     bug waiting to happen.
     """
     return _CONFIG_TRANSACTION_LOCK
-
-
-def _canonical_provider_boolean(value):
-    """Return a provider boolean field as the only spelling every reader agrees on.
-
-    `_PROVIDER_BOOLEAN_VALUES` accepts eight spellings, but the consumers do
-    not. `search.py` and `rsscheck.py` read verify as `bool(int(field))`, which
-    raises `ValueError` on `"True"`; the enabled filters in `search.py` compare
-    against the literal `"1"` while `health.py` and the providers API accept
-    `true`/`yes`/`on`. So an entry stored as `True` was reported enabled by the
-    Acquisition tab and skipped by the searcher -- and one stored with a
-    non-numeric verify took the search down. Both fields are normalised here,
-    at the single boundary every reader and writer passes through, so tolerance
-    at the edge cannot become disagreement in the middle.
-    """
-    return "1" if str(value).strip().lower() in _PROVIDER_BOOLEAN_TRUE else "0"
-
-
-def _provider_entry_is_structurally_valid(entry):
-    """Distinguish historical six- and seven-field provider records safely."""
-    if len(entry) not in _PROVIDER_EXTRA_WIDTHS:
-        return False
-    if str(entry[2]).strip().lower() not in _PROVIDER_BOOLEAN_VALUES:
-        return False
-    if str(entry[5]).strip().lower() not in _PROVIDER_BOOLEAN_VALUES:
-        return False
-    if len(entry) == 7:
-        try:
-            int(entry[6])
-        except (TypeError, ValueError):
-            return False
-    return True
-
-
-def parse_provider_extras(value, config_version=15):
-    """Parse provider extras without assuming one historical tuple width."""
-    if value in (None, "", "None"):
-        return []
-
-    if isinstance(value, (list, tuple)):
-        entries = value
-    elif isinstance(value, str):
-        parts = value.split(", ")
-        candidates = []
-        for width in _PROVIDER_EXTRA_WIDTHS:
-            if len(parts) % width:
-                continue
-            candidate = [parts[index : index + width] for index in range(0, len(parts), width)]
-            if all(_provider_entry_is_structurally_valid(entry) for entry in candidate):
-                candidates.append(candidate)
-        if len(candidates) != 1:
-            raise ValueError("Provider configuration has an invalid field count")
-        entries = candidates[0]
-    else:
-        raise ValueError("Provider configuration must be a list of entries")
-
-    parsed = []
-    for entry in entries:
-        if not isinstance(entry, (list, tuple)) or not _provider_entry_is_structurally_valid(entry):
-            raise ValueError("Provider entries must contain six or seven fields")
-        values = list(entry)
-        for index in _PROVIDER_BOOLEAN_INDEXES:
-            values[index] = _canonical_provider_boolean(values[index])
-        parsed.append(tuple(values))
-    return parsed
-
-
-def serialize_provider_extras(entries):
-    """Serialize validated provider entries using the legacy flat INI format."""
-    flattened = []
-    for entry in parse_provider_extras(entries):
-        for index, value in enumerate(entry):
-            field = "" if value is None else str(value)
-            if index == 4:
-                field = field.replace(",", "#")
-            elif ", " in field:
-                raise ValueError("Provider fields cannot contain the INI delimiter")
-            flattened.append(field)
-    return ", ".join(flattened)
 
 
 def decrypt_provider_credential(value, secure_dir):

--- a/comicarr/rsscheck.py
+++ b/comicarr/rsscheck.py
@@ -34,6 +34,7 @@ from sqlalchemy.exc import OperationalError
 
 import comicarr
 from comicarr import auth32p, db, filechecker, ftpsshup, helpers, logger, utorrent
+from comicarr.app.search.provider_config import provider_enabled
 from comicarr.cfscrape_compat import import_cfscrape
 from comicarr.tables import comics, rssdb
 from comicarr.torrent.clients import deluge as deluge
@@ -556,7 +557,7 @@ def nzbs(provider=None, forcerss=False):
 
     if comicarr.CONFIG.NEWZNAB is True:
         for newznab_host in comicarr.CONFIG.EXTRA_NEWZNABS:
-            if str(newznab_host[5]) == "1":
+            if provider_enabled(newznab_host):
                 newznab_hosts.append(newznab_host)
 
     providercount = len(newznab_hosts) + int(comicarr.CONFIG.EXPERIMENTAL is True)

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -64,6 +64,7 @@ from comicarr.app.common.remote_artifacts import (
 )
 from comicarr.app.core.workers import submit_background_future
 from comicarr.app.downloads import handoff
+from comicarr.app.search.provider_config import provider_enabled, split_newznab_category_field
 from comicarr.downloaders import external_server as exs
 from comicarr.tables import (
     annuals,
@@ -940,8 +941,7 @@ def NZB_SEARCH(
         if any([category_torznab is None, category_torznab == "None"]):
             category_torznab = "8020"
         if "#" in category_torznab:
-            t_cats = category_torznab.split("#")
-            category_torznab = ",".join(t_cats)
+            category_torznab = category_torznab.replace("#", ",")
         logger.fdebug("Using Torznab host of : %s" % name_torznab)
     elif provider_stat["type"] == "newznab":
         # updated to include Newznab Name now
@@ -957,8 +957,7 @@ def NZB_SEARCH(
         apikey = newznab_host[3].rstrip()
         verify = bool(int(newznab_host[2]))
         if "#" in newznab_host[4].rstrip():
-            catstart = newznab_host[4].find("#")
-            category_newznab = re.sub("#", ",", newznab_host[4][catstart + 1 :]).strip()
+            category_newznab = split_newznab_category_field(newznab_host[4])[1]
             logger.fdebug("Non-default Newznab category set to : %s" % category_newznab)
         else:
             category_newznab = "7030"
@@ -1815,8 +1814,8 @@ def searchforissue(
         logger.info("A search is currently in progress....queueing this up again to try in a bit.")
         return {"status": "IN PROGRESS"}
 
-    ens = [x for x in comicarr.CONFIG.EXTRA_NEWZNABS if x[5] == "1"]
-    ets = [x for x in comicarr.CONFIG.EXTRA_TORZNABS if x[5] == "1"]
+    ens = [x for x in comicarr.CONFIG.EXTRA_NEWZNABS if provider_enabled(x)]
+    ets = [x for x in comicarr.CONFIG.EXTRA_TORZNABS if provider_enabled(x)]
     if (
         (
             comicarr.CONFIG.ENABLE_DDL is True
@@ -2811,8 +2810,8 @@ def searchforissue(
 
 
 def searchIssueIDList(issuelist):
-    ens = [x for x in comicarr.CONFIG.EXTRA_NEWZNABS if x[5] == "1"]
-    ets = [x for x in comicarr.CONFIG.EXTRA_TORZNABS if x[5] == "1"]
+    ens = [x for x in comicarr.CONFIG.EXTRA_NEWZNABS if provider_enabled(x)]
+    ets = [x for x in comicarr.CONFIG.EXTRA_TORZNABS if provider_enabled(x)]
     if (
         (
             comicarr.CONFIG.ENABLE_DDL is True

--- a/tests/unit/test_provider_config.py
+++ b/tests/unit/test_provider_config.py
@@ -1,0 +1,134 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""The SearchProvider record and the legacy INI codec behind it."""
+
+import pytest
+
+from comicarr.app.search.provider_config import (
+    SearchProvider,
+    canonical_provider_boolean,
+    join_newznab_category_field,
+    normalize_category_list,
+    parse_provider_extras,
+    provider_enabled,
+    providers_from_config,
+    serialize_provider_extras,
+    split_newznab_category_field,
+)
+
+NEWZNAB_ENTRY = ("nzb.su", "https://api.nzb.su", "1", "apikey123", "1#7030#7020", "1", 3)
+TORZNAB_ENTRY = ("prowlarr", "https://prowlarr.local/api", "0", "torkey", "8020#7030", "1", 4)
+
+
+class TestCodecRoundTrip:
+    def test_serialize_then_parse_is_identity_for_canonical_entries(self):
+        entries = [NEWZNAB_ENTRY, ("Backup", "https://b.example", "0", "", "1", "0", 9)]
+        stored = serialize_provider_extras(entries)
+        reparsed = parse_provider_extras(stored)
+        assert reparsed == [tuple(str(field) for field in entry) for entry in entries]
+
+    def test_parse_canonicalises_every_boolean_spelling(self):
+        entry = ("n", "https://h", "True", "key", "1#7030", "yes", 1)
+        (parsed,) = parse_provider_extras([entry])
+        assert parsed[2] == "1"
+        assert parsed[5] == "1"
+
+    def test_parse_rejects_ambiguous_field_counts(self):
+        with pytest.raises(ValueError):
+            parse_provider_extras("just, six, fields, of, nonsense, text")
+
+    def test_legacy_six_field_entries_survive(self):
+        (parsed,) = parse_provider_extras([("n", "https://h", "1", "key", "7030", "1")])
+        assert len(parsed) == 6
+
+
+class TestBooleanConvergence:
+    @pytest.mark.parametrize("spelling", ["1", "true", "True", " YES ", "on"])
+    def test_every_true_spelling_reads_enabled(self, spelling):
+        assert provider_enabled(("n", "h", "1", "k", "7030", spelling)) is True
+        assert canonical_provider_boolean(spelling) == "1"
+
+    @pytest.mark.parametrize("spelling", ["0", "false", "no", "off", "", "garbage"])
+    def test_every_other_spelling_reads_disabled(self, spelling):
+        assert provider_enabled(("n", "h", "1", "k", "7030", spelling)) is False
+        assert canonical_provider_boolean(spelling) == "0"
+
+    def test_short_or_malformed_entries_read_disabled(self):
+        assert provider_enabled(("n", "h")) is False
+        assert provider_enabled(None) is False
+
+
+class TestNewznabCategoryField:
+    def test_split_separates_uid_from_categories(self):
+        assert split_newznab_category_field("1#7030#7020") == ("1", "7030,7020")
+
+    def test_bare_value_is_a_uid_with_no_categories(self):
+        assert split_newznab_category_field("7030") == ("7030", "")
+
+    def test_join_defaults_the_uid_and_drops_a_trailing_hash(self):
+        assert join_newznab_category_field(None, "7030, 7020") == "1#7030#7020"
+        assert join_newznab_category_field("5", "") == "5"
+
+    def test_normalize_strips_padding_and_blanks(self):
+        assert normalize_category_list("7030, 7020, ,") == ["7030", "7020"]
+
+
+class TestSearchProviderRecord:
+    def test_newznab_record_unpacks_uid_and_categories(self):
+        provider = SearchProvider.from_entry("newznab", NEWZNAB_ENTRY)
+        assert provider.rss_uid == "1"
+        assert provider.categories == ("7030", "7020")
+        assert provider.verify is True
+        assert provider.enabled is True
+        assert provider.id == 3
+
+    def test_torznab_record_never_carries_an_rss_uid(self):
+        provider = SearchProvider.from_entry("torznab", TORZNAB_ENTRY)
+        assert provider.rss_uid is None
+        assert provider.categories == ("8020", "7030")
+        assert provider.verify is False
+
+    def test_record_round_trips_to_the_exact_legacy_tuple(self):
+        for kind, entry in (("newznab", NEWZNAB_ENTRY), ("torznab", TORZNAB_ENTRY)):
+            assert SearchProvider.from_entry(kind, entry).to_entry() == entry
+
+    def test_legacy_six_field_entry_round_trips_without_an_id(self):
+        entry = ("n", "https://h", "1", "key", "7030", "0")
+        provider = SearchProvider.from_entry("newznab", entry)
+        assert provider.id is None
+        assert provider.to_entry() == entry
+
+    def test_unknown_kind_is_rejected(self):
+        with pytest.raises(ValueError):
+            SearchProvider.from_entry("prowlarr", NEWZNAB_ENTRY)
+
+    def test_malformed_entry_is_rejected(self):
+        with pytest.raises(ValueError):
+            SearchProvider.from_entry("newznab", ("only", "four", "fields", "here"))
+
+
+class TestProvidersFromConfig:
+    def test_reads_each_kind_from_its_config_attribute(self):
+        class Config:
+            EXTRA_NEWZNABS = [NEWZNAB_ENTRY]
+            EXTRA_TORZNABS = [TORZNAB_ENTRY]
+
+        newznabs = providers_from_config(Config(), "newznab")
+        torznabs = providers_from_config(Config(), "torznab")
+        assert [provider.name for provider in newznabs] == ["nzb.su"]
+        assert [provider.name for provider in torznabs] == ["prowlarr"]
+
+    def test_skips_malformed_rows_instead_of_raising(self):
+        class Config:
+            EXTRA_NEWZNABS = [("too", "short"), NEWZNAB_ENTRY]
+            EXTRA_TORZNABS = None
+
+        assert [provider.name for provider in providers_from_config(Config(), "newznab")] == ["nzb.su"]
+        assert providers_from_config(Config(), "torznab") == []

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -22,6 +22,7 @@ if comicarr.LOG_LEVEL is None:
     comicarr.LOG_LEVEL = 0
 
 from comicarr.app.config import log_level
+from comicarr.app.search.provider_config import split_newznab_category_field
 from comicarr.app.core.context import AppContext
 from comicarr.app.core.security import (
     create_session_token,
@@ -924,7 +925,7 @@ class TestConfigService:
 
         persisted = ctx.config.apply_transaction.call_args.args[0]["EXTRA_NEWZNABS"][0]
         assert persisted[4] == "1#7030#7020"
-        assert system_service.split_newznab_category_field(persisted[4]) == ("1", "7030,7020")
+        assert split_newznab_category_field(persisted[4]) == ("1", "7030,7020")
 
     def test_category_lists_tolerate_the_spacing_operators_type(self):
         """`7030, 7020` must not reach the indexer as `cat=7030, 7020`."""


### PR DESCRIPTION
## What

Deepens the search-provider configuration behind one module. `comicarr/app/search/provider_config.py` now owns the **Search provider** record (`SearchProvider`, fields by name) and the entire legacy INI codec: parse, serialize, boolean canonicalisation, the 6/7 width tiling, and the `uid#categories` packing. `config.py` calls the codec at its load/store choke points and keeps only the INI plumbing plus credential crypto.

## Why

The provider record's interface was "a list of 6-or-7-element string tuples", and six modules knew the indexes. That shape already shipped a bug (#669: a provider reported enabled by the Acquisition tab and skipped by the searcher, because three readers had three truthiness rules). The #669 fix normalised the *writer*; the divergent readers were all still live. This PR converges them:

- **One enabled test** (`provider_enabled`): replaces `str(entry[5]) == "1"` (providers.py, search.py ×4, rsscheck.py) and `str(row[5]).lower() in {...}` (health.py, system/service.py).
- **One `uid#categories` decoder**: `system/service.py`'s three codec functions moved to the owning module; `search.py`'s inline `re.sub` decode now uses it. (`rsscheck.py`'s feed-param decode intentionally keeps its raw `#`-remainder semantics — converting it is not behaviour-preserving.)
- `_safe_provider_projection` and `update_providers` work on `SearchProvider` records instead of tuple indexes.

The legacy provider loop (`search.py`) keeps consuming tuples through the single `runtime_provider_entry` adapter — one countable seam, deletable when the loop modernises.

## Behaviour

Intended verified-identical; **no changeset**. The on-disk INI encoding is byte-compatible (storage still goes through the same parse/serialize pair, now imported). Two edge differences exist only for states unreachable through the canonical load path (hand-edited in-memory rows with illegal boolean spellings or padded category fields) — both now resolve to the strict side the searcher already required.

`CONTEXT.md` gains **Search provider** and **Acquisition route** definitions (the latter is used by the follow-up PR).

## Testing

- New `tests/unit/test_provider_config.py`: codec round-trip, boolean-spelling convergence, `uid#categories` semantics, record round-trip to the exact legacy tuple, torznab-never-has-rss_uid invariant.
- Full suite: 2507 passed. `npm run lint` (modern, guards, backend, generated, frontend) all green.
- One test migrated with the concept: the `split_newznab_category_field` assertion in `test_system_domain.py` now imports from the owning module.

## Follow-ups (will file as issues)

- No torznab editing UI exists (Settings tab and mutation hook are newznab-only; `Config.torznab` is mistyped as the newznab response type).
- The provider payload's boolean contract in `update_providers` should be stated on the API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD8xf27f66PariNkQ25sqi