### PR TITLE
refactor: One classifier and one published read for Acquisition routes

### DIFF
--- a/comicarr/app/attention/_resolution.py
+++ b/comicarr/app/attention/_resolution.py
@@ -39,9 +39,9 @@ class _RuntimeResolutionEffects:
         self.ctx = ctx
 
     def search_health(self):
-        from comicarr.app.search import service as search_service
+        from comicarr.app.search import routes as search_routes
 
-        return search_service._search_route_health(self.ctx)
+        return search_routes.route_health(self.ctx)
 
     def rewant(self, issue_id, actor):
         from comicarr.app.series import queries as series_queries

--- a/comicarr/app/search/health.py
+++ b/comicarr/app/search/health.py
@@ -20,11 +20,12 @@ from comicarr import db
 from comicarr.app.search import queries
 from comicarr.app.search.provider_config import provider_enabled
 from comicarr.app.search.providers import effective_provider_plan, enabled_provider_entries, ordered_provider_names
+from comicarr.app.search.routes import ROUTES, classify
 from comicarr.db import get_engine
 
 WORKER_PREFIX = "Worker: "
 ROUTE_PREFIX = "Acquisition Route: "
-_ROUTES = ("ddl", "nzb", "torrent")
+_ROUTES = ROUTES
 
 # Last-resort reason when no route reported anything usable.
 NO_VIABLE_ROUTE = "no_viable_acquisition_route"
@@ -81,44 +82,12 @@ def _enabled_extra(entries):
     return any(enabled_provider_entries(entries))
 
 
-def _route_for_provider(row):
-    provider_type = str(row.get("type") or "").strip().lower()
-    if provider_type.startswith("ddl"):
-        return "ddl"
-    if provider_type in {"torrent", "torznab"}:
-        return "torrent"
-    if provider_type in {"nzb", "newznab", "experimental"}:
-        return "nzb"
-    name = str(row.get("provider") or "").strip().lower()
-    if name.startswith("ddl(") or "getcomics" in name:
-        return "ddl"
-    if "torznab" in name or name in {"32p", "public torrents", "torrent"}:
-        return "torrent"
-    return "nzb"
-
-
-def route_for_site(site, config=None):
-    """Classify a configured provider name without persisting its URL or credentials."""
-    config = config or getattr(comicarr, "CONFIG", None)
-    name = str(site or "").strip().lower()
-    if name.startswith("ddl(") or "getcomics" in name or name == "external":
-        return "ddl"
-    if name in {"32p", "public torrents", "torrent"}:
-        return "torrent"
-    if config is not None:
-        for entry in getattr(config, "EXTRA_TORZNABS", None) or []:
-            candidates = [str(value or "").strip().lower() for value in entry[:2]]
-            if name in candidates:
-                return "torrent"
-    return "nzb"
-
-
 def _route_provider_names(config, provider_stats):
     names = {route: [] for route in _ROUTES}
     for row in provider_stats:
         name = str(row.get("provider") or "").strip()
         if name:
-            names[_route_for_provider(row)].append(name)
+            names[classify(row)].append(name)
 
     ordered = _provider_names(config)
     if not names["ddl"]:
