### PR TITLE
fix: Serve cached manga covers instead of hotlinking MangaDex

### DIFF
--- a/.changeset/cached-manga-covers.md
+++ b/.changeset/cached-manga-covers.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Library and series-detail covers now load from Comicarr's local cache (or a same-origin fallback) instead of hotlinking MangaDex, so manga series no longer show the "You can read this at MANGADEX" placeholder.

--- a/comicarr/app/core/image_hosts.py
+++ b/comicarr/app/core/image_hosts.py
@@ -16,11 +16,11 @@ One set, two derived views:
 - ``core.middleware`` splices ``https://host`` tokens into the CSP img-src
   directive, permitting the browser to load a cover directly.
 
-Both are needed because covers reach the browser two ways: proxied through
-``/api/metadata/art/{comic_id}``, and — when the cache-on-add fetch failed —
-as the raw external URL left in ``comics.ComicImage``, which the library grid
-renders with no proxy fallback. This module lives in ``core`` rather than
-``metadata`` because ``middleware`` may not import from a domain package.
+Library and series-detail covers load only through
+``/api/metadata/art/{comic_id}``. The CSP ``img-src`` tokens still matter
+for search-result thumbnails and any cache-miss path that still renders a
+raw provider URL. This module lives in ``core`` rather than ``metadata``
+because ``middleware`` may not import from a domain package.
 """
 
 ALLOWED_IMAGE_DOMAINS = frozenset(

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -32,7 +32,8 @@ from comicarr.tables import upcoming as t_upcoming
 COMICS_COLUMNS = [
     t_comics.c.ComicID.label("ComicID"),
     t_comics.c.ComicName.label("ComicName"),
-    t_comics.c.ComicImageURL.label("ComicImage"),
+    t_comics.c.ComicImage.label("ComicImage"),
+    t_comics.c.ComicImageURL.label("ComicImageURL"),
     t_comics.c.Status.label("Status"),
     t_comics.c.ComicPublisher.label("ComicPublisher"),
     t_comics.c.ComicYear.label("ComicYear"),
@@ -82,6 +83,29 @@ ANNUALS_COLUMNS = [
 # ---------------------------------------------------------------------------
 # Series (comics) queries
 # ---------------------------------------------------------------------------
+
+
+def library_cover_src(comic_id):
+    """Same-origin cover URL for a library series.
+
+    The browser must load covers through ``GET /api/metadata/art/{id}``
+    (cache-first, server-side fallback). Never return a provider CDN URL
+    here — MangaDex hotlink-protects ``uploads.mangadex.org``.
+    """
+    if not comic_id:
+        return None
+    return "/api/metadata/art/%s" % comic_id
+
+
+def with_library_cover_src(row):
+    """Copy a comics row and point ComicImage at the same-origin art URL."""
+    if row is None:
+        return None
+    item = dict(row)
+    src = library_cover_src(item.get("ComicID"))
+    if src:
+        item["ComicImage"] = src
+    return item
 
 
 def list_comics():

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -291,7 +291,7 @@ def list_comics(ctx, limit=None, offset=None):
     if limit is not None:
         paginated = series_queries.list_comics_paginated(limit, offset=offset or 0)
         return {
-            "comics": paginated["results"],
+            "comics": [series_queries.with_library_cover_src(row) for row in paginated["results"]],
             "pagination": {
                 "total": paginated["total"],
                 "limit": paginated["limit"],
@@ -299,12 +299,12 @@ def list_comics(ctx, limit=None, offset=None):
                 "has_more": paginated["has_more"],
             },
         }
-    return series_queries.list_comics()
+    return [series_queries.with_library_cover_src(row) for row in series_queries.list_comics()]
 
 
 def get_comic_detail(ctx, comic_id):
     """Get a single comic with its issues and annuals."""
-    comic = series_queries.get_comic(comic_id)
+    comic = [series_queries.with_library_cover_src(row) for row in series_queries.get_comic(comic_id)]
     issue_rows = series_queries.get_issues(comic_id)
 
     annuals_on = getattr(ctx.config, "ANNUALS_ON", False) if ctx.config else False

--- a/frontend/src/components/ai/ChatResultCard.tsx
+++ b/frontend/src/components/ai/ChatResultCard.tsx
@@ -3,6 +3,7 @@ import type { ChatResult } from "@/types/chat";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ArrowUpRight } from "lucide-react";
+import { seriesCoverSrc } from "@/lib/series-utils";
 
 interface ChatResultCardProps {
   result: ChatResult;
@@ -18,12 +19,13 @@ export function ChatResultCard({ result }: ChatResultCardProps) {
     result.pct ?? (total > 0 ? Math.round((have / total) * 100) : 0),
   );
 
+  const coverSrc = seriesCoverSrc(comicId);
   const card = (
     <div className="group flex min-w-0 flex-1 items-center gap-3 text-left">
       <div className="h-16 w-11 shrink-0 overflow-hidden rounded-sm border bg-muted shadow-sm">
-        {result.ComicImage ? (
+        {coverSrc ? (
           <img
-            src={result.ComicImage}
+            src={coverSrc}
             alt=""
             className="size-full object-cover transition-transform group-hover:scale-105 motion-reduce:transition-none"
             loading="lazy"

--- a/frontend/src/components/data-table/cells/CoverCell.tsx
+++ b/frontend/src/components/data-table/cells/CoverCell.tsx
@@ -1,10 +1,11 @@
 import { useState, SyntheticEvent } from "react";
 import { BookOpen, ImageOff } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { seriesCoverSrc } from "@/lib/series-utils";
 
 interface CoverCellProps {
   comicId?: string;
-  /** External image URL (e.g., from ComicVine). Takes precedence over API URL. */
+  /** External image URL used only when the row has no library ComicID. */
   imageUrl?: string | null;
   /** Full variant shows title, year, and manga badge alongside the image */
   variant?: "thumbnail" | "full";
@@ -23,7 +24,7 @@ export function CoverCell({
 }: CoverCellProps) {
   const [imageError, setImageError] = useState(false);
 
-  const src = imageUrl || (comicId ? `/api/metadata/art/${comicId}` : null);
+  const src = seriesCoverSrc(comicId) || imageUrl || null;
 
   const thumbnail = (
     <div className="w-10 h-14 bg-muted rounded overflow-hidden flex-shrink-0">

--- a/frontend/src/components/series/SeriesCard.tsx
+++ b/frontend/src/components/series/SeriesCard.tsx
@@ -2,7 +2,7 @@ import { useState, type SyntheticEvent } from "react";
 import { BookOpen, ImageOff } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import StatusBadge from "@/components/StatusBadge";
-import { getProgressPercentage } from "@/lib/series-utils";
+import { getProgressPercentage, seriesCoverSrc } from "@/lib/series-utils";
 import type { Comic } from "@/types";
 
 interface SeriesCardProps {
@@ -13,11 +13,7 @@ interface SeriesCardProps {
 export default function SeriesCard({ comic, onClick }: SeriesCardProps) {
   const [imageError, setImageError] = useState(false);
 
-  const src =
-    comic.ComicImage ||
-    (comic.ComicID
-      ? `/api/metadata/art/${encodeURIComponent(comic.ComicID)}`
-      : null);
+  const src = seriesCoverSrc(comic.ComicID);
 
   const percentage = getProgressPercentage(comic);
   const have = parseInt(String(comic.Have)) || 0;

--- a/frontend/src/components/series/SeriesTable.tsx
+++ b/frontend/src/components/series/SeriesTable.tsx
@@ -39,7 +39,11 @@ import {
 } from "@/components/data-table/useTableState";
 import { DataTableFooter } from "@/components/data-table/DataTableFooter";
 import { useTableUrlStore } from "@/components/data-table/tableUrlStore";
-import { getProgressPercentage, getProgressCategory } from "@/lib/series-utils";
+import {
+  getProgressPercentage,
+  getProgressCategory,
+  seriesCoverSrc,
+} from "@/lib/series-utils";
 import {
   useBulkDeleteSeries,
   useBulkPauseSeries,
@@ -621,7 +625,7 @@ function SeriesRow({ row, onClick }: SeriesRowProps) {
         />
       </div>
 
-      <CoverThumb url={comic.ComicImage} alt={comic.ComicName} />
+      <CoverThumb comicId={comic.ComicID} alt={comic.ComicName} />
 
       <div className="min-w-0" data-series-title-slot>
         <div className="flex min-w-0 items-center gap-2">
@@ -710,23 +714,24 @@ function statusTextColor(status: string): string {
 }
 
 interface CoverThumbProps {
-  url?: string | null;
+  comicId?: string | null;
   alt?: string;
 }
 
-function CoverThumb({ url, alt }: CoverThumbProps) {
-  const [erroredUrl, setErroredUrl] = useState<string | null>(null);
-  const errored = erroredUrl !== null && erroredUrl === url;
+function CoverThumb({ comicId, alt }: CoverThumbProps) {
+  const src = seriesCoverSrc(comicId);
+  const [erroredSrc, setErroredSrc] = useState<string | null>(null);
+  const errored = erroredSrc !== null && erroredSrc === src;
 
   return (
     <div className="w-[32px] h-[44px] bg-muted rounded-sm overflow-hidden flex-shrink-0">
-      {url && !errored ? (
+      {src && !errored ? (
         <img
-          src={url}
+          src={src}
           alt={alt || ""}
           className="w-full h-full object-cover"
           loading="lazy"
-          onError={() => setErroredUrl(url)}
+          onError={() => setErroredSrc(src)}
         />
       ) : (
         <div className="w-full h-full flex items-center justify-center text-muted-foreground/40">

--- a/frontend/src/lib/series-utils.ts
+++ b/frontend/src/lib/series-utils.ts
@@ -1,5 +1,13 @@
 import type { Comic } from "@/types";
 
+/** Same-origin cover URL. Library/detail views must never hotlink provider CDNs. */
+export function seriesCoverSrc(
+  comicId: string | null | undefined,
+): string | null {
+  if (!comicId) return null;
+  return `/api/metadata/art/${encodeURIComponent(comicId)}`;
+}
+
 export function getProgressPercentage(comic: Comic): number {
   const total = parseInt(String(comic.Total)) || 0;
   const have = parseInt(String(comic.Have)) || 0;

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -48,6 +48,7 @@ import type {
   ContentType,
 } from "@/types";
 import { displayComicDate, pickComicDate } from "@/lib/format";
+import { seriesCoverSrc } from "@/lib/series-utils";
 
 type IssueFilter = "all" | "have" | "missing" | "monitored";
 
@@ -338,6 +339,7 @@ export default function SeriesDetailPage() {
   const isPaused = comic.Status?.toLowerCase() === "paused";
   const allowPacks = comic.AllowPacks === 1 || comic.AllowPacks === "1";
   const ignoreType = Boolean(comic.IgnoreType);
+  const coverSrc = seriesCoverSrc(comic.ComicID);
 
   const handleSearchSettingChange = async (
     setting: "allowPacks" | "ignoreType",
@@ -488,9 +490,9 @@ export default function SeriesDetailPage() {
           className="aspect-[2/3] w-[112px] overflow-hidden rounded-[5px] border md:w-[140px]"
           style={{ borderColor: "var(--border)" }}
         >
-          {comic.ComicImage && (
+          {coverSrc && (
             <img
-              src={comic.ComicImage}
+              src={coverSrc}
               alt={comic.ComicName}
               className="h-full w-full object-cover"
               onError={(event) => {

--- a/frontend/tests/components/SeriesTable.test.tsx
+++ b/frontend/tests/components/SeriesTable.test.tsx
@@ -48,6 +48,48 @@ describe("SeriesTable", () => {
     vi.restoreAllMocks();
   });
 
+  it("loads list covers from the art proxy, never a MangaDex hotlink", () => {
+    window.history.pushState({}, "", "/library");
+    const comics: Comic[] = [
+      {
+        ComicID: "md-onepiece",
+        ComicName: "One Piece",
+        ComicPublisher: "Shueisha",
+        ComicYear: "1997",
+        Status: "Active",
+        Have: 0,
+        Total: 1,
+        ComicImage: "https://uploads.mangadex.org/covers/uuid/cover.jpg",
+      },
+      {
+        ComicID: "mal-13",
+        ComicName: "Naruto",
+        ComicPublisher: "Shueisha",
+        ComicYear: "1999",
+        Status: "Active",
+        Have: 0,
+        Total: 1,
+        ComicImage: "https://cdn.myanimelist.net/images/manga/2/x.jpg",
+      },
+    ];
+
+    render(
+      <NuqsAdapter>
+        <SeriesTable data={comics} />
+      </NuqsAdapter>,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "One Piece" }).getAttribute("src"),
+    ).toBe("/api/metadata/art/md-onepiece");
+    expect(
+      screen.getByRole("img", { name: "Naruto" }).getAttribute("src"),
+    ).toBe("/api/metadata/art/mal-13");
+    expect(
+      screen.getByRole("img", { name: "One Piece" }).getAttribute("src"),
+    ).not.toContain("uploads.mangadex.org");
+  });
+
   it("shows the next page when pagination advances", async () => {
     const user = userEvent.setup();
     window.history.pushState({}, "", "/library");

--- a/frontend/tests/pages/SeriesDetailPage.test.tsx
+++ b/frontend/tests/pages/SeriesDetailPage.test.tsx
@@ -208,6 +208,29 @@ describe("SeriesDetailPage", () => {
     );
   });
 
+  it("loads the cover from the art proxy, never a MangaDex hotlink", async () => {
+    server.use(
+      http.get("/api/series/1", () =>
+        HttpResponse.json({
+          comic: {
+            ComicID: "md-onepiece",
+            ComicName: "One Piece",
+            Status: "Active",
+            ComicImage: "https://uploads.mangadex.org/covers/uuid/cover.jpg",
+            ComicImageURL: "https://uploads.mangadex.org/covers/uuid/cover.jpg",
+          },
+          issues: canonicalIssues,
+          annuals: [],
+          summary: { total: 0, owned: 0, missing: 0 },
+        }),
+      ),
+    );
+    renderDetail();
+    const cover = await screen.findByRole("img", { name: "One Piece" });
+    expect(cover.getAttribute("src")).toBe("/api/metadata/art/md-onepiece");
+    expect(cover.getAttribute("src")).not.toContain("uploads.mangadex.org");
+  });
+
   it("links out to the series page on its metadata provider", async () => {
     renderDetail();
     const link = await screen.findByRole("link", { name: "View on ComicVine" });
@@ -244,12 +267,14 @@ describe("SeriesDetailPage", () => {
     );
     renderDetail();
     expect(
-      (await screen.findByRole("link", { name: "View on MyAnimeList" })).getAttribute(
-        "href",
-      ),
+      (
+        await screen.findByRole("link", { name: "View on MyAnimeList" })
+      ).getAttribute("href"),
     ).toBe("https://myanimelist.net/manga/161890");
     expect(
-      screen.getByRole("link", { name: "View on MangaDex" }).getAttribute("href"),
+      screen
+        .getByRole("link", { name: "View on MangaDex" })
+        .getAttribute("href"),
     ).toBe("https://mangadex.org/title/uuid-2");
   });
 

--- a/frontend/tests/unit/lib/seriesCoverSrc.test.ts
+++ b/frontend/tests/unit/lib/seriesCoverSrc.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { seriesCoverSrc } from "@/lib/series-utils";
+
+describe("seriesCoverSrc", () => {
+  it("returns the cache-first art proxy for library ids", () => {
+    expect(seriesCoverSrc("md-onepiece")).toBe("/api/metadata/art/md-onepiece");
+    expect(seriesCoverSrc("mal-13")).toBe("/api/metadata/art/mal-13");
+  });
+
+  it("encodes the id and never emits a provider CDN", () => {
+    const src = seriesCoverSrc("md-abc/../x");
+    expect(src).toBe("/api/metadata/art/md-abc%2F..%2Fx");
+    expect(src).not.toContain("uploads.mangadex.org");
+  });
+
+  it("returns null when there is no series id", () => {
+    expect(seriesCoverSrc(null)).toBeNull();
+    expect(seriesCoverSrc(undefined)).toBeNull();
+    expect(seriesCoverSrc("")).toBeNull();
+  });
+});

--- a/tests/unit/test_metadata_domain.py
+++ b/tests/unit/test_metadata_domain.py
@@ -293,6 +293,40 @@ class TestGetArtwork:
         result = metadata_service.get_artwork(ctx, comic_id)
         assert result == str(cache_file)
 
+    def test_mal_comic_id_cache_hit(self, tmp_path):
+        """MyAnimeList-style mal-* ids are accepted for cache paths."""
+        ctx = _make_test_ctx()
+        ctx.config.CACHE_DIR = str(tmp_path)
+        comic_id = "mal-13"
+        cache_file = tmp_path / (comic_id + ".jpg")
+        cache_file.write_bytes(_jpeg_bytes())
+
+        result = metadata_service.get_artwork(ctx, comic_id)
+        assert result == str(cache_file)
+
+    @patch("comicarr.app.metadata.image_fetch.requests.get")
+    @patch("comicarr.db")
+    def test_mangadex_url_fallback_writes_cache_server_side(self, mock_db, mock_get, tmp_path):
+        """Cache miss fetches MangaDex server-side; the browser never hotlinks."""
+        ctx = _make_test_ctx()
+        ctx.config.CACHE_DIR = str(tmp_path)
+        comic_id = "md-onepiece"
+        jpeg = _jpeg_bytes()
+        mock_db.select_all.return_value = [
+            {
+                "ComicID": comic_id,
+                "ComicImageURL": "https://uploads.mangadex.org/covers/uuid/cover.jpg",
+                "ComicImageALTURL": None,
+            }
+        ]
+        mock_get.return_value = _mock_image_response(jpeg)
+
+        result = metadata_service.get_artwork(ctx, comic_id)
+        assert result == str(tmp_path / (comic_id + ".jpg"))
+        assert (tmp_path / (comic_id + ".jpg")).read_bytes() == jpeg
+        mock_get.assert_called_once()
+        assert mock_get.call_args.args[0] == "https://uploads.mangadex.org/covers/uuid/cover.jpg"
+
     @patch("comicarr.app.metadata.image_fetch.requests.get")
     @patch("comicarr.db")
     def test_ssrf_url_does_not_call_network(self, mock_db, mock_get, tmp_path):

--- a/tests/unit/test_series_cover_api.py
+++ b/tests/unit/test_series_cover_api.py
@@ -1,0 +1,127 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Series API covers are same-origin, never a MangaDex hotlink."""
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import insert
+
+import comicarr
+from comicarr import db
+from comicarr.app.series import queries as series_queries
+from comicarr.app.series import service as series_service
+from comicarr.tables import comics, metadata
+
+MANGADEX_COVER = "https://uploads.mangadex.org/covers/uuid/cover.jpg"
+MAL_COVER = "https://cdn.myanimelist.net/images/manga/2/253146l.jpg"
+
+
+@pytest.fixture
+def query_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+def _seed_manga(engine):
+    with engine.begin() as conn:
+        conn.execute(
+            insert(comics),
+            [
+                {
+                    "ComicID": "md-onepiece",
+                    "ComicName": "One Piece",
+                    "ComicSortName": "One Piece",
+                    "ComicYear": "1997",
+                    "Status": "Active",
+                    "Have": 0,
+                    "Total": 1100,
+                    "ContentType": "manga",
+                    "ComicImage": "cache/md-onepiece.jpg",
+                    "ComicImageURL": MANGADEX_COVER,
+                },
+                {
+                    "ComicID": "mal-13",
+                    "ComicName": "One Piece",
+                    "ComicSortName": "One Piece MAL",
+                    "ComicYear": "1997",
+                    "Status": "Active",
+                    "Have": 0,
+                    "Total": 1100,
+                    "ContentType": "manga",
+                    "ComicImage": "cache/mal-13.jpg",
+                    "ComicImageURL": MAL_COVER,
+                },
+            ],
+        )
+
+
+def test_library_cover_src_is_same_origin_art_path():
+    assert series_queries.library_cover_src("md-onepiece") == "/api/metadata/art/md-onepiece"
+    assert series_queries.library_cover_src("mal-13") == "/api/metadata/art/mal-13"
+    assert series_queries.library_cover_src(None) is None
+    assert series_queries.library_cover_src("") is None
+
+
+def test_with_library_cover_src_drops_provider_cdn():
+    row = series_queries.with_library_cover_src(
+        {
+            "ComicID": "md-onepiece",
+            "ComicImage": MANGADEX_COVER,
+            "ComicImageURL": MANGADEX_COVER,
+        }
+    )
+    assert row["ComicImage"] == "/api/metadata/art/md-onepiece"
+    assert "uploads.mangadex.org" not in row["ComicImage"]
+    assert row["ComicImageURL"] == MANGADEX_COVER
+
+
+def test_query_projection_keeps_cached_path_and_external_url(query_db):
+    _seed_manga(query_db)
+
+    md = series_queries.get_comic("md-onepiece")[0]
+    assert md["ComicImage"] == "cache/md-onepiece.jpg"
+    assert md["ComicImageURL"] == MANGADEX_COVER
+    assert md["ComicImage"] != md["ComicImageURL"]
+
+    mal = series_queries.get_comic("mal-13")[0]
+    assert mal["ComicImage"] == "cache/mal-13.jpg"
+    assert mal["ComicImageURL"] == MAL_COVER
+
+
+def test_series_api_comicimage_is_art_proxy_not_mangadex(query_db):
+    _seed_manga(query_db)
+    ctx = SimpleNamespace(config=SimpleNamespace(ANNUALS_ON=False))
+
+    listed = series_service.list_comics(ctx)
+    by_id = {row["ComicID"]: row for row in listed}
+    assert by_id["md-onepiece"]["ComicImage"] == series_queries.library_cover_src("md-onepiece")
+    assert by_id["mal-13"]["ComicImage"] == series_queries.library_cover_src("mal-13")
+    assert "uploads.mangadex.org" not in by_id["md-onepiece"]["ComicImage"]
+    assert by_id["md-onepiece"]["ComicImageURL"] == MANGADEX_COVER
+
+    paged = series_service.list_comics(ctx, limit=10, offset=0)
+    paged_by_id = {row["ComicID"]: row for row in paged["comics"]}
+    assert paged_by_id["md-onepiece"]["ComicImage"] == "/api/metadata/art/md-onepiece"
+
+    detail = series_service.get_comic_detail(ctx, "md-onepiece")
+    comic = detail["comic"][0]
+    assert comic["ComicImage"] == "/api/metadata/art/md-onepiece"
+    assert "uploads.mangadex.org" not in comic["ComicImage"]
+    assert comic["ComicImageURL"] == MANGADEX_COVER
+
+    mal_detail = series_service.get_comic_detail(ctx, "mal-13")
+    assert mal_detail["comic"][0]["ComicImage"] == "/api/metadata/art/mal-13"


### PR DESCRIPTION
## Summary

Library and series-detail covers now load through the cache-first `/api/metadata/art/{id}` proxy instead of hotlinking `uploads.mangadex.org`. MangaDex's CDN was serving the "You can read this at MANGADEX" placeholder because Comicarr sends a foreign Referer.

- Series API returns the real `ComicImage` cache path plus `ComicImageURL`, then rewrites `ComicImage` on the wire to the same-origin art URL.
- Series list, grid, detail, cover cells, and chat result cards use `seriesCoverSrc`.
- Tests drive `get_comic` / `list_comics` / `get_comic_detail` and the React surfaces for `md-` and `mal-` series.

Closes #683

## Test plan

- [x] `pytest tests/unit/test_series_cover_api.py tests/unit/test_metadata_domain.py::TestGetArtwork`
- [x] Frontend: `seriesCoverSrc`, SeriesDetailPage, SeriesTable
- [ ] After merge: confirm an `md-` and a `mal-` series show their cached cover with no request to `uploads.mangadex.org`