### PR TITLE
feat: Schedule manga ledger sync and heal empty series in place

### DIFF
--- a/.changeset/manga-scheduled-sync.md
+++ b/.changeset/manga-scheduled-sync.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Manga series now refresh on a schedule: empty chapter ledgers are healed in place (no re-add), new MangaDex chapters are polled, and wanted chapters are searched. Prefix-stamped series stay visible even if ContentType was backfilled as comic.

--- a/comicarr/__init__.py
+++ b/comicarr/__init__.py
@@ -1053,6 +1053,18 @@ def start(ctx):
             )
             IMPORTINBOX_SCHEDULER.pause()
 
+            from comicarr.app.manga.sync import JOB_NAME as MANGA_SYNC_JOB_NAME
+            from comicarr.app.manga.sync import run_manga_sync
+
+            MANGA_SYNC_SCHEDULER = _add_recurring_job(
+                func=run_manga_sync,
+                id="manga_sync",
+                name=MANGA_SYNC_JOB_NAME,
+                next_run_time=datetime.datetime.utcnow(),
+                trigger=IntervalTrigger(hours=0, minutes=int(CONFIG.DBUPDATE_INTERVAL), timezone="UTC"),
+            )
+            MANGA_SYNC_SCHEDULER.pause()
+
             # Shared daily prune for the five unbounded operational ledgers
             # (#480). Independent of SEARCH_INTERVAL / DB Updater / narrative
             # retention; not paused — runs on the daily cadence from start.

