### PR TITLE
feat: Add series-level Interactive release search

### DIFF
--- a/.changeset/series-interactive-search.md
+++ b/.changeset/series-interactive-search.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+The series page now has **Review missing**, an Interactive release search for the series' eligible missing issues. Results include packs, show which missing issues each release would satisfy, and a single grab can cover more than one issue. Per-issue Interactive release search is unchanged.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,7 +62,7 @@ _Avoid_: Search result, NZB result, torrent result
 
 ## Interactive release search
 
-An operator-initiated review of release candidates for one tracked acquisition item, followed optionally by a deliberate manual grab. It is distinct from metadata search, which finds a Series to add to the library.
+An operator-initiated review of release candidates for one tracked acquisition item, or for the eligible missing issues on a Series. A series-scoped review can surface packs and show which missing issues each release would satisfy, then optionally perform a deliberate manual grab. It is distinct from metadata search, which finds a Series to add to the library, and from Search all missing, which queues automatic acquisition.
 
 _Avoid_: Manual search, interactive search
 

--- a/comicarr/app/search/interactive.py
+++ b/comicarr/app/search/interactive.py
@@ -303,20 +303,23 @@ def _union_satisfies(existing, incoming):
 
 def _merge_series_evaluation(collected, evaluation):
     identity = _evaluation_identity(evaluation)
-    for existing_identity, existing in collected:
-        if existing_identity == identity:
-            _union_satisfies(existing, evaluation)
-            return
-    collected.append((identity, evaluation))
+    existing = collected.get(identity)
+    if existing is not None:
+        _union_satisfies(existing, evaluation)
+        return
+    collected[identity] = evaluation
 
 
 def _order_series_evaluations(collected):
-    evaluations = [evaluation for _identity, evaluation in collected]
+    # Acceptance ranks above coverage and the pack flag: complete_search_session
+    # truncates this ordered list, so rejected packs must never crowd out
+    # grabbable releases.
+    evaluations = list(collected.values())
     evaluations.sort(
         key=lambda evaluation: (
-            0 if evaluation.candidate.get("pack") else 1,
-            -len(evaluation.satisfies or []),
             0 if (evaluation.verdict or {}).get("accepted") else 1,
+            -len(evaluation.satisfies or []),
+            0 if evaluation.candidate.get("pack") else 1,
         )
     )
     return evaluations
@@ -405,20 +408,23 @@ def _collect(*, session_id, entity, initial_failures, provider_total):
 
 
 def _collect_series(*, session_id, entity, initial_failures, provider_total):
-    collected = []
+    collected = {}
     failures = list(initial_failures)
     completed_count = 0
     engine = db.get_engine()
     missing = entity.get("missing") or []
     targets = entity.get("targets") or _search_targets(missing)
     eligible = {(item["entity_type"], str(item["entity_id"])): item for item in missing}
+    # provider_total counts every provider once per target, so blocked providers
+    # (which never report completion) have to be offset per target too.
+    blocked_offset = len(initial_failures) * max(1, len(targets))
 
     def publish_progress(provider=None):
         update_search_progress(
             engine,
             session_id=session_id,
             state="running",
-            provider_completed=min(provider_total, completed_count + len(initial_failures)),
+            provider_completed=min(provider_total, completed_count + blocked_offset),
             current_provider=provider,
             provider_failures=failures,
         )
@@ -487,7 +493,7 @@ def _collect_series(*, session_id, entity, initial_failures, provider_total):
             engine,
             session_id=session_id,
             state="failed",
-            provider_completed=min(provider_total, completed_count + len(initial_failures)),
+            provider_completed=min(provider_total, completed_count + blocked_offset),
             provider_failures=failures,
         )
         return

--- a/comicarr/app/search/interactive.py
+++ b/comicarr/app/search/interactive.py
@@ -33,11 +33,69 @@ from comicarr.app.search.interactive_sessions import (
 )
 from comicarr.app.search.providers import effective_provider_plan
 from comicarr.app.series import queries as series_queries
-from comicarr.tables import storyarcs
+from comicarr.tables import comics, storyarcs
 
-_ENTITY_TYPES = frozenset({"issue", "annual", "story_arc_issue"})
+_ENTITY_TYPES = frozenset({"issue", "annual", "story_arc_issue", "series"})
 _WORKER_LOCK = threading.Lock()
 _GRAB_LOCK = threading.Lock()
+MAX_SERIES_SEARCH_TARGETS = 8
+_ISSUE_NUMBER_STEP = 1000
+
+
+def _series_missing_items(ctx, series_id):
+    """Eligible missing issues for a series-scoped Interactive release search."""
+
+    from comicarr.app.search.bulk import selection_from_detail
+    from comicarr.app.series.service import get_comic_detail
+
+    return selection_from_detail(get_comic_detail(ctx, series_id))
+
+
+def _ordered_missing(missing):
+    from comicarr.helpers import issuedigits
+
+    return sorted(
+        missing or [],
+        key=lambda item: (
+            str(item.get("entity_type") or ""),
+            issuedigits(item.get("issue_number")),
+            str(item.get("entity_id") or ""),
+        ),
+    )
+
+
+def _search_targets(missing, *, limit=MAX_SERIES_SEARCH_TARGETS):
+    """Eligible missing items to query live, preferring each range start.
+
+    Every eligible item is searched when the set fits the bound. Larger
+    series keep range starts first so packs are still discovered.
+    """
+
+    from comicarr.helpers import issuedigits
+
+    ordered = _ordered_missing(missing)
+    starts = []
+    previous_type = None
+    previous_number = None
+    for item in ordered:
+        number = issuedigits(item.get("issue_number"))
+        entity_type = item.get("entity_type")
+        if previous_type != entity_type or previous_number is None or number - previous_number > _ISSUE_NUMBER_STEP:
+            starts.append(item)
+            if len(starts) >= limit:
+                return starts
+        previous_type = entity_type
+        previous_number = number
+    seen = {(item["entity_type"], str(item["entity_id"])) for item in starts}
+    targets = list(starts)
+    for item in ordered:
+        key = (item["entity_type"], str(item["entity_id"]))
+        if key in seen:
+            continue
+        targets.append(item)
+        if len(targets) >= limit:
+            break
+    return targets
 
 
 def _resolve_entity(entity_type, entity_id):
