### PR TITLE
fix: Stop quarantining every NZBGet download on provider label mismatch

### DIFF
--- a/.changeset/nzb-provider-quarantine.md
+++ b/.changeset/nzb-provider-quarantine.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Usenet downloads are no longer quarantined at completion with "immutable_payload_conflict:provider". The download pipeline recorded the provider two different ways for the same download — as "DrunkenSlug (newznab)" when the release was grabbed and as plain "DrunkenSlug" when the download finished — so the safety check that guards against a download changing identity mid-flight fired on every completed NZBGet download, sending it to Needs attention instead of importing it. Both spellings now resolve to the same provider, and existing pipeline records written under the old spelling are reconciled automatically on the next startup.

--- a/comicarr/app/downloads/journal.py
+++ b/comicarr/app/downloads/journal.py
@@ -161,13 +161,18 @@ def normalize_provider(provider):
     The snatch seam passes an RSS-stripped `tmpprov` (search.py:1678/1694) or a
     raw `nzbprov`; the downloaded seam reads `download_info['provider']` (the
     raw `nzbprov`); anchor reconstruction reads `snatched.Provider`. These can
-    differ by an `[RSS]` suffix, surrounding whitespace, or case. Stripping the
-    `[RSS]` marker, collapsing whitespace and lowercasing makes the four seams
-    converge on one token. None/empty normalizes to "" (stable)."""
+    differ by an `[RSS]` suffix, a `(newznab)`/`(torznab)` type-label suffix
+    (search.py's `tmpprov` carries it, the raw `nzbprov` does not — #745),
+    surrounding whitespace, or case. Stripping the `[RSS]` marker and the
+    trailing type label, collapsing whitespace and lowercasing makes the four
+    seams converge on one token. None/empty normalizes to "" (stable)."""
     if provider is None:
         return ""
     p = str(provider)
     p = re.sub(r"\[RSS\]", "", p, flags=re.IGNORECASE)
+    # `+` so a provider literally NAMED "Foo (newznab)" converges with its own
+    # tmpprov form "Foo (newznab) (newznab)" instead of drifting by one label.
+    p = re.sub(r"(\s*\((?:newznab|torznab)\))+\s*$", "", p, flags=re.IGNORECASE)
     p = re.sub(r"\s+", " ", p).strip()
     return p.lower()
 
@@ -968,6 +973,68 @@ def read_one(release_key):
     """Cheap point lookup of a single journal row by release_key (used by the
     U6 replay snapshot-then-recheck), or None."""
     return db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == release_key))