@@ -256,7 +225,7 @@ def build_route_readiness(
     planned_by_route = {
         route: [candidate for candidate in provider_plan if candidate.route == route] for route in _ROUTES
     }
-    stats_by_route = {route: [row for row in provider_stats if _route_for_provider(row) == route] for route in _ROUTES}
+    stats_by_route = {route: [row for row in provider_stats if classify(row) == route] for route in _ROUTES}
     routes = {}
 
     for route in _ROUTES:

--- a/comicarr/app/search/interactive.py
+++ b/comicarr/app/search/interactive.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 from comicarr import db, helpers, logger, search, search_filer
 from comicarr.app.common.redaction import redact_sensitive_text
 from comicarr.app.core.workers import start_background_thread
+from comicarr.app.search import routes as search_routes
 from comicarr.app.search.interactive_sessions import (
     InteractiveCandidateConflict,
     claim_server_candidate,
@@ -31,7 +32,6 @@ from comicarr.app.search.interactive_sessions import (
     update_search_progress,
 )
 from comicarr.app.search.providers import effective_provider_plan
-from comicarr.app.search.service import _search_route_health
 from comicarr.app.series import queries as series_queries
 from comicarr.tables import storyarcs
 
@@ -80,7 +80,7 @@ def start_search(ctx, *, actor, browser_session, entity_type, entity_id):
     entity, error = _resolve_entity(entity_type, entity_id)
     if error:
         return error
-    route_health = _search_route_health(ctx)
+    route_health = search_routes.route_health(ctx)
     if not route_health.get("success"):
         return {
             "success": False,
@@ -378,7 +378,7 @@ def grab_candidate(
                 code="item_not_eligible",
             )
 
-        route_health = _search_route_health(ctx)
+        route_health = search_routes.route_health(ctx)
         if not route_health.get("success"):
             return _release_with_error(
                 engine,

--- a/comicarr/app/search/providers.py
+++ b/comicarr/app/search/providers.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import Callable, Iterable
 
 from comicarr.app.search.provider_config import provider_enabled
+from comicarr.app.search.routes import classify
 
 
 @dataclass(frozen=True)
@@ -27,11 +28,7 @@ class ProviderCandidate:
 
     @property
     def route(self) -> str:
-        if self.kind in {"torznab", "torrent"}:
-            return "torrent"
-        if self.kind in {"newznab", "experimental"}:
-            return "nzb"
-        return "ddl"
+        return classify(self)
 
 
 def enabled_provider_entries(entries: Iterable[object]):

--- a/comicarr/app/search/routes.py
+++ b/comicarr/app/search/routes.py
@@ -1,0 +1,106 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""The Acquisition route seam: one classifier, one published health read.
+
+An Acquisition route is the delivery channel a Search provider serves --
+``ddl``, ``nzb``, or ``torrent`` -- and every provider serves exactly one.
+:func:`classify` is the single answer to "which route does this provider
+serve": kind-based when the caller has a provider candidate, with name
+heuristics surviving only as fallbacks for stats rows and bare site names
+where the kind is not recorded.  :func:`route_health` is the published
+route-readiness precheck that Needs attention, Interactive release search,
+and the search commands share; readiness assembly stays in ``health.py``
+as this module's implementation.
+"""
+
+from __future__ import annotations
+
+import comicarr
+
+ROUTES = ("ddl", "nzb", "torrent")
+
+
+def classify(provider, config=None) -> str:
+    """Return the Acquisition route a Search provider serves.
+
+    Accepts a provider candidate (anything with a ``kind`` attribute), a
+    provider-stats row (a dict), or a bare site name.  The kind rule is the
+    ground truth; the row and name rules are historical fallbacks for
+    surfaces that only recorded a name.
+    """
+    kind = getattr(provider, "kind", None)
+    if kind is not None:
+        return _from_kind(kind)
+    if isinstance(provider, dict):
+        return _from_stats_row(provider)
+    return _from_site_name(provider, config)
+
+
+def _from_kind(kind) -> str:
+    if kind in {"torznab", "torrent"}:
+        return "torrent"
+    if kind in {"newznab", "experimental"}:
+        return "nzb"
+    return "ddl"
+
+
+def _from_stats_row(row) -> str:
+    provider_type = str(row.get("type") or "").strip().lower()
+    if provider_type.startswith("ddl"):
+        return "ddl"
+    if provider_type in {"torrent", "torznab"}:
+        return "torrent"
+    if provider_type in {"nzb", "newznab", "experimental"}:
+        return "nzb"
+    name = str(row.get("provider") or "").strip().lower()
+    if name.startswith("ddl(") or "getcomics" in name:
+        return "ddl"
+    if "torznab" in name or name in {"32p", "public torrents", "torrent"}:
+        return "torrent"
+    return "nzb"
+
+
+def _from_site_name(site, config=None) -> str:
+    """Classify a configured provider name without persisting its URL or credentials."""
+    config = config or getattr(comicarr, "CONFIG", None)
+    name = str(site or "").strip().lower()
+    if name.startswith("ddl(") or "getcomics" in name or name == "external":
+        return "ddl"
+    if name in {"32p", "public torrents", "torrent"}:
+        return "torrent"
+    if config is not None:
+        for entry in getattr(config, "EXTRA_TORZNABS", None) or []:
+            candidates = [str(value or "").strip().lower() for value in entry[:2]]
+            if name in candidates:
+                return "torrent"
+    return "nzb"
+
+
+def route_health(ctx):
+    """Shared route-readiness precheck for anything that starts a search."""
+    from comicarr.app.search.health import blocking_route_reason, get_search_health
+
+    health = get_search_health(
+        ctx.config,
+        provider_blocklist=getattr(ctx, "provider_blocklist", None) or comicarr.PROVIDER_BLOCKLIST,
+    )
+    routes = health.get("routes") or {}
+    viable = bool(health.get("viable_route")) or any(
+        bool((routes.get(name) or {}).get("ready") or (routes.get(name) or {}).get("viable")) for name in ROUTES
+    )
+    if not viable:
+        return {
+            "success": False,
+            "status": "blocked",
+            "error": blocking_route_reason(routes),
+            "message": "Search blocked: no complete acquisition route is ready",
+            "routes": routes,
+        }
+    return {"success": True, "routes": routes, "health": health}

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -30,6 +30,7 @@ from comicarr import db, logger
 from comicarr.app.acquisition.models import DispatchState, ItemOutcome, RunState
 from comicarr.app.core.workers import start_background_thread
 from comicarr.app.search.commands import SearchCommand, SearchCommandError
+from comicarr.app.search.routes import classify, route_health
 from comicarr.tables import issues, ref32p
 from comicarr.torrent import monitor as torrent_monitor
 
@@ -184,30 +185,6 @@ def add_manga(ctx, manga_id):
         return {"success": False, "error": "Error adding manga: %s" % str(e)}
 
 
-def _search_route_health(ctx):
-    """Shared get_search_health precheck for force_search and search_issue."""
-    from comicarr.app.search.health import blocking_route_reason, get_search_health
-
-    health = get_search_health(
-        ctx.config,
-        provider_blocklist=getattr(ctx, "provider_blocklist", None) or comicarr.PROVIDER_BLOCKLIST,
-    )
-    routes = health.get("routes") or {}
-    viable = bool(health.get("viable_route")) or any(
-        bool((routes.get(name) or {}).get("ready") or (routes.get(name) or {}).get("viable"))
-        for name in ("ddl", "nzb", "torrent")
-    )
-    if not viable:
-        return {
-            "success": False,
-            "status": "blocked",
-            "error": blocking_route_reason(routes),
-            "message": "Search blocked: no complete acquisition route is ready",
-            "routes": routes,
-        }
-    return {"success": True, "routes": routes, "health": health}
-
-
 def search_issue(ctx, issue_id, *, trigger="issue_retry"):
     """Scoped single-issue search with the same route precheck as force_search.
 
@@ -224,7 +201,7 @@ def search_issue(ctx, issue_id, *, trigger="issue_retry"):
             "message": "Missing issue_id",
         }
 
-    precheck = _search_route_health(ctx)
+    precheck = route_health(ctx)
     if not precheck.get("success"):
         return {
             "success": False,
@@ -253,7 +230,7 @@ def force_search(ctx):
     from comicarr import search
     from comicarr.app.acquisition.runs import RunLedger
 
-    precheck = _search_route_health(ctx)
+    precheck = route_health(ctx)
     if not precheck.get("success"):
         return {
             "success": False,
@@ -811,9 +788,9 @@ def block_provider_check(site, simple=True, force=False):
             if force is True:
                 comicarr.PROVIDER_BLOCKLIST.remove(prov)
                 try:
-                    from comicarr.app.search.health import clear_route_block, route_for_site
+                    from comicarr.app.search.health import clear_route_block
 
-                    clear_route_block(route_for_site(site))
+                    clear_route_block(classify(site))
                 except Exception as e:
                     logger.fdebug("[SEARCH] Unable to clear durable route block: %s" % e)
                 if simple is True:
@@ -900,10 +877,10 @@ def disable_provider(site, reason=None, delay=0):
     newentry = {"site": site, "resume": int(time.time()) + delay, "reason": reason}
     comicarr.PROVIDER_BLOCKLIST.append(newentry)
     try:
-        from comicarr.app.search.health import record_route_outcome, route_for_site
+        from comicarr.app.search.health import record_route_outcome
 
         record_route_outcome(
-            route_for_site(site),
+            classify(site),
             success=False,
             error=reason or "Provider temporarily blocked",
             blocked_until=newentry["resume"],

--- a/tests/unit/test_interactive_search_api.py
+++ b/tests/unit/test_interactive_search_api.py
@@ -52,7 +52,7 @@ def engine(tmp_path, monkeypatch):
     monkeypatch.setattr(interactive.db, "get_engine", lambda: value)
     monkeypatch.setattr(comicarr, "PROVIDER_BLOCKLIST", [])
     monkeypatch.setattr(interactive.helpers, "block_provider_check", lambda _name: False)
-    monkeypatch.setattr(interactive, "_search_route_health", lambda _ctx: {"success": True, "routes": {}})
+    monkeypatch.setattr(interactive.search_routes, "route_health", lambda _ctx: {"success": True, "routes": {}})
     yield value
     value.dispose()
 
@@ -284,8 +284,8 @@ def test_start_exposes_sanitized_route_health_block(engine, monkeypatch):
         lambda *_args, **_kwargs: ({"ComicID": "series-1"}, "want", False),
     )
     monkeypatch.setattr(
-        interactive,
-        "_search_route_health",
+        interactive.search_routes,
+        "route_health",
         lambda _ctx: {
             "success": False,
             "error": "client_not_ready",

--- a/tests/unit/test_search_routes.py
+++ b/tests/unit/test_search_routes.py
@@ -1,0 +1,94 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""One classifier and one published health read for Acquisition routes."""
+
+import pytest
+
+from comicarr.app.search import routes
+from comicarr.app.search.providers import ProviderCandidate
+
+
+class TestClassifyByKind:
+    @pytest.mark.parametrize(
+        ("kind", "route"),
+        [
+            ("torznab", "torrent"),
+            ("torrent", "torrent"),
+            ("newznab", "nzb"),
+            ("experimental", "nzb"),
+            ("ddl", "ddl"),
+        ],
+    )
+    def test_every_provider_kind_maps_to_its_route(self, kind, route):
+        candidate = ProviderCandidate(name="p", kind=kind, execution_name="p")
+        assert routes.classify(candidate) == route
+        assert candidate.route == route
+
+
+class TestClassifyByStatsRow:
+    @pytest.mark.parametrize(
+        ("row", "route"),
+        [
+            ({"type": "ddl(getcomics)"}, "ddl"),
+            ({"type": "torznab"}, "torrent"),
+            ({"type": "newznab"}, "nzb"),
+            ({"type": "", "provider": "DDL(External)"}, "ddl"),
+            ({"type": "", "provider": "my torznab"}, "torrent"),
+            ({"type": "", "provider": "32p"}, "torrent"),
+            ({"type": "", "provider": "nzb.su"}, "nzb"),
+        ],
+    )
+    def test_stats_rows_classify_by_type_then_name(self, row, route):
+        assert routes.classify(row) == route
+
+
+class TestClassifyBySiteName:
+    class _Config:
+        EXTRA_TORZNABS = [("prowlarr", "https://prowlarr.local/api", "1", "key", "8020", "1", 4)]
+
+    @pytest.mark.parametrize(
+        ("site", "route"),
+        [
+            ("DDL(GetComics)", "ddl"),
+            ("external", "ddl"),
+            ("32p", "torrent"),
+            ("public torrents", "torrent"),
+            ("prowlarr", "torrent"),
+            ("https://prowlarr.local/api", "torrent"),
+            ("nzb.su", "nzb"),
+        ],
+    )
+    def test_bare_site_names_classify_with_the_config_fallback(self, site, route):
+        assert routes.classify(site, config=self._Config()) == route
+
+
+class TestRouteHealth:
+    class _Ctx:
+        config = object()
+        provider_blocklist = []
+
+    def test_blocked_when_no_route_is_viable(self, monkeypatch):
+        from comicarr.app.search import health
+
+        monkeypatch.setattr(health, "get_search_health", lambda *_a, **_k: {"routes": {"nzb": {"ready": False}}})
+        monkeypatch.setattr(health, "blocking_route_reason", lambda _routes: "client_not_ready")
+        result = routes.route_health(self._Ctx())
+        assert result["success"] is False
+        assert result["status"] == "blocked"
+        assert result["error"] == "client_not_ready"
+
+    def test_succeeds_when_any_route_is_ready(self, monkeypatch):
+        from comicarr.app.search import health
+
+        payload = {"routes": {"torrent": {"ready": True}}}
+        monkeypatch.setattr(health, "get_search_health", lambda *_a, **_k: payload)
+        result = routes.route_health(self._Ctx())
+        assert result["success"] is True
+        assert result["routes"] == payload["routes"]


### PR DESCRIPTION
Follow-up to #702 (the SearchProvider record).

## What

Adds `comicarr/app/search/routes.py`, the seam for the **Acquisition route** concept (`ddl` / `nzb` / `torrent`, defined in `CONTEXT.md`):

- **`classify(provider, config=None)`** — the single answer to "which route does this Search provider serve". Kind-based classification (the `ProviderCandidate.route` rule) is ground truth; the stats-row and bare-site-name heuristics survive only as private fallbacks for surfaces that recorded a name without a kind.
- **`route_health(ctx)`** — the published route-readiness precheck. Readiness assembly (`build_route_readiness` and friends) stays in `health.py` as this module's implementation.

## Why

Route classification existed four times with drifting rules: `ProviderCandidate.route`, `health._route_for_provider`, `health.route_for_site` (hardcoded name literals), and the fallback ladder in `_route_provider_names`. And `_search_route_health` was a private with two out-of-module callers — `attention/_resolution.py` and `interactive.py` — plus tests pinning the underscore name; a crossing invisible to every guard script. This PR converges the classifiers and publishes the read:

- `ProviderCandidate.route`, `health.py`'s row classification, and `service.py`'s two `route_for_site` call sites all delegate to `routes.classify`.
- Needs attention and Interactive release search import `routes.route_health` — a public name — and the test monkeypatches migrate with it.
- `health.route_for_site` and `health._route_for_provider` are deleted; `service.py` no longer defines `_search_route_health`.

## Behaviour

Verified-identical — each classifier's rules moved verbatim, and `route_health` is the same body under a public name. **No changeset.**

## Testing

- New `tests/unit/test_search_routes.py`: classification tables for all three input shapes (candidate kind, stats row, site name with config fallback) and the `route_health` blocked/ready contract.
- Full suite after rebasing onto merged #702: 2547 passed. `npm run lint` (all lanes) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD8xf27f66PariNkQ25sqi