### PR TITLE
feat: Interpret bare manga numbers as volumes, chapters, or auto

### DIFF
--- a/.changeset/bare-number-interpretation.md
+++ b/.changeset/bare-number-interpretation.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Manga filenames with a bare number (`Naruto 12.cbr`) can now be treated as a volume, a chapter, or auto — auto compares the folder's numbers to the series' known volume and chapter counts. Prefixed names like `One Piece v10.cbz` stay volumes.

--- a/comicarr/app/manga/__init__.py
+++ b/comicarr/app/manga/__init__.py
@@ -9,6 +9,7 @@
 
 """Manga ledger contract — chapters, volumes, and the blended frontier."""
 
+from comicarr.app.manga.bare_numbers import interpret_bare_numbers
 from comicarr.app.manga.ledger import (
     apply_volume_coverage,
     blended_progress,
@@ -21,6 +22,7 @@ from comicarr.app.manga.ledger import (
 )
 
 __all__ = [
+    "interpret_bare_numbers",
     "apply_volume_coverage",
     "blended_progress",
     "chapter_id",

--- a/comicarr/app/manga/bare_numbers.py
+++ b/comicarr/app/manga/bare_numbers.py
@@ -1,0 +1,87 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Per-series bare-number interpretation for manga filenames.
+
+Prefixed tokens (`v10`, `c001`) always win. A bare number (`Naruto 12.cbr`)
+is a volume, a chapter, or auto — auto compares the folder's bare-number
+set to known volume and chapter counts.
+"""
+
+MODES = frozenset({"volumes", "chapters", "auto"})
+DEFAULT_MODE = "auto"
+
+
+def normalize_mode(value):
+    if value is None:
+        return DEFAULT_MODE
+    mode = str(value).strip().lower()
+    return mode if mode in MODES else DEFAULT_MODE
+
+
+def interpret_bare_numbers(mode, *, bare_numbers, volume_count=None, chapter_count=None):
+    """Return ``volumes`` or ``chapters`` for a folder of bare-numbered files.
+
+    Rules (auto):
+    1. If any bare number is greater than the known volume count, they are
+       chapters (One Piece 1161 vs 115 volumes).
+    2. Otherwise pick the ledger whose count is closer to the file count
+       (19 files vs 72 volumes / 700 chapters → volumes).
+    3. Tie → volumes when a volume count is known, else chapters.
+    """
+    mode = normalize_mode(mode)
+    if mode in {"volumes", "chapters"}:
+        return mode
+
+    numbers = [int(n) for n in (bare_numbers or ()) if str(n).strip().isdigit()]
+    file_count = len(numbers)
+    vol_count = _as_int(volume_count)
+    ch_count = _as_int(chapter_count)
+
+    if vol_count is not None and numbers and max(numbers) > vol_count:
+        return "chapters"
+    if file_count == 0:
+        return "chapters"
+
+    vol_delta = abs(file_count - vol_count) if vol_count is not None else None
+    ch_delta = abs(file_count - ch_count) if ch_count is not None else None
+    if vol_delta is not None and ch_delta is not None:
+        if vol_delta < ch_delta:
+            return "volumes"
+        if ch_delta < vol_delta:
+            return "chapters"
+        return "volumes"
+    if vol_delta is not None:
+        return "volumes"
+    if ch_delta is not None:
+        return "chapters"
+    return "chapters"
+
+
+def apply_bare_number(result, mode):
+    """Rewrite a parser result that used the bare-number chapter group."""
+    if not result or result.get("volume_number") is not None:
+        return result
+    if result.get("chapter_number") is None:
+        return result
+    if normalize_mode(mode) != "volumes":
+        return result
+    rewritten = dict(result)
+    rewritten["volume_number"] = int(result["chapter_number"])
+    rewritten["chapter_number"] = None
+    return rewritten
+
+
+def _as_int(value):
+    if value is None or value == "":
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None

--- a/comicarr/manga_parser.py
+++ b/comicarr/manga_parser.py
@@ -26,7 +26,7 @@ Handles common naming conventions found in manga libraries:
     Title v01 c001.cbz
     Title - Chapter 001.cbz
     Title Vol.01 Ch.001.cbz
-    Title 001.cbz              (bare number = chapter)
+    Title 001.cbz              (bare number; volumes/chapters/auto)
     Title v01.cbz              (volume only)
     chapter 001.cbz            (when series_name is supplied)
 """
@@ -122,7 +122,14 @@ _PATTERNS = [
 ]
 
 
-def parse_manga_filename(filename, series_name=None):
+def parse_manga_filename(
+    filename,
+    series_name=None,
+    bare_number_mode="auto",
+    bare_numbers=None,
+    volume_count=None,
+    chapter_count=None,
+):
     """Parse a manga filename and return extracted metadata.
 
     Args:
@@ -130,6 +137,10 @@ def parse_manga_filename(filename, series_name=None):
         series_name: Optional folder-derived series name. When supplied, the
             parser can infer chapter-only names like ``chapter 1.cbz`` without
             replacing the caller's series name.
+        bare_number_mode: ``volumes``, ``chapters``, or ``auto``.
+        bare_numbers: Folder-level bare numbers used by auto.
+        volume_count: Known volume-ledger size for auto.
+        chapter_count: Known chapter-ledger size for auto.
 
     Returns:
         A dict with keys ``series_name``, ``chapter_number`` (float or None),
@@ -155,10 +166,21 @@ def parse_manga_filename(filename, series_name=None):
             return None
         return _build_context_result(series_name, chapter_only)
 
+    from comicarr.app.manga.bare_numbers import apply_bare_number, interpret_bare_numbers
+
+    resolved_mode = interpret_bare_numbers(
+        bare_number_mode,
+        bare_numbers=bare_numbers,
+        volume_count=volume_count,
+        chapter_count=chapter_count,
+    )
     for pattern in _PATTERNS:
         m = pattern.match(stem)
         if m:
-            return _build_result(m)
+            result = _build_result(m)
+            if result is not None and pattern is _PAT_BARE_NUMBER:
+                return apply_bare_number(result, resolved_mode)
+            return result
 
     if series_name:
         chapter = parse_manga_chapter_number(filename)

--- a/tests/unit/test_bare_numbers.py
+++ b/tests/unit/test_bare_numbers.py
@@ -1,0 +1,64 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Bare-number interpretation for manga filenames."""
+
+from comicarr.app.manga.bare_numbers import interpret_bare_numbers
+from comicarr.manga_parser import parse_manga_filename
+
+
+def test_prefixed_volume_is_always_a_volume():
+    result = parse_manga_filename("One Piece v10.cbz", bare_number_mode="chapters")
+    assert result["volume_number"] == 10
+    assert result["chapter_number"] is None
+
+
+def test_explicit_volumes_mode_reads_naruto_bare_number_as_volume():
+    result = parse_manga_filename("Naruto 12.cbr", bare_number_mode="volumes")
+    assert result["volume_number"] == 12
+    assert result["chapter_number"] is None
+
+
+def test_explicit_chapters_mode_keeps_bare_number_as_chapter():
+    result = parse_manga_filename("One Piece 1161.cbz", bare_number_mode="chapters")
+    assert result["chapter_number"] == 1161.0
+    assert result["volume_number"] is None
+
+
+def test_auto_uses_volume_count_when_folder_matches_completed_set():
+    numbers = list(range(1, 20))
+    assert interpret_bare_numbers("auto", bare_numbers=numbers, volume_count=72, chapter_count=700) == "volumes"
+    result = parse_manga_filename(
+        "Naruto 12.cbr",
+        bare_number_mode="auto",
+        bare_numbers=numbers,
+        volume_count=72,
+        chapter_count=700,
+    )
+    assert result["volume_number"] == 12
+    assert result["chapter_number"] is None
+
+
+def test_auto_treats_number_beyond_last_volume_as_chapter():
+    assert interpret_bare_numbers("auto", bare_numbers=[1161], volume_count=115, chapter_count=1190) == "chapters"
+    result = parse_manga_filename(
+        "One Piece 1161.cbz",
+        bare_number_mode="auto",
+        bare_numbers=[1161],
+        volume_count=115,
+        chapter_count=1190,
+    )
+    assert result["chapter_number"] == 1161.0
+    assert result["volume_number"] is None
+
+
+def test_default_auto_without_folder_counts_stays_chapter():
+    result = parse_manga_filename("Chainsaw Man 165.cbz")
+    assert result["chapter_number"] == 165.0
+    assert result["volume_number"] is None


### PR DESCRIPTION
## Summary

Per-series bare-number interpretation: `volumes` / `chapters` / `auto` (default).

- Auto: if any bare number exceeds the known volume count → chapters (`One Piece 1161`). Otherwise pick the ledger closer to the file count (`Naruto 12` in a 19-file folder vs 72 volumes / 700 chapters → volumes).
- Prefixed `v10` is always a volume.
- Changing the setting rematches on the next parse; historical Status is not rewritten.

Closes #689

## Test plan

- [x] `pytest tests/unit/test_bare_numbers.py tests/unit/test_manga_parser.py`