+
+
+def migrate_release_key_provider_format():
+    """One-shot #745 key-format reconciliation (idempotent, safe every boot).
+
+    normalize_provider now strips the trailing `(newznab)`/`(torznab)` type
+    label, so keys derived BEFORE the fix (snatch seam passed the labelled
+    `tmpprov`) no longer reproduce from the same durable inputs: anchor
+    reconstruction and the downloaded-seam fallback would re-derive the new
+    form, miss the existing row, and either duplicate or re-drive an
+    obligation that already advanced. Rewrite the provider segment of every
+    stored key (terminal rows included — read_one on a terminal row is what
+    stops a re-drive) through the current normalizer.
+
+    A collision (old-form and new-form rows both present) is left alone and
+    logged loudly — never silently coalesced. Post-fix derivations cannot
+    produce a labelled segment, so after the first pass this is a no-op scan.
+
+    Returns the number of rewritten rows.
+    """
+    try:
+        rows = db.select_all(select(pipeline_journal.c.release_key))
+    except Exception as e:
+        logger.error("[JOURNAL] #745 key migration could not read journal rows: %s" % type(e).__name__)
+        return 0
+    renames = []
+    for row in rows:
+        key = row.get("release_key") or ""
+        parts = key.split("|")
+        if len(parts) < 2:
+            continue
+        new_prov = normalize_provider(parts[1])
+        if new_prov == parts[1]:
+            continue
+        renames.append((key, "|".join([parts[0], new_prov] + parts[2:])))
+    migrated = 0
+    for old_key, new_key in renames:
+        try:
+            with db.get_engine().begin() as conn:
+                collision = conn.execute(
+                    select(pipeline_journal.c.release_key).where(pipeline_journal.c.release_key == new_key)
+                ).fetchone()
+                if collision is not None:
+                    logger.warn(
+                        "[JOURNAL] #745 key migration collision: %r already exists — "
+                        "leaving %r unmigrated (operator attention may be required)." % (new_key, old_key)
+                    )
+                    continue
+                result = conn.execute(
+                    update(pipeline_journal)
+                    .where(pipeline_journal.c.release_key == old_key)
+                    .values(release_key=new_key)
+                )
+                migrated += int(bool(result.rowcount))
+        except Exception as e:
+            logger.error(
+                "[JOURNAL] #745 key migration failed for %r — SKIPPED (resumable next start): %s"
+                % (old_key, type(e).__name__)
+            )
+    if migrated:
+        logger.info("[JOURNAL] #745 key migration rewrote %d journal release_key(s)." % migrated)
+    return migrated
 
 
 def stamp_resolution(release_key, status, *, increment_retry=False, conn=None):

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -972,6 +972,7 @@ def replay_pipeline(probes=None):
     Returns a small summary dict (counts) for logging/tests.
     """
     summary = {
+        "key_migration": 0,
         "reconstructed": 0,
         "legacy_ddl_review": 0,
         "band_reconcile": None,
@@ -985,6 +986,15 @@ def replay_pipeline(probes=None):
         return summary
 
     logger.info("[RECOVERY] Startup recovery replay starting (post-start, lock-free).")
+
+    # #745: converge pre-fix `(newznab)`/`(torznab)`-labelled release_keys onto
+    # the current normalize_provider derivation BEFORE anchor reconstruction —
+    # reconstruction re-derives keys from snatched.Provider and would otherwise
+    # miss (and duplicate) every pre-fix row. Idempotent; safe every boot.
+    try:
+        summary["key_migration"] = journal.migrate_release_key_provider_format()
+    except Exception as e:
+        logger.error("[RECOVERY] #745 key-format migration failed; continuing: %s" % type(e).__name__)
 
     try:
         summary["legacy_ddl_review"] = _reconcile_legacy_ddl_downloading()

--- a/tests/unit/test_pipeline_journal.py
+++ b/tests/unit/test_pipeline_journal.py
@@ -446,6 +446,47 @@ def test_provider_normalization_converges_seam_variants():
     assert journal.release_key("99", "nzb.su[RSS]") == base
 
 
+def test_provider_normalization_strips_type_label_suffix():
+    # #745: the snatch seam writes search.py's tmpprov ("Name (newznab)"),
+    # the downloaded seam writes the raw nzbprov ("Name"). Both must converge
+    # on ONE token for the key AND the immutable-field conflict comparison.
+    base = journal.release_key("99", "DrunkenSlug")
+    assert journal.release_key("99", "DrunkenSlug (newznab)") == base
+    assert journal.release_key("99", "DrunkenSlug (torznab)") == base
+    assert journal.release_key("99", "DrunkenSlug (newznab) [RSS]") == base
+    # A provider literally NAMED with a label converges with its own tmpprov.
+    named = journal.release_key("99", "Foo (newznab)")
+    assert journal.release_key("99", "Foo (newznab) (newznab)") == named
+    assert named == journal.release_key("99", "Foo")
+    # The label is only stripped as a trailing suffix, never mid-name.
+    assert journal.normalize_provider("newznab mirror") == "newznab mirror"
+
+
+def test_labelled_snatch_then_bare_downloaded_does_not_quarantine():
+    # #745 regression: snatch-time provider carries the "(newznab)" label,
+    # completion-time provider is the bare name; the row must ADVANCE, not
+    # quarantine with immutable_payload_conflict:provider.
+    key = journal.release_key("1099461", "DrunkenSlug (newznab)")
+    journal.record_transition(
+        key,
+        journal.SNATCHED,
+        payload={"issueid": "1099461", "provider": "DrunkenSlug (newznab)"},
+        issueid="1099461",
+        provider="DrunkenSlug (newznab)",
+    )
+    won = journal.record_transition(
+        key,
+        journal.DOWNLOADED,
+        payload={"issueid": "1099461", "provider": "DrunkenSlug"},
+        issueid="1099461",
+        provider="DrunkenSlug",
+    )
+    assert won is True
+    row = _row(key)
+    assert row["stage"] == journal.DOWNLOADED
+    assert row["fail_reason"] is None
+
+
 def test_oneoff_release_key_reproducible_across_two_builds():
     # Synthetic HIGHCOUNT issueid differs across restart, but a stable
     # discriminant (downloader id) reproduces the same key.
@@ -844,3 +885,52 @@ def test_is_terminal_predicate():
     assert journal.is_terminal(journal.FAILED) is True
     assert journal.is_terminal(journal.SNATCHED) is False
     assert journal.is_terminal(journal.MOVED) is False
+
+
+# ---------------------------------------------------------------------------
+# #745 release_key provider-format migration
+# ---------------------------------------------------------------------------
+
+
+def test_key_migration_rewrites_labelled_provider_segment():
+    # Pre-fix rows keyed with the "(newznab)"-labelled provider segment must
+    # be rewritten so post-fix re-derivation (anchor reconstruction, the
+    # downloaded-seam fallback) finds them again. Terminal rows included —
+    # read_one on a terminal row is what stops a spurious re-drive.
+    old_open = "42|drunkenslug (newznab)"
+    old_terminal = "oneoff|drunkenslug (newznab)|Absolute.Flash.001|disc-1"
+    journal.record_transition(old_open, journal.SNATCHED, issueid="42", provider="DrunkenSlug (newznab)")
+    journal.record_transition(old_terminal, journal.SNATCHED, provider="DrunkenSlug (newznab)")
+    journal.record_transition(old_terminal, journal.DOWNLOADED, provider="DrunkenSlug (newznab)")
+    journal.record_transition(old_terminal, journal.POST_PROCESSED, provider="DrunkenSlug (newznab)")
+
+    migrated = journal.migrate_release_key_provider_format()
+
+    assert migrated == 2
+    assert _row(old_open) is None
+    assert _row(old_terminal) is None
+    assert _row("42|drunkenslug")["stage"] == journal.SNATCHED
+    assert _row("oneoff|drunkenslug|Absolute.Flash.001|disc-1")["stage"] == journal.POST_PROCESSED
+    # New-form key now matches post-fix derivation.
+    assert journal.release_key("42", "DrunkenSlug") == "42|drunkenslug"
+    # Idempotent: a second pass is a no-op.
+    assert journal.migrate_release_key_provider_format() == 0
+
+
+def test_key_migration_leaves_collisions_alone(capture_logs):
+    journal.record_transition("42|drunkenslug (newznab)", journal.SNATCHED, issueid="42", provider="DrunkenSlug")
+    journal.record_transition("42|drunkenslug", journal.DOWNLOADED, issueid="42", provider="DrunkenSlug")
+
+    assert journal.migrate_release_key_provider_format() == 0
+    assert _row("42|drunkenslug (newznab)")["stage"] == journal.SNATCHED
+    assert _row("42|drunkenslug")["stage"] == journal.DOWNLOADED
+    assert "collision" in capture_logs.text
+
+
+def test_key_migration_ignores_unlabelled_and_malformed_keys():
+    journal.record_transition("42|nzb.su", journal.SNATCHED, issueid="42", provider="nzb.su")
+    journal.record_transition("weird-key-no-pipe", journal.SNATCHED)
+
+    assert journal.migrate_release_key_provider_format() == 0
+    assert _row("42|nzb.su") is not None
+    assert _row("weird-key-no-pipe") is not None


### PR DESCRIPTION
## Summary

Fixes #745 — every NZBGet download was quarantined at completion with `immutable_payload_conflict:provider`.

The snatch seam journals `search.py`'s type-labelled `tmpprov` (`"DrunkenSlug (newznab)"`) while the downloaded seam journals the raw `nzbprov` (`"DrunkenSlug"`). `normalize_provider()` stripped `[RSS]` but not the type label, so the immutable-identity conflict check treated the two writes as disagreeing on `provider` and quarantined the row every time — unconditionally, on every NZBGet completion, once #696 let downloads get that far.

## Changes

- `normalize_provider()` now strips a trailing `(newznab)`/`(torznab)` label (repeated, so a provider literally named `"Foo (newznab)"` still converges with its own tmpprov form). This is the reporter's suggested option 1 and matches the function's stated purpose of reconciling seam-to-seam formatting drift. It converges both the immutable-field conflict comparison and the `release_key` derivation at all four seams — including the downloaded-seam fallback re-derivation, which previously produced a divergent key from bare `nzbprov`.
- Because the fix changes key derivation, pre-fix journal rows keyed under the labelled form would no longer be found by anchor reconstruction or fallback re-derivation (risking duplicate rows and spurious re-drives of completed items). A one-shot, idempotent `migrate_release_key_provider_format()` runs at the top of `replay_pipeline()` and rewrites the provider segment of every stored key — terminal rows included, since `read_one` on a terminal row is what stops a re-drive. Collisions are left alone and logged loudly.

## Testing

- New unit tests: label-stripping normalization, the snatch-labelled/completion-bare regression (row advances instead of quarantining), and the key migration (rewrite, idempotence, collision, malformed keys).
- Full `tests/unit` suite: 2679 passed.
- `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hk2zVCQ2SNgAN2igR44kjz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed NZB provider naming inconsistencies that could incorrectly quarantine completed downloads.
  * Existing download records are now automatically reconciled during startup.
  * Improved handling of provider labels, including RSS, Newznab, and Torznab variations.
  * Migration safely handles duplicate, malformed, or already-correct records without interrupting recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->