### PR TITLE
fix: Rematch manga folders in forceRescan with BareNumberMode

### DIFF
--- a/.changeset/manga-forcerescan.md
+++ b/.changeset/manga-forcerescan.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Refreshing a manga series rematches the folder with the series' bare-number setting, so a volume file like `Naruto 12.cbr` marks the chapters in volume 12 instead of being read as issue 12.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ When using Vite with a separate backend process, the proxy targets `http://local
 
 [Comicarr Code Index]|root: ./comicarr
 |Web Layer:{app/main.py:FastAPI app+lifespan,app/<domain>/router.py:HTTP routes,app/core/security.py:JWT+API key+OPDS auth,app/core/middleware.py:CSRF+headers+setup gate}
-|Business Logic:{search.py:provider search,postprocessor.py:post-processing,cv.py:ComicVine,metron.py:Metron,mangadex.py:MangaDex,importer.py:library scanning,rsscheck.py:RSS,weeklypull.py:pull list,app/attention/:needs-attention policy+resolution,app/downloads/:journal+recovery}
+|Business Logic:{search.py:provider search,postprocessor.py:post-processing,cv.py:ComicVine,metron.py:Metron,mangadex.py:MangaDex,myanimelist.py:MyAnimeList,mangasync.py:manga library scan,manga_parser.py:manga filenames,series_kind.py:comic-vs-manga,app/manga/:ledger+sync+bare-numbers+rescan,importer.py:library scanning,rsscheck.py:RSS,weeklypull.py:pull list,app/attention/:needs-attention policy+resolution,app/downloads/:journal+recovery}
 |Config/Data:{config.py:INI config,encrypted.py:Fernet,db.py:SQLAlchemy Core,__init__.py:global state+scheduler,helpers.py:compat re-exports,migration.py:Mylar3 migration}
 |Downloaders:{downloaders/:Mega/MediaFire/Pixeldrain,torrent/clients/:qBittorrent/Deluge/Transmission/rTorrent/uTorrent,nzbget.py,sabnzbd.py}
 |Frontend:{frontend/src/pages,components,hooks,lib,contexts,types}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Comicarr is built on the foundation of Mylar3 with a completely rebuilt React 19
 
 [Comicarr Code Index]|root: ./comicarr
 |Web Layer:{app/main.py:FastAPI app+lifespan,app/<domain>/router.py:HTTP routes,app/core/security.py:JWT+API key+OPDS auth,app/core/middleware.py:CSRF+headers+setup gate}
-|Business Logic:{search.py:provider search,postprocessor.py:post-processing,cv.py:ComicVine,metron.py:Metron,mangadex.py:MangaDex,importer.py:library scanning,rsscheck.py:RSS,weeklypull.py:pull list,app/attention/:needs-attention policy+resolution,app/downloads/:journal+recovery}
+|Business Logic:{search.py:provider search,postprocessor.py:post-processing,cv.py:ComicVine,metron.py:Metron,mangadex.py:MangaDex,myanimelist.py:MyAnimeList,mangasync.py:manga library scan,manga_parser.py:manga filenames,series_kind.py:comic-vs-manga,app/manga/:ledger+sync+bare-numbers+rescan,importer.py:library scanning,rsscheck.py:RSS,weeklypull.py:pull list,app/attention/:needs-attention policy+resolution,app/downloads/:journal+recovery}
 |Config/Data:{config.py:INI config,encrypted.py:Fernet,db.py:SQLAlchemy Core,__init__.py:global state+scheduler,helpers.py:compat re-exports,migration.py:Mylar3 migration}
 |Downloaders:{downloaders/:Mega/MediaFire/Pixeldrain,torrent/clients/:qBittorrent/Deluge/Transmission/rTorrent/uTorrent,nzbget.py,sabnzbd.py}
 |Frontend:{frontend/src/pages,components,hooks,lib,contexts,types}