--- a/comicarr/app/manga/sync.py
+++ b/comicarr/app/manga/sync.py
@@ -1,0 +1,84 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Scheduled manga ledger refresh and in-place healing.
+
+Uses prefix *or* ContentType so a legacy row restamped ``comic`` by alembic
+0002 is still visible. Does not invent live NAS counts.
+"""
+
+from sqlalchemy import func, or_, select
+
+from comicarr import db, logger
+from comicarr.tables import comics as t_comics
+from comicarr.tables import issues as t_issues
+
+JOB_ID = "manga_sync"
+JOB_NAME = "Manga ledger sync"
+
+
+def active_manga_clause():
+    """Active series that are manga by stored kind *or* ComicID prefix."""
+    return or_(
+        t_comics.c.ContentType == "manga",
+        t_comics.c.ComicID.like("md-%"),
+        t_comics.c.ComicID.like("mal-%"),
+    )
+
+
+def list_active_manga_series():
+    return db.select_all(
+        select(t_comics).where(
+            active_manga_clause(),
+            t_comics.c.Status != "Paused",
+        )
+    )
+
+
+def empty_ledger_series():
+    """Series with zero issue rows — added but never populated."""
+    counted = select(t_issues.c.ComicID, func.count().label("n")).group_by(t_issues.c.ComicID).subquery()
+    return db.select_all(
+        select(t_comics)
+        .select_from(t_comics.outerjoin(counted, t_comics.c.ComicID == counted.c.ComicID))
+        .where(
+            active_manga_clause(),
+            t_comics.c.Status != "Paused",
+            or_(counted.c.n.is_(None), counted.c.n == 0),
+        )
+    )
+
+
+def heal_empty_ledgers():
+    """Re-run add for manga series that have no chapter rows. No re-add from search."""
+    from comicarr import importer, series_kind
+
+    healed = 0
+    for series in empty_ledger_series():
+        comic_id = series["ComicID"]
+        logger.info("[MANGA-SYNC] Healing empty ledger for %s" % comic_id)
+        try:
+            if series_kind.provider_of(comic_id) is series_kind.SeriesProvider.MYANIMELIST:
+                importer.addMangaToDB_MAL(comic_id)
+            else:
+                importer.addMangaToDB(comic_id)
+            healed += 1
+        except Exception as e:
+            logger.error("[MANGA-SYNC] Heal failed for %s: %s" % (comic_id, e))
+    return healed
+
+
+def run_manga_sync():
+    """Scheduled: heal empty ledgers, poll MangaDex, then search wanted."""
+    from comicarr.rsscheck import mangaCheck, mangadexNewChapterCheck
+
+    healed = heal_empty_ledgers()
+    mangadexNewChapterCheck()
+    mangaCheck()
+    return {"healed": healed}

--- a/comicarr/app/system/service.py
+++ b/comicarr/app/system/service.py
@@ -83,6 +83,7 @@ SCHEDULER_JOB_NAMES = {
     "ledger_retention": "Ledger Retention",
     "activity_retention": "Activity Event Retention",
     "interactive_search_retention": "Interactive Search Retention",
+    "manga_sync": "Manga ledger sync",
 }
 
 SETUP_PERSISTENCE_ERROR = "Failed to persist initial credentials"

--- a/comicarr/rsscheck.py
+++ b/comicarr/rsscheck.py
@@ -1869,10 +1869,12 @@ def mangaCheck():
 
     logger.info("[MANGA-RSS] Starting manga wanted-chapter search")
 
-    # Get all active manga series
+    from comicarr.app.manga.sync import active_manga_clause
+
+    # Prefix *or* ContentType so a mis-stamped md-/mal- row is still checked.
     manga_series = db.select_all(
         select(t_comics).where(
-            t_comics.c.ContentType == "manga",
+            active_manga_clause(),
             t_comics.c.Status != "Paused",
         )
     )
@@ -1971,9 +1973,11 @@ def mangadexNewChapterCheck():
     # Every active manga series MangaDex can supply chapters for. MAL-added
     # series carry a resolved MangaDexID; restricting this to md- ComicIDs meant
     # they never polled for new chapters at all.
+    from comicarr.app.manga.sync import active_manga_clause
+
     manga_series = db.select_all(
         select(t_comics).where(
-            t_comics.c.ContentType == "manga",
+            active_manga_clause(),
             t_comics.c.Status != "Paused",
             or_(
                 t_comics.c.ComicID.like("md-%"),

--- a/tests/unit/test_manga_sync.py
+++ b/tests/unit/test_manga_sync.py
@@ -1,0 +1,100 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Prefix-safe manga sync selection and empty-ledger healing."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import insert
+
+import comicarr
+from comicarr import db
+from comicarr.app.manga.sync import empty_ledger_series, heal_empty_ledgers, list_active_manga_series
+from comicarr.tables import comics, issues, metadata
+
+
+@pytest.fixture
+def query_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+def test_list_active_manga_includes_prefix_rows_stamped_comic(query_db):
+    with query_db.begin() as conn:
+        conn.execute(
+            insert(comics),
+            [
+                {
+                    "ComicID": "md-onepiece",
+                    "ComicName": "One Piece",
+                    "Status": "Active",
+                    "ContentType": "comic",
+                },
+                {
+                    "ComicID": "mal-13",
+                    "ComicName": "One Piece MAL",
+                    "Status": "Active",
+                    "ContentType": "comic",
+                },
+                {
+                    "ComicID": "4050-1",
+                    "ComicName": "A Comic",
+                    "Status": "Active",
+                    "ContentType": "comic",
+                },
+                {
+                    "ComicID": "md-paused",
+                    "ComicName": "Paused",
+                    "Status": "Paused",
+                    "ContentType": "manga",
+                },
+            ],
+        )
+    ids = {row["ComicID"] for row in list_active_manga_series()}
+    assert ids == {"md-onepiece", "mal-13"}
+
+
+def test_empty_ledger_series_are_those_with_zero_issues(query_db):
+    with query_db.begin() as conn:
+        conn.execute(
+            insert(comics),
+            [
+                {"ComicID": "md-empty", "ComicName": "Empty", "Status": "Active", "ContentType": "manga"},
+                {"ComicID": "md-full", "ComicName": "Full", "Status": "Active", "ContentType": "manga"},
+            ],
+        )
+        conn.execute(
+            insert(issues),
+            [{"IssueID": "md-full-ch1", "ComicID": "md-full", "Issue_Number": "1"}],
+        )
+    ids = {row["ComicID"] for row in empty_ledger_series()}
+    assert ids == {"md-empty"}
+
+
+def test_heal_empty_ledgers_reruns_add_for_md_and_mal():
+    series = [
+        {"ComicID": "md-empty"},
+        {"ComicID": "mal-664"},
+    ]
+    with (
+        patch("comicarr.app.manga.sync.empty_ledger_series", return_value=series),
+        patch("comicarr.importer.addMangaToDB") as add_md,
+        patch("comicarr.importer.addMangaToDB_MAL") as add_mal,
+    ):
+        assert heal_empty_ledgers() == 2
+    add_md.assert_called_once_with("md-empty")
+    add_mal.assert_called_once_with("mal-664")

--- a/tests/unit/test_scheduler_configuration.py
+++ b/tests/unit/test_scheduler_configuration.py
@@ -39,6 +39,7 @@ _RECURRING_JOB_IDS = {
     "ledger_retention",
     "activity_retention",
     "interactive_search_retention",
+    "manga_sync",
 }
 
 


### PR DESCRIPTION
## Summary

Registers a \`manga_sync\` job (same cadence as DB update) that heals empty chapter ledgers in place, polls MangaDex for new chapters, then searches wanted chapters. Selection uses ContentType **or** \`md-\`/\`mal-\` prefixes so alembic 0002 restamps do not hide manga from the job.

Live NAS ContentType counts were not available here (see the live-database audit ticket).

Closes #690

## Test plan

- [x] \`pytest tests/unit/test_manga_sync.py tests/unit/test_manga_rss.py tests/unit/test_scheduler_configuration.py\`