### PR TITLE
feat: Add a Torznab indexer editor in Settings

### DIFF
--- a/.changeset/torznab-settings-editor.md
+++ b/.changeset/torznab-settings-editor.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Torznab indexers can now be added, edited, and removed in Settings → Search, next to the existing Newznab editor. You no longer have to hand-edit `extra_torznabs` in `config.ini` to manage torrent indexers.

--- a/comicarr/config.py
+++ b/comicarr/config.py
@@ -522,10 +522,10 @@ class Config(object):
         if missing:
             logger.warn(
                 "[CONFIG] Legacy torznab_* fields under [Torznab] are set but incomplete "
-                "(missing: %s) and are NOT used for searching. Complete them, or add the "
-                "provider to extra_torznabs under [Torznab] in config.ini as "
-                "'Name, https://host/api, 1, apikey, 7030, 1'. Ignoring the legacy entry."
-                % ", ".join("torznab_%s" % m for m in missing)
+                "(missing: %s) and are NOT used for searching. Complete them in "
+                "Settings → Search, or add the provider to extra_torznabs under [Torznab] "
+                "in config.ini as 'Name, https://host/api, 1, apikey, 7030, 1'. "
+                "Ignoring the legacy entry." % ", ".join("torznab_%s" % m for m in missing)
             )
             return
 
@@ -549,7 +549,7 @@ class Config(object):
             logger.warn(
                 "[CONFIG] Legacy torznab_* fields under [Torznab] reuse the provider name "
                 "'%s' and are NOT used for searching. Rename or remove the legacy fields, or "
-                "edit the existing entry in extra_torznabs under [Torznab] in config.ini." % legacy["name"]
+                "edit the existing indexer in Settings → Search." % legacy["name"]
             )
             return
 
@@ -577,7 +577,7 @@ class Config(object):
         logger.info(
             "[CONFIG] Migrated legacy torznab_* fields under [Torznab] into extra_torznabs "
             "as provider '%s' (%s). The legacy single-provider fields are no longer read; "
-            "manage this provider through extra_torznabs from now on." % (legacy["name"], legacy["host"])
+            "manage this provider in Settings → Search from now on." % (legacy["name"], legacy["host"])
         )
         _scrub()
 

