### PR TITLE
feat: Lock the manga chapter and volume ledger contract

### DIFF
--- a/.changeset/manga-ledger-contract.md
+++ b/.changeset/manga-ledger-contract.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Manga series now have a defined chapter and volume ledger: owning a volume covers the chapters it is known to contain (without counting them as individually owned), and the default missing set is released volumes plus chapters beyond the last released volume.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,34 @@ Who issued a Series' identifier: ComicVine, MangaDex (`md-` prefix), or MyAnimeL
 
 The MangaDex UUID a manga Series polls for new chapters. MangaDex Series carry it in their ComicID; MyAnimeList Series supply metadata from MAL but keep the chapter source in `MangaDexID`, and have none until it is resolved.
 
+## Chapter ledger
+
+The complete, language-unfiltered list of chapters MangaDex knows for a Series. It is not a language-filtered reading list.
+
+_Avoid_: Chapter list (when the filtered English subset is meant)
+
+## Volume ledger
+
+The complete roster of released volumes for a manga Series, taken from MangaDex cover art. A volume's date is a known-to-exist bound, not a street date.
+
+_Avoid_: Volume entity inside issues, street date
+
+## Covered-by-volume
+
+The chapter fulfillment that means a physically owned volume lists that chapter. It is not Have, not Downloaded, and not Missing.
+
+_Avoid_: Have, downloaded-via-volume
+
+## Last released volume
+
+The highest volume number present on the Volume ledger. Volumes up to this number are the released set; chapters beyond it are the chapter frontier.
+
+## Blended frontier
+
+The default acquisition surface for a manga Series: missing released volumes, plus missing chapters beyond the last released volume.
+
+_Avoid_: Missing issues (unqualified, for manga)
+
 ## Release candidate
 
 A provider result considered for acquiring one tracked issue, chapter, annual, or story-arc item. Its match verdict explains whether automatic search would accept it, whether an operator may override that decision, and every reason for rejection.

--- a/comicarr/app/acquisition/models.py
+++ b/comicarr/app/acquisition/models.py
@@ -32,10 +32,15 @@ class Fulfillment(str, Enum):
     DOWNLOADED = "downloaded"
     ARCHIVED = "archived"
     FAILED = "failed"
+    COVERED = "covered"
 
     @property
     def is_owned(self):
         return self in {self.DOWNLOADED, self.ARCHIVED}
+
+    @property
+    def is_covered(self):
+        return self is self.COVERED
 
     @property
     def is_in_flight(self):

--- a/comicarr/app/acquisition/policy.py
+++ b/comicarr/app/acquisition/policy.py
@@ -134,6 +134,8 @@ def evaluate_eligibility(item, today=None):
         return EligibilityDecision(False, "paused")
     if item.fulfillment.is_owned:
         return EligibilityDecision(False, "owned")
+    if getattr(item.fulfillment, "is_covered", False):
+        return EligibilityDecision(False, "covered")
     if item.fulfillment.is_in_flight:
         return EligibilityDecision(False, "in_flight")
     if item.intent is AcquisitionIntent.SKIPPED:

