### PR TITLE
feat: Match pack and multi-issue releases from any indexer

### DIFF
--- a/.changeset/pack-aware-search.md
+++ b/.changeset/pack-aware-search.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Searches can now match pack releases from any indexer, not just DDL. When a series has *Allow packs* enabled (which still requires torrent search to be on), a result like `Solo Leveling v01-14` or `Invincible #001-144` is recognized as a multi-volume or multi-issue pack instead of being thrown away for having no single issue number. Comicarr checks the pack against what the series is missing, and one grab marks every issue it covers as Snatched — so during "Search all missing", the queued searches for the rest of those issues stop instead of hunting for each one individually. A volume pack covers every chapter belonging to its volumes, and only ever matches volume-tracked series, so a `v01-14` release can never claim issues 1–14 of an issue-tracked comic.

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -1005,7 +1005,32 @@ def duplicate_filecheck(filename, ComicID=None, IssueID=None, StoryArcID=None, r
     return rtnval
 
 
-def issue_find_ids(ComicName, ComicID, pack, IssueNumber, pack_id):
+def _pack_row_matches(row, int_iss, iss_item, kind):
+    """Decide whether one issues-table row belongs to a pack range entry.
+
+    A volume pack (e.g. ``v01-14``) covers rows by their ``VolumeNumber``
+    — including manga chapter rows that belong to a covered volume — but
+    must never claim a chapter numbered like a volume (a chapter 7 with
+    an unknown volume is not volume 7). Rows without volume metadata
+    (TPB/GN-tracked series) fall back to the plain issue-number match.
+    Issue/chapter packs symmetrically never claim volume rows.
+    """
+    volume = row.get("VolumeNumber")
+    chapter = row.get("ChapterNumber")
+    if kind == "volume":
+        if volume not in (None, ""):
+            try:
+                return int(float(volume)) == int(iss_item)
+            except (TypeError, ValueError):
+                return False
+        if chapter not in (None, ""):
+            return False
+    elif volume not in (None, "") and chapter in (None, ""):
+        return False
+    return row["Int_IssueNumber"] == int_iss
+
+
+def issue_find_ids(ComicName, ComicID, pack, IssueNumber, pack_id, kind="issue"):
     from sqlalchemy import select
 
     from comicarr.helpers import issuedigits
@@ -1054,12 +1079,15 @@ def issue_find_ids(ComicName, ComicID, pack, IssueNumber, pack_id):
         int_iss = issuedigits(str(iss_item))
         for xb in issuelist:
             if xb["Status"] != "Downloaded":
-                if xb["Int_IssueNumber"] == int_iss:
+                if _pack_row_matches(xb, int_iss, iss_item, kind):
                     if Int_IssueNumber == xb["Int_IssueNumber"]:
                         valid = True
                     issueinfo.append({"issueid": xb["IssueID"], "int_iss": int_iss, "issuenumber": xb["Issue_Number"]})
                     write_valids.append({"issueid": xb["IssueID"], "pack_id": pack_id})
-                    break
+                    if kind != "volume":
+                        # one row per issue number, but a covered volume can
+                        # hold many chapter rows - keep collecting those.
+                        break
             else:
                 ignores.append(iss_item)
 

--- a/comicarr/app/search/packs.py
+++ b/comicarr/app/search/packs.py
@@ -34,7 +34,7 @@ _VOLUME_RANGE = re.compile(
     re.IGNORECASE,
 )
 _CHAPTER_RANGE = re.compile(
-    r"\bc(?:h(?:apter)?s?)?\.?\s*(?P<start>\d{1,4})(?:\.\d+)?\s*[-–]\s*c?h?\.?\s*(?P<end>\d{1,4})(?:\.\d+)?(?!\d)",
+    r"\bc(?:h(?:apter)?s?)?\.?\s*(?P<start>\d{1,4}(?:\.\d+)?)\s*[-–]\s*c?h?\.?\s*(?P<end>\d{1,4}(?:\.\d+)?)(?!\d)",
     re.IGNORECASE,
 )
 _ISSUE_RANGE = re.compile(r"(?P<marker>#)?\s*(?P<start>\d{1,4})\s*[-–]\s*#?(?P<end>\d{1,4})(?!\d)")
@@ -44,6 +44,12 @@ _ISSUE_RANGE = re.compile(r"(?P<marker>#)?\s*(?P<start>\d{1,4})\s*[-–]\s*#?(?P
 _MIN_UNMARKED_SPAN = 2
 
 _FIRST_YEAR = re.compile(r"\(\s*((?:19|20)\d{2})")
+
+# Range expansion downstream is integer-only, so a fractional endpoint
+# ("c001.5-003.5") cannot be represented: truncating it to 1-3 would claim
+# chapter 1, which the pack does not contain. Refuse the whole title rather
+# than let a looser pattern re-match the same text into a wrong range.
+_FRACTIONAL_ENDPOINT = re.compile(r"\d+\.\d+\s*[-–]|[-–]\s*[a-z]*\.?\s*\d+\.\d+", re.IGNORECASE)
 
 
 def _range_values(match, kind):
@@ -86,6 +92,8 @@ def parse_pack_title(title):
         return None
 
     stripped = _PARENTHESIZED.sub(" ", title)
+    if _FRACTIONAL_ENDPOINT.search(stripped):
+        return None
 
     for pattern, kind, booktype in (
         (_VOLUME_RANGE, "volume", "TPB"),

--- a/comicarr/app/search/packs.py
+++ b/comicarr/app/search/packs.py
@@ -1,0 +1,112 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Detect multi-issue/volume pack releases from provider result titles.
+
+DDL providers detect packs upstream (``getcomics.check_for_pack`` /
+``rsscheck.ddlrss_pack_detect``) and hand ``search_filer`` a pre-parsed
+entry. Every other provider only supplies a raw title, so pack-shaped
+releases like ``Solo Leveling v01-14 (2021-2025)`` used to die in the
+single-issue parser (#730). This module is the title-only detector for
+those providers.
+"""
+
+import re
+
+# Range spans above this are assumed to be noise (e.g. phone-number-like
+# digit runs), not a real pack.
+_MAX_RANGE_SPAN = 2000
+
+# Both endpoints written as full 4-digit years means a publication-year
+# range (e.g. "Batman 1999-2005"), not an issue range.
+_YEAR_RANGE = re.compile(r"^(?:19|20)\d{2}$")
+
+_PARENTHESIZED = re.compile(r"\([^)]*\)|\[[^\]]*\]")
+
+_VOLUME_RANGE = re.compile(
+    r"\bv(?:ol(?:ume)?s?)?\.?\s*(?P<start>\d{1,3})\s*[-–]\s*(?:v(?:ol(?:ume)?s?)?\.?\s*)?(?P<end>\d{1,3})(?!\d)",
+    re.IGNORECASE,
+)
+_CHAPTER_RANGE = re.compile(
+    r"\bc(?:h(?:apter)?s?)?\.?\s*(?P<start>\d{1,4})(?:\.\d+)?\s*[-–]\s*c?h?\.?\s*(?P<end>\d{1,4})(?:\.\d+)?(?!\d)",
+    re.IGNORECASE,
+)
+_ISSUE_RANGE = re.compile(r"(?P<marker>#)?\s*(?P<start>\d{1,4})\s*[-–]\s*#?(?P<end>\d{1,4})(?!\d)")
+
+# An unmarked bare range spanning only two numbers ("Series 05-06") is more
+# often a date fragment than a pack, so it needs a '#' marker to be trusted.
+_MIN_UNMARKED_SPAN = 2
+
+_FIRST_YEAR = re.compile(r"\(\s*((?:19|20)\d{2})")
+
+
+def _range_values(match, kind):
+    raw_start = match.group("start")
+    raw_end = match.group("end")
+    try:
+        start = int(raw_start)
+        end = int(raw_end)
+    except (TypeError, ValueError):
+        return None
+    if start >= end or (end - start) > _MAX_RANGE_SPAN:
+        return None
+    if _YEAR_RANGE.match(raw_start) and _YEAR_RANGE.match(raw_end):
+        return None
+    if kind == "issue" and match.groupdict().get("marker") is None:
+        # zero-padded issue numbering ("001-144") is itself a pack marker.
+        padded = len(raw_start) >= 3 and raw_start.startswith("0")
+        if not padded and (end - start) < _MIN_UNMARKED_SPAN:
+            return None
+    return start, end
+
+
+def _series_before(text, match_start):
+    series = text[:match_start]
+    series = re.sub(r"[#\-–\s]+$", "", series).strip()
+    if not re.search(r"[A-Za-z]", series):
+        return None
+    return series
+
+
+def parse_pack_title(title):
+    """Return pack info parsed from a release title, or None.
+
+    The result mirrors what the DDL pack detectors feed ``search_filer``:
+    ``{"series", "issues", "kind", "year", "booktype"}`` where ``issues``
+    is a normalized ``"start-end"`` range string and ``kind`` is one of
+    ``"volume"``, ``"chapter"``, or ``"issue"``.
+    """
+    if not title or not isinstance(title, str):
+        return None
+
+    stripped = _PARENTHESIZED.sub(" ", title)
+
+    for pattern, kind, booktype in (
+        (_VOLUME_RANGE, "volume", "TPB"),
+        (_CHAPTER_RANGE, "chapter", "issue"),
+        (_ISSUE_RANGE, "issue", "issue"),
+    ):
+        match = pattern.search(stripped)
+        if match is None:
+            continue
+        values = _range_values(match, kind)
+        if values is None:
+            continue
+        series = _series_before(stripped, match.start())
+        if series is None:
+            continue
+        year_match = _FIRST_YEAR.search(title)
+        return {
+            "series": series,
+            "issues": "%d-%d" % values,
+            "kind": kind,
+            "year": year_match.group(1) if year_match else None,
+            "booktype": booktype,
+        }
+    return None

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -1078,6 +1078,7 @@ def NZB_SEARCH(
         "chktpb": chktpb,
         "smode": smode,
         "provider_stat": provider_stat,
+        "allow_packs": allow_packs,
         "foundc": foundc,
     }
 
@@ -2490,6 +2491,9 @@ def searchforissue(
                             "chktpb": chktpb,
                             "smode": xr["searchmode"],
                             "provider_stat": provider_stat,
+                            "allow_packs": (
+                                xr["AllowPacks"] in (1, "1", True) and comicarr.CONFIG.ENABLE_TORRENT_SEARCH
+                            ),
                             "foundc": foundc,
                         }
 
@@ -2644,7 +2648,9 @@ def searchforissue(
                             " still wanted, perform a Manual search or mark issue as Skipped"
                             " or Wanted."
                         )
-                        return
+                        # an explicit outcome so queued bulk-search items that a
+                        # pack already covered terminalise as blocked, not failed.
+                        return {"status": "BLOCKED", "reason": "already downloaded or snatched"}
 
                 allow_packs = False
                 ComicID = result["ComicID"]

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -328,11 +328,13 @@ class search_check(object):
             intIss = is_info["intIss"]
             chktpb = is_info["chktpb"]
             provider_stat = is_info["provider_stat"]
+            allow_packs = is_info.get("allow_packs") in (1, "1", True)
 
         try:
             pack = entry["pack"]
         except Exception:
             pack = False
+        detected_pack = None
 
         alt_match = False
         # logger.fdebug('entry: %s' % (entry,))
@@ -644,8 +646,54 @@ class search_check(object):
 
         # send it to the parser here.
         else:
-            p_comic = filechecker.FileChecker(file=ComicTitle, watchcomic=ComicName)
-            parsed_comic = p_comic.listFiles()
+            if pack is not True and allow_packs and "DDL" not in nzbprov:
+                from comicarr.app.manga.acquisition import booktype_bypasses_format_gates as _manga_bypass
+                from comicarr.app.search.packs import parse_pack_title
+
+                detected_pack = parse_pack_title(ComicTitle)
+                if detected_pack is not None and detected_pack["kind"] == "volume":
+                    # a v01-14 release holds volumes; matching it against an
+                    # issue-tracked series would mark the wrong issues.
+                    volume_ok = booktype in ("TPB", "HC", "GN", "TPB/GN/HC/One-Shot") or _manga_bypass(booktype)
+                    if not volume_ok:
+                        detected_pack = None
+            if detected_pack is not None:
+                logger.fdebug(
+                    "[PACK-DETECT] %s detected as a multi-%s release covering %s"
+                    % (ComicTitle, detected_pack["kind"], detected_pack["issues"])
+                )
+                pack = True
+                entry["pack"] = True
+                entry["issues"] = detected_pack["issues"]
+                # the pack snatch/notify path reads these off the entry.
+                entry["series"] = detected_pack["series"]
+                entry["year"] = detected_pack["year"]
+                if "filename" not in entry:
+                    entry["filename"] = entry["title"]
+                ffc = filechecker.FileChecker()
+                dnr = ffc.dynamic_replace(detected_pack["series"])
+                parsed_comic = {
+                    "booktype": detected_pack["booktype"],
+                    "comicfilename": entry["title"],
+                    "series_name": detected_pack["series"],
+                    "series_name_decoded": detected_pack["series"],
+                    "issueid": None,
+                    "dynamic_name": dnr["mod_seriesname"],
+                    "issues": detected_pack["issues"],
+                    "series_volume": None,
+                    "alt_series": None,
+                    "alt_issue": None,
+                    "issue_year": detected_pack["year"],
+                    "issue_number": None,
+                    "scangroup": None,
+                    "reading_order": None,
+                    "sub": None,
+                    "comiclocation": None,
+                    "parse_status": "success",
+                }
+            else:
+                p_comic = filechecker.FileChecker(file=ComicTitle, watchcomic=ComicName)
+                parsed_comic = p_comic.listFiles()
 
         logger.fdebug("parsed_info: %s" % parsed_comic)
         logger.fdebug(
@@ -936,7 +984,7 @@ class search_check(object):
 
         downloadit = False
 
-        if all(["DDL" in nzbprov, pack is True]):
+        if pack is True and any(["DDL" in nzbprov, detected_pack is not None]):
             logger.fdebug("[PACK-QUEUE] %s Pack detected for %s." % (nzbprov, entry["filename"]))
 
             # find the pack range.
@@ -945,7 +993,11 @@ class search_check(object):
             try:
                 if not entry["title"].startswith("0-Day Comics Pack"):
                     pack_issuelist = entry["issues"]
-                    issueid_info = helpers.issue_find_ids(ComicName, ComicID, pack_issuelist, IssueNumber, entry["id"])
+                    pack_kind = detected_pack["kind"] if detected_pack is not None else "issue"
+                    pack_ref = entry["id"] if "id" in entry else entry["link"]
+                    issueid_info = helpers.issue_find_ids(
+                        ComicName, ComicID, pack_issuelist, IssueNumber, pack_ref, kind=pack_kind
+                    )
                     if issueid_info["valid"] is True:
                         logger.info("Issue Number %s exists within pack. Continuing." % IssueNumber)
                     else:

--- a/tests/unit/test_pack_issue_find_ids.py
+++ b/tests/unit/test_pack_issue_find_ids.py
@@ -1,0 +1,110 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+import pytest
+
+import comicarr
+from comicarr.app.downloads import service as downloads_service
+from comicarr.helpers import issuedigits
+
+
+def _row(issueid, number, status="Wanted", chapter=None, volume=None):
+    return {
+        "IssueID": issueid,
+        "Issue_Number": str(number),
+        "Int_IssueNumber": issuedigits(str(number)),
+        "Status": status,
+        "ChapterNumber": chapter,
+        "VolumeNumber": volume,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _pack_state(monkeypatch):
+    monkeypatch.setattr(comicarr, "PACK_ISSUEIDS_DONT_QUEUE", {}, raising=False)
+
+
+def _install_rows(monkeypatch, rows):
+    monkeypatch.setattr(downloads_service.db, "select_all", lambda _query: rows)
+
+
+def test_default_kind_matches_issue_numbers_and_registers_pack_ids(monkeypatch):
+    rows = [_row("id-1", 1), _row("id-2", 2), _row("id-3", 3, status="Downloaded")]
+    _install_rows(monkeypatch, rows)
+
+    result = downloads_service.issue_find_ids("Example", "comic-1", "1-3", "2", "pack-1")
+
+    assert result["valid"] is True
+    assert [x["issueid"] for x in result["issues"]] == ["id-1", "id-2"]
+    assert comicarr.PACK_ISSUEIDS_DONT_QUEUE == {"id-1": "pack-1", "id-2": "pack-1"}
+
+
+def test_volume_kind_skips_chapter_rows_of_unknown_volume(monkeypatch):
+    rows = [
+        _row("chap-7", 7, chapter="7"),
+        _row("vol-7", 7, volume="7"),
+        _row("vol-8", 8, volume="8"),
+    ]
+    _install_rows(monkeypatch, rows)
+
+    result = downloads_service.issue_find_ids("Example", "comic-1", "1-14", "7", "pack-2", kind="volume")
+
+    assert result["valid"] is True
+    assert [x["issueid"] for x in result["issues"]] == ["vol-7", "vol-8"]
+    assert "chap-7" not in comicarr.PACK_ISSUEIDS_DONT_QUEUE
+
+
+def test_volume_pack_covers_every_chapter_row_in_its_volumes(monkeypatch):
+    # The reported Solo Leveling case: a chapter-tracked manga where a
+    # v01-14 pack must satisfy every chapter belonging to those volumes.
+    rows = [
+        _row("c-1", 1, chapter="1", volume="1"),
+        _row("c-2", 2, chapter="2", volume="1"),
+        _row("c-3", 3, chapter="3", volume="2"),
+        _row("c-99", 99, chapter="99", volume="20"),
+    ]
+    _install_rows(monkeypatch, rows)
+
+    result = downloads_service.issue_find_ids("Example", "comic-1", "1-14", "2", "pack-5", kind="volume")
+
+    assert result["valid"] is True
+    assert [x["issueid"] for x in result["issues"]] == ["c-1", "c-2", "c-3"]
+    assert "c-99" not in comicarr.PACK_ISSUEIDS_DONT_QUEUE
+
+
+def test_chapter_kind_does_not_claim_volume_rows(monkeypatch):
+    rows = [_row("vol-2", 2, volume="2"), _row("c-2", 2, chapter="2", volume="1")]
+    _install_rows(monkeypatch, rows)
+
+    result = downloads_service.issue_find_ids("Example", "comic-1", "1-10", "2", "pack-6", kind="chapter")
+
+    assert result["valid"] is True
+    assert [x["issueid"] for x in result["issues"]] == ["c-2"]
+
+
+def test_volume_kind_falls_back_to_issue_numbers_for_plain_rows(monkeypatch):
+    # A TPB/GN-tracked series has no VolumeNumber column values; its
+    # Issue_Number values are the volume numbers.
+    rows = [_row("tpb-1", 1), _row("tpb-2", 2)]
+    _install_rows(monkeypatch, rows)
+
+    result = downloads_service.issue_find_ids("Example", "comic-1", "1-2", "1", "pack-3", kind="volume")
+
+    assert result["valid"] is True
+    assert [x["issueid"] for x in result["issues"]] == ["tpb-1", "tpb-2"]
+
+
+def test_volume_kind_invalid_when_searched_number_outside_pack(monkeypatch):
+    rows = [_row("vol-1", 1, volume="1")]
+    _install_rows(monkeypatch, rows)
+
+    result = downloads_service.issue_find_ids("Example", "comic-1", "1-2", "9", "pack-4", kind="volume")
+
+    assert result["valid"] is False
+    assert comicarr.PACK_ISSUEIDS_DONT_QUEUE == {}

--- a/tests/unit/test_search_filer.py
+++ b/tests/unit/test_search_filer.py
@@ -374,7 +374,7 @@ def _pack_entry(**overrides):
 
 
 def test_pack_candidate_and_pack_failure_reasons(monkeypatch):
-    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args: {"valid": True, "issues": []})
+    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args, **_kwargs: {"valid": True, "issues": []})
     info = _info(nzbprov="DDL(GetComics)", tmpprov="DDL(GetComics)")
 
     accepted = search_filer.search_check().evaluate_entry(_pack_entry(), info)
@@ -382,7 +382,7 @@ def test_pack_candidate_and_pack_failure_reasons(monkeypatch):
     assert accepted.verdict["match_kind"] == "pack"
     assert accepted.candidate["source_kind"] == "ddl"
 
-    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args: {"valid": False})
+    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args, **_kwargs: {"valid": False})
     absent = search_filer.search_check().evaluate_entry(_pack_entry(), info)
     assert _reason(absent) == "rejected.pack_issue_absent"
 
@@ -391,8 +391,84 @@ def test_pack_candidate_and_pack_failure_reasons(monkeypatch):
     assert _reason(failed) == "error.pack_lookup_exception"
 
 
+def test_non_ddl_volume_pack_is_detected_and_accepted(monkeypatch):
+    calls = {}
+
+    def fake_issue_find_ids(*args, **kwargs):
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return {"valid": True, "issues": [{"issueid": "id-1"}]}
+
+    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", fake_issue_find_ids)
+    info = _info(
+        nzbprov="torznab",
+        tmpprov="nyaa [api]",
+        booktype="manga",
+        allow_packs=True,
+        RSS="yes",
+        torznab_host=("nyaa", "https://nyaa.test", "0", "key"),
+    )
+    entry = _entry(title="Example Series v01-14 (2021-2025) (Digital)", site="torznab")
+
+    evaluation = search_filer.search_check().evaluate_entry(entry, info)
+
+    assert _reason(evaluation) == "accepted.pack"
+    assert evaluation.verdict["match_kind"] == "pack"
+    assert evaluation.legacy_match["pack"] is True
+    assert evaluation.legacy_match["pack_numbers"] == "1-14"
+    assert evaluation.legacy_match["kind"] == "torrent"
+    # the entry is enriched so the downstream pack snatch/notify path works
+    assert entry["pack"] is True
+    assert entry["issues"] == "1-14"
+    assert entry["series"] == "Example Series"
+    assert calls["args"][2] == "1-14"
+    assert calls["kwargs"] == {"kind": "volume"}
+
+
+def test_non_ddl_issue_range_pack_is_accepted_for_print_series(monkeypatch):
+    monkeypatch.setattr(
+        search_filer.helpers, "issue_find_ids", lambda *_args, **_kwargs: {"valid": True, "issues": []}
+    )
+    info = _info(allow_packs=True)
+    entry = _entry(title="Example Series #1-10 (2024)")
+
+    evaluation = search_filer.search_check().evaluate_entry(entry, info)
+
+    assert _reason(evaluation) == "accepted.pack"
+
+
+def test_pack_title_without_allow_packs_uses_single_issue_path():
+    entry = _entry(title="Example Series v01-14 (2021-2025) (Digital)")
+
+    evaluation = search_filer.search_check().evaluate_entry(entry, _info(booktype="manga"))
+
+    # the stub parser matches, proving the legacy single-issue path ran
+    assert _reason(evaluation) == "accepted.issue"
+    assert evaluation.legacy_match["pack"] is False
+
+
+def test_volume_pack_is_not_matched_against_issue_tracked_series():
+    # A v01-14 release cannot satisfy individual issues 1-14 of a Print
+    # series, so detection must not trigger for issue-tracked booktypes.
+    entry = _entry(title="Example Series v01-14 (2021-2025) (Digital)")
+
+    evaluation = search_filer.search_check().evaluate_entry(entry, _info(allow_packs=True, booktype="Print"))
+
+    assert evaluation.legacy_match["pack"] is False
+
+
+def test_non_ddl_pack_missing_wanted_issue_is_rejected(monkeypatch):
+    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args, **_kwargs: {"valid": False})
+    info = _info(allow_packs=True)
+    entry = _entry(title="Example Series #1-10 (2024)")
+
+    evaluation = search_filer.search_check().evaluate_entry(entry, info)
+
+    assert _reason(evaluation) == "rejected.pack_issue_absent"
+
+
 def test_rss_getcomics_pack_uses_post_id_as_nzbid(monkeypatch):
-    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args: {"valid": True, "issues": []})
+    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args, **_kwargs: {"valid": True, "issues": []})
     info = _info(nzbprov="DDL(GetComics)", tmpprov="DDL(GetComics)", RSS="yes")
 
     evaluation = search_filer.search_check().evaluate_entry(_pack_entry(link=123), info)

--- a/tests/unit/test_search_packs.py
+++ b/tests/unit/test_search_packs.py
@@ -98,6 +98,20 @@ class TestChapterRangePacks:
         assert result["kind"] == "chapter"
         assert result["issues"] == "0-179"
 
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "One Piece c001.5-003.5",
+            "One Piece c1.5-10",
+            "One Piece c1-10.5",
+        ],
+    )
+    def test_fractional_endpoints_are_not_truncated_into_a_wrong_range(self, title):
+        # Truncating "c001.5-003.5" to 1-3 would claim chapter 1, which the
+        # pack does not contain. Range expansion is integer-only, so refuse
+        # the release rather than cover the wrong chapters.
+        assert parse_pack_title(title) is None
+
 
 class TestNonPacks:
     @pytest.mark.parametrize(

--- a/tests/unit/test_search_packs.py
+++ b/tests/unit/test_search_packs.py
@@ -1,0 +1,138 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+import pytest
+
+from comicarr.app.search.packs import parse_pack_title
+
+
+class TestVolumeRangePacks:
+    def test_manga_volume_pack_with_year_range(self):
+        result = parse_pack_title("Solo Leveling v01-14 (2021-2025) (Digital) (1r0n)")
+        assert result == {
+            "series": "Solo Leveling",
+            "issues": "1-14",
+            "kind": "volume",
+            "year": "2021",
+            "booktype": "TPB",
+        }
+
+    def test_vol_dot_spelling(self):
+        result = parse_pack_title("Monster Vol. 1-9 (2014-2016)")
+        assert result["kind"] == "volume"
+        assert result["issues"] == "1-9"
+        assert result["series"] == "Monster"
+
+    def test_volumes_word_spelling(self):
+        result = parse_pack_title("Berserk Volumes 1-41 (Digital)")
+        assert result["kind"] == "volume"
+        assert result["issues"] == "1-41"
+
+    def test_v_to_v_range(self):
+        result = parse_pack_title("Vagabond v1-v37")
+        assert result["kind"] == "volume"
+        assert result["issues"] == "1-37"
+
+    def test_single_volume_is_not_a_pack(self):
+        assert parse_pack_title("Solo Leveling v05 (2022) (Digital)") is None
+
+
+class TestIssueRangePacks:
+    def test_hash_issue_range(self):
+        result = parse_pack_title("Batman #1-10 (2020)")
+        assert result == {
+            "series": "Batman",
+            "issues": "1-10",
+            "kind": "issue",
+            "year": "2020",
+            "booktype": "issue",
+        }
+
+    def test_zero_padded_issue_range(self):
+        result = parse_pack_title("Invincible 001-144 (2003-2018) (digital)")
+        assert result["kind"] == "issue"
+        assert result["issues"] == "1-144"
+        assert result["series"] == "Invincible"
+
+    def test_series_with_number_in_name(self):
+        result = parse_pack_title("Spider-Man 2099 #1-10 (2019)")
+        assert result["series"] == "Spider-Man 2099"
+        assert result["issues"] == "1-10"
+
+    def test_single_issue_is_not_a_pack(self):
+        assert parse_pack_title("Batman #5 (2020)") is None
+        assert parse_pack_title("Example Series 001 (2024)") is None
+
+    def test_ambiguous_short_bare_range_is_not_a_pack(self):
+        # "05-06" is more likely a date fragment than a two-issue pack;
+        # an unmarked range needs at least three issues to be believed.
+        assert parse_pack_title("Example Series 05-06") is None
+
+    def test_marked_short_range_is_still_a_pack(self):
+        assert parse_pack_title("Example Series #5-6")["issues"] == "5-6"
+
+    def test_unmarked_long_range_is_a_pack(self):
+        assert parse_pack_title("Example Series 5-40")["issues"] == "5-40"
+
+
+class TestChapterRangePacks:
+    def test_chapter_range(self):
+        result = parse_pack_title("One Piece c001-100 (Digital)")
+        assert result["kind"] == "chapter"
+        assert result["issues"] == "1-100"
+        assert result["booktype"] == "issue"
+
+    def test_chapters_word_spelling(self):
+        result = parse_pack_title("Naruto Chapters 1-700")
+        assert result["kind"] == "chapter"
+        assert result["issues"] == "1-700"
+
+    def test_chapter_zero_start(self):
+        result = parse_pack_title("Solo Leveling c000-179 (2018-2023)")
+        assert result["kind"] == "chapter"
+        assert result["issues"] == "0-179"
+
+
+class TestNonPacks:
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "Batman (2016-2020)",  # year range in parens only
+            "Batman 1999-2005",  # bare year-to-year range
+            "Batman - Detective Comics 027 (1939)",
+            "2000AD prog 2000 (2016)",
+            "Batman v2 #7 (2012)",  # volume marker + single issue
+            "52 (2006)",
+            "",
+        ],
+    )
+    def test_not_detected_as_pack(self, title):
+        assert parse_pack_title(title) is None
+
+    def test_none_title(self):
+        assert parse_pack_title(None) is None
+
+    def test_reversed_range_rejected(self):
+        assert parse_pack_title("Example 10-1 (2020)") is None
+
+    def test_range_without_series_name_rejected(self):
+        assert parse_pack_title("1-10") is None
+
+    def test_huge_range_rejected(self):
+        assert parse_pack_title("Example 1-5000") is None
+
+
+class TestYearExtraction:
+    def test_year_absent(self):
+        result = parse_pack_title("Berserk Volumes 1-41 (Digital)")
+        assert result["year"] is None
+
+    def test_single_year_after_range(self):
+        result = parse_pack_title("Batman #1-10 (2020)")
+        assert result["year"] == "2020"


### PR DESCRIPTION
Closes #730

## The problem

"Search all missing" hunts every missing issue individually, and pack releases that could satisfy many of them at once get thrown away. The reporter's logs show exactly this: `Solo Leveling v01-14 (2021-2025) (Digital) (1r0n)` comes back from Nyaa during an ordinary per-issue search, gets parsed with no individual issue number, and fails the match.

Almost all the pack machinery already existed and worked — range expansion to IssueIDs, marking every issue in a pack as Snatched, pack post-processing. One line kept it unreachable:

```python
if all(["DDL" in nzbprov, pack is True]):
```

The DDL providers detect packs upstream and hand the matcher a pre-parsed entry. Every other provider supplies only a title, so pack-shaped releases fell into the single-issue parser and died as `rejected.issue_mismatch`.

## The change

A title-only pack detector (`comicarr/app/search/packs.py`) for the non-DDL providers, feeding the pack path that was already there. It recognizes volume ranges (`v01-14`, `Vol. 1-9`, `Volumes 1-41`), chapter ranges (`c001-100`, `Chapters 1-700`), and issue ranges (`#1-10`, `001-144`).

Two safety rules matter more than the detection itself:

- **Volume packs only match volume-tracked series** (manga/TPB/GN/HC). A `v01-14` release can never claim issues 1–14 of an issue-tracked comic.
- **`issue_find_ids` now knows the pack kind.** A volume pack covers every chapter row belonging to its volumes — the reporter's actual case, since Solo Leveling is chapter-tracked — while an issue or chapter pack never claims a volume row.

Detection only runs when the series has *Allow packs* enabled.

For the "avoid unnecessary individual searches" half of the request, one pack grab marks all covered issues Snatched, and non-manual `searchforissue` now returns an explicit `BLOCKED` outcome for already-snatched issues, so queued searches a pack already satisfied terminalise as blocked rather than failed.

## Deliberately out of scope

The issue's step 3 asked for a separate series-level pack query. This PR doesn't add one — detection is opportunistic on the searches already running, which covers the reported symptom. A dedicated query means reworking provider query generation and deserves its own issue if the opportunistic path proves insufficient.

Also worth knowing: pack matching still requires torrent search to be enabled (a pre-existing gate in `NZB_SEARCH`), so usenet-only setups get nothing from this. The changeset says so rather than overclaiming.

## Testing

Full backend suite passes (2660 tests), `npm run lint` clean. New coverage: 28 parser tests, 6 for pack-kind ID expansion, 5 for the matcher path.

A two-axis review (standards + spec) ran against the diff. Three real findings fixed before commit: chapter rows in volume packs, the missing symmetric guard for chapter packs, and a bare-range pattern loose enough to read `Series 05-06` as a pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCGB58u7ECR3D6uBFrwF4p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pack-aware search for multi-issue, chapter, and volume releases.
  * Packs can match missing content, mark covered items as acquired, and prevent redundant searches.
  * Added recognition of labeled and numeric pack ranges, including publication years.

* **Bug Fixes**
  * Improved matching for volume- and chapter-tracked series.
  * Searches now clearly report when content is already downloaded or queued.
  * Invalid, ambiguous, and incompatible pack releases are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->