@@ -45,6 +103,16 @@ def _resolve_entity(entity_type, entity_id):
     entity_id = str(entity_id or "").strip()
     if entity_type not in _ENTITY_TYPES or not entity_id:
         return None, {"success": False, "status_code": 400, "error": "Unsupported tracked item"}
+    if entity_type == "series":
+        row = db.select_one(select(comics).where(comics.c.ComicID == entity_id))
+        if row is None:
+            return None, {"success": False, "status_code": 404, "error": "Tracked item not found"}
+        return {
+            "entity_type": "series",
+            "entity_id": entity_id,
+            "series_id": entity_id,
+            "comic_name": row.get("ComicName"),
+        }, None
     if entity_type == "story_arc_issue":
         row = db.select_one(select(storyarcs).where(storyarcs.c.IssueArcID == entity_id))
         mode = "story_arc" if row is not None else None
@@ -67,6 +135,23 @@ def _resolve_entity(entity_type, entity_id):
     }, None
 
 
+def _resolve_grab_entity(candidate):
+    """Resolve the tracked item used to revalidate and hand off a candidate."""
+
+    reconstruction = candidate.get("reconstruction") or {}
+    if candidate.get("entity_type") == "series":
+        anchor_type = reconstruction.get("anchor_entity_type")
+        anchor_id = reconstruction.get("anchor_entity_id")
+        if not anchor_type or not anchor_id:
+            return None, {
+                "success": False,
+                "status_code": 409,
+                "error": "Release candidate has no tracked issue to grab against",
+            }
+        return _resolve_entity(anchor_type, anchor_id)
+    return _resolve_entity(candidate["entity_type"], candidate["entity_id"])
+
+
 def _provider_plan(ctx):
     return effective_provider_plan(
         ctx.config,
@@ -75,11 +160,22 @@ def _provider_plan(ctx):
 
 
 def start_search(ctx, *, actor, browser_session, entity_type, entity_id):
-    """Validate one tracked item, create polling state, and start collection."""
+    """Validate one tracked item or series, create polling state, and start collection."""
 
     entity, error = _resolve_entity(entity_type, entity_id)
     if error:
         return error
+    if entity["entity_type"] == "series":
+        missing = _series_missing_items(ctx, entity["entity_id"])
+        if not missing:
+            return {
+                "success": False,
+                "status_code": 409,
+                "status": "blocked",
+                "error": "No eligible missing issues remain to search",
+            }
+        entity["missing"] = missing
+        entity["targets"] = _search_targets(missing)
     route_health = search_routes.route_health(ctx)
     if not route_health.get("success"):
         return {
@@ -103,6 +199,7 @@ def start_search(ctx, *, actor, browser_session, entity_type, entity_id):
         for provider in plan
         if provider.blocked
     ]
+    provider_total = len(plan) * max(1, len(entity.get("targets") or [entity]))
     try:
         pending = create_pending_session(
             db.get_engine(),
@@ -111,7 +208,7 @@ def start_search(ctx, *, actor, browser_session, entity_type, entity_id):
             entity_type=entity["entity_type"],
             entity_id=entity["entity_id"],
             series_id=entity["series_id"],
-            provider_total=len(plan),
+            provider_total=provider_total,
             provider_failures=initial_failures,
         )
     except InteractiveCandidateConflict as e:
@@ -128,7 +225,7 @@ def start_search(ctx, *, actor, browser_session, entity_type, entity_id):
                 "session_id": pending["session_id"],
                 "entity": entity,
                 "initial_failures": initial_failures,
-                "provider_total": len(plan),
+                "provider_total": provider_total,
             },
             name="InteractiveReleaseSearch",
             registry=getattr(ctx, "background_workers", None),
@@ -146,7 +243,94 @@ def start_search(ctx, *, actor, browser_session, entity_type, entity_id):
     return pending
 
 
+def _evaluation_identity(evaluation):
+    reconstruction = evaluation_reconstruction(evaluation)
+    return tuple(
+        str(reconstruction.get(key))
+        for key in (
+            "provider_config_id",
+            "provider_type",
+            "provider_name",
+            "source_kind",
+            "provider_item_digest",
+            "pack",
+        )
+    )
+
+
+def _satisfies_for_evaluation(evaluation, searched_item, eligible):
+    legacy = evaluation.legacy_match or {}
+    pack_info = legacy.get("pack_issuelist")
+    found = []
+    if legacy.get("pack") and isinstance(pack_info, dict):
+        for issue in pack_info.get("issues") or []:
+            issue_id = str(issue.get("issueid") or issue.get("IssueID") or "")
+            match = eligible.get(("issue", issue_id))
+            if match is None:
+                continue
+            found.append(
+                {
+                    "entity_type": "issue",
+                    "entity_id": issue_id,
+                    "issue_number": match.get("issue_number") or issue.get("issuenumber"),
+                }
+            )
+        if found:
+            return found
+    match = eligible.get((searched_item["entity_type"], str(searched_item["entity_id"])))
+    if match is None:
+        return []
+    return [
+        {
+            "entity_type": match["entity_type"],
+            "entity_id": match["entity_id"],
+            "issue_number": match.get("issue_number"),
+        }
+    ]
+
+
+def _union_satisfies(existing, incoming):
+    merged = list(existing.satisfies or [])
+    seen = {(item["entity_type"], str(item["entity_id"])) for item in merged}
+    for item in incoming.satisfies or []:
+        key = (item["entity_type"], str(item["entity_id"]))
+        if key in seen:
+            continue
+        merged.append(item)
+        seen.add(key)
+    existing.satisfies = merged
+
+
+def _merge_series_evaluation(collected, evaluation):
+    identity = _evaluation_identity(evaluation)
+    for existing_identity, existing in collected:
+        if existing_identity == identity:
+            _union_satisfies(existing, evaluation)
+            return
+    collected.append((identity, evaluation))
+
+
+def _order_series_evaluations(collected):
+    evaluations = [evaluation for _identity, evaluation in collected]
+    evaluations.sort(
+        key=lambda evaluation: (
+            0 if evaluation.candidate.get("pack") else 1,
+            -len(evaluation.satisfies or []),
+            0 if (evaluation.verdict or {}).get("accepted") else 1,
+        )
+    )
+    return evaluations
+
+
 def _collect(*, session_id, entity, initial_failures, provider_total):