--- a/frontend/src/components/settings/SearchProviderEditor.tsx
+++ b/frontend/src/components/settings/SearchProviderEditor.tsx
@@ -1,0 +1,414 @@
+import { useEffect, useMemo, useState } from "react";
+import { LoaderCircle, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/components/ui/toast";
+import { useUpdateSearchProviders } from "@/hooks/useConfig";
+import { httpOrigin } from "@/lib/httpOrigin";
+import type {
+  NewznabProvider,
+  SearchProviderKind,
+  TorznabProvider,
+} from "@/types";
+import { SettingField } from "./SettingField";
+
+type EditableProvider = {
+  id?: number;
+  name: string;
+  host: string;
+  verify: boolean;
+  categories: string;
+  enabled: boolean;
+  api_key_set: boolean;
+  api_key: string;
+  rss_uid?: string;
+};
+
+type ProviderGroup = {
+  enabled: boolean;
+  providers: Array<NewznabProvider | TorznabProvider>;
+};
+
+type EditorCopy = {
+  enableLabel: string;
+  enableHelp: string;
+  empty: string;
+  add: string;
+  reset: string;
+  save: string;
+  saved: string;
+  unsaved: string;
+  heading: (index: number) => string;
+  remove: (index: number) => string;
+  name: string;
+  host: string;
+  hostPlaceholder: string;
+  key: string;
+  categoriesHelp: string;
+  enableRow: (index: number) => string;
+  verifyRow: (index: number) => string;
+  idPrefix: string;
+  showRssUid: boolean;
+};
+
+const COPY: Record<SearchProviderKind, EditorCopy> = {
+  newznab: {
+    enableLabel: "Enable Newznab indexers",
+    enableHelp: "At least one enabled indexer is required for Usenet search.",
+    empty:
+      "No Usenet indexers are configured. Add a Newznab-compatible indexer to make the NZB route searchable.",
+    add: "Add indexer",
+    reset: "Reset indexers",
+    save: "Save indexers",
+    saved: "Search indexers saved",
+    unsaved: "Unsaved indexer changes",
+    heading: (index) => `Indexer ${index}`,
+    remove: (index) => `Remove indexer ${index}`,
+    name: "Indexer name",
+    host: "Indexer URL",
+    hostPlaceholder: "https://indexer.example/api",
+    key: "Indexer API key",
+    categoriesHelp:
+      "Newznab category IDs, comma-separated. 7030 is Books/Comics.",
+    enableRow: (index) => `Enable indexer ${index}`,
+    verifyRow: (index) => `Verify TLS for indexer ${index}`,
+    idPrefix: "indexer",
+    showRssUid: true,
+  },
+  torznab: {
+    enableLabel: "Enable Torznab indexers",
+    enableHelp: "At least one enabled indexer is required for torrent search.",
+    empty:
+      "No torrent indexers are configured. Add a Torznab-compatible indexer to make the torrent route searchable.",
+    add: "Add Torznab indexer",
+    reset: "Reset Torznab indexers",
+    save: "Save Torznab indexers",
+    saved: "Torznab indexers saved",
+    unsaved: "Unsaved Torznab indexer changes",
+    heading: (index) => `Torznab indexer ${index}`,
+    remove: (index) => `Remove Torznab indexer ${index}`,
+    name: "Torznab indexer name",
+    host: "Torznab indexer URL",
+    hostPlaceholder: "https://prowlarr.example/1/api",
+    key: "Torznab indexer API key",
+    categoriesHelp:
+      "Torznab category IDs, comma-separated. Use the IDs your indexer documents for comics.",
+    enableRow: (index) => `Enable Torznab indexer ${index}`,
+    verifyRow: (index) => `Verify TLS for Torznab indexer ${index}`,
+    idPrefix: "torznab-indexer",
+    showRssUid: false,
+  },
+};
+
+function blankProvider(kind: SearchProviderKind): EditableProvider {
+  return {
+    name: "",
+    host: "",
+    verify: true,
+    // 7030 is Books/Comics in the standard Newznab category numbering.
+    // The old 5030 default was a TV category — harmless while categories
+    // were being discarded before reaching the search, and wrong now that
+    // they are not. Torznab indexers that speak the same numbering use it too.
+    categories: "7030",
+    enabled: true,
+    api_key_set: false,
+    api_key: "",
+    ...(kind === "newznab" ? { rss_uid: "1" } : {}),
+  };
+}
+
+export function SearchProviderEditor({
+  kind,
+  initial,
+  onDirtyChange,
+}: {
+  kind: SearchProviderKind;
+  initial: ProviderGroup;
+  onDirtyChange?: (dirty: boolean) => void;
+}) {
+  const copy = COPY[kind];
+  const { addToast } = useToast();
+  const updateProviders = useUpdateSearchProviders();
+  const [enabled, setEnabled] = useState(initial.enabled);
+  const initialProviders = useMemo(
+    () => initial.providers.map((provider) => ({ ...provider, api_key: "" })),
+    [initial.providers],
+  );
+  const [providers, setProviders] =
+    useState<EditableProvider[]>(initialProviders);
+  const isDirty =
+    enabled !== initial.enabled ||
+    JSON.stringify(providers) !== JSON.stringify(initialProviders);
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+    return () => onDirtyChange?.(false);
+  }, [isDirty, onDirtyChange]);
+
+  const updateProvider = (index: number, patch: Partial<EditableProvider>) => {
+    setProviders((current) =>
+      current.map((provider, providerIndex) =>
+        providerIndex === index ? { ...provider, ...patch } : provider,
+      ),
+    );
+  };
+
+  const addProvider = () => {
+    setProviders((current) => [...current, blankProvider(kind)]);
+  };
+
+  const resetProviders = () => {
+    setEnabled(initial.enabled);
+    setProviders(initialProviders);
+  };
+
+  const saveProviders = async () => {
+    const incomplete = providers.some(
+      (provider) =>
+        !provider.name.trim() ||
+        !provider.host.trim() ||
+        (!provider.api_key_set && !provider.api_key.trim()),
+    );
+    if (incomplete) {
+      addToast({
+        type: "error",
+        message: "Each indexer needs a name, URL, and API key.",
+      });
+      return;
+    }
+    const redirectedSecret = providers.some((provider) => {
+      if (!provider.api_key_set || provider.api_key.trim()) return false;
+      const original = initial.providers.find(
+        (candidate) => candidate.id === provider.id,
+      );
+      return Boolean(
+        original && httpOrigin(original.host) !== httpOrigin(provider.host),
+      );
+    });
+    if (redirectedSecret) {
+      addToast({
+        type: "error",
+        message: "Enter the API key again when changing an indexer server.",
+      });
+      return;
+    }
+    const payload = providers.map((provider) => {
+      if (kind === "newznab") return provider;
+      const { rss_uid: _rssUid, ...torznab } = provider;
+      return torznab;
+    });
+    try {
+      await updateProviders.mutateAsync({
+        type: kind,
+        enabled,
+        providers: payload,
+      });
+      addToast({ type: "success", message: copy.saved });
+    } catch (error) {
+      addToast({
+        type: "error",
+        message:
+          error instanceof Error ? error.message : "Failed to save indexers",
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <SettingField
+        label={copy.enableLabel}
+        type="checkbox"
+        checked={enabled}
+        onChange={(value) => setEnabled(value as boolean)}
+        helpText={copy.enableHelp}
+      />
+
+      <p className="text-[12px] text-muted-foreground">
+        Indexer edits are saved separately from the page-level settings
+        controls.
+      </p>
+
+      {providers.length === 0 ? (
+        <div className="rounded-[6px] border border-dashed px-4 py-5 text-[12px] text-muted-foreground">
+          {copy.empty}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {providers.map((provider, index) => {
+            const suffix =
+              provider.id != null ? `saved-${provider.id}` : `new-${index}`;
+            return (
+              <article
+                key={provider.id ?? `new-${index}`}
+                className="rounded-[6px] border p-4"
+                style={{ borderColor: "var(--border)" }}
+              >
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.06em]">
+                    {copy.heading(index + 1)}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={copy.remove(index + 1)}
+                    onClick={() =>
+                      setProviders((current) =>
+                        current.filter(
+                          (_, providerIndex) => providerIndex !== index,
+                        ),
+                      )
+                    }
+                  >
+                    <Trash2 />
+                  </Button>
+                </div>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <Label htmlFor={`${copy.idPrefix}-name-${suffix}`}>
+                      {copy.name}
+                    </Label>
+                    <Input
+                      id={`${copy.idPrefix}-name-${suffix}`}
+                      className="mt-1.5"
+                      value={provider.name}
+                      onChange={(event) =>
+                        updateProvider(index, { name: event.target.value })
+                      }
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor={`${copy.idPrefix}-host-${suffix}`}>
+                      {copy.host}
+                    </Label>
+                    <Input
+                      id={`${copy.idPrefix}-host-${suffix}`}
+                      className="mt-1.5"
+                      value={provider.host}
+                      placeholder={copy.hostPlaceholder}
+                      onChange={(event) =>
+                        updateProvider(index, { host: event.target.value })
+                      }
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor={`${copy.idPrefix}-key-${suffix}`}>
+                      {copy.key}
+                    </Label>
+                    <Input
+                      id={`${copy.idPrefix}-key-${suffix}`}
+                      className="mt-1.5"
+                      type="password"
+                      value={provider.api_key}
+                      placeholder={
+                        provider.api_key_set
+                          ? "API key saved (enter a new value to change)"
+                          : "Enter the indexer API key"
+                      }
+                      onChange={(event) =>
+                        updateProvider(index, { api_key: event.target.value })
+                      }
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor={`${copy.idPrefix}-categories-${suffix}`}>
+                      Categories
+                    </Label>
+                    <Input
+                      id={`${copy.idPrefix}-categories-${suffix}`}
+                      className="mt-1.5"
+                      value={provider.categories}
+                      placeholder="7030"
+                      onChange={(event) =>
+                        updateProvider(index, {
+                          categories: event.target.value,
+                        })
+                      }
+                    />
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      {copy.categoriesHelp}
+                    </p>
+                  </div>
+                  {copy.showRssUid ? (
+                    <div>
+                      <Label htmlFor={`${copy.idPrefix}-rss-uid-${suffix}`}>
+                        RSS user ID
+                      </Label>
+                      <Input
+                        id={`${copy.idPrefix}-rss-uid-${suffix}`}
+                        className="mt-1.5"
+                        value={provider.rss_uid ?? ""}
+                        placeholder="1"
+                        onChange={(event) =>
+                          updateProvider(index, {
+                            rss_uid: event.target.value,
+                          })
+                        }
+                      />
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        The <code>i=</code> parameter of this indexer&rsquo;s
+                        RSS URL. Leave as 1 unless your indexer says otherwise.
+                      </p>
+                    </div>
+                  ) : null}
+                </div>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <SettingField
+                    label={copy.enableRow(index + 1)}
+                    type="checkbox"
+                    checked={provider.enabled}
+                    onChange={(value) =>
+                      updateProvider(index, { enabled: value as boolean })
+                    }
+                  />
+                  <SettingField
+                    label={copy.verifyRow(index + 1)}
+                    type="checkbox"
+                    checked={provider.verify}
+                    onChange={(value) =>
+                      updateProvider(index, { verify: value as boolean })
+                    }
+                  />
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={addProvider}>
+          <Plus /> {copy.add}
+        </Button>
+        <div className="flex items-center gap-2">
+          {isDirty && (
+            <span className="text-[11px] text-muted-foreground">
+              {copy.unsaved}
+            </span>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={!isDirty}
+            onClick={resetProviders}
+          >
+            {copy.reset}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            disabled={!isDirty || updateProviders.isPending}
+            onClick={() => void saveProviders()}
+          >
+            {updateProviders.isPending && (
+              <LoaderCircle className="animate-spin" />
+            )}
+            {copy.save}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/SearchTab.tsx
+++ b/frontend/src/components/settings/SearchTab.tsx
@@ -1,17 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
-import { LoaderCircle, Plus, Trash2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { useToast } from "@/components/ui/toast";
-import {
-  useProviderConfig,
-  useUpdateNewznabProviders,
-} from "@/hooks/useConfig";
-import { httpOrigin } from "@/lib/httpOrigin";
-import type { NewznabProvider } from "@/types";
+import { useEffect, useState, type ReactNode } from "react";
+import { LoaderCircle } from "lucide-react";
+import { useProviderConfig } from "@/hooks/useConfig";
+import type { ProviderConfigResponse } from "@/types";
 import { SettingGroup } from "./SettingGroup";
 import { SettingField } from "./SettingField";
+import { SearchProviderEditor } from "./SearchProviderEditor";
 import type {
   ReadableConfig,
   SettingsFormData,
@@ -28,16 +21,21 @@ interface SearchTabProps {
   onProviderDirtyChange?: (dirty: boolean) => void;
 }
 
-type EditableProvider = NewznabProvider & { api_key: string };
+const EMPTY_GROUP: ProviderConfigResponse["newznab"] = {
+  enabled: false,
+  providers: [],
+};
 
-function NewznabProviderSettings({
-  onDirtyChange,
+function ProviderQueryStatus({
+  isLoading,
+  error,
+  children,
 }: {
-  onDirtyChange?: (dirty: boolean) => void;
+  isLoading: boolean;
+  error: Error | null;
+  children: ReactNode;
 }) {
-  const providerQuery = useProviderConfig();
-
-  if (providerQuery.isLoading) {
+  if (isLoading) {
     return (
       <div className="flex items-center gap-2 py-4 text-[12px] text-muted-foreground">
         <LoaderCircle className="h-4 w-4 animate-spin" /> Loading indexers…
@@ -45,321 +43,80 @@ function NewznabProviderSettings({
     );
   }
 
-  if (providerQuery.error) {
+  if (error) {
     return (
       <div role="alert" className="py-3 text-[12px] text-destructive">
-        {providerQuery.error.message}
+        {error.message}
       </div>
     );
   }
 
-  if (!providerQuery.data) return null;
-
-  return (
-    <NewznabProviderForm
-      key={JSON.stringify(providerQuery.data.newznab)}
-      initial={providerQuery.data.newznab}
-      onDirtyChange={onDirtyChange}
-    />
-  );
+  return children;
 }
 
-function NewznabProviderForm({
-  initial,
+function SearchProviderSettings({
   onDirtyChange,
 }: {
-  initial: { enabled: boolean; providers: NewznabProvider[] };
   onDirtyChange?: (dirty: boolean) => void;
 }) {
-  const { addToast } = useToast();
-  const updateProviders = useUpdateNewznabProviders();
-  const [enabled, setEnabled] = useState(initial.enabled);
-  const initialProviders = useMemo(
-    () => initial.providers.map((provider) => ({ ...provider, api_key: "" })),
-    [initial.providers],
-  );
-  const [providers, setProviders] =
-    useState<EditableProvider[]>(initialProviders);
-  const isDirty =
-    enabled !== initial.enabled ||
-    JSON.stringify(providers) !== JSON.stringify(initialProviders);
+  const providerQuery = useProviderConfig();
+  const [newznabDirty, setNewznabDirty] = useState(false);
+  const [torznabDirty, setTorznabDirty] = useState(false);
+  const dirty = newznabDirty || torznabDirty;
 
   useEffect(() => {
-    onDirtyChange?.(isDirty);
+    onDirtyChange?.(dirty);
+  }, [dirty, onDirtyChange]);
+
+  useEffect(() => {
     return () => onDirtyChange?.(false);
-  }, [isDirty, onDirtyChange]);
+  }, [onDirtyChange]);
 
-  const updateProvider = (index: number, patch: Partial<EditableProvider>) => {
-    setProviders((current) =>
-      current.map((provider, providerIndex) =>
-        providerIndex === index ? { ...provider, ...patch } : provider,
-      ),
-    );
-  };
-
-  const addProvider = () => {
-    setProviders((current) => [
-      ...current,
-      {
-        name: "",
-        host: "",
-        verify: true,
-        // 7030 is Books/Comics in the standard Newznab category numbering.
-        // The old 5030 default was a TV category — harmless while categories
-        // were being discarded before reaching the search, and wrong now that
-        // they are not.
-        categories: "7030",
-        rss_uid: "1",
-        enabled: true,
-        api_key_set: false,
-        api_key: "",
-      },
-    ]);
-  };
-
-  const resetProviders = () => {
-    setEnabled(initial.enabled);
-    setProviders(initialProviders);
-  };
-
-  const saveProviders = async () => {
-    const incomplete = providers.some(
-      (provider) =>
-        !provider.name.trim() ||
-        !provider.host.trim() ||
-        (!provider.api_key_set && !provider.api_key.trim()),
-    );
-    if (incomplete) {
-      addToast({
-        type: "error",
-        message: "Each indexer needs a name, URL, and API key.",
-      });
-      return;
-    }
-    const redirectedSecret = providers.some((provider) => {
-      if (!provider.api_key_set || provider.api_key.trim()) return false;
-      const original = initial.providers.find(
-        (candidate) => candidate.id === provider.id,
-      );
-      return Boolean(
-        original && httpOrigin(original.host) !== httpOrigin(provider.host),
-      );
-    });
-    if (redirectedSecret) {
-      addToast({
-        type: "error",
-        message: "Enter the API key again when changing an indexer server.",
-      });
-      return;
-    }
-    try {
-      await updateProviders.mutateAsync({ enabled, providers });
-      addToast({ type: "success", message: "Search indexers saved" });
-    } catch (error) {
-      addToast({
-        type: "error",
-        message:
-          error instanceof Error ? error.message : "Failed to save indexers",
-      });
-    }
-  };
+  const newznab = providerQuery.data?.newznab ?? EMPTY_GROUP;
+  const torznab = providerQuery.data?.torznab ?? EMPTY_GROUP;
+  const queryError =
+    providerQuery.error instanceof Error ? providerQuery.error : null;
 
   return (
-    <div className="space-y-4">
-      <SettingField
-        label="Enable Newznab indexers"
-        type="checkbox"
-        checked={enabled}
-        onChange={(value) => setEnabled(value as boolean)}
-        helpText="At least one enabled indexer is required for Usenet search."
-      />
+    <>
+      <SettingGroup
+        title="Usenet indexers"
+        description="Configure the Newznab-compatible sources Comicarr searches before handing an NZB to your download client."
+      >
+        <ProviderQueryStatus
+          isLoading={providerQuery.isLoading}
+          error={queryError}
+        >
+          {providerQuery.data ? (
+            <SearchProviderEditor
+              key={`newznab:${JSON.stringify(newznab)}`}
+              kind="newznab"
+              initial={newznab}
+              onDirtyChange={setNewznabDirty}
+            />
+          ) : null}
+        </ProviderQueryStatus>
+      </SettingGroup>
 
-      <p className="text-[12px] text-muted-foreground">
-        Indexer edits are saved separately from the page-level settings
-        controls.
-      </p>
-
-      {providers.length === 0 ? (
-        <div className="rounded-[6px] border border-dashed px-4 py-5 text-[12px] text-muted-foreground">
-          No Usenet indexers are configured. Add a Newznab-compatible indexer to
-          make the NZB route searchable.
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {providers.map((provider, index) => {
-            const suffix =
-              provider.id != null ? `saved-${provider.id}` : `new-${index}`;
-            return (
-              <article
-                key={provider.id ?? `new-${index}`}
-                className="rounded-[6px] border p-4"
-                style={{ borderColor: "var(--border)" }}
-              >
-                <div className="mb-3 flex items-center justify-between gap-3">
-                  <div className="font-mono text-[11px] font-semibold uppercase tracking-[0.06em]">
-                    Indexer {index + 1}
-                  </div>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    aria-label={`Remove indexer ${index + 1}`}
-                    onClick={() =>
-                      setProviders((current) =>
-                        current.filter(
-                          (_, providerIndex) => providerIndex !== index,
-                        ),
-                      )
-                    }
-                  >
-                    <Trash2 />
-                  </Button>
-                </div>
-                <div className="grid gap-4 sm:grid-cols-2">
-                  <div>
-                    <Label htmlFor={`indexer-name-${suffix}`}>
-                      Indexer name
-                    </Label>
-                    <Input
-                      id={`indexer-name-${suffix}`}
-                      className="mt-1.5"
-                      value={provider.name}
-                      onChange={(event) =>
-                        updateProvider(index, { name: event.target.value })
-                      }
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor={`indexer-host-${suffix}`}>
-                      Indexer URL
-                    </Label>
-                    <Input
-                      id={`indexer-host-${suffix}`}
-                      className="mt-1.5"
-                      value={provider.host}
-                      placeholder="https://indexer.example/api"
-                      onChange={(event) =>
-                        updateProvider(index, { host: event.target.value })
-                      }
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor={`indexer-key-${suffix}`}>
-                      Indexer API key
-                    </Label>
-                    <Input
-                      id={`indexer-key-${suffix}`}
-                      className="mt-1.5"
-                      type="password"
-                      value={provider.api_key}
-                      placeholder={
-                        provider.api_key_set
-                          ? "API key saved (enter a new value to change)"
-                          : "Enter the indexer API key"
-                      }
-                      onChange={(event) =>
-                        updateProvider(index, { api_key: event.target.value })
-                      }
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor={`indexer-categories-${suffix}`}>
-                      Categories
-                    </Label>
-                    <Input
-                      id={`indexer-categories-${suffix}`}
-                      className="mt-1.5"
-                      value={provider.categories}
-                      placeholder="7030"
-                      onChange={(event) =>
-                        updateProvider(index, {
-                          categories: event.target.value,
-                        })
-                      }
-                    />
-                    <p className="mt-1 text-[11px] text-muted-foreground">
-                      Newznab category IDs, comma-separated. 7030 is
-                      Books/Comics.
-                    </p>
-                  </div>
-                  <div>
-                    <Label htmlFor={`indexer-rss-uid-${suffix}`}>
-                      RSS user ID
-                    </Label>
-                    <Input
-                      id={`indexer-rss-uid-${suffix}`}
-                      className="mt-1.5"
-                      value={provider.rss_uid ?? ""}
-                      placeholder="1"
-                      onChange={(event) =>
-                        updateProvider(index, {
-                          rss_uid: event.target.value,
-                        })
-                      }
-                    />
-                    <p className="mt-1 text-[11px] text-muted-foreground">
-                      The <code>i=</code> parameter of this indexer&rsquo;s RSS
-                      URL. Leave as 1 unless your indexer says otherwise.
-                    </p>
-                  </div>
-                </div>
-                <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                  <SettingField
-                    label={`Enable indexer ${index + 1}`}
-                    type="checkbox"
-                    checked={provider.enabled}
-                    onChange={(value) =>
-                      updateProvider(index, { enabled: value as boolean })
-                    }
-                  />
-                  <SettingField
-                    label={`Verify TLS for indexer ${index + 1}`}
-                    type="checkbox"
-                    checked={provider.verify}
-                    onChange={(value) =>
-                      updateProvider(index, { verify: value as boolean })
-                    }
-                  />
-                </div>
-              </article>
-            );
-          })}
-        </div>
-      )}
-
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <Button type="button" variant="outline" size="sm" onClick={addProvider}>
-          <Plus /> Add indexer
-        </Button>
-        <div className="flex items-center gap-2">
-          {isDirty && (
-            <span className="text-[11px] text-muted-foreground">
-              Unsaved indexer changes
-            </span>
-          )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            disabled={!isDirty}
-            onClick={resetProviders}
-          >
-            Reset indexers
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            disabled={!isDirty || updateProviders.isPending}
-            onClick={() => void saveProviders()}
-          >
-            {updateProviders.isPending && (
-              <LoaderCircle className="animate-spin" />
-            )}
-            Save indexers
-          </Button>
-        </div>
-      </div>
-    </div>
+      <SettingGroup
+        title="Torrent indexers"
+        description="Configure the Torznab-compatible sources Comicarr searches before handing a torrent to your download client."
+      >
+        <ProviderQueryStatus
+          isLoading={providerQuery.isLoading}
+          error={queryError}
+        >
+          {providerQuery.data ? (
+            <SearchProviderEditor
+              key={`torznab:${JSON.stringify(torznab)}`}
+              kind="torznab"
+              initial={torznab}
+              onDirtyChange={setTorznabDirty}
+            />
+          ) : null}
+        </ProviderQueryStatus>
+      </SettingGroup>
+    </>
   );
 }
 
@@ -376,12 +133,7 @@ export function SearchTab({
 
   return (
     <div className="space-y-6">
-      <SettingGroup
-        title="Usenet indexers"
-        description="Configure the Newznab-compatible sources Comicarr searches before handing an NZB to your download client."
-      >
-        <NewznabProviderSettings onDirtyChange={onProviderDirtyChange} />
-      </SettingGroup>
+      <SearchProviderSettings onDirtyChange={onProviderDirtyChange} />
 
       <SettingGroup
         title="Quality Settings"

--- a/frontend/src/hooks/useConfig.ts
+++ b/frontend/src/hooks/useConfig.ts
@@ -12,6 +12,8 @@ import type {
   ConfigUpdate,
   NewznabProvider,
   ProviderConfigResponse,
+  SearchProviderKind,
+  TorznabProvider,
 } from "@/types";
 
 interface RegenerateApiKeyResponse {
@@ -83,17 +85,21 @@ export function useProviderConfig(): UseQueryResult<ProviderConfigResponse> {
   });
 }
 
-export function useUpdateNewznabProviders(): UseMutationResult<
+export function useUpdateSearchProviders(): UseMutationResult<
   unknown,
   Error,
-  { enabled: boolean; providers: NewznabProvider[] }
+  {
+    type: SearchProviderKind;
+    enabled: boolean;
+    providers: Array<NewznabProvider | TorznabProvider>;
+  }
 > {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ enabled, providers }) =>
+    mutationFn: ({ type, enabled, providers }) =>
       apiRequest<unknown>("PUT", "/api/config/providers", {
-        type: "newznab",
+        type,
         enabled,
         providers,
       }),

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -4,6 +4,44 @@
 
 import type { ReadableConfig } from "./config.generated";
 
+export type SearchProviderKind = "newznab" | "torznab";
+
+/** Shared Search-provider fields returned by the settings API. */
+interface SearchProviderFields {
+  id?: number;
+  name: string;
+  host: string;
+  verify: boolean;
+  categories: string;
+  enabled: boolean;
+  api_key_set: boolean;
+  api_key?: string;
+}
+
+/** Sanitized Newznab provider configuration returned by the settings API. */
+export interface NewznabProvider extends SearchProviderFields {
+  /**
+   * The `i=` parameter of the indexer's RSS URL. Stored joined to the
+   * categories as `uid#categories`, split apart by the API so the categories
+   * field means categories. Newznab only — Torznab records have no uid.
+   */
+  rss_uid?: string;
+}
+
+/** Sanitized Torznab provider configuration. No `rss_uid` — enforced by
+ *  `SearchProvider` on the server. */
+export type TorznabProvider = SearchProviderFields;
+
+export interface SearchProviderGroup<T extends SearchProviderFields> {
+  enabled: boolean;
+  providers: T[];
+}
+
+export interface ProviderConfigResponse {
+  newznab: SearchProviderGroup<NewznabProvider>;
+  torznab: SearchProviderGroup<TorznabProvider>;
+}
+
 /** Shape of `GET /api/config`: the registry-derived readable keys plus the
  *  handful of extras `get_safe_config` bolts on outside the registry. */
 export interface Config extends ReadableConfig {
@@ -13,35 +51,8 @@ export interface Config extends ReadableConfig {
   python_version?: string;
 
   newznab?: ProviderConfigResponse["newznab"];
-  torznab?: ProviderConfigResponse["newznab"];
+  torznab?: ProviderConfigResponse["torznab"];
 }
-
-/** Sanitized Newznab provider configuration returned by the settings API. */
-export interface NewznabProvider {
-  id?: number;
-  name: string;
-  host: string;
-  verify: boolean;
-  categories: string;
-  enabled: boolean;
-  api_key_set: boolean;
-  api_key?: string;
-  /**
-   * The `i=` parameter of the indexer's RSS URL. Stored joined to the
-   * categories as `uid#categories`, split apart by the API so the categories
-   * field means categories. Newznab only — Torznab records have no uid.
-   */
-  rss_uid?: string;
-}
-
-export interface ProviderConfigResponse {
-  newznab: {
-    enabled: boolean;
-    providers: NewznabProvider[];
-  };
-}
-
-export type TorznabProvider = NewznabProvider;
 
 /** Config update payload */
 export type ConfigUpdate = Partial<Config>;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -81,6 +81,8 @@ export type {
   Config,
   NewznabProvider,
   ProviderConfigResponse,
+  SearchProviderGroup,
+  SearchProviderKind,
   TorznabProvider,
   ConfigUpdate,
 } from "./config";

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -461,6 +461,13 @@ export const handlers = [
     });
   }),
 
+  http.get("/api/config/providers", () => {
+    return HttpResponse.json({
+      newznab: { enabled: false, providers: [] },
+      torznab: { enabled: false, providers: [] },
+    });
+  }),
+
   // -------------------------------------------------------------------------
   // System endpoints
   // -------------------------------------------------------------------------

--- a/frontend/tests/pages/SettingsPage.test.ts
+++ b/frontend/tests/pages/SettingsPage.test.ts
@@ -332,6 +332,228 @@ describe("settings configuration", () => {
     expect(saved).toBeNull();
   });
 
+  it("adds a Torznab indexer when both provider lists start empty", async () => {
+    server.use(
+      http.get("/api/config/providers", () =>
+        HttpResponse.json({
+          newznab: { enabled: false, providers: [] },
+          torznab: { enabled: false, providers: [] },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+
+    render(createElement(SettingsPage));
+    await screen.findByText("Settings");
+    await user.click(screen.getAllByRole("button", { name: "Search" })[0]);
+    await screen.findByRole("button", { name: "Add Torznab indexer" });
+    await user.click(
+      screen.getByRole("button", { name: "Add Torznab indexer" }),
+    );
+
+    expect(await screen.findByLabelText("Torznab indexer name")).toBeTruthy();
+    expect(screen.queryByLabelText("RSS user ID")).toBeNull();
+    expect(screen.getByText("Unsaved Torznab indexer changes")).toBeTruthy();
+  });
+
+  it("edits Torznab indexers without an RSS user ID field", async () => {
+    let saved: unknown = null;
+    server.use(
+      http.get("/api/config/providers", () =>
+        HttpResponse.json({
+          newznab: { enabled: false, providers: [] },
+          torznab: {
+            enabled: true,
+            providers: [
+              {
+                id: 202,
+                name: "Prowlarr",
+                host: "https://prowlarr.test/1/api",
+                verify: true,
+                categories: "7030",
+                enabled: true,
+                api_key_set: true,
+              },
+            ],
+          },
+        }),
+      ),
+      http.put("/api/config/providers", async ({ request }) => {
+        saved = await request.json();
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    const user = userEvent.setup();
+
+    render(createElement(SettingsPage));
+    await screen.findByText("Settings");
+    await user.click(screen.getAllByRole("button", { name: "Search" })[0]);
+
+    const name = await screen.findByLabelText("Torznab indexer name");
+    expect(screen.queryByLabelText("RSS user ID")).toBeNull();
+    expect(
+      screen
+        .getByLabelText("Torznab indexer API key")
+        .getAttribute("placeholder"),
+    ).toBe("API key saved (enter a new value to change)");
+    await user.clear(name);
+    await user.type(name, "My tracker");
+    expect(screen.getByText("Unsaved Torznab indexer changes")).toBeTruthy();
+    await user.click(
+      screen.getByRole("button", { name: "Save Torznab indexers" }),
+    );
+
+    await waitFor(() => expect(saved).not.toBeNull());
+    expect(saved).toMatchObject({
+      type: "torznab",
+      enabled: true,
+      providers: [
+        expect.objectContaining({
+          id: 202,
+          name: "My tracker",
+          api_key: "",
+          api_key_set: true,
+        }),
+      ],
+    });
+    expect(
+      (saved as { providers: Array<Record<string, unknown>> }).providers[0],
+    ).not.toHaveProperty("rss_uid");
+  });
+
+  it("requires a replacement Torznab key when its server changes", async () => {
+    let saved: unknown = null;
+    server.use(
+      http.get("/api/config/providers", () =>
+        HttpResponse.json({
+          newznab: { enabled: false, providers: [] },
+          torznab: {
+            enabled: true,
+            providers: [
+              {
+                id: 202,
+                name: "Prowlarr",
+                host: "https://prowlarr.test/1/api",
+                verify: true,
+                categories: "7030",
+                enabled: true,
+                api_key_set: true,
+              },
+            ],
+          },
+        }),
+      ),
+      http.put("/api/config/providers", async ({ request }) => {
+        saved = await request.json();
+        return HttpResponse.json({ success: true });
+      }),
+    );
+    const user = userEvent.setup();
+
+    render(createElement(SettingsPage));
+    await screen.findByText("Settings");
+    await user.click(screen.getAllByRole("button", { name: "Search" })[0]);
+    const host = await screen.findByLabelText("Torznab indexer URL");
+    await user.clear(host);
+    await user.type(host, "https://other.test/1/api");
+    await user.click(
+      screen.getByRole("button", { name: "Save Torznab indexers" }),
+    );
+
+    expect(
+      await screen.findByText(
+        "Enter the API key again when changing an indexer server.",
+      ),
+    ).toBeTruthy();
+    expect(saved).toBeNull();
+  });
+
+  it("keeps Newznab and Torznab field IDs unique when both have the same saved id", async () => {
+    server.use(
+      http.get("/api/config/providers", () =>
+        HttpResponse.json({
+          newznab: {
+            enabled: true,
+            providers: [
+              {
+                id: 1,
+                name: "Usenet",
+                host: "https://usenet.test",
+                verify: true,
+                categories: "7030",
+                enabled: true,
+                api_key_set: false,
+              },
+            ],
+          },
+          torznab: {
+            enabled: true,
+            providers: [
+              {
+                id: 1,
+                name: "Prowlarr",
+                host: "https://prowlarr.test",
+                verify: true,
+                categories: "7030",
+                enabled: true,
+                api_key_set: false,
+              },
+            ],
+          },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+
+    render(createElement(SettingsPage));
+    await screen.findByText("Settings");
+    await user.click(screen.getAllByRole("button", { name: "Search" })[0]);
+    await screen.findByLabelText("Indexer name");
+
+    const newznabName = screen.getByLabelText("Indexer name");
+    const torznabName = screen.getByLabelText("Torznab indexer name");
+    expect(newznabName.id).toBe("indexer-name-saved-1");
+    expect(torznabName.id).toBe("torznab-indexer-name-saved-1");
+    expect(newznabName.id).not.toBe(torznabName.id);
+  });
+
+  it("blocks dirty Torznab edits on section change when confirmation is declined", async () => {
+    server.use(
+      http.get("/api/config/providers", () =>
+        HttpResponse.json({
+          newznab: { enabled: false, providers: [] },
+          torznab: {
+            enabled: true,
+            providers: [
+              {
+                id: 202,
+                name: "Prowlarr",
+                host: "https://prowlarr.test/1/api",
+                verify: true,
+                categories: "7030",
+                enabled: true,
+                api_key_set: true,
+              },
+            ],
+          },
+        }),
+      ),
+    );
+    const user = userEvent.setup();
+    const confirm = vi.fn(() => false);
+    vi.stubGlobal("confirm", confirm);
+
+    render(createElement(SettingsPage));
+    await screen.findByText("Settings");
+    await user.click(screen.getAllByRole("button", { name: "Search" })[0]);
+    const name = await screen.findByLabelText("Torznab indexer name");
+    await user.type(name, " changed");
+    await user.click(screen.getAllByRole("button", { name: "General" })[0]);
+
+    expect(confirm).toHaveBeenCalledWith("Discard unsaved indexer changes?");
+    expect(screen.getByLabelText("Torznab indexer name")).toBeTruthy();
+  });
+
   it("keeps explicit replacement secret values", () => {
     const saveData = prepareConfigSaveData(
       {

--- a/tests/unit/test_config_version_migrations.py
+++ b/tests/unit/test_config_version_migrations.py
@@ -306,6 +306,7 @@ torznab_host = http://prowlarr.example:9696/1/api
     assert cfg.EXTRA_TORZNABS == []
     assert warn.called
     assert "NOT used for searching" in warn.call_args_list[0][0][0]
+    assert "Settings" in warn.call_args_list[0][0][0]
 
 
 def test_legacy_torznab_absorption_verifies_tls_and_stores_canonical_booleans(tmp_path, monkeypatch):


### PR DESCRIPTION
Settings → Search now lets you add, edit, and remove Torznab indexers. You no longer have to hand-edit `extra_torznabs` in `config.ini`.

Fixes #704.

## Summary

The backend already projected Newznab and Torznab (`GET /api/config/providers`), but Settings only rendered and saved Newznab. This adds a Torrent indexers section that mirrors the Newznab editor and writes `type: "torznab"` through the existing providers API.

## Changes

- Add a Settings → Search editor for Torznab providers (enable, add, edit, remove, save) without the Newznab-only RSS user ID field
- Type `Config.torznab` / `ProviderConfigResponse.torznab` correctly, and send updates through a shared `useUpdateSearchProviders` hook
- Point leftover `torznab_*` absorption log messages at Settings → Search now that the UI exists

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [ ] No app release impact; no changeset needed (omit rather than "No user-visible behaviour changes.")

## Testing

- [x] Tests pass locally (`pytest tests/unit/test_config_version_migrations.py`; Settings page frontend tests)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [x] Backend lint/format (`ruff check comicarr/` and `ruff format --check comicarr/`)
- [x] Frontend lint/format (`cd frontend && npm run lint && npm run format:check`)
- [x] Or one-shot: `npm run lint` (from repo root; requires `uv` + `frontend/node_modules`)
- [x] Manually tested: logged into a local instance, added a Prowlarr Torznab indexer, saved, reloaded, and confirmed `extra_torznabs` persisted with a bare category list (no RSS uid prefix). Confirmed Newznab still shows RSS user ID. Caught and fixed a React key collision that made **Add Torznab indexer** a no-op when both lists started empty.

## Screenshots

N/A — new Settings section; exercise Search → Torrent indexers after merge.

## Additional Notes

Shared editor keys are prefixed (`newznab:…` / `torznab:…`) so two empty provider lists do not remount as one component.