### PR TITLE
fix: Use renamed has-changesets output from changesets/action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Prepare GitHub release
         id: prepare
-        if: steps.changesets.outputs.hasChangesets == 'false'
+        if: steps.changesets.outputs['has-changesets'] == 'false'
         run: npm run prepare-github-release
 
       - name: Create GitHub release


### PR DESCRIPTION
Follow-up to #738: the same `changesets/action` revamp that renamed the inputs also kebab-cased the outputs (`hasChangesets` → `has-changesets`, per its `action.yml`). The old name evaluates to empty, so the `Prepare GitHub release` step was skipped after merging Version Packages #739 and the v0.34.0 release was never cut.

Uses bracket syntax (`outputs['has-changesets']`) since hyphenated names can't be dot-accessed in Actions expressions.

Merging this should also cut the stranded v0.34.0 release: the Release run on the merge push will see no pending changesets, `has-changesets` will now correctly read `'false'`, and the prepare step will pick up the 0.34.0 version already on `main`.

No changeset: CI/tooling-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvQRHwzWBHFNTtKLPCNKKX