### PR TITLE
feat: Queue add-manga on the background importer thread

### DIFF
--- a/.changeset/add-manga-background.md
+++ b/.changeset/add-manga-background.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Adding a manga now returns immediately and populates chapters in the background, the same way adding a comic does. Failures show up in Activity instead of hanging or silently dying in the request.

--- a/comicarr/app/search/service.py
+++ b/comicarr/app/search/service.py
@@ -155,34 +155,29 @@ def add_comic(ctx, comic_id):
 
 
 def add_manga(ctx, manga_id):
-    """Add a manga by MAL ID or MangaDex ID."""
+    """Queue a manga add on the mass-add thread (same contract as add_comic)."""
     mal_ok = getattr(ctx.config, "MAL_ENABLED", False) and getattr(ctx.config, "MAL_CLIENT_ID", None)
     mdex_ok = getattr(ctx.config, "MANGADEX_ENABLED", False)
     if not ctx.config or not (mal_ok or mdex_ok):
         return {"success": False, "error": "Manga integration is not enabled"}
 
+    from comicarr import importer, series_kind
+
     try:
-        from comicarr import importer, series_kind
-
         if series_kind.provider_of(manga_id) is series_kind.SeriesProvider.MYANIMELIST:
-            # MAL-sourced manga: fetch metadata from MAL, chapters from MangaDex
-            result = importer.addMangaToDB_MAL(manga_id)
+            comic_id = series_kind.add_prefix(manga_id, series_kind.SeriesProvider.MYANIMELIST)
         else:
-            # An unprefixed id here is a raw MangaDex uuid.
-            manga_id = series_kind.add_prefix(manga_id, series_kind.SeriesProvider.MANGADEX)
-            result = importer.addMangaToDB(manga_id)
-
-        if result and result.get("status") == "complete":
-            return {
-                "success": True,
-                "message": "Successfully added manga: %s" % result.get("comicname", manga_id),
-                "comicid": result.get("comicid", manga_id),
-                "content_type": "manga",
-            }
-        return {"success": False, "error": "Failed to add manga: %s" % manga_id}
+            comic_id = series_kind.add_prefix(manga_id, series_kind.SeriesProvider.MANGADEX)
+        importer.importer_thread([{"comicid": comic_id, "comicname": None, "seriesyear": None}])
     except Exception as e:
-        logger.error("[SEARCH] Error adding manga %s: %s" % (manga_id, e))
+        logger.error("[SEARCH] Error queueing manga %s: %s" % (manga_id, e))
         return {"success": False, "error": "Error adding manga: %s" % str(e)}
+    return {
+        "success": True,
+        "message": "Successfully queued adding id: %s" % comic_id,
+        "comicid": comic_id,
+        "content_type": "manga",
+    }
 
 
 def search_issue(ctx, issue_id, *, trigger="issue_retry"):

--- a/comicarr/importer.py
+++ b/comicarr/importer.py
@@ -99,6 +99,23 @@ def is_exists(comicid):
         return False
 
 
+def _emit_add_activity(status, comicid, comicname=None, reason_detail=None):
+    """Narrate a series add. Failures must not be swallowed silently."""
+    try:
+        from comicarr.app.activity.producers import emit_series_activity
+
+        emit_series_activity(
+            "add",
+            status,
+            comicid,
+            comicname=comicname,
+            reason_code="import_failed" if status == "failed" else None,
+            reason_detail=reason_detail,
+        )
+    except Exception as e:
+        logger.fdebug("[ACTIVITY] add.%s emit skipped: %s" % (status, e))
+
+
 def addvialist(seriesQueue, issueWantQueue):
     while True:
         if seriesQueue.qsize() >= 1:
@@ -123,10 +140,14 @@ def addvialist(seriesQueue, issueWantQueue):
             else:
                 logger.info("[MASS-ADD][1/%s] Now adding ComicID: %s " % (seriesQueue.qsize() + 1, item["comicid"]))
 
-            if "suppress_addall" in item.keys():
-                addComictoDB(item["comicid"], suppress_addall=item["suppress_addall"])
-            else:
-                addComictoDB(item["comicid"])
+            try:
+                if "suppress_addall" in item.keys():
+                    addComictoDB(item["comicid"], suppress_addall=item["suppress_addall"])
+                else:
+                    addComictoDB(item["comicid"])
+            except Exception as e:
+                logger.error("[MASS-ADD] Failed adding %s: %s" % (item["comicid"], e))
+                _emit_add_activity("failed", item["comicid"], comicname=item.get("comicname"), reason_detail=str(e))
         elif issueWantQueue.qsize() > 0:
             time.sleep(1)
             issueItem = issueWantQueue.get(True)
@@ -1306,6 +1327,7 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
                 {"ComicName": "Fetch failed, try refreshing. (%s)" % mangaid, "Status": "Active"},
                 controlValueDict,
             )
+        _emit_add_activity("failed", mangaid, reason_detail="MangaDex details fetch failed")
         return {"status": "incomplete"}
 
     manga_name = manga.get("name", "Unknown")
@@ -1407,6 +1429,7 @@ def addMangaToDB(mangaid, imported=None, calledfrom=None):
     helpers.ComicSort(comicorder=comicarr.COMICSORT, imported=mangaid)
 
     logger.info("[MANGADEX] Successfully added manga: %s" % manga_name)
+    _emit_add_activity("succeeded", mangaid, comicname=manga_name)
 
     return {"status": "complete", "comicid": mangaid, "comicname": manga_name, "content_type": "manga"}
 
@@ -1472,6 +1495,7 @@ def addMangaToDB_MAL(mangaid, imported=None, calledfrom=None):
                 {"ComicName": "Fetch failed, try refreshing. (%s)" % mangaid, "Status": "Active"},
                 controlValueDict,
             )
+        _emit_add_activity("failed", mangaid, reason_detail="MyAnimeList details fetch failed")
         return {"status": "incomplete"}
 
     manga_name = manga.get("name", "Unknown")
@@ -1580,6 +1604,7 @@ def addMangaToDB_MAL(mangaid, imported=None, calledfrom=None):
     helpers.ComicSort(comicorder=comicarr.COMICSORT, imported=mangaid)
 
     logger.info("[MAL] Successfully added manga: %s" % manga_name)
+    _emit_add_activity("succeeded", mangaid, comicname=manga_name)
 
     return {"status": "complete", "comicid": mangaid, "comicname": manga_name, "content_type": "manga"}
 

--- a/tests/unit/test_add_manga_handoff.py
+++ b/tests/unit/test_add_manga_handoff.py
@@ -1,0 +1,86 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""add-manga hands off to the mass-add thread instead of blocking the HTTP request."""
+
+import queue
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from comicarr import importer
+from comicarr.app.search.service import add_manga
+from comicarr.importer import addvialist
+
+
+def test_add_manga_queues_prefixed_mangadex_id_and_returns_immediately():
+    ctx = SimpleNamespace(config=SimpleNamespace(MANGADEX_ENABLED=True, MAL_ENABLED=False, MAL_CLIENT_ID=None))
+    with patch("comicarr.importer.importer_thread") as mock_thread:
+        result = add_manga(ctx, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+    assert result["success"] is True
+    assert "queued" in result["message"].lower()
+    assert result["comicid"] == "md-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    mock_thread.assert_called_once_with(
+        [{"comicid": "md-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "comicname": None, "seriesyear": None}]
+    )
+
+
+def test_add_manga_keeps_mal_prefix_and_does_not_call_add_on_the_request_thread():
+    ctx = SimpleNamespace(config=SimpleNamespace(MANGADEX_ENABLED=False, MAL_ENABLED=True, MAL_CLIENT_ID="client"))
+    with (
+        patch("comicarr.importer.importer_thread") as mock_thread,
+        patch("comicarr.importer.addMangaToDB_MAL") as add_mal,
+        patch("comicarr.importer.addMangaToDB") as add_md,
+    ):
+        result = add_manga(ctx, "mal-13")
+
+    assert result["success"] is True
+    assert result["comicid"] == "mal-13"
+    mock_thread.assert_called_once_with([{"comicid": "mal-13", "comicname": None, "seriesyear": None}])
+    add_mal.assert_not_called()
+    add_md.assert_not_called()
+
+
+def test_add_manga_does_not_queue_when_manga_integration_is_off():
+    ctx = SimpleNamespace(config=SimpleNamespace(MANGADEX_ENABLED=False, MAL_ENABLED=False, MAL_CLIENT_ID=None))
+    with patch("comicarr.importer.importer_thread") as mock_thread:
+        result = add_manga(ctx, "md-abc")
+
+    assert result["success"] is False
+    mock_thread.assert_not_called()
+
+
+def test_addvialist_narrates_add_failed_when_importer_raises():
+    series_queue = queue.Queue()
+    issue_queue = queue.Queue()
+    series_queue.put({"comicid": "md-onepiece", "comicname": "One Piece"})
+    series_queue.put("exit")
+
+    with (
+        patch("comicarr.importer.addComictoDB", side_effect=RuntimeError("rate limited")),
+        patch("comicarr.importer.time.sleep"),
+        patch.object(importer, "_emit_add_activity") as emit,
+    ):
+        addvialist(series_queue, issue_queue)
+
+    emit.assert_called_once_with("failed", "md-onepiece", comicname="One Piece", reason_detail="rate limited")
+
+
+def test_emit_add_activity_drives_the_series_activity_facade():
+    with patch("comicarr.app.activity.producers.emit_series_activity") as emit:
+        importer._emit_add_activity("failed", "md-onepiece", comicname="One Piece", reason_detail="boom")
+
+    emit.assert_called_once_with(
+        "add",
+        "failed",
+        "md-onepiece",
+        comicname="One Piece",
+        reason_code="import_failed",
+        reason_detail="boom",
+    )


### PR DESCRIPTION
## Summary

`POST /api/search/add-manga` no longer runs MangaDex/MAL chapter population inside the HTTP request. It prefixes `md-`/`mal-` ids and hands off to `importer_thread`, matching add-comic.

- Immediate queued response
- Chapters populate on the mass-add worker
- Worker exceptions and failed metadata fetches narrate as `add.failed` (`import_failed`) instead of dying silently

Closes #685

## Test plan

- [x] `pytest tests/unit/test_add_manga_handoff.py tests/unit/test_importer_addvialist.py tests/unit/test_manga_import_regressions.py`