--- a/comicarr/app/manga/rescan.py
+++ b/comicarr/app/manga/rescan.py
@@ -1,0 +1,122 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Rematch a manga series folder using BareNumberMode.
+
+``updater.forceRescan`` uses FileChecker and comic booktypes. Manga refresh
+calls forceRescan after add, so volume files must go through the manga parser.
+"""
+
+import os
+
+from sqlalchemy import select
+
+from comicarr import db, logger
+from comicarr.app.manga.parse import parse_in_series_context
+from comicarr.scanutil import COMIC_EXTENSIONS
+from comicarr.tables import issues as t_issues
+
+MANGA_EXTENSIONS = COMIC_EXTENSIONS
+
+
+def list_manga_files(directory):
+    """Absolute paths of comic archives under ``directory``."""
+    found = []
+    if not directory or not os.path.isdir(directory):
+        return found
+    for root, _dirs, names in os.walk(directory):
+        for name in names:
+            if os.path.splitext(name)[1].lower() in MANGA_EXTENSIONS:
+                found.append(os.path.join(root, name))
+    found.sort()
+    return found
+
+
+def parse_folder_files(series, filenames, *, issues=None, series_name=None):
+    """Parse sibling files with the series BareNumberMode."""
+    name = series_name or (series or {}).get("ComicName")
+    return [
+        (
+            path,
+            parse_in_series_context(
+                os.path.basename(path),
+                series=series,
+                filenames=filenames,
+                series_name=name,
+                issues=issues,
+            ),
+        )
+        for path in filenames
+    ]
+
+
+def mark_parsed_files_downloaded(comic_id, files):
+    """Mark matching chapter/volume rows Downloaded. Returns the mark count."""
+    all_issues = db.select_all(select(t_issues).where(t_issues.c.ComicID == comic_id))
+    if not all_issues:
+        return 0
+
+    chapter_lookup = {}
+    volume_lookup = {}
+    for issue in all_issues:
+        ch = issue.get("ChapterNumber")
+        vol = issue.get("VolumeNumber")
+        if ch not in (None, ""):
+            try:
+                chapter_lookup[float(ch)] = issue
+            except (TypeError, ValueError):
+                pass
+        if vol not in (None, ""):
+            try:
+                vol_key = int(float(vol))
+                volume_lookup.setdefault(vol_key, []).append(issue)
+            except (TypeError, ValueError):
+                pass
+
+    count = 0
+    for filepath, parsed in files:
+        if not parsed:
+            continue
+        filename = os.path.basename(filepath)
+        matched = []
+        if parsed.get("chapter_number") is not None:
+            match = chapter_lookup.get(float(parsed["chapter_number"]))
+            if match:
+                matched = [match]
+        if not matched and parsed.get("volume_number") is not None:
+            matched = volume_lookup.get(int(parsed["volume_number"]), [])
+        for issue in matched:
+            if issue.get("Status") == "Downloaded":
+                continue
+            db.upsert(
+                "issues",
+                {"Status": "Downloaded", "Location": filename},
+                {"IssueID": issue["IssueID"]},
+            )
+            issue["Status"] = "Downloaded"
+            count += 1
+            logger.fdebug("[MANGA-RESCAN] Marked as downloaded: %s -> %s" % (filename, issue["IssueID"]))
+
+    if count > 0:
+        have = db.select_all(select(t_issues).where(t_issues.c.ComicID == comic_id, t_issues.c.Status == "Downloaded"))
+        db.upsert("comics", {"Have": len(have)}, {"ComicID": comic_id})
+    return count
+
+
+def rescan_manga_series(series, *, directory=None):
+    """Walk the series folder and rematch files with the manga parser."""
+    folder = directory or (series or {}).get("ComicLocation")
+    comic_id = (series or {}).get("ComicID")
+    logger.info("[MANGA-RESCAN] Checking files for %s in %s" % ((series or {}).get("ComicName"), folder))
+    paths = list_manga_files(folder)
+    if not comic_id:
+        return 0
+    issue_rows = db.select_all(select(t_issues).where(t_issues.c.ComicID == comic_id))
+    parsed = parse_folder_files(series, paths, issues=issue_rows)
+    return mark_parsed_files_downloaded(comic_id, parsed)

--- a/comicarr/mangasync.py
+++ b/comicarr/mangasync.py
@@ -375,83 +375,10 @@ def _match_series(series_name, files):
 
 
 def _mark_chapters_downloaded(comic_id, files):
-    """Mark chapters as Downloaded based on files found on disk.
+    """Mark chapters as Downloaded based on files found on disk."""
+    from comicarr.app.manga.rescan import mark_parsed_files_downloaded
 
