### PR TITLE
fix: Reject non-boolean provider verify and enabled flags

### DIFF
--- a/comicarr/app/system/router.py
+++ b/comicarr/app/system/router.py
@@ -229,7 +229,10 @@ async def regenerate_api_key(
 
 @router.put("/config/providers", dependencies=[Depends(require_session)])
 async def update_providers(request: Request, ctx: AppContext = Depends(get_context)):
-    """Update Newznab/Torznab provider configuration."""
+    """Update Newznab/Torznab provider configuration.
+
+    Object-payload ``verify`` and ``enabled`` must be JSON booleans when present.
+    """
     body = await request.json()
     result = await asyncio.to_thread(system_service.update_providers, ctx, body)
     if not result["success"]:

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -543,7 +543,14 @@ def regenerate_api_key(ctx, username, ip):
 
 
 def update_providers(ctx, provider_data):
-    """Update Newznab/Torznab provider configuration."""
+    """Update Newznab/Torznab provider configuration.
+
+    Object-payload ``verify`` and ``enabled`` — on each provider row and the
+    top-level enablement flag — must be JSON booleans when present. Non-boolean
+    values are rejected so a string like ``"false"`` cannot silently enable a
+    provider.
+    """
+
     if not ctx.config:
         return {"success": False, "error": "Config not loaded"}
 
@@ -570,6 +577,10 @@ def update_providers(ctx, provider_data):
         for row in providers:
             if not isinstance(row, dict):
                 return {"success": False, "error": "Invalid provider configuration"}
+            if "enabled" in row and not isinstance(row["enabled"], bool):
+                return {"success": False, "error": "Provider enabled must be a boolean"}
+            if "verify" in row and not isinstance(row["verify"], bool):
+                return {"success": False, "error": "Provider verify must be a boolean"}
             old = by_id.get(str(row.get("id"))) or by_identity.get(
                 (str(row.get("name") or ""), _safe_provider_host(row.get("host")))
             )

--- a/tests/unit/test_system_domain.py
+++ b/tests/unit/test_system_domain.py
@@ -1061,6 +1061,46 @@ class TestConfigService:
         assert result == {"success": False, "error": "Provider enabled must be a boolean"}
         ctx.config.apply_transaction.assert_not_called()
 
+    @pytest.mark.parametrize("field", ("verify", "enabled"))
+    @pytest.mark.parametrize("value", ("false", 0, 1, None))
+    def test_update_providers_rejects_non_boolean_row_flags(self, field, value):
+        """Object-payload verify/enabled must be JSON booleans, like top-level enabled."""
+        ctx = _make_test_ctx()
+        row = {
+            "name": "Indexer",
+            "host": "https://indexer.test",
+            "verify": True,
+            "api_key": "secret",
+            "categories": "5030",
+            "enabled": True,
+        }
+        row[field] = value
+
+        result = system_service.update_providers(ctx, {"type": "newznab", "providers": [row]})
+
+        assert result == {"success": False, "error": "Provider %s must be a boolean" % field}
+        ctx.config.apply_transaction.assert_not_called()
+
+    def test_update_providers_persists_json_false_row_flags(self):
+        ctx = _make_test_ctx()
+        providers = [
+            {
+                "name": "Indexer",
+                "host": "https://indexer.test",
+                "verify": False,
+                "api_key": "secret",
+                "categories": "5030",
+                "enabled": False,
+            }
+        ]
+
+        result = system_service.update_providers(ctx, {"type": "newznab", "providers": providers})
+
+        assert result["success"] is True
+        persisted = ctx.config.apply_transaction.call_args.args[0]["EXTRA_NEWZNABS"][0]
+        assert persisted[2] == "0"
+        assert persisted[5] == "0"
+
     def test_update_providers_persists_rows_and_enablement_atomically(self):
         old_providers = [("Old", "https://old.test", "1", "old-key", "5030", "1", 100)]
         new_providers = [


### PR DESCRIPTION
## Summary

`PUT /api/config/providers` now requires JSON booleans for `verify` and `enabled` on each provider row, the same way it already rejects a non-boolean top-level `enabled` flag. A string like `"false"` can no longer silently enable a provider.

Fixes #705.

## Changes

- Reject non-boolean `verify`/`enabled` on object-payload provider rows
- Persist JSON `false` as disabled
- Document the boolean contract on the update-providers API

## Release Impact

- [ ] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [x] No app release impact; no changeset needed (omit rather than "No user-visible behaviour changes.")

Settings already sends real booleans. This only rejects a malformed API payload.

## Testing

- [x] Tests pass locally (`pytest tests/unit -v`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [x] Backend lint/format (`ruff check comicarr/` and `ruff format --check comicarr/`)
- [x] Frontend lint/format (`cd frontend && npm run lint && npm run format:check`)
- [x] Or one-shot: `npm run lint` (from repo root; requires `uv` + `frontend/node_modules`)
- [ ] Manually tested (describe what you tested):

No UI change. Covered by `test_update_providers_rejects_non_boolean_row_flags` and `test_update_providers_persists_json_false_row_flags`. Full unit suite: 2535 passed.

## Screenshots

N/A — API contract only.

## Additional Notes

Follow-up from the Search-provider deepening in #702.