+    if entity.get("entity_type") == "series":
+        _collect_series(
+            session_id=session_id,
+            entity=entity,
+            initial_failures=initial_failures,
+            provider_total=provider_total,
+        )
+        return
     evaluations = []
     failures = list(initial_failures)
     completed = set()
@@ -215,6 +399,102 @@ def _collect(*, session_id, entity, initial_failures, provider_total):
         engine,
         session_id=session_id,
         evaluations=evaluations,
+        provider_completed=provider_total,
+        provider_failures=failures,
+    )
+
+
+def _collect_series(*, session_id, entity, initial_failures, provider_total):
+    collected = []
+    failures = list(initial_failures)
+    completed_count = 0
+    engine = db.get_engine()
+    missing = entity.get("missing") or []
+    targets = entity.get("targets") or _search_targets(missing)
+    eligible = {(item["entity_type"], str(item["entity_id"])): item for item in missing}
+
+    def publish_progress(provider=None):
+        update_search_progress(
+            engine,
+            session_id=session_id,
+            state="running",
+            provider_completed=min(provider_total, completed_count + len(initial_failures)),
+            current_provider=provider,
+            provider_failures=failures,
+        )
+
+    publish_progress()
+
+    def _bind_progress():
+        finished_providers = set()
+
+        def on_complete(provider):
+            nonlocal completed_count
+            key = provider.casefold()
+            if key not in finished_providers:
+                finished_providers.add(key)
+                completed_count += 1
+            publish_progress(provider)
+
+        return on_complete
+
+    target_failures = 0
+    for target in targets:
+
+        def on_evaluations(values, searched=target):
+            for evaluation in values:
+                evaluation.satisfies = _satisfies_for_evaluation(evaluation, searched, eligible)
+                _merge_series_evaluation(collected, evaluation)
+
+        def on_failure(provider, code, detail):
+            failures.append(
+                {
+                    "provider": provider,
+                    "code": code,
+                    "detail": redact_sensitive_text(detail),
+                }
+            )
+            publish_progress(provider)
+
+        on_complete = _bind_progress()
+
+        try:
+            with (
+                _WORKER_LOCK,
+                search_filer.interactive_collection(
+                    on_evaluations=on_evaluations,
+                    on_provider_complete=on_complete,
+                    on_provider_failure=on_failure,
+                ),
+            ):
+                result = search.searchforissue(
+                    issueid=target["entity_id"],
+                    manual=True,
+                    entity_type=target["entity_type"] if target["entity_type"] != "story_arc_issue" else None,
+                )
+            if isinstance(result, dict) and result.get("status") == "IN PROGRESS":
+                failures.append(
+                    {"provider": "Search", "code": "search_busy", "detail": "Another search is already running"}
+                )
+                target_failures += 1
+        except Exception as e:
+            logger.error("[INTERACTIVE-SEARCH] Series collection failed: %s" % redact_sensitive_text(e))
+            failures.append({"provider": "Search", "code": "collection_failed", "detail": redact_sensitive_text(e)})
+            target_failures += 1
+
+    if target_failures == len(targets) and not collected:
+        update_search_progress(
+            engine,
+            session_id=session_id,
+            state="failed",
+            provider_completed=min(provider_total, completed_count + len(initial_failures)),
+            provider_failures=failures,
+        )
+        return
+    complete_search_session(
+        engine,
+        session_id=session_id,
+        evaluations=_order_series_evaluations(collected),
         provider_completed=provider_total,
         provider_failures=failures,
     )
@@ -365,7 +645,7 @@ def grab_candidate(
         else:
             override_reason = None
 
-        entity, error = _resolve_entity(candidate["entity_type"], candidate["entity_id"])
+        entity, error = _resolve_grab_entity(candidate)
         if error:
             return _release_with_error(engine, candidate, error=error["error"], status_code=error["status_code"])
 

--- a/comicarr/app/search/interactive_sessions.py
+++ b/comicarr/app/search/interactive_sessions.py
@@ -42,7 +42,7 @@ CLAIM_LEASE_SECONDS = 60 * 60
 JOB_ID = "interactive_search_retention"
 JOB_NAME = "Interactive Search Retention"
 
-_ENTITY_TYPES = frozenset({"issue", "annual", "story_arc_issue"})
+_ENTITY_TYPES = frozenset({"issue", "annual", "story_arc_issue", "series"})
 _SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,254}$")
 _SAFE_PROVIDER_TYPE = re.compile(r"^[a-z0-9_-]{1,32}$")
 _URL_PATTERN = re.compile(r"(?i)https?://[^\s]+")
@@ -179,6 +179,13 @@ def _candidate_reconstruction(evaluation, public):
         "match_kind": str(verdict.get("match_kind") or "none")[:32],
         "pack": bool(candidate.get("pack")),
     }
+    satisfies = getattr(evaluation, "satisfies", None) or public.get("satisfies")
+    if isinstance(satisfies, list) and satisfies and isinstance(satisfies[0], Mapping):
+        anchor_type = str(satisfies[0].get("entity_type") or "").strip().lower()
+        anchor_id = str(satisfies[0].get("entity_id") or "").strip()
+        if anchor_type in {"issue", "annual", "story_arc_issue"} and anchor_id:
+            reconstruction["anchor_entity_type"] = anchor_type
+            reconstruction["anchor_entity_id"] = anchor_id[:255]
     # The digest is useful when an unsafe identity must be re-found under the
     # current provider config; it is not reversible and grants no access.
     return reconstruction

--- a/comicarr/app/search/router.py
+++ b/comicarr/app/search/router.py
@@ -177,7 +177,7 @@ async def start_interactive_search(
     username: str = Depends(require_session),
     ctx: AppContext = Depends(get_context),
 ):
-    """Start provider collection for one tracked acquisition item."""
+    """Start provider collection for one tracked item or a series' missing issues."""
 
     try:
         body = await request.json()

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -81,9 +81,13 @@ class ReleaseCandidateEvaluation:
     legacy_match: dict | None = field(default=None, repr=False)
     exception: Exception | None = field(default=None, repr=False)
     reconstruction_hint: dict | None = field(default=None, repr=False)