-    Matches parsed chapter/volume numbers from filenames to existing
-    issue records in the database.
-
-    Returns count of chapters marked.
-    """
-    count = 0
-
-    # Get all issues for this comic
-    with db.get_engine().connect() as conn:
-        stmt = select(issues).where(issues.c.ComicID == comic_id)
-        all_issues = [dict(row._mapping) for row in conn.execute(stmt)]
-
-    if not all_issues:
-        return 0
-
-    # Build lookup by chapter number and volume number
-    # Volume lookup maps to a list since multiple chapters share a volume
-    chapter_lookup = {}
-    volume_lookup = {}
-    for issue in all_issues:
-        ch = issue.get("ChapterNumber")
-        vol = issue.get("VolumeNumber")
-        if ch:
-            try:
-                chapter_lookup[float(ch)] = issue
-            except (ValueError, TypeError):
-                pass
-        if vol:
-            try:
-                vol_key = int(float(vol))
-                if vol_key not in volume_lookup:
-                    volume_lookup[vol_key] = []
-                volume_lookup[vol_key].append(issue)
-            except (ValueError, TypeError):
-                pass
-
-    for filepath, parsed in files:
-        if not parsed:
-            continue
-
-        filename = os.path.basename(filepath)
-        matched_issues = []
-
-        # Try chapter match first
-        if parsed.get("chapter_number") is not None:
-            match = chapter_lookup.get(parsed["chapter_number"])
-            if match:
-                matched_issues = [match]
-
-        # Fall back to volume match — mark all chapters in the volume
-        if not matched_issues and parsed.get("volume_number") is not None:
-            matched_issues = volume_lookup.get(parsed["volume_number"], [])
-
-        for matched_issue in matched_issues:
-            if matched_issue.get("Status") != "Downloaded":
-                issue_id = matched_issue["IssueID"]
-                db.upsert(
-                    "issues",
-                    {"Status": "Downloaded", "Location": filename},
-                    {"IssueID": issue_id},
-                )
-                count += 1
-                logger.fdebug("[MANGA-SCAN] Marked as downloaded: %s -> %s" % (filename, issue_id))
-
-    # Update the Have count for the comic
-    if count > 0:
-        with db.get_engine().connect() as conn:
-            stmt = select(issues).where(
-                issues.c.ComicID == comic_id,
-                issues.c.Status == "Downloaded",
-            )
-            have_count = len([dict(row._mapping) for row in conn.execute(stmt)])
-        db.upsert("comics", {"Have": have_count}, {"ComicID": comic_id})
-
-    return count
+    return mark_parsed_files_downloaded(comic_id, files)
 
 
 def import_selected_manga(selected_ids, scan_id):

--- a/comicarr/updater.py
+++ b/comicarr/updater.py
@@ -1688,6 +1688,11 @@ def forceRescan(ComicID, archive=None, module=None, recheck=False):
     module += "[FILE-RESCAN]"
     # file check to see if issue exists
     rescan = db.select_one(select(comics).where(comics.c.ComicID == ComicID))
+    if rescan and (series_kind.is_manga(rescan) or series_kind.provider_of(ComicID) in series_kind.MANGA_PROVIDERS):
+        from comicarr.app.manga.rescan import rescan_manga_series
+
+        rescan_manga_series(rescan, directory=archive or rescan.get("ComicLocation"))
+        return
     if rescan["AlternateSearch"] is not None:
         altnames = rescan["AlternateSearch"] + "##"
     else:

--- a/tests/unit/test_manga_force_rescan.py
+++ b/tests/unit/test_manga_force_rescan.py
@@ -1,0 +1,103 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""forceRescan rematches manga folders with BareNumberMode, not FileChecker."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sqlalchemy import create_engine, select
+
+import comicarr
+from comicarr import updater
+from comicarr.tables import comics, issues, metadata
+
+
+def _config():
+    return SimpleNamespace(
+        ANNUALS_ON=False,
+        MULTIPLE_DEST_DIRS=None,
+        DUPECONSTRAINT="filesize",
+        IGNORE_HAVETOTAL=False,
+        IGNORE_TOTAL=False,
+        SNATCHED_HAVETOTAL=False,
+        ENFORCE_PERMS=False,
+        AUTOWANT_ALL=False,
+    )
+
+
+def _seed_manga(engine, tmp_path, *, bare_mode="volumes"):
+    with engine.begin() as conn:
+        conn.execute(
+            comics.insert(),
+            {
+                "ComicID": "md-naruto",
+                "ComicName": "Naruto",
+                "ComicPublisher": "Shueisha",
+                "ComicYear": "1999",
+                "ComicLocation": str(tmp_path),
+                "AlternateSearch": None,
+                "Type": "Print",
+                "Corrected_Type": None,
+                "Status": "Active",
+                "ContentType": "manga",
+                "BareNumberMode": bare_mode,
+            },
+        )
+        conn.execute(
+            issues.insert(),
+            {
+                "IssueID": "md-naruto-ch100",
+                "ComicID": "md-naruto",
+                "Issue_Number": "100",
+                "Int_IssueNumber": 100000,
+                "ChapterNumber": "100",
+                "VolumeNumber": "12",
+                "IssueName": "Chapter 100",
+                "IssueDate": "2001-01-01",
+                "Status": "Wanted",
+                "forced_file": None,
+            },
+        )
+
+
+def test_force_rescan_volume_bare_file_marks_chapters_in_that_volume(monkeypatch, tmp_path):
+    (tmp_path / "Naruto 12.cbr").write_bytes(b"cbz")
+    engine = create_engine("sqlite://")
+    metadata.create_all(engine)
+    _seed_manga(engine, tmp_path, bare_mode="volumes")
+
+    monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+    monkeypatch.setattr(comicarr, "CONFIG", _config(), raising=False)
+    monkeypatch.setattr(
+        updater.filechecker,
+        "FileChecker",
+        MagicMock(side_effect=AssertionError("manga forceRescan must not use FileChecker")),
+    )
+
+    updater.forceRescan("md-naruto")
+
+    with engine.connect() as conn:
+        row = conn.execute(select(issues).where(issues.c.IssueID == "md-naruto-ch100")).mappings().one()
+    assert row["Status"] == "Downloaded"
+    assert row["Location"] == "Naruto 12.cbr"
+
+
+def test_force_rescan_empty_manga_folder_does_not_crash(monkeypatch, tmp_path):
+    engine = create_engine("sqlite://")
+    metadata.create_all(engine)
+    _seed_manga(engine, tmp_path, bare_mode="auto")
+    monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+    monkeypatch.setattr(comicarr, "CONFIG", _config(), raising=False)
+
+    updater.forceRescan("md-naruto")
+
+    with engine.connect() as conn:
+        row = conn.execute(select(issues).where(issues.c.IssueID == "md-naruto-ch100")).mappings().one()
+    assert row["Status"] == "Wanted"


### PR DESCRIPTION
## Summary

Graduates leftover fog from #682:

- **#726** — `updater.forceRescan` for manga series walks the folder with `parse_in_series_context` / BareNumberMode. A volume file like `Naruto 12.cbr` marks chapters in volume 12. FileChecker is not used on the manga path.
- **#727** — `AGENTS.md` / `CLAUDE.md` code index now names `myanimelist.py`, `mangasync.py`, `manga_parser.py`, `series_kind.py`, and `app/manga/`.

Closes #726. Closes #727.

## Test plan

- [x] `tests/unit/test_manga_force_rescan.py`
- [x] existing `test_manga_refresh_regressions` / `test_mangasync` still pass