### PR TITLE
fix: Rename changesets/action inputs after action upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,9 @@ jobs:
         id: changesets
         uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v1
         with:
-          version: npm run version-packages
-          title: Version Packages
-          commit: 'chore: version packages'
+          version-script: npm run version-packages
+          pr-title: Version Packages
+          commit-message: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The pinned `changesets/action` version renamed its inputs, and the old names now hard-fail instead of warning:

- `version` → `version-script`
- `title` → `pr-title`
- `commit` → `commit-message`

This broke the Release workflow on every push to `main` (first seen on run #346), which blocks the Version Packages PR from being created. This PR updates `release.yml` to the new input names.

No changeset: CI/tooling-only change, not operator-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvQRHwzWBHFNTtKLPCNKKX