### PR TITLE
fix: Keep the web UI responsive during grabs and search kickoffs

### DIFF
--- a/.changeset/interactive-grab-nonblocking.md
+++ b/.changeset/interactive-grab-nonblocking.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+The web UI stays responsive while "Override and grab this release" is processing. The grab's revalidation and download-client handoff now run off the server's request loop, so other tabs and pages load normally instead of hanging until the grab finishes or fails. The same fix covers starting an Interactive release search, series "Search all missing", single-issue search, and AI story arc generation. Grabbing a release while another grab is still processing now answers immediately with "Another release grab is already being processed" instead of silently waiting its turn.

--- a/comicarr/app/search/interactive.py
+++ b/comicarr/app/search/interactive.py
@@ -616,8 +616,19 @@ def grab_candidate(
 ):
     """Re-find, revalidate, and journal-handoff one owned release candidate."""
 
-    engine = db.get_engine()
-    with _GRAB_LOCK:
+    # Fail fast instead of queueing: a grab holds the lock for its whole
+    # revalidation + handoff, and each waiter would park a worker thread from
+    # the shared to_thread pool for that duration (#733).
+    if not _GRAB_LOCK.acquire(blocking=False):
+        return {
+            "success": False,
+            "status_code": 409,
+            "status": "blocked",
+            "code": "grab_busy",
+            "error": "Another release grab is already being processed",
+        }
+    try:
+        engine = db.get_engine()
         claim = claim_server_candidate(
             engine,
             session_id=session_id,
@@ -753,3 +764,5 @@ def grab_candidate(
         }
         outcome = finish_candidate_claim(engine, candidate=candidate, state="submitted", outcome=outcome)
         return dict(outcome, success=True, idempotent=False)
+    finally:
+        _GRAB_LOCK.release()

--- a/comicarr/app/search/router.py
+++ b/comicarr/app/search/router.py
@@ -13,6 +13,8 @@ Search domain router — provider search, RSS monitoring.
 Depends on series domain for cross-domain lookups (Phase 5).
 """
 
+import asyncio
+
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
@@ -185,7 +187,10 @@ async def start_interactive_search(
         body = {}
     if not isinstance(body, dict):
         body = {}
-    result = interactive_search.start_search(
+    # Off the event loop: validation hits the DB and provider plan checks
+    # before the collection thread is spawned (#733).
+    result = await asyncio.to_thread(
+        interactive_search.start_search,
         ctx,
         actor=username,
         browser_session=_session_identity(request, username),
@@ -237,7 +242,11 @@ async def grab_interactive_candidate(
     if not isinstance(body, dict):
         body = {}
     try:
-        result = interactive_search.grab_candidate(
+        # Off the event loop: revalidation re-runs a provider search and the
+        # handoff talks to the download client — minutes, not milliseconds.
+        # Running it inline froze every other request (#733).
+        result = await asyncio.to_thread(
+            interactive_search.grab_candidate,
             ctx,
             session_id=session_id,
             candidate_id=candidate_id,

--- a/comicarr/app/series/router.py
+++ b/comicarr/app/series/router.py
@@ -14,6 +14,8 @@ The core domain. Largest route count but well-understood patterns
 established by Phases 1-3 (Phase 4).
 """
 
+import asyncio
+
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
 
@@ -279,7 +281,9 @@ async def search_all_missing(
     if not isinstance(body, dict):
         body = {}
     confirm = bool(body.get("confirm"))
-    result = series_service.search_all_missing(
+    # Off the event loop: durable-run queue handoff is DB-bound (#733).
+    result = await asyncio.to_thread(
+        series_service.search_all_missing,
         ctx,
         comic_id,
         audit_identity=username,
@@ -344,7 +348,9 @@ async def search_one_wanted_issue(
         body = await request.json()
     except Exception:
         body = {}
-    result = series_service.search_wanted_issue(
+    # Off the event loop: durable-run queue handoff is DB-bound (#733).
+    result = await asyncio.to_thread(
+        series_service.search_wanted_issue,
         issue_id,
         username,
         preview_token=(body or {}).get("preview_token"),

--- a/comicarr/app/storyarcs/router.py
+++ b/comicarr/app/storyarcs/router.py
@@ -13,6 +13,8 @@ Story Arcs domain router — arc CRUD, reading list, upcoming endpoints.
 Small, well-bounded, minimal cross-domain dependencies (Phase 3).
 """
 
+import asyncio
+
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse
 
@@ -42,16 +44,17 @@ async def generate_story_arc(request: Request):
             content={"success": False, "error": "Description must be at least 3 characters"},
         )
 
-    # Generate reading order via AI
-    result = story_arcs.generate_reading_order(description)
+    # Off the event loop: AI generation and ComicVine enrichment are
+    # network-bound and would stall every other request (#733).
+    result = await asyncio.to_thread(story_arcs.generate_reading_order, description)
     if not result["success"]:
         return JSONResponse(content=result)
 
     # Enrich with provider data (ComicVine match)
-    issues = story_arcs.enrich_with_providers(result["issues"])
+    issues = await asyncio.to_thread(story_arcs.enrich_with_providers, result["issues"])
 
     # Map against user's library
-    issues = story_arcs.map_to_library(issues)
+    issues = await asyncio.to_thread(story_arcs.map_to_library, issues)
 
     return JSONResponse(content={"success": True, "issues": issues, "description": description})
 
@@ -71,7 +74,8 @@ async def save_generated_arc(request: Request):
             content={"success": False, "error": "arc_name and issues are required"},
         )
 
-    result = story_arcs.save_arc(arc_name, issues)
+    # Off the event loop: the save writes the storyarcs table (#733).
+    result = await asyncio.to_thread(story_arcs.save_arc, arc_name, issues)
     return JSONResponse(content=result)
 
 

--- a/tests/unit/test_interactive_search_api.py
+++ b/tests/unit/test_interactive_search_api.py
@@ -9,6 +9,7 @@
 
 """Collection and polling contracts for issue-scoped Interactive search."""
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -195,6 +196,73 @@ def test_grab_endpoint_binds_owner_and_explicit_override(api_client, monkeypatch
         "browser_session": "browser-cookie",
         "override": True,
     }
+
+
+def test_grab_returns_busy_instead_of_waiting_on_a_concurrent_grab():
+    acquired = interactive._GRAB_LOCK.acquire(blocking=False)
+    assert acquired, "test requires the grab lock to be free"
+    try:
+        result = interactive.grab_candidate(
+            None,
+            session_id="session-1",
+            candidate_id="candidate-1",
+            actor="alice",
+            browser_session="browser-cookie",
+        )
+    finally:
+        interactive._GRAB_LOCK.release()
+
+    assert result == {
+        "success": False,
+        "status_code": 409,
+        "status": "blocked",
+        "code": "grab_busy",
+        "error": "Another release grab is already being processed",
+    }
+
+
+def _record_event_loop_presence(observed):
+    try:
+        asyncio.get_running_loop()
+        observed["on_event_loop"] = True
+    except RuntimeError:
+        observed["on_event_loop"] = False
+
+
+def test_grab_endpoint_runs_service_off_the_event_loop(api_client, monkeypatch):
+    observed = {}
+
+    def grab(_ctx, **_kwargs):
+        _record_event_loop_presence(observed)
+        return {"success": True, "status": "submitted"}
+
+    monkeypatch.setattr(interactive, "grab_candidate", grab)
+
+    response = api_client.post(
+        "/api/search/interactive/session-1/candidates/candidate-1/grab",
+        json={},
+    )
+
+    assert response.status_code == 200
+    assert observed["on_event_loop"] is False
+
+
+def test_start_endpoint_runs_service_off_the_event_loop(api_client, monkeypatch):
+    observed = {}
+
+    def start(_ctx, **_kwargs):
+        _record_event_loop_presence(observed)
+        return {"success": True, "session_id": "opaque", "state": "queued"}
+
+    monkeypatch.setattr(interactive, "start_search", start)
+
+    response = api_client.post(
+        "/api/search/interactive",
+        json={"entity_type": "issue", "entity_id": "issue-1"},
+    )
+
+    assert response.status_code == 202
+    assert observed["on_event_loop"] is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_router_event_loop.py
+++ b/tests/unit/test_router_event_loop.py
@@ -1,0 +1,110 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Async routes must dispatch blocking service work off the event loop (#733)."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from comicarr.app.core.context import AppContext, get_context
+from comicarr.app.core.security import require_session
+from comicarr.app.series import service as series_service
+from comicarr.app.series.router import router as series_router
+from comicarr.app.storyarcs.router import router as storyarcs_router
+
+
+def _on_event_loop():
+    try:
+        asyncio.get_running_loop()
+        return True
+    except RuntimeError:
+        return False
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(series_router)
+    app.include_router(storyarcs_router)
+    app.dependency_overrides[require_session] = lambda: "alice"
+    app.dependency_overrides[get_context] = lambda: AppContext(config=SimpleNamespace())
+    return TestClient(app)
+
+
+def test_search_all_missing_runs_service_off_the_event_loop(client, monkeypatch):
+    observed = {}
+
+    def search_all_missing(_ctx, _comic_id, **_kwargs):
+        observed["on_event_loop"] = _on_event_loop()
+        return {"success": True, "run_id": "run-1"}
+
+    monkeypatch.setattr(series_service, "search_all_missing", search_all_missing)
+
+    response = client.post("/api/series/123/search-missing", json={"confirm": True})
+
+    assert response.status_code == 200
+    assert observed["on_event_loop"] is False
+
+
+def test_search_one_wanted_issue_runs_service_off_the_event_loop(client, monkeypatch):
+    observed = {}
+
+    def search_wanted_issue(_issue_id, _actor, **_kwargs):
+        observed["on_event_loop"] = _on_event_loop()
+        return {"success": True, "run_id": "run-1"}
+
+    monkeypatch.setattr(series_service, "search_wanted_issue", search_wanted_issue)
+
+    response = client.post("/api/series/issues/456/search", json={})
+
+    assert response.status_code == 200
+    assert observed["on_event_loop"] is False
+
+
+def test_generate_story_arc_runs_ai_pipeline_off_the_event_loop(client, monkeypatch):
+    from comicarr.app.ai import story_arcs
+
+    observed = {}
+
+    def generate_reading_order(_description):
+        observed["on_event_loop"] = _on_event_loop()
+        return {"success": True, "issues": [{"series": "X-Men", "issue": "1"}]}
+
+    monkeypatch.setattr(story_arcs, "generate_reading_order", generate_reading_order)
+    monkeypatch.setattr(story_arcs, "enrich_with_providers", lambda issues: issues)
+    monkeypatch.setattr(story_arcs, "map_to_library", lambda issues: issues)
+
+    response = client.post("/api/storyarcs/generate", json={"description": "Dark Phoenix Saga"})
+
+    assert response.status_code == 200
+    assert observed["on_event_loop"] is False
+
+
+def test_save_generated_arc_runs_service_off_the_event_loop(client, monkeypatch):
+    from comicarr.app.ai import story_arcs
+
+    observed = {}
+
+    def save_arc(_arc_name, _issues):
+        observed["on_event_loop"] = _on_event_loop()
+        return {"success": True}
+
+    monkeypatch.setattr(story_arcs, "save_arc", save_arc)
+
+    response = client.post(
+        "/api/storyarcs/generate/save",
+        json={"arc_name": "Dark Phoenix Saga", "issues": [{"series": "X-Men", "issue": "1"}]},
+    )
+
+    assert response.status_code == 200
+    assert observed["on_event_loop"] is False


### PR DESCRIPTION
## Summary

Fixes #733 — the whole web UI froze while "Override and grab this release" was processing.

Several `async def` routes ran synchronous service work inline on uvicorn's event loop, so one slow request stalled every other request:

- **Interactive grab** (`POST /api/search/interactive/.../grab`) — provider revalidation plus download-client handoff, the reported symptom
- **Interactive search start** (`POST /api/search/interactive`) — DB and provider-plan validation before the collection thread spawns
- **Series "Search all missing"** and **single-issue search** — durable-run queue handoff, DB-bound
- **AI story arc generate/save** — AI and ComicVine network calls

All now dispatch through `await asyncio.to_thread(...)`, matching the established pattern in `comicarr/app/system/router.py`.

Additionally, `_GRAB_LOCK` in `grab_candidate` now acquires with `blocking=False`: a grab arriving while another is still processing answers immediately with 409 `grab_busy` instead of parking a worker thread from the shared `to_thread` pool for the duration. The lock releases in a `finally`, so every return and exception path frees it.

## Tests

- New `tests/unit/test_router_event_loop.py`: four route-level tests asserting the series and storyarcs service calls execute off the event-loop thread
- `tests/unit/test_interactive_search_api.py`: off-loop assertions for grab and search start, plus the `grab_busy` fail-fast contract
- All written red-first; full unit suite passes (2664) and `npm run lint` is clean

## Notes

- The ai router's chat routes are streaming-native and untouched
- Patch changeset included; the 409-instead-of-wait behavior is operator-visible and called out there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W83a6PEjnejKwKThatDvzj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness during interactive searches, missing-issue searches, wanted-issue searches, and story arc generation.
  * Concurrent release grabs now return immediately with a clear “already processing” message instead of waiting.
* **Tests**
  * Added coverage for concurrent grab handling and background processing.
  * Added tests confirming search and story arc operations remain responsive while running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->