### PR TITLE
chore: Add FUNDING.yml with GitHub Sponsors and Ko-fi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [frankieramirez]
+ko_fi: frankieramirez


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the repo shows a Sponsor button linking to GitHub Sponsors (frankieramirez) and Ko-fi.

No changeset: repo metadata only, no operator-visible behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvQRHwzWBHFNTtKLPCNKKX