### PR TITLE
fix: Require library placement evidence before recovery marks imports done

### DIFF
--- a/.changeset/recovery-placement-evidence.md
+++ b/.changeset/recovery-placement-evidence.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Startup recovery no longer reports *import / succeeded* for downloads that were never actually moved into the library. Previously, recovery could trust old download-history state as proof of completion and mark an item post-processed without running file placement, leaving the files stranded in the download directory while activity claimed a successful import. Recovery now also checks the library itself (the issue's stored location or Downloaded status) before closing an item out. When the download really did finish but was never imported, recovery re-runs the import if it can resolve the completed folder; otherwise the item lands in Needs attention as "download finished but was never imported into the library", with the files still in the download directory ready for a manual import.

--- a/comicarr/app/attention/_policy.py
+++ b/comicarr/app/attention/_policy.py
@@ -35,6 +35,7 @@ REASON_PHRASES = {
     "torrent_artifact_state_persistence_error": "could not save download state (torrent)",
     "nzb_artifact_state_persistence_error": "could not save download state (NZB)",
     "reserved_without_persisted_acceptance": "download reserved but never fully accepted",
+    "done_signal_without_library_placement": "download finished but was never imported into the library",
     "route_acceptance_missing_identity": "the downloader accepted it without identifying it",
     "submission_outcome_unknown": "submission result unknown — check the downloader",
     "route_not_restart_safe": "this route can't resume after a restart",

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -811,14 +811,30 @@ def _resolve_row(snapshot_row, probes=None, pp_cap=None):
         return "downloaded-pp-enqueued"
 
     # --- authoritative done-check (history-eviction safe) -----------------
+    # #734: a done-signal (Status/nzblog) proves only that the DOWNLOAD
+    # finished. mark_done advances to `post_processed` — which activity
+    # renders as "import / succeeded" — so it additionally requires library
+    # placement evidence (Location / Downloaded status written by a real
+    # import). Without it, fall through to classification so the import can
+    # be re-driven (probe may still resolve the completed folder) instead of
+    # silently stranding the files in the download directory.
+    done_without_placement = False
     if recovery_classify.has_done_signal(row):
-        logger.info("[RECOVERY] %s authoritatively done (Status/nzblog) — mark_done, skip." % rkey)
-        journal.mark_done(
-            rkey,
-            issueid=row.get("issueid"),
-            provider=row.get("provider"),
+        if recovery_classify.has_library_placement(row, payload=payload):
+            logger.info("[RECOVERY] %s authoritatively done (Status/nzblog) — mark_done, skip." % rkey)
+            journal.mark_done(
+                rkey,
+                issueid=row.get("issueid"),
+                provider=row.get("provider"),
+            )
+            return "done-check"
+        done_without_placement = True
+        logger.warn(
+            "[RECOVERY] %s has a done-signal (Status/nzblog) but NO library "
+            "placement evidence — download complete is not import complete "
+            "(#734); NOT marking post_processed. Classifying so the import "
+            "can be re-driven." % rkey
         )
-        return "done-check"
 
     # --- per-downloader classification (U5) -------------------------------
     # classify_details keeps historycheck location/name/failed. classify()
@@ -831,6 +847,31 @@ def _resolve_row(snapshot_row, probes=None, pp_cap=None):
         return "gone-failed"
 
     if verdict == recovery_classify.UNKNOWN:
+        if done_without_placement:
+            # The downloader says it is done with this item but the library
+            # never received it, and no probe can resolve where the files
+            # landed (a reconstructed payload has no client id). Leaving it
+            # UNKNOWN would re-loop every start with no owner; quarantine so
+            # the operator sees needs_attention (files remain in the download
+            # directory, importable via manual PP) instead of a false
+            # import/succeeded (#734).
+            record(
+                ManualReview(
+                    release_key=rkey,
+                    reason="done_signal_without_library_placement",
+                    payload=payload,
+                    issue_id=row.get("issueid"),
+                    provider=row.get("provider"),
+                    downloader_type=row.get("downloader_type"),
+                    nzb_name=row.get("nzbname") or (payload or {}).get("nzbname") or (payload or {}).get("nzb_name"),
+                )
+            )
+            logger.warn(
+                "[RECOVERY] %s -> MANUAL REVIEW (download reported done but "
+                "never imported and the completed folder is unresolvable); "
+                "files remain in the download directory (#734)." % rkey
+            )
+            return "done-unplaced-manual-review"
         logger.warn(
             "[RECOVERY] %s -> UNKNOWN (transient downloader outage) — stage "
             "left UNCHANGED, reclassified next start." % rkey

--- a/comicarr/app/downloads/recovery_classify.py
+++ b/comicarr/app/downloads/recovery_classify.py
@@ -41,7 +41,7 @@ import comicarr
 from comicarr import db, logger
 from comicarr.app.attention import Failure, record
 from comicarr.app.downloads import journal
-from comicarr.tables import ddl_info, issues, nzblog
+from comicarr.tables import annuals, ddl_info, issues, nzblog, storyarcs
 
 # ---------------------------------------------------------------------------
 # Verdict enum
@@ -151,6 +151,59 @@ def _nzblog_present(issueid, provider, story_arc=None):
     except Exception as e:
         logger.warn("[RECOVERY-CLASSIFY] nzblog lookup failed for %s: %s" % (issueid, e))
         return None
+
+
+_PLACED_STATUSES = ("Downloaded", "Post-Processed")
+
+
+def _row_shows_placement(rec):
+    if rec is None:
+        return False
+    if (rec["Status"] or "") in _PLACED_STATUSES:
+        return True
+    return bool(str(rec["Location"] or "").strip())
+
+
+def has_library_placement(row, payload=None):
+    """True iff the LIBRARY itself shows the import happened for this
+    obligation (#734). A done-signal (nzblog absent / snatched history) only
+    proves the DOWNLOAD finished; successful placement additionally writes
+    Location + Status='Downloaded' onto the issues/annuals row (postprocessor
+    ~3214/4052/4458) or Status='Downloaded' onto the storyarcs row
+    (updater.foundsearch). Absent that evidence, "download complete" must not
+    be conflated with "import complete".
+
+    Arc scoping mirrors has_done_signal: payload["mode"]=="story_arc" means
+    row.issueid is the IssueArcID and the storyarcs row is the authority.
+    When mode is absent (e.g. a reconstructed anchor payload), check
+    storyarcs first, then issues/annuals — evidence on any matching row
+    counts. A lookup failure returns False (never fabricate placement)."""
+    row = row or {}
+    issueid = row.get("issueid")
+    if issueid is None:
+        return False
+    if payload is None:
+        payload = journal.load_payload(row.get("payload_json"))
+    story_arc = None
+    if isinstance(payload, dict) and "mode" in payload:
+        story_arc = payload.get("mode") == "story_arc"
+    try:
+        if story_arc is not False:
+            rec = db.select_one(
+                select(storyarcs.c.Status, storyarcs.c.Location).where(storyarcs.c.IssueArcID == str(issueid))
+            )
+            if _row_shows_placement(rec):
+                return True
+            if story_arc is True:
+                return False
+        for table in (issues, annuals):
+            rec = db.select_one(select(table.c.Status, table.c.Location).where(table.c.IssueID == str(issueid)))
+            if _row_shows_placement(rec):
+                return True
+    except Exception as e:
+        logger.warn("[RECOVERY-CLASSIFY] library placement lookup failed for %s: %s" % (issueid, e))
+        return False
+    return False
 
 
 def has_done_signal(row):

--- a/tests/unit/test_band_actionability.py
+++ b/tests/unit/test_band_actionability.py
@@ -49,9 +49,9 @@ def _journal(**overrides):
     return base
 
 
-def test_registry_covers_exactly_twenty_two_bases():
-    assert len(reasons.KNOWN_BASE_TOKENS) == 22
-    assert len(reasons.REASON_PHRASES) == 14
+def test_registry_covers_exactly_twenty_three_bases():
+    assert len(reasons.KNOWN_BASE_TOKENS) == 23
+    assert len(reasons.REASON_PHRASES) == 15
     assert len(reasons.NON_ACTIONABLE_FLAT) == 7
     assert len(reasons.NON_ACTIONABLE_COMPOSITE) == 1
     # Every exclusion has a reconciliation obligation; no admitted token is excluded.

--- a/tests/unit/test_recovery_classify.py
+++ b/tests/unit/test_recovery_classify.py
@@ -443,3 +443,74 @@ def test_sab_real_historycheck_status_false_is_absent_then_gone():
     )
     with patch("comicarr.sabnzbd.SABnzbd.historycheck", return_value={"status": False}):
         assert recovery_classify.classify(row) == recovery_classify.GONE
+
+
+# ---------------------------------------------------------------------------
+# has_library_placement — the import-evidence cross-check (#734). A done-signal
+# proves the DOWNLOAD finished; only the library row (Location / a
+# Downloaded/Post-Processed status written by successful placement) proves the
+# IMPORT happened.
+# ---------------------------------------------------------------------------
+
+
+def test_placement_false_when_no_library_row_exists():
+    row = _insert_journal("P1|nzb.su|n", journal.SNATCHED, issueid="P1", provider="nzb.su", downloader_type="nzb")
+    assert recovery_classify.has_library_placement(row) is False
+
+
+def test_placement_false_for_snatched_issue_without_location():
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="P2", Status="Snatched", Location=None))
+    row = _insert_journal("P2|nzb.su|n", journal.SNATCHED, issueid="P2", provider="nzb.su", downloader_type="nzb")
+    assert recovery_classify.has_library_placement(row) is False
+
+
+def test_placement_true_when_issue_has_location():
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="P3", Status="Snatched", Location="Spawn 344 (2024).cbz"))
+    row = _insert_journal("P3|nzb.su|n", journal.SNATCHED, issueid="P3", provider="nzb.su", downloader_type="nzb")
+    assert recovery_classify.has_library_placement(row) is True
+
+
+def test_placement_true_when_issue_status_downloaded_or_post_processed():
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="P4", Status="Downloaded"))
+        conn.execute(issues.insert().values(IssueID="P5", Status="Post-Processed"))
+    row4 = _insert_journal("P4|nzb.su|n", journal.SNATCHED, issueid="P4", provider="nzb.su", downloader_type="nzb")
+    row5 = _insert_journal("P5|nzb.su|n", journal.SNATCHED, issueid="P5", provider="nzb.su", downloader_type="nzb")
+    assert recovery_classify.has_library_placement(row4) is True
+    assert recovery_classify.has_library_placement(row5) is True
+
+
+def test_placement_true_for_annual_with_location():
+    from comicarr.tables import annuals
+
+    with get_engine().begin() as conn:
+        conn.execute(annuals.insert().values(IssueID="P6", Status="Snatched", Location="Ann 2024.cbz"))
+    row = _insert_journal("P6|nzb.su|n", journal.SNATCHED, issueid="P6", provider="nzb.su", downloader_type="nzb")
+    assert recovery_classify.has_library_placement(row) is True
+
+
+def test_placement_for_story_arc_obligation_uses_storyarcs_row():
+    from comicarr.tables import storyarcs
+
+    with get_engine().begin() as conn:
+        conn.execute(storyarcs.insert().values(IssueArcID="P7", StoryArc="Arc", Status="Downloaded"))
+    placed = _insert_journal(
+        "P7|nzb.su|n",
+        journal.SNATCHED,
+        issueid="P7",
+        provider="nzb.su",
+        downloader_type="nzb",
+        payload={"mode": "story_arc"},
+    )
+    assert recovery_classify.has_library_placement(placed) is True
+    unplaced = _insert_journal(
+        "P8|nzb.su|n",
+        journal.SNATCHED,
+        issueid="P8",
+        provider="nzb.su",
+        downloader_type="nzb",
+        payload={"mode": "story_arc"},
+    )
+    assert recovery_classify.has_library_placement(unplaced) is False

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -1252,3 +1252,116 @@ def test_plain_issue_finalize_does_not_delete_unrelated_arc_S_row(queues, monkey
         arc = conn.execute(select(nzblog).where(nzblog.c.IssueID == "S302")).fetchall()
     assert plain == [], "the plain issue's own nzblog row must still be deleted"
     assert len(arc) == 1, "the UNRELATED arc's S302 row must NOT be deleted by a plain finalize"
+
+
+# ===========================================================================
+# #734 — a done-signal proves the DOWNLOAD finished, not that the IMPORT ran.
+# Recovery must never advance a row to `post_processed` (=> activity
+# "import / succeeded") without library placement evidence.
+# ===========================================================================
+
+
+def _issue_row(issueid, status="Snatched", location=None):
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID=issueid, ComicID="C%s" % issueid, Status=status, Location=location))
+
+
+def test_done_signal_without_placement_is_not_marked_post_processed(queues):
+    """#734 repro: reconstructed snatched row, nzblog ABSENT (done-signal),
+    but the issue row is still Snatched with no Location — no import ever
+    ran. The downloader cannot be probed (reconstructed payload has no
+    client id). The row must NOT become `post_processed`; it must be
+    quarantined to manual_review so the operator sees needs_attention
+    instead of a false import/succeeded."""
+    rkey = journal.release_key("734", "nzb.su", nzbname="Ghosted.001.cbz")
+    _issue_row("734")
+    _insert_journal(
+        rkey,
+        journal.SNATCHED,
+        payload={"issueid": "734", "provider": "nzb.su", "nzbname": "Ghosted.001.cbz"},
+        issueid="734",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    summary = recovery.replay_pipeline(probes=_probe("unreachable"))
+
+    row = _journal_row(rkey)
+    assert row["stage"] != journal.POST_PROCESSED, "#734: no placement evidence => never post_processed"
+    assert row["stage"] == journal.MANUAL_REVIEW
+    assert str(row["fail_reason"] or "").startswith("done_signal_without_library_placement")
+    assert _drain(queues["pp"]) == []
+    assert summary["actions"].get("done-check") is None
+
+
+def test_done_signal_without_placement_redrives_import_when_probe_resolves_folder(queues):
+    """When the downloader history is still available and resolves the
+    completed folder, the unplaced row falls through to classification and
+    is re-driven through PP (real import) instead of being marked done."""
+    rkey = journal.release_key("735", "nzb.su", nzbname="Ghosted.002.cbz")
+    _issue_row("735")
+    _insert_journal(
+        rkey,
+        journal.SNATCHED,
+        payload={"issueid": "735", "provider": "nzb.su", "nzbname": "Ghosted.002.cbz"},
+        issueid="735",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    probes = _probe({"status": True, "location": "/downloads/Ghosted.002", "name": "Ghosted.002.cbz"})
+    recovery.replay_pipeline(probes=probes)
+
+    row = _journal_row(rkey)
+    assert row["stage"] == journal.DOWNLOADED, "#734: unplaced done-signal row is re-driven, not marked done"
+    items = _drain(queues["pp"])
+    assert len(items) == 1
+    assert items[0]["nzb_folder"] == "/downloads/Ghosted.002"
+    assert items[0]["journal_release_key"] == rkey
+
+
+def test_done_signal_with_placement_evidence_still_marks_done(queues):
+    """The history-eviction guard is preserved: nzblog absent AND the issue
+    row shows the import happened (Location written by placement) => the
+    done-check marks the journal terminal without re-importing."""
+    rkey = journal.release_key("736", "nzb.su", nzbname="Ghosted.003.cbz")
+    _issue_row("736", status="Downloaded", location="Ghosted 003 (2026).cbz")
+    _insert_journal(
+        rkey,
+        journal.SNATCHED,
+        payload={"issueid": "736", "provider": "nzb.su", "nzbname": "Ghosted.003.cbz"},
+        issueid="736",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    summary = recovery.replay_pipeline(probes=_probe("absent"))
+
+    assert _journal_row(rkey)["stage"] == journal.POST_PROCESSED
+    assert summary["actions"].get("done-check") == 1
+    assert _drain(queues["pp"]) == []
+
+
+def test_done_signal_without_placement_absent_probe_enqueues_pp_not_done(queues):
+    """Downloader history evicted (probe absent) + done-signal + NO placement:
+    the cross-check inside classification still yields COMPLETE (never GONE),
+    so the row advances to `downloaded` and is handed to the PP worker —
+    whose validation owns the missing-folder quarantine. It must not be
+    marked post_processed by the done-check."""
+    rkey = journal.release_key("737", "nzb.su", nzbname="Ghosted.004.cbz")
+    _issue_row("737")
+    _insert_journal(
+        rkey,
+        journal.SNATCHED,
+        payload={"issueid": "737", "provider": "nzb.su", "nzbname": "Ghosted.004.cbz"},
+        issueid="737",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    summary = recovery.replay_pipeline(probes=_probe("absent"))
+
+    row = _journal_row(rkey)
+    assert row["stage"] == journal.DOWNLOADED
+    assert summary["actions"].get("done-check") is None
+    assert len(_drain(queues["pp"])) == 1


### PR DESCRIPTION
## Summary

Closes #734.

Startup recovery's authoritative done-check trusted a Status/nzblog done-signal alone and called `mark_done`, advancing the journal straight to `post_processed` — which activity renders as *import / succeeded* — even when file placement never ran and the files were still sitting in the download directory.

A done-signal only proves the **download** finished. This PR makes recovery also require **library placement evidence** before closing an item out:

- New `recovery_classify.has_library_placement()` checks what a real import actually writes: a `Location` or `Downloaded`/`Post-Processed` status on the issues/annuals/storyarcs row (same story-arc scoping the module already uses). A lookup failure returns False — placement is never fabricated.
- The done-check in `recovery._resolve_row` now requires the done-signal **and** placement evidence to `mark_done`. Without evidence it falls through to classification:
  - probe resolves the completed folder → the import is re-driven through the normal PP path (issue's expected behavior, option 1);
  - probe can't answer (UNKNOWN) → the row is quarantined to `manual_review` with the new `done_signal_without_library_placement` reason, so the operator sees *needs attention* with the files still importable from the download directory (option 2);
  - probe says absent (history evicted) → COMPLETE as before (never GONE), handed to the PP worker whose validation owns the missing-folder quarantine.
- The new reason token is registered in the attention policy (`lint:guards` passes) and the fix carries an operator-facing patch changeset.

Deliberate trade-offs: placement evidence is issue-level (a re-snatch of a previously-imported issue can still resolve as done on the old file's evidence — strictly better than before), and `Post-Processed` status stays valid evidence to preserve the existing AE2 recovery contract; the actual #734 state (`Snatched`, no `Location`) is blocked.

## Testing

- 10 new tests: 6 placement-evidence unit tests (`test_recovery_classify.py`) and 4 replay scenarios including the #734 repro (`test_recovery_replay.py`)
- Full unit suite: 2667 passed; only pre-existing failures remain in `tests/integration/test_schema_migration_dialects.py` (fail on a clean tree too)
- `npm run lint` fully green (modern, guards, backend, generated, frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCE2x3aKz9qB1kTWj1itX3