--- a/comicarr/app/manga/__init__.py
+++ b/comicarr/app/manga/__init__.py
@@ -1,0 +1,32 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Manga ledger contract — chapters, volumes, and the blended frontier."""
+
+from comicarr.app.manga.ledger import (
+    apply_volume_coverage,
+    blended_progress,
+    chapter_id,
+    covers_to_volume_rows,
+    last_released_volume,
+    merge_refresh_row,
+    normalize_volume_number,
+    volume_id,
+)
+
+__all__ = [
+    "apply_volume_coverage",
+    "blended_progress",
+    "chapter_id",
+    "covers_to_volume_rows",
+    "last_released_volume",
+    "merge_refresh_row",
+    "normalize_volume_number",
+    "volume_id",
+]

--- a/comicarr/app/manga/ledger.py
+++ b/comicarr/app/manga/ledger.py
@@ -1,0 +1,219 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Chapter and volume ledger contract for manga Series.
+
+MangaDex is the sole ledger source. Volumes come from the cover feed;
+chapters and volume→chapter containment come from unfiltered `/aggregate`.
+Owning a volume covers only the chapters that mapping actually lists.
+"""
+
+from comicarr.app.acquisition.models import Fulfillment
+
+_OPERATOR_FIELDS = ("Status", "AcquisitionIntent", "Location", "status", "acquisitionIntent", "location")
+_NON_VOLUME = frozenset({"", "none", "null", "unknown"})
+
+
+def normalize_volume_number(value):
+    """Canonical volume number, or None when the source has no volume."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or text.lower() in _NON_VOLUME:
+        return None
+    try:
+        number = float(text)
+    except ValueError:
+        return text
+    if number.is_integer():
+        return str(int(number))
+    return format(number, "g")
+
+
+def chapter_id(comic_id, chapter_number):
+    """Stable chapter IssueID — matches `_populate_manga_chapters`."""
+    return "%s-ch%s" % (comic_id, chapter_number)
+
+
+def volume_id(comic_id, volume_number):
+    """Stable volume identity. Volumes are not issues."""
+    normalized = normalize_volume_number(volume_number)
+    if not comic_id or normalized is None:
+        return None
+    return "%s-v%s" % (comic_id, normalized)
+
+
+def last_released_volume(cover_volumes):
+    """Last released volume is the highest cover-feed volume number.
+
+    Cover `createdAt` is a known-to-exist bound, never a street date.
+    """
+    numbers = []
+    for volume in cover_volumes or ():
+        normalized = normalize_volume_number(_cover_volume_number(volume))
+        if normalized is None:
+            continue
+        try:
+            numbers.append((float(normalized), normalized))
+        except ValueError:
+            continue
+    if not numbers:
+        return None
+    return max(numbers, key=lambda item: item[0])[1]
+
+
+def covers_to_volume_rows(comic_id, covers):
+    """Project MangaDex cover-feed entries into first-class volume rows."""
+    rows = []
+    seen = set()
+    for cover in covers or ():
+        number = normalize_volume_number(_cover_volume_number(cover))
+        identity = volume_id(comic_id, number)
+        if identity is None or identity in seen:
+            continue
+        seen.add(identity)
+        attrs = cover.get("attributes") if isinstance(cover, dict) else None
+        attrs = attrs if isinstance(attrs, dict) else cover if isinstance(cover, dict) else {}
+        rows.append(
+            {
+                "VolumeID": identity,
+                "ComicID": comic_id,
+                "VolumeNumber": number,
+                "KnownAt": attrs.get("createdAt") or attrs.get("knownAt"),
+                "CoverLocale": attrs.get("locale"),
+                "CoverFileName": attrs.get("fileName"),
+            }
+        )
+    return rows
+
+
+def merge_refresh_row(existing, incoming):
+    """Refresh-safe merge: incoming metadata, preserved operator state."""
+    merged = dict(incoming or {})
+    if not existing:
+        return merged
+    for field in _OPERATOR_FIELDS:
+        value = existing.get(field)
+        if value not in (None, ""):
+            merged[field] = value
+    return merged
+
+
+def apply_volume_coverage(chapters, owned_volumes, containment):
+    """Mark mapped chapters Covered when an owned volume lists them.
+
+    A volume present in the cover feed but absent from `containment` covers
+    nothing — unknown contents stay missing. Physical ownership and in-flight
+    states win. Explicit skip/ignore stays on the chapter.
+    """
+    owned = {normalize_volume_number(volume) for volume in owned_volumes or ()}
+    owned.discard(None)
+    covered_ids = set()
+    for volume, chapter_ids in (containment or {}).items():
+        if normalize_volume_number(volume) in owned:
+            covered_ids.update(chapter_ids)
+
+    projected = []
+    for chapter in chapters or ():
+        row = dict(chapter)
+        fulfillment = row.get("fulfillment")
+        if fulfillment in {
+            Fulfillment.DOWNLOADED.value,
+            Fulfillment.ARCHIVED.value,
+            Fulfillment.RESERVED.value,
+            Fulfillment.SNATCHED.value,
+        }:
+            projected.append(row)
+            continue
+        if row.get("acquisitionIntent") in {"skipped", "ignored"}:
+            projected.append(row)
+            continue
+        identity = row.get("id") or row.get("IssueID")
+        if identity in covered_ids:
+            row["fulfillment"] = Fulfillment.COVERED.value
+            row["displayState"] = "Covered"
+            row["covered"] = True
+            row["owned"] = False
+            row["missing"] = False
+            row["eligible"] = False
+            row["eligibilityReason"] = "covered"
+        projected.append(row)
+    return projected
+
+
+def blended_progress(volumes, chapters, *, owned_volumes=None, containment=None):
+    """Have / total / missing under the blended frontier.
+
+    Missing = unowned released volumes + unowned/uncovered chapters beyond
+    the last released volume. Chapters inside a released volume are counted
+    on the volume, not twice.
+    """
+    volume_numbers = []
+    for volume in volumes or ():
+        number = normalize_volume_number(volume.get("VolumeNumber") if isinstance(volume, dict) else volume)
+        if number is not None:
+            volume_numbers.append(number)
+    last = last_released_volume(volumes)
+    owned = {normalize_volume_number(item) for item in (owned_volumes or ())}
+    owned.discard(None)
+
+    last_numeric = _as_float(last)
+    beyond = []
+    for chapter in chapters or ():
+        number = normalize_volume_number(
+            chapter.get("volumeNumber") or chapter.get("VolumeNumber") if isinstance(chapter, dict) else None
+        )
+        chapter_volume = _as_float(number)
+        if last_numeric is None or chapter_volume is None or chapter_volume > last_numeric:
+            beyond.append(chapter)
+
+    covered_beyond = apply_volume_coverage(beyond, owned, containment or {})
+    volume_have = sum(1 for number in volume_numbers if number in owned)
+    chapter_have = sum(
+        1
+        for row in covered_beyond
+        if row.get("owned")
+        or row.get("covered")
+        or row.get("fulfillment") in {Fulfillment.DOWNLOADED.value, Fulfillment.COVERED.value}
+    )
+    volume_missing = len(volume_numbers) - volume_have
+    chapter_missing = len(beyond) - chapter_have
+    total = len(volume_numbers) + len(beyond)
+    have = volume_have + chapter_have
+    return {
+        "volumeTotal": len(volume_numbers),
+        "volumeHave": volume_have,
+        "volumeMissing": volume_missing,
+        "chapterBeyondTotal": len(beyond),
+        "chapterBeyondHave": chapter_have,
+        "chapterBeyondMissing": chapter_missing,
+        "total": total,
+        "have": have,
+        "missing": volume_missing + chapter_missing,
+        "lastReleasedVolume": last,
+        "completionPercent": round((have / total) * 100) if total else 0,
+    }
+
+
+def _cover_volume_number(cover):
+    if not isinstance(cover, dict):
+        return cover
+    attrs = cover.get("attributes")
+    if isinstance(attrs, dict) and "volume" in attrs:
+        return attrs.get("volume")
+    return cover.get("volume") or cover.get("VolumeNumber")
+
+
+def _as_float(value):
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -57,6 +57,7 @@ _DISPLAY_BY_FULFILLMENT = {
     Fulfillment.DOWNLOADED: "Downloaded",
     Fulfillment.ARCHIVED: "Archived",
     Fulfillment.FAILED: "Failed",
+    Fulfillment.COVERED: "Covered",
 }
 _DISPLAY_BY_INTENT = {
     AcquisitionIntent.WANTED: "Wanted",
@@ -141,7 +142,8 @@ def project_issue_state(row, *, series_status, today=None, annual=False, series_
     )
     owned = fulfillment.is_owned
     in_flight = fulfillment.is_in_flight
-    missing = not owned and not in_flight
+    covered = fulfillment is Fulfillment.COVERED
+    missing = not owned and not in_flight and not covered
     monitored = projection.intent not in {AcquisitionIntent.SKIPPED, AcquisitionIntent.IGNORED}
     selected_date = decision.selected_date.isoformat() if decision.selected_date else None
     date_source = _DATE_SOURCE_NAMES.get(decision.date_source, decision.date_source)
@@ -166,6 +168,7 @@ def project_issue_state(row, *, series_status, today=None, annual=False, series_
                 "source": date_source,
             },
             "owned": owned,
+            "covered": covered,
             "physicalOwned": bool(verified_file),
             "archived": fulfillment is Fulfillment.ARCHIVED,
             "inFlight": in_flight,
@@ -187,6 +190,7 @@ def _issue_summary(projected):
         "issues": sum(not row["annual"] for row in projected),
         "annuals": sum(bool(row["annual"]) for row in projected),
         "owned": owned,
+        "covered": sum(bool(row.get("covered")) for row in projected),
         "physicalOwned": sum(bool(row["physicalOwned"]) for row in projected),
         "archived": sum(bool(row["archived"]) for row in projected),
         "inFlight": sum(bool(row["inFlight"]) for row in projected),

--- a/docs/adr/0004-manga-chapter-volume-ledgers.md
+++ b/docs/adr/0004-manga-chapter-volume-ledgers.md
@@ -1,0 +1,9 @@
+# ADR-0004: Manga chapter and volume ledgers
+
+MangaDex is the sole ledger source. Volumes are first-class rows with ids `{comicId}-v{n}`, not issues with a type discriminator — issue Status, attention, and Have/Total assume one row kind, and stuffing volumes there would leak manga into comic paths. Chapters stay in `issues` as `{comicId}-ch{n}`.
+
+The volume roster comes from `GET /cover?manga[]={uuid}` (complete even when `/aggregate` has holes). `/aggregate` is unfiltered and supplies chapter rows plus *partial* volume→chapter containment. A volume in the cover feed but absent from aggregate is released with unknown contents: owning it does not mark unknown chapters Covered-by-volume.
+
+Covered-by-volume is fulfillment `covered`, distinct from Have. Explicit skip/ignore and in-flight/downloaded states win. Refresh upserts by those stable ids and never overwrites operator Status, AcquisitionIntent, or Location.
+
+Last released volume is `max(cover volume number)`. Series progress is the blended frontier: owned released volumes plus owned-or-covered chapters beyond that volume, over released volumes plus those later chapters.

--- a/tests/integration/test_acquisition_pipeline.py
+++ b/tests/integration/test_acquisition_pipeline.py
@@ -228,6 +228,7 @@ def test_bulk_wanted_run_handoff_restart_and_owned_projection(monkeypatch, tmp_p
         "issues": 1,
         "annuals": 0,
         "owned": 1,
+        "covered": 0,
         "physicalOwned": 1,
         "archived": 0,
         "inFlight": 0,

--- a/tests/unit/test_acquisition_policy.py
+++ b/tests/unit/test_acquisition_policy.py
@@ -100,6 +100,7 @@ def test_release_date_precedence_and_eligibility_are_deterministic():
         ({"intent": AcquisitionIntent.SKIPPED}, "intent_skipped"),
         ({"fulfillment": Fulfillment.SNATCHED}, "in_flight"),
         ({"fulfillment": Fulfillment.DOWNLOADED}, "owned"),
+        ({"fulfillment": Fulfillment.COVERED}, "covered"),
     ],
 )
 def test_policy_defers_non_actionable_work(changes, reason):

--- a/tests/unit/test_manga_ledger.py
+++ b/tests/unit/test_manga_ledger.py
@@ -1,0 +1,123 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Executable contract for manga chapter and volume ledgers."""
+
+from comicarr.app.acquisition.models import AcquisitionIntent, Fulfillment
+from comicarr.app.acquisition.policy import EligibilityInput, evaluate_eligibility
+from comicarr.app.manga.ledger import (
+    apply_volume_coverage,
+    blended_progress,
+    chapter_id,
+    covers_to_volume_rows,
+    last_released_volume,
+    merge_refresh_row,
+    normalize_volume_number,
+    volume_id,
+)
+
+
+def test_ids_match_importer_chapter_scheme_and_keep_volumes_off_issues():
+    assert chapter_id("md-onepiece", "1100") == "md-onepiece-ch1100"
+    assert volume_id("md-onepiece", "1.0") == "md-onepiece-v1"
+    assert volume_id("md-onepiece", "none") is None
+
+
+def test_last_released_volume_is_cover_feed_max_not_aggregate_holes():
+    covers = [
+        {"attributes": {"volume": "1", "createdAt": "2022-06-13T00:00:00"}},
+        {"attributes": {"volume": "115", "createdAt": "2022-06-13T00:00:00"}},
+        {"attributes": {"volume": "7", "createdAt": "2022-06-13T00:00:00"}},
+    ]
+    assert last_released_volume(covers) == "115"
+    rows = covers_to_volume_rows("md-onepiece", covers)
+    assert [row["VolumeID"] for row in rows] == [
+        "md-onepiece-v1",
+        "md-onepiece-v115",
+        "md-onepiece-v7",
+    ]
+    assert rows[0]["KnownAt"] == "2022-06-13T00:00:00"
+
+
+def test_owning_a_volume_covers_only_mapped_chapters():
+    chapters = [
+        {"id": "md-x-ch1", "fulfillment": "missing", "acquisitionIntent": "policy"},
+        {"id": "md-x-ch2", "fulfillment": "missing", "acquisitionIntent": "policy"},
+        {"id": "md-x-ch3", "fulfillment": "missing", "acquisitionIntent": "skipped"},
+        {"id": "md-x-ch4", "fulfillment": "downloaded", "acquisitionIntent": "policy"},
+    ]
+    projected = apply_volume_coverage(
+        chapters,
+        owned_volumes=["1"],
+        containment={"1": ["md-x-ch1", "md-x-ch3"], "2": ["md-x-ch2"]},
+    )
+    by_id = {row["id"]: row for row in projected}
+    assert by_id["md-x-ch1"]["fulfillment"] == Fulfillment.COVERED.value
+    assert by_id["md-x-ch1"]["covered"] is True
+    assert by_id["md-x-ch1"]["owned"] is False
+    assert by_id["md-x-ch1"]["missing"] is False
+    assert by_id["md-x-ch2"]["fulfillment"] == "missing"
+    assert by_id["md-x-ch3"]["fulfillment"] == "missing"
+    assert by_id["md-x-ch4"]["fulfillment"] == "downloaded"
+
+
+def test_unknown_containment_does_not_cover_chapters():
+    chapters = [{"id": "md-x-ch8", "fulfillment": "missing", "acquisitionIntent": "policy"}]
+    projected = apply_volume_coverage(chapters, owned_volumes=["8"], containment={})
+    assert projected[0]["fulfillment"] == "missing"
+    assert projected[0].get("covered") is not True
+
+
+def test_blended_frontier_counts_volumes_then_chapters_beyond():
+    volumes = [{"VolumeNumber": n} for n in ("1", "2", "3")]
+    chapters = [
+        {"id": "md-x-ch1", "VolumeNumber": "1", "owned": False},
+        {"id": "md-x-ch100", "VolumeNumber": None, "owned": False, "fulfillment": "missing"},
+        {"id": "md-x-ch101", "VolumeNumber": "4", "owned": True, "fulfillment": "downloaded"},
+    ]
+    progress = blended_progress(volumes, chapters, owned_volumes=["1"], containment={"1": ["md-x-ch1"]})
+    assert progress["lastReleasedVolume"] == "3"
+    assert progress["volumeTotal"] == 3
+    assert progress["volumeHave"] == 1
+    assert progress["volumeMissing"] == 2
+    assert progress["chapterBeyondTotal"] == 2
+    assert progress["chapterBeyondHave"] == 1
+    assert progress["missing"] == 3
+    assert progress["have"] == 2
+    assert progress["total"] == 5
+
+
+def test_refresh_preserves_operator_status():
+    incoming = {"IssueID": "md-x-ch1", "ChapterNumber": "1", "Status": "Skipped"}
+    existing = {"IssueID": "md-x-ch1", "Status": "Downloaded", "AcquisitionIntent": "skipped", "Location": "v1.cbz"}
+    merged = merge_refresh_row(existing, incoming)
+    assert merged["Status"] == "Downloaded"
+    assert merged["AcquisitionIntent"] == "skipped"
+    assert merged["Location"] == "v1.cbz"
+    assert merged["ChapterNumber"] == "1"
+
+
+def test_covered_fulfillment_is_not_have_and_is_not_searchable():
+    assert Fulfillment.COVERED.is_owned is False
+    assert Fulfillment.COVERED.is_covered is True
+    decision = evaluate_eligibility(
+        EligibilityInput(
+            series_active=True,
+            intent=AcquisitionIntent.POLICY,
+            fulfillment=Fulfillment.COVERED,
+        ),
+    )
+    assert decision.eligible is False
+    assert decision.reason == "covered"
+
+
+def test_normalize_volume_number_treats_none_sentinel_as_absent():
+    assert normalize_volume_number("1.0") == "1"
+    assert normalize_volume_number("none") is None
+    assert normalize_volume_number("") is None

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -151,6 +151,7 @@ def test_absolute_batman_projection_reconciles_18_owned_2_released_2_future(tmp_
         "issues": 22,
         "annuals": 0,
         "owned": 18,
+        "covered": 0,
         "physicalOwned": 18,
         "archived": 0,
         "inFlight": 0,


### PR DESCRIPTION
## Summary

Locks the manga chapter/volume ledger contract (grilling recommendations accepted):

- MangaDex is the sole ledger source. Volumes are first-class `{comicId}-v{n}` rows from the cover feed, not issues.
- Chapters stay `{comicId}-ch{n}` in `issues`. `/aggregate` is unfiltered and only *partially* maps volumes to chapters.
- Covered-by-volume is fulfillment `covered` — not Have, not Missing, not searchable. Unknown containment does not cover.
- Refresh preserves operator Status / AcquisitionIntent / Location.
- Default missing set is the blended frontier: released volumes plus chapters beyond the last released volume.

See ADR-0004 and `comicarr.app.manga.ledger`.

Closes #688

## Test plan

- [x] `pytest tests/unit/test_manga_ledger.py tests/unit/test_series_domain.py tests/unit/test_acquisition_policy.py`