+    satisfies: list | None = None
 
     def as_dict(self):
-        return {"candidate": dict(self.candidate), "verdict": dict(self.verdict)}
+        payload = {"candidate": dict(self.candidate), "verdict": dict(self.verdict)}
+        if self.satisfies:
+            payload["satisfies"] = [dict(item) for item in self.satisfies]
+        return payload
 
 
 _INTERACTIVE_COLLECTOR = contextvars.ContextVar("interactive_release_collector", default=None)

--- a/frontend/src/components/releases/ReleaseReviewSheet.tsx
+++ b/frontend/src/components/releases/ReleaseReviewSheet.tsx
@@ -34,6 +34,7 @@ import { getErrorMessage } from "@/lib/api";
 import type {
   InteractiveGrabResult,
   InteractiveReleaseCandidate,
+  InteractiveSatisfiedIssue,
   ReleaseReviewIssue,
 } from "@/types";
 
@@ -116,12 +117,34 @@ function formatPublished(value: string | null) {
   }).format(date);
 }
 
+function formatSatisfies(
+  satisfies: InteractiveSatisfiedIssue[] | undefined,
+): string | null {
+  if (!satisfies?.length) return null;
+  const numbers = satisfies
+    .map((item) => String(item.issue_number ?? "").trim())
+    .filter(Boolean);
+  if (numbers.length === 0) return null;
+  if (numbers.length === 1) return `#${numbers[0]}`;
+  const numeric = numbers.map((value) => Number(value));
+  const contiguous =
+    numeric.every((value) => Number.isFinite(value)) &&
+    numeric.every(
+      (value, index) => index === 0 || value === numeric[index - 1] + 1,
+    );
+  if (contiguous) {
+    return `#${numbers[0]}–#${numbers[numbers.length - 1]}`;
+  }
+  return numbers.map((value) => `#${value}`).join(", ");
+}
+
 function CandidateFacts({
   candidate,
 }: {
   candidate: InteractiveReleaseCandidate;
 }) {
   const metrics = Object.entries(candidate.candidate.metrics ?? {});
+  const coverage = formatSatisfies(candidate.satisfies);
   return (
     <div className="flex flex-wrap gap-x-3 gap-y-1 font-mono text-[10px] tabular-nums text-muted-foreground">
       <span>{candidate.candidate.provider}</span>
@@ -129,6 +152,7 @@ function CandidateFacts({
       <span>{formatBytes(candidate.candidate.size_bytes)}</span>
       <span>{formatPublished(candidate.candidate.published_at)}</span>
       {candidate.candidate.pack ? <span>pack</span> : null}
+      {coverage ? <span>covers {coverage}</span> : null}
       {metrics.slice(0, 3).map(([key, value]) => (
         <span key={key}>
           {value} {key}
@@ -167,8 +191,13 @@ function IssueContext({
   issue: ReleaseReviewIssue;
   expiresAt?: string;
 }) {
+  const isSeries = issue.scope === "series";
   const number = issue.IssueNumber ?? issue.Issue_Number ?? "—";
   const name = issue.ComicName ?? issue.ReleaseComicName ?? "Tracked issue";
+  const missingLabel =
+    issue.missingCount === 1
+      ? "1 missing issue"
+      : `${issue.missingCount ?? 0} missing issues`;
   return (
     <div className="flex min-w-0 items-center gap-3">
       <div
@@ -180,12 +209,14 @@ function IssueContext({
         }}
         aria-hidden="true"
       >
-        #{number}
+        {isSeries ? "Series" : `#${number}`}
       </div>
       <div className="min-w-0">
         <div className="truncate text-sm font-semibold">{name}</div>
         <div className="mt-1 truncate font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
-          {issue.annual ? "Annual" : "Issue"} · {issue.Status ?? "Tracked"}
+          {isSeries
+            ? missingLabel
+            : `${issue.annual ? "Annual" : "Issue"} · ${issue.Status ?? "Tracked"}`}
           {expiresAt ? ` · available until ${formatPublished(expiresAt)}` : ""}
         </div>
       </div>
@@ -325,8 +356,9 @@ export function ReleaseReviewSheet({
           <SheetHeader className="shrink-0 border-b border-border p-5 pr-12 text-left">
             <SheetTitle>Review releases</SheetTitle>
             <SheetDescription>
-              Choose one result for this issue. Nothing downloads until you
-              confirm.
+              {issue?.scope === "series"
+                ? "Choose a release for this series. A pack can cover several missing issues at once. Nothing downloads until you confirm."
+                : "Choose one result for this issue. Nothing downloads until you confirm."}
             </SheetDescription>
             {issue ? (
               <div className="pt-2">

--- a/frontend/src/hooks/useInteractiveSearch.ts
+++ b/frontend/src/hooks/useInteractiveSearch.ts
@@ -12,7 +12,7 @@ const INTERACTIVE_POLL_MS = 2_000;
 const ACTIVE_STATES = new Set(["queued", "running"]);
 
 export interface StartInteractiveSearchInput {
-  entityType: "issue" | "annual" | "story_arc_issue";
+  entityType: "issue" | "annual" | "story_arc_issue" | "series";
   entityId: string;
 }
 

--- a/frontend/src/hooks/useInteractiveSearch.ts
+++ b/frontend/src/hooks/useInteractiveSearch.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/components/ui/toast";
 import { apiRequest } from "@/lib/api";
@@ -84,12 +84,17 @@ export function useInteractiveReview() {
   const [reviewSessionId, setReviewSessionId] = useState<string | null>(null);
   const [reviewTarget, setReviewTarget] =
     useState<StartInteractiveSearchInput | null>(null);
+  // Guards overlapping starts. `isPending` from the closure is stale for two
+  // clicks in the same tick, so the in-flight flag lives in a ref instead.
+  const startInFlight = useRef(false);
 
   const startReview = async (
     issue: ReleaseReviewIssue,
     target: StartInteractiveSearchInput,
   ) => {
     if (!target.entityId) return;
+    if (startInFlight.current) return;
+    startInFlight.current = true;
     setReviewIssue(issue);
     setReviewTarget(target);
     setReviewSessionId(null);
@@ -99,6 +104,10 @@ export function useInteractiveReview() {
       setReviewSessionId(session.session_id);
     } catch {
       // The sheet owns the actionable error and retry affordance.
+    } finally {
+      // Always clears, so a failed start still allows retry and closing the
+      // sheet mid-flight cannot strand the flag.
+      startInFlight.current = false;
     }
   };
 

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -633,7 +633,11 @@ export default function SeriesDetailPage() {
                     )
                   : undefined
               }
-              disabled={!comicId || reviewableMissing === 0}
+              disabled={
+                !comicId ||
+                reviewableMissing === 0 ||
+                reviewSheetProps.startPending
+              }
               className={ghostBtn}
               style={{ borderColor: "var(--border)" }}
               aria-label="Interactive Search for missing issues"

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -327,6 +327,7 @@ export default function SeriesDetailPage() {
   const total = summary?.total ?? allIssues.length;
   const have = summary?.owned ?? allIssues.filter(isIssueOwned).length;
   const missing = summary?.missing ?? allIssues.filter(isIssueMissing).length;
+  const reviewableMissing = summary?.eligible ?? missing;
   const monitored =
     summary?.monitored ?? allIssues.filter(isIssueMonitored).length;
   const inFlight =
@@ -613,6 +614,32 @@ export default function SeriesDetailPage() {
             >
               <Search className="h-3.5 w-3.5" />
               Search all missing
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                comicId
+                  ? void startReview(
+                      {
+                        ComicName: comic.ComicName,
+                        Status: comic.Status,
+                        scope: "series",
+                        missingCount: reviewableMissing,
+                      },
+                      {
+                        entityType: "series",
+                        entityId: String(comicId),
+                      },
+                    )
+                  : undefined
+              }
+              disabled={!comicId || reviewableMissing === 0}
+              className={ghostBtn}
+              style={{ borderColor: "var(--border)" }}
+              aria-label="Interactive Search for missing issues"
+            >
+              <Search className="h-3.5 w-3.5" />
+              Review missing
             </button>
             <button
               type="button"

--- a/frontend/src/types/entities.ts
+++ b/frontend/src/types/entities.ts
@@ -355,6 +355,13 @@ export interface UpcomingIssue extends Omit<Issue, "Status"> {
   Store_Date?: string;
 }
 
+/** One missing issue a series-scoped release candidate would satisfy. */
+export interface InteractiveSatisfiedIssue {
+  entity_type: "issue" | "annual" | "story_arc_issue";
+  entity_id: string;
+  issue_number?: string | null;
+}
+
 /** Fields the interactive-search review sheet actually renders. */
 export interface ReleaseReviewIssue {
   IssueNumber?: string | null;
@@ -363,6 +370,8 @@ export interface ReleaseReviewIssue {
   ReleaseComicName?: string | null;
   Status?: string | null;
   annual?: boolean;
+  scope?: "issue" | "series";
+  missingCount?: number;
 }
 
 export interface InteractiveVerdictReason {
@@ -396,6 +405,7 @@ export interface InteractiveReleaseCandidate {
     reasons: InteractiveVerdictReason[];
     match_kind: string;
   };
+  satisfies?: InteractiveSatisfiedIssue[];
 }
 
 export interface InteractiveProviderFailure {
@@ -407,7 +417,7 @@ export interface InteractiveProviderFailure {
 export interface InteractiveSearchSession {
   success?: boolean;
   session_id: string;
-  entity_type: "issue" | "annual" | "story_arc_issue";
+  entity_type: "issue" | "annual" | "story_arc_issue" | "series";
   entity_id: string;
   series_id: string | null;
   state: "queued" | "running" | "complete" | "failed";

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,6 +41,7 @@ export type {
   WantedIssue,
   UpcomingIssue,
   ReleaseReviewIssue,
+  InteractiveSatisfiedIssue,
   InteractiveVerdictReason,
   InteractiveReleaseCandidate,
   InteractiveProviderFailure,

--- a/frontend/tests/components/ReleaseReviewSheet.test.tsx
+++ b/frontend/tests/components/ReleaseReviewSheet.test.tsx
@@ -125,7 +125,9 @@ describe("ReleaseReviewSheet", () => {
       />,
     );
 
-    expect(await screen.findByText("Example 001 (2026) (Digital)")).toBeTruthy();
+    expect(
+      await screen.findByText("Example 001 (2026) (Digital)"),
+    ).toBeTruthy();
     expect(screen.getByText("Issue, year, and volume match")).toBeTruthy();
     expect(screen.getByText("Slow indexer")).toBeTruthy();
     expect(screen.getByText("Provider timed out")).toBeTruthy();
@@ -135,6 +137,81 @@ describe("ReleaseReviewSheet", () => {
 
     await waitFor(() => expect(grabBody).toEqual({ override: false }));
     expect(onGrabbed).toHaveBeenCalledOnce();
+  });
+
+  it("shows which missing issues a pack would satisfy", async () => {
+    server.use(
+      http.get("/api/search/interactive/session-series", () =>
+        HttpResponse.json({
+          session_id: "session-series",
+          entity_type: "series",
+          entity_id: "comic-1",
+          state: "complete",
+          candidate_count: 1,
+          progress: {
+            provider_total: 1,
+            provider_completed: 1,
+            current_provider: null,
+          },
+          provider_failures: [],
+          created_at: "2026-08-12T04:00:00Z",
+          expires_at: "2026-08-12T04:10:00Z",
+          candidates: [
+            {
+              ...sessionCandidate(true, false),
+              candidate: {
+                ...sessionCandidate(true, false).candidate,
+                title: "Example 001-003 (2026)",
+                pack: true,
+              },
+              verdict: {
+                ...sessionCandidate(true, false).verdict,
+                reason_code: "accepted.pack",
+                match_kind: "pack",
+              },
+              satisfies: [
+                {
+                  entity_type: "issue",
+                  entity_id: "i1",
+                  issue_number: "1",
+                },
+                {
+                  entity_type: "issue",
+                  entity_id: "i2",
+                  issue_number: "2",
+                },
+                {
+                  entity_type: "issue",
+                  entity_id: "i3",
+                  issue_number: "3",
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+
+    render(
+      <ReleaseReviewSheet
+        issue={{
+          ComicName: "Example",
+          Status: "Wanted",
+          scope: "series",
+          missingCount: 4,
+        }}
+        sessionId="session-series"
+        startPending={false}
+        startError={null}
+        onRetry={vi.fn()}
+        onClose={vi.fn()}
+        onGrabbed={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("Example 001-003 (2026)")).toBeTruthy();
+    expect(screen.getByText("covers #1–#3")).toBeTruthy();
+    expect(screen.getByText(/4 missing issues/i)).toBeTruthy();
   });
 
   it("requires acknowledgement before submitting an override", async () => {

--- a/frontend/tests/pages/SeriesDetailPage.test.tsx
+++ b/frontend/tests/pages/SeriesDetailPage.test.tsx
@@ -786,4 +786,51 @@ describe("SeriesDetailPage", () => {
       await screen.findByRole("heading", { name: "Review releases" }),
     ).toBeTruthy();
   });
+
+  it("starts Interactive Search for missing issues on the series", async () => {
+    let searchBody: unknown;
+    server.use(
+      http.post("/api/search/interactive", async ({ request }) => {
+        searchBody = await request.json();
+        return HttpResponse.json({
+          session_id: "session-series",
+          entity_type: "series",
+          entity_id: "1",
+          series_id: "1",
+          state: "complete",
+          candidate_count: 0,
+          progress: {
+            provider_total: 0,
+            provider_completed: 0,
+            current_provider: null,
+          },
+          provider_failures: [],
+          created_at: "2026-08-12T04:00:00Z",
+          expires_at: "2026-08-12T04:10:00Z",
+          candidates: [],
+        });
+      }),
+    );
+    const user = userEvent.setup();
+    renderDetail();
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Interactive Search for missing issues",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(searchBody).toEqual({
+        entity_type: "series",
+        entity_id: "1",
+      });
+    });
+    expect(
+      await screen.findByRole("heading", { name: "Review releases" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/pack can cover several missing issues/i),
+    ).toBeTruthy();
+  });
 });

--- a/tests/unit/test_interactive_search_api.py
+++ b/tests/unit/test_interactive_search_api.py
@@ -542,3 +542,265 @@ def test_grab_requires_and_revalidates_explicit_candidate_override(engine, monke
 
     assert result["status"] == "submitted"
     assert reasons == ["ignored.search_word"]
+
+
+def _missing_items():
+    return [
+        {"entity_type": "issue", "entity_id": "i1", "issue_number": "1"},
+        {"entity_type": "issue", "entity_id": "i2", "issue_number": "2"},
+        {"entity_type": "issue", "entity_id": "i3", "issue_number": "3"},
+        {"entity_type": "issue", "entity_id": "i10", "issue_number": "10"},
+    ]
+
+
+def _pack_evaluation(title="Example 001-010"):
+    evaluation = _evaluation(title)
+    evaluation.candidate["pack"] = True
+    evaluation.verdict.update(
+        {
+            "reason_code": "accepted.pack",
+            "reasons": [{"code": "accepted.pack", "message": "Accepted pack match"}],
+            "match_kind": "pack",
+        }
+    )
+    evaluation.legacy_match = {
+        "ComicName": "Example",
+        "ComicID": "series-1",
+        "IssueID": "i1",
+        "IssueNumber": "1",
+        "pack": True,
+        "pack_numbers": "1-10",
+        "pack_issuelist": {
+            "valid": True,
+            "issues": [
+                {"issueid": "i1", "issuenumber": "1"},
+                {"issueid": "i2", "issuenumber": "2"},
+                {"issueid": "i3", "issuenumber": "3"},
+                {"issueid": "owned-4", "issuenumber": "4"},
+            ],
+        },
+        "nzbprov": "DDL(GetComics)",
+        "provider": "DDL(GetComics)",
+        "nzbtitle": title,
+        "nzbid": "pack-1",
+        "link": "https://provider.invalid/pack",
+        "entry": {"id": "pack-1"},
+        "provider_stat": {"id": 200, "type": "ddl", "active": True, "hits": 0},
+        "comyear": "2026",
+        "downloadit": False,
+        "oneoff": False,
+        "SARC": None,
+        "IssueArcID": None,
+        "ComicTitle": title,
+        "tmpprov": "DDL(GetComics)",
+        "kind": "ddl",
+        "booktype": "Print",
+        "newznab": None,
+        "torznab": None,
+        "pubdate": None,
+        "size": None,
+        "modcomicname": title,
+        "ComicVolume": None,
+        "IssueDate": "2026-08-11",
+    }
+    evaluation.reconstruction_hint = {
+        "provider_config_id": 200,
+        "provider_type": "ddl",
+        "provider_item_id": "pack-1",
+    }
+    return evaluation
+
+
+def test_start_accepts_series_with_eligible_missing_issues(engine, monkeypatch):
+    monkeypatch.setattr(
+        interactive.db,
+        "select_one",
+        lambda _stmt: {"ComicID": "series-1", "ComicName": "Example"},
+    )
+    monkeypatch.setattr(interactive, "_series_missing_items", lambda *_args, **_kwargs: _missing_items())
+    worker = {}
+    monkeypatch.setattr(
+        interactive, "start_background_thread", lambda target, **kwargs: worker.update({"target": target, **kwargs})
+    )
+
+    result = interactive.start_search(
+        AppContext(config=_config()),
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="series",
+        entity_id="series-1",
+    )
+
+    assert result["success"] is True
+    assert result["entity_type"] == "series"
+    assert result["entity_id"] == "series-1"
+    assert result["state"] == "queued"
+    assert worker["target"] is interactive._collect
+    assert [item["entity_id"] for item in worker["kwargs"]["entity"]["targets"]] == [
+        "i1",
+        "i10",
+        "i2",
+        "i3",
+    ]
+    assert worker["kwargs"]["provider_total"] == result["progress"]["provider_total"] == 4
+
+
+def test_start_rejects_series_with_no_eligible_missing_issues(engine, monkeypatch):
+    monkeypatch.setattr(
+        interactive.db,
+        "select_one",
+        lambda _stmt: {"ComicID": "series-1", "ComicName": "Example"},
+    )
+    monkeypatch.setattr(interactive, "_series_missing_items", lambda *_args, **_kwargs: [])
+
+    result = interactive.start_search(
+        AppContext(config=_config()),
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="series",
+        entity_id="series-1",
+    )
+
+    assert result == {
+        "success": False,
+        "status_code": 409,
+        "status": "blocked",
+        "error": "No eligible missing issues remain to search",
+    }
+
+
+def test_start_rejects_unknown_series(engine, monkeypatch):
+    monkeypatch.setattr(interactive.db, "select_one", lambda _stmt: None)
+
+    result = interactive.start_search(
+        AppContext(config=_config()),
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="series",
+        entity_id="missing",
+    )
+
+    assert result == {"success": False, "status_code": 404, "error": "Tracked item not found"}
+
+
+def test_series_worker_searches_gap_starts_and_annotates_pack_coverage(engine, monkeypatch):
+    pending = interactive.create_pending_session(
+        engine,
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="series",
+        entity_id="series-1",
+        series_id="series-1",
+        provider_total=1,
+    )
+    searched = []
+
+    def _single(title, item_id):
+        evaluation = _evaluation(title)
+        evaluation.reconstruction_hint = {
+            "provider_config_id": 200,
+            "provider_type": "ddl",
+            "provider_item_id": item_id,
+        }
+        return evaluation
+
+    def manual_search(**kwargs):
+        searched.append(kwargs)
+        evaluations = [_pack_evaluation(), _single("Example 001", "item-1")]
+        if kwargs["issueid"] == "i10":
+            evaluations = [_single("Example 010", "item-10")]
+        interactive.search_filer._INTERACTIVE_COLLECTOR.get()["evaluations"](evaluations)
+        interactive.search_filer.report_provider_complete("DDL(GetComics)")
+        return []
+
+    monkeypatch.setattr(interactive.search, "searchforissue", manual_search)
+
+    interactive._collect(
+        session_id=pending["session_id"],
+        entity={
+            "entity_type": "series",
+            "entity_id": "series-1",
+            "series_id": "series-1",
+            "missing": _missing_items(),
+            "targets": [
+                {"entity_type": "issue", "entity_id": "i1", "issue_number": "1"},
+                {"entity_type": "issue", "entity_id": "i10", "issue_number": "10"},
+            ],
+        },
+        initial_failures=[],
+        provider_total=1,
+    )
+
+    result = read_session(
+        engine,
+        session_id=pending["session_id"],
+        actor="alice",
+        browser_session="browser-cookie",
+    )
+    assert [call["issueid"] for call in searched] == ["i1", "i10"]
+    assert all(call["manual"] is True for call in searched)
+    assert result["state"] == "complete"
+    pack = next(candidate for candidate in result["candidates"] if candidate["candidate"]["pack"])
+    assert pack["satisfies"] == [
+        {"entity_type": "issue", "entity_id": "i1", "issue_number": "1"},
+        {"entity_type": "issue", "entity_id": "i2", "issue_number": "2"},
+        {"entity_type": "issue", "entity_id": "i3", "issue_number": "3"},
+    ]
+    titles = [candidate["candidate"]["title"] for candidate in result["candidates"]]
+    assert titles[0] == "Example 001-010"
+    assert "Example 001" in titles
+    assert "Example 010" in titles
+    assert titles.count("Example 001-010") == 1
+
+
+def test_series_grab_revalidates_against_the_pack_anchor_issue(engine, monkeypatch):
+    pack = _pack_evaluation()
+    pack.satisfies = [
+        {"entity_type": "issue", "entity_id": "i1", "issue_number": "1"},
+        {"entity_type": "issue", "entity_id": "i2", "issue_number": "2"},
+    ]
+    created = create_session(
+        engine,
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="series",
+        entity_id="series-1",
+        series_id="series-1",
+        evaluations=[pack],
+    )
+    resolved = []
+
+    def resolve(entity_type, entity_id):
+        resolved.append((entity_type, entity_id))
+        return {"entity_type": entity_type, "entity_id": entity_id, "series_id": "series-1"}, None
+
+    monkeypatch.setattr(interactive, "_resolve_entity", resolve)
+    monkeypatch.setattr(interactive, "_candidate_eligibility", lambda _entity: {"status": True})
+    searches = []
+
+    def manual_search(**kwargs):
+        searches.append(kwargs)
+        interactive.search_filer._INTERACTIVE_COLLECTOR.get()["evaluations"]([_pack_evaluation()])
+        return []
+
+    monkeypatch.setattr(interactive.search, "searchforissue", manual_search)
+
+    def verify(matches, info):
+        info["foundc"] = {"status": True, "info": {"journal_release_key": "pack-release", "journal_managed": True}}
+        return info
+
+    monkeypatch.setattr(interactive.search, "verification", verify)
+
+    result = interactive.grab_candidate(
+        AppContext(config=_config()),
+        session_id=created["session_id"],
+        candidate_id=created["candidates"][0]["candidate_id"],
+        actor="alice",
+        browser_session="browser-cookie",
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "submitted"
+    assert ("issue", "i1") in resolved
+    assert ("series", "series-1") not in resolved
+    assert searches == [{"issueid": "i1", "manual": True, "entity_type": "issue"}]

--- a/tests/unit/test_interactive_search_api.py
+++ b/tests/unit/test_interactive_search_api.py
@@ -804,3 +804,162 @@ def test_series_grab_revalidates_against_the_pack_anchor_issue(engine, monkeypat
     assert ("issue", "i1") in resolved
     assert ("series", "series-1") not in resolved
     assert searches == [{"issueid": "i1", "manual": True, "entity_type": "issue"}]
+
+
+def test_series_worker_scales_the_blocked_provider_offset_across_targets(engine, monkeypatch):
+    initial_failures = [
+        {"provider": "Indexer", "code": "temporarily_blocked", "detail": "Provider is temporarily blocked"}
+    ]
+    targets = [
+        {"entity_type": "issue", "entity_id": "i1", "issue_number": "1"},
+        {"entity_type": "issue", "entity_id": "i10", "issue_number": "10"},
+    ]
+    # Two planned providers over two targets, one of them blocked before the
+    # worker starts, so provider_total is len(plan) * len(targets).
+    provider_total = 2 * len(targets)
+    pending = interactive.create_pending_session(
+        engine,
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="series",
+        entity_id="series-1",
+        series_id="series-1",
+        provider_total=provider_total,
+        provider_failures=initial_failures,
+    )
+    reported = []
+
+    def manual_search(**kwargs):
+        evaluation = _evaluation("Example %s" % kwargs["issueid"])
+        evaluation.reconstruction_hint = {
+            "provider_config_id": 200,
+            "provider_type": "ddl",
+            "provider_item_id": "item-%s" % kwargs["issueid"],
+        }
+        interactive.search_filer._INTERACTIVE_COLLECTOR.get()["evaluations"]([evaluation])
+        interactive.search_filer.report_provider_complete("DDL(GetComics)")
+        reported.append(
+            read_session(
+                engine,
+                session_id=pending["session_id"],
+                actor="alice",
+                browser_session="browser-cookie",
+            )["progress"]["provider_completed"]
+        )
+        return []
+
+    monkeypatch.setattr(interactive.search, "searchforissue", manual_search)
+
+    interactive._collect(
+        session_id=pending["session_id"],
+        entity={
+            "entity_type": "series",
+            "entity_id": "series-1",
+            "series_id": "series-1",
+            "missing": _missing_items(),
+            "targets": targets,
+        },
+        initial_failures=initial_failures,
+        provider_total=provider_total,
+    )
+
+    result = read_session(
+        engine,
+        session_id=pending["session_id"],
+        actor="alice",
+        browser_session="browser-cookie",
+    )
+    # One blocked provider over two targets occupies two of the four slots, so
+    # the first target finishing reports 1 + 2 and not the unscaled 1 + 1.
+    assert reported == [3, 4]
+    assert result["state"] == "complete"
+    assert result["progress"]["provider_total"] == provider_total
+    assert result["progress"]["provider_completed"] == provider_total
+
+
+def test_series_worker_marks_the_session_failed_when_every_target_fails(engine, monkeypatch):
+    initial_failures = [
+        {"provider": "Indexer", "code": "temporarily_blocked", "detail": "Provider is temporarily blocked"}
+    ]
+    targets = [
+        {"entity_type": "issue", "entity_id": "i1", "issue_number": "1"},
+        {"entity_type": "issue", "entity_id": "i10", "issue_number": "10"},
+    ]
+    provider_total = 2 * len(targets)
+    pending = interactive.create_pending_session(
+        engine,
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="series",
+        entity_id="series-1",
+        series_id="series-1",
+        provider_total=provider_total,
+        provider_failures=initial_failures,
+    )
+    monkeypatch.setattr(
+        interactive.search,
+        "searchforissue",
+        lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("https://host/api?token=secret")),
+    )
+
+    interactive._collect(
+        session_id=pending["session_id"],
+        entity={
+            "entity_type": "series",
+            "entity_id": "series-1",
+            "series_id": "series-1",
+            "missing": _missing_items(),
+            "targets": targets,
+        },
+        initial_failures=initial_failures,
+        provider_total=provider_total,
+    )
+
+    result = read_session(
+        engine,
+        session_id=pending["session_id"],
+        actor="alice",
+        browser_session="browser-cookie",
+    )
+    assert result["state"] == "failed"
+    assert result["candidates"] == []
+    assert [failure["code"] for failure in result["provider_failures"]] == [
+        "temporarily_blocked",
+        "collection_failed",
+        "collection_failed",
+    ]
+    # No provider ever completed, so only the blocked provider slots count.
+    assert result["progress"]["provider_completed"] == 2
+    assert "secret" not in str(result)
+    assert "https://" not in str(result)
+
+
+def test_series_grab_rejects_a_candidate_without_a_tracked_anchor(engine, monkeypatch):
+    pack = _pack_evaluation()
+    pack.satisfies = []
+    created = create_session(
+        engine,
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="series",
+        entity_id="series-1",
+        series_id="series-1",
+        evaluations=[pack],
+    )
+    searches = []
+    monkeypatch.setattr(interactive.search, "searchforissue", lambda **kwargs: searches.append(kwargs) or [])
+    monkeypatch.setattr(interactive, "_candidate_eligibility", lambda _entity: {"status": True})
+
+    result = interactive.grab_candidate(
+        AppContext(config=_config()),
+        session_id=created["session_id"],
+        candidate_id=created["candidates"][0]["candidate_id"],
+        actor="alice",
+        browser_session="browser-cookie",
+    )
+
+    assert result["success"] is False
+    assert result["status_code"] == 409
+    assert result["status"] == "blocked"
+    assert result["error"] == "Release candidate has no tracked issue to grab against"
+    assert searches == []


### PR DESCRIPTION
## Summary

Series pages can now start an Interactive release search across eligible missing issues, so operators can find and grab packs without searching one issue at a time.

Closes #729

## Changes

- Add **Review missing** on the series page, next to **Search all missing**
- Annotate pack candidates with the missing issues they would satisfy, and grab a pack against one tracked issue so it can cover several at once
- Leave per-issue Interactive release search unchanged

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [ ] No app release impact; no changeset needed (omit rather than "No user-visible behaviour changes.")

## Testing

- [x] Tests pass locally (`pytest tests/unit -v`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [x] Backend lint/format (`ruff check comicarr/` and `ruff format --check comicarr/`)
- [x] Frontend lint/format (`cd frontend && npm run lint && npm run format:check`)
- [x] Or one-shot: `npm run lint` (from repo root; requires `uv` + `frontend/node_modules`)
- [ ] Manually tested (describe what you tested):

Covered by unit tests for series start/collect/grab and Series Detail / Release Review sheet tests. Not exercised in a running browser in this change.

## Screenshots

N/A — no running app available to capture.

## Additional Notes

Live collection searches every eligible missing issue when the set is small, prefers the start of each missing range on larger series, and caps at 8 targets so the global search lock is not held for a full-library walk. **Search all missing** remains the automatic queue path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Review missing** action on series pages to search for all eligible missing issues.
  * Release reviews now show pack coverage, covered issue ranges, remaining missing issues, and support multi-issue grabs.
  * Existing per-issue interactive search remains unchanged.

* **Bug Fixes**
  * Improved duplicate result handling and validation when selecting series release candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->