### PR TITLE
fix: Reopen rows falsely marked post_processed before the #736 recovery fix

### DIFF
--- a/.changeset/reopen-false-terminal-imports.md
+++ b/.changeset/reopen-false-terminal-imports.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Downloads that were falsely marked as imported before v0.34.0's recovery fix are now healed automatically. That fix stopped startup recovery from reporting *import / succeeded* for downloads that were never actually moved into the library, but rows already corrupted by earlier versions stayed permanently stuck: the pipeline considered them finished, so no future startup would ever look at them again, while the files sat stranded in the download directory. On the next startup, recovery now re-examines finished pipeline records that the library itself contradicts — no stored file location, no Downloaded status, and no operator decision such as Ignored or Archived — and puts them back through the normal recovery path. When the completed download folder can still be resolved, the import runs for real; otherwise the item lands in Needs attention as "download finished but was never imported into the library", with the files still in the download directory ready for a manual import. Genuinely imported items, one-off downloads, and issues from removed series are left untouched.

--- a/comicarr/app/downloads/journal.py
+++ b/comicarr/app/downloads/journal.py
@@ -1037,6 +1037,47 @@ def migrate_release_key_provider_format():
     return migrated
 
 
+def reopen_false_terminal(release_key):
+    """#742 backfill: demote ONE falsely-terminal ``post_processed`` row back
+    to ``snatched`` so startup replay re-evaluates it under the #736 library
+    placement contract.
+
+    This is the single sanctioned BACKWARD write in the lattice, and it is
+    deliberately not a record_transition path: the monotonic guard exists to
+    reject exactly this shape of write from every live seam. The gate is the
+    stage predicate — only a row currently at exactly ``post_processed`` can
+    be demoted, so failed/manual_review/cancelled terminals (other contracts)
+    and open rows are untouchable, and the write is race-safe against a
+    concurrent re-snatch (whose reset leaves the stage != post_processed).
+    The CALLER (recovery's #742 scan) owns the evidence check
+    (recovery_classify.false_terminal_reopen_candidate); this helper is pure
+    mechanism. status/fail_reason are cleared so the reopened row replays as
+    a clean open obligation; the payload is retained for reconstruction.
+
+    Returns True iff a row was demoted."""
+    if release_key in (None, ""):
+        return False
+    with db.get_engine().begin() as conn:
+        result = conn.execute(
+            update(pipeline_journal)
+            .where(pipeline_journal.c.release_key == release_key)
+            .where(pipeline_journal.c.stage == POST_PROCESSED)
+            .values(
+                stage=SNATCHED,
+                stage_rank=STAGE_RANK[SNATCHED],
+                status=None,
+                fail_reason=None,
+                updated_date=_now(),
+            )
+        )
+        won = bool(result.rowcount)
+    if won:
+        # Mechanism-level trace only; the recovery scan owns the operator-
+        # facing narration for the reopen.
+        logger.fdebug("[JOURNAL] demoted release_key=%s post_processed -> snatched (#742 backfill)." % release_key)
+    return won
+
+
 def stamp_resolution(release_key, status, *, increment_retry=False, conn=None):
     """Stamp an R9 resolution status without rewriting stage / stage_rank.
 

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -373,6 +373,55 @@ def _reconstruct_anchors():
 
 
 # ---------------------------------------------------------------------------
+# #742 — reopen rows the pre-#736 code falsely terminalized
+# ---------------------------------------------------------------------------
+
+
+def _reclassify_false_terminal_imports():
+    """#742 backfill (idempotent, safe every boot): rows the pre-#736 recovery
+    marked ``post_processed`` off a bare done-signal are terminal, so
+    read_open() never revisits them — the false "import / succeeded" is
+    permanent and the files stay stranded in the download directory. Scan the
+    terminal ``post_processed`` rows, and for each one the LIBRARY contradicts
+    (no placement evidence, still tracked, no operator-intent status — the
+    recovery_classify.false_terminal_reopen_candidate contract), demote it
+    back to ``snatched`` via the journal's single sanctioned backward write.
+    The reopened rows join THIS pass's read_open() snapshot, where the fixed
+    #736 path re-drives the import or quarantines to needs_attention.
+
+    Rows that end the pass at manual_review/failed/post_processed-with-
+    placement are never re-scanned; a row left open (UNKNOWN) is a normal
+    obligation from then on. Returns the number of reopened rows."""
+    try:
+        rows = db.select_all(select(pipeline_journal).where(pipeline_journal.c.stage == journal.POST_PROCESSED)) or []
+    except Exception as e:
+        logger.error("[RECOVERY] #742 backfill could not read terminal rows: %s" % type(e).__name__)
+        return 0
+
+    reopened = 0
+    for row in rows:
+        rkey = row.get("release_key")
+        try:
+            payload = journal.load_payload(row.get("payload_json"))
+            if not recovery_classify.false_terminal_reopen_candidate(row, payload=payload):
+                continue
+            if journal.reopen_false_terminal(rkey):
+                reopened += 1
+                logger.warn(
+                    "[RECOVERY] %s was terminal `post_processed` but the library "
+                    "shows NO placement evidence (pre-#736 false done-signal) — "
+                    "reopened for re-evaluation this pass (#742)." % rkey
+                )
+        except Exception as e:
+            # A single bad row must never abort the backfill scan.
+            logger.error("[RECOVERY] #742 backfill error for %s — SKIPPED: %s" % (rkey, type(e).__name__))
+            continue
+    if reopened:
+        logger.info("[RECOVERY] #742 backfill reopened %d falsely-terminal row(s)." % reopened)
+    return reopened
+
+
+# ---------------------------------------------------------------------------
 # Payload reconstruction for re-enqueue
 # ---------------------------------------------------------------------------
 
@@ -975,6 +1024,7 @@ def replay_pipeline(probes=None):
         "key_migration": 0,
         "reconstructed": 0,
         "legacy_ddl_review": 0,
+        "reopened_false_terminal": 0,
         "band_reconcile": None,
         "open": 0,
         "actions": {},
@@ -1009,6 +1059,15 @@ def replay_pipeline(probes=None):
         summary["band_reconcile"] = reconcile_existing_excluded_rows()
     except Exception as e:
         logger.error("[RECOVERY] band actionability one-shot failed; continuing: %s" % type(e).__name__)
+
+    # #742: reopen rows the pre-#736 code falsely terminalized to
+    # `post_processed` off a bare done-signal (library shows no placement).
+    # BEFORE the read_open() snapshot so the reopened rows are re-evaluated
+    # in THIS pass. Idempotent; safe every boot.
+    try:
+        summary["reopened_false_terminal"] = _reclassify_false_terminal_imports()
+    except Exception as e:
+        logger.error("[RECOVERY] #742 false-terminal backfill failed; continuing: %s" % type(e).__name__)
 
     # 1. Anchor reconstruction FIRST (U2 residual window).
     try:

--- a/comicarr/app/downloads/recovery_classify.py
+++ b/comicarr/app/downloads/recovery_classify.py
@@ -164,6 +164,39 @@ def _row_shows_placement(rec):
     return bool(str(rec["Location"] or "").strip())
 
 
+def _payload_story_arc(payload):
+    """Tri-state arc signal from a journal payload: True (story arc), False
+    (plain issue), or None when the payload carries no `mode`."""
+    if isinstance(payload, dict) and "mode" in payload:
+        return payload.get("mode") == "story_arc"
+    return None
+
+
+def _library_rows(issueid, story_arc):
+    """The library rows that can carry placement evidence for an obligation
+    (arc scoping as documented on has_library_placement): storyarcs unless the
+    obligation is known-plain, issues/annuals unless it is known-arc. Returns
+    a list of (Status, Location) rows, or None when a lookup failed — callers
+    must treat None as "no evidence available", never fabricate."""
+    recs = []
+    try:
+        if story_arc is not False:
+            rec = db.select_one(
+                select(storyarcs.c.Status, storyarcs.c.Location).where(storyarcs.c.IssueArcID == str(issueid))
+            )
+            if rec is not None:
+                recs.append(rec)
+        if story_arc is not True:
+            for table in (issues, annuals):
+                rec = db.select_one(select(table.c.Status, table.c.Location).where(table.c.IssueID == str(issueid)))
+                if rec is not None:
+                    recs.append(rec)
+    except Exception as e:
+        logger.warn("[RECOVERY-CLASSIFY] library row lookup failed for %s: %s" % (issueid, e))
+        return None
+    return recs
+
+
 def has_library_placement(row, payload=None):
     """True iff the LIBRARY itself shows the import happened for this
     obligation (#734). A done-signal (nzblog absent / snatched history) only
@@ -184,26 +217,59 @@ def has_library_placement(row, payload=None):
         return False
     if payload is None:
         payload = journal.load_payload(row.get("payload_json"))
-    story_arc = None
-    if isinstance(payload, dict) and "mode" in payload:
-        story_arc = payload.get("mode") == "story_arc"
-    try:
-        if story_arc is not False:
-            rec = db.select_one(
-                select(storyarcs.c.Status, storyarcs.c.Location).where(storyarcs.c.IssueArcID == str(issueid))
-            )
-            if _row_shows_placement(rec):
-                return True
-            if story_arc is True:
-                return False
-        for table in (issues, annuals):
-            rec = db.select_one(select(table.c.Status, table.c.Location).where(table.c.IssueID == str(issueid)))
-            if _row_shows_placement(rec):
-                return True
-    except Exception as e:
-        logger.warn("[RECOVERY-CLASSIFY] library placement lookup failed for %s: %s" % (issueid, e))
+    recs = _library_rows(issueid, _payload_story_arc(payload))
+    if recs is None:
         return False
-    return False
+    return any(_row_shows_placement(rec) for rec in recs)
+
+
+# Library statuses that carry NO operator intent to keep the issue out of the
+# pipeline. Anything else (Ignored/Skipped/Archived/...) is an explicit
+# decision the #742 backfill must not override by resurrecting the download.
+_REOPEN_SAFE_STATUSES = frozenset({"", "Snatched", "Wanted", "Failed"})
+
+
+def false_terminal_reopen_candidate(row, payload=None):
+    """#742: True iff a terminal ``post_processed`` journal row is safe to
+    reopen for re-evaluation under the #736 placement contract. The pre-#736
+    recovery could terminalize a row off a bare done-signal; such rows are
+    structurally invisible to replay (read_open excludes terminals), so a
+    startup backfill has to identify them from the library's own evidence.
+
+    Reopenable ONLY when ALL hold:
+      * the row is exactly at ``post_processed`` (never failed/manual_review/
+        cancelled — those are other contracts);
+      * the issueid is real (a synthetic-HIGHCOUNT one-off has no library row
+        by design, so placement is unverifiable — leave terminal);
+      * the library still tracks the obligation (a matching issues/annuals/
+        storyarcs row exists — a removed series has nothing to recover into);
+      * NO matching row shows placement evidence (same authority as
+        has_library_placement); and
+      * every matching row's status is placement-neutral (Snatched/Wanted/
+        Failed/empty) — an operator-intent status stays untouched.
+
+    Arc scoping mirrors has_library_placement. A lookup failure returns
+    False — never reopen a terminal row on uncertainty."""
+    row = row or {}
+    if row.get("stage") != journal.POST_PROCESSED:
+        return False
+    issueid = row.get("issueid")
+    if issueid is None or journal.is_synthetic_oneoff(issueid):
+        return False
+    if payload is None:
+        payload = journal.load_payload(row.get("payload_json"))
+    recs = _library_rows(issueid, _payload_story_arc(payload))
+    if not recs:
+        # Lookup failed (None) or the library no longer tracks the issue ([]):
+        # either way there is nothing to verify placement against — stay
+        # terminal.
+        return False
+    for rec in recs:
+        if _row_shows_placement(rec):
+            return False
+        if (rec["Status"] or "") not in _REOPEN_SAFE_STATUSES:
+            return False
+    return True
 
 
 def has_done_signal(row):

--- a/tests/integration/test_restart_recovery.py
+++ b/tests/integration/test_restart_recovery.py
@@ -196,8 +196,16 @@ def test_ae1_snatched_then_externally_completed_pp_exactly_once(fake_pp_queue):
     # Re-running replay (second restart) must NOT double-enqueue
     # (idempotent / re-runnable): the U4 claim convergence is simulated by
     # advancing the row as the PP consumer would, then asserting a second
-    # replay is a no-op.
+    # replay is a no-op. A real import also writes the library placement
+    # facts (#736/#742: a terminal row the library contradicts is rightly
+    # reopened by the startup backfill).
     journal.record_transition(rkey, journal.POST_PROCESSED)
+    with get_engine().begin() as conn:
+        conn.execute(
+            issues.update()
+            .where(issues.c.IssueID == "500")
+            .values(Status="Downloaded", Location="Batman 010 (2026).cbz")
+        )
     recovery.replay_pipeline(probes=_probe("complete"))
     assert _drain(fake_pp_queue) == [], "AE1: completed row must not be re-driven"
     assert journal.read_one(rkey)["stage"] == journal.POST_PROCESSED
@@ -486,6 +494,15 @@ def test_ae3_same_release_interrupted_across_two_restarts_completes_exactly_once
         "AE3: the real downloaded->post_processing atomic claim must succeed once"
     )
     journal.record_transition(rkey, journal.POST_PROCESSED)
+    # A real import also writes the library placement facts (#736/#742: a
+    # terminal row the library contradicts is rightly reopened by the
+    # startup backfill).
+    with get_engine().begin() as conn:
+        conn.execute(
+            issues.update()
+            .where(issues.c.IssueID == "550")
+            .values(Status="Downloaded", Location="Flash 001 (2026).cbz")
+        )
 
     # ---- Restart #2: SAME release replayed again — must be a pure no-op
     # (terminal-state / advanced-stage guard), no duplicate grab/PP. --------

--- a/tests/unit/test_recovery_classify.py
+++ b/tests/unit/test_recovery_classify.py
@@ -514,3 +514,78 @@ def test_placement_for_story_arc_obligation_uses_storyarcs_row():
         payload={"mode": "story_arc"},
     )
     assert recovery_classify.has_library_placement(unplaced) is False
+
+
+# ---------------------------------------------------------------------------
+# false_terminal_reopen_candidate — the #742 backfill's evidence check. A
+# terminal `post_processed` row is reopenable ONLY when the library still
+# tracks the obligation, shows NO placement evidence, and carries no
+# operator-intent status. Anything unverifiable stays terminal.
+# ---------------------------------------------------------------------------
+
+
+def _terminal_row(release_key, issueid, payload=None):
+    return _insert_journal(
+        release_key,
+        journal.POST_PROCESSED,
+        issueid=issueid,
+        provider="nzb.su",
+        downloader_type="nzb",
+        payload=payload,
+    )
+
+
+def test_reopen_candidate_true_for_snatched_issue_without_location():
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="R1", Status="Snatched", Location=None))
+    row = _terminal_row("R1|nzb.su", "R1")
+    assert recovery_classify.false_terminal_reopen_candidate(row) is True
+
+
+def test_reopen_candidate_false_with_placement_evidence():
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="R2", Status="Snatched", Location="Placed.cbz"))
+        conn.execute(issues.insert().values(IssueID="R3", Status="Downloaded", Location=None))
+    assert recovery_classify.false_terminal_reopen_candidate(_terminal_row("R2|nzb.su", "R2")) is False
+    assert recovery_classify.false_terminal_reopen_candidate(_terminal_row("R3|nzb.su", "R3")) is False
+
+
+def test_reopen_candidate_false_without_library_row():
+    row = _terminal_row("R4|nzb.su", "R4")
+    assert recovery_classify.false_terminal_reopen_candidate(row) is False
+
+
+def test_reopen_candidate_false_for_oneoff_and_missing_issueid():
+    oneoff = _terminal_row("oneoff|nzb.su|x|d", "900001")
+    assert recovery_classify.false_terminal_reopen_candidate(oneoff) is False
+    orphan = _terminal_row("R5|nzb.su", None)
+    assert recovery_classify.false_terminal_reopen_candidate(orphan) is False
+
+
+def test_reopen_candidate_false_for_operator_intent_status():
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="R6", Status="Ignored", Location=None))
+        conn.execute(issues.insert().values(IssueID="R7", Status="Skipped", Location=None))
+        conn.execute(issues.insert().values(IssueID="R8", Status="Archived", Location=None))
+    for issueid in ("R6", "R7", "R8"):
+        row = _terminal_row("%s|nzb.su" % issueid, issueid)
+        assert recovery_classify.false_terminal_reopen_candidate(row) is False
+
+
+def test_reopen_candidate_false_for_non_terminal_stage():
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="R9", Status="Snatched", Location=None))
+    row = _insert_journal("R9|nzb.su", journal.SNATCHED, issueid="R9", provider="nzb.su", downloader_type="nzb")
+    assert recovery_classify.false_terminal_reopen_candidate(row) is False
+
+
+def test_reopen_candidate_story_arc_scoped_to_storyarcs_row():
+    from comicarr.tables import storyarcs
+
+    with get_engine().begin() as conn:
+        conn.execute(storyarcs.insert().values(IssueArcID="R10", StoryArc="Arc", Status="Wanted", Location=None))
+        conn.execute(storyarcs.insert().values(IssueArcID="R11", StoryArc="Arc", Status="Downloaded"))
+    reopenable = _terminal_row("R10|nzb.su", "R10", payload={"mode": "story_arc"})
+    assert recovery_classify.false_terminal_reopen_candidate(reopenable) is True
+    placed = _terminal_row("R11|nzb.su", "R11", payload={"mode": "story_arc"})
+    assert recovery_classify.false_terminal_reopen_candidate(placed) is False

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -828,9 +828,13 @@ def test_ae3_two_replays_complete_exactly_once(queues, tmp_path):
     assert len(first) == 1
 
     # The PP consumer (U4) wins the claim downloaded -> post_processing, then
-    # completes -> post_processed. Simulate that durable progression.
+    # completes -> post_processed. Simulate that durable progression — a real
+    # import also writes the library placement facts (#736/#742: without them
+    # the terminal row would rightly be reopened by the startup backfill).
     assert journal.record_transition(rkey, journal.POST_PROCESSING) is True
     journal.record_transition(rkey, journal.POST_PROCESSED)
+    with get_engine().begin() as conn:
+        conn.execute(issues.update().where(issues.c.IssueID == "100").values(Status="Downloaded", Location="L.cbz"))
 
     # Second replay (process restarted again): row is terminal -> NOT
     # re-driven. Exactly once overall.
@@ -1340,6 +1344,198 @@ def test_done_signal_with_placement_evidence_still_marks_done(queues):
     assert _journal_row(rkey)["stage"] == journal.POST_PROCESSED
     assert summary["actions"].get("done-check") == 1
     assert _drain(queues["pp"]) == []
+
+
+# ===========================================================================
+# #742 — rows already falsely terminalized to `post_processed` by the
+# pre-#736 code have no open obligation for replay to revisit. The startup
+# backfill must reopen exactly those rows (terminal post_processed, library
+# still tracks the issue, NO placement evidence, no operator-intent status)
+# so the #736 placement contract re-evaluates them in the same pass.
+# ===========================================================================
+
+
+def test_false_terminal_without_placement_is_reopened_and_quarantined(queues):
+    """#742 repro: a row the pre-#736 recovery marked `post_processed` off a
+    bare done-signal — issue still Snatched, Location NULL, files stranded in
+    the download directory. The backfill reopens it; the downloader cannot be
+    probed (old payload has no client id), so the #736 path quarantines it to
+    manual_review with the placement reason instead of leaving it a false
+    import/succeeded forever."""
+    rkey = journal.release_key("742", "nzb.su", nzbname="Stranded.001.cbz")
+    _issue_row("742")
+    _insert_journal(
+        rkey,
+        journal.POST_PROCESSED,
+        payload={"issueid": "742", "provider": "nzb.su", "nzbname": "Stranded.001.cbz"},
+        issueid="742",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    summary = recovery.replay_pipeline(probes=_probe("unreachable"))
+
+    assert summary["reopened_false_terminal"] == 1
+    row = _journal_row(rkey)
+    assert row["stage"] == journal.MANUAL_REVIEW
+    assert str(row["fail_reason"] or "").startswith("done_signal_without_library_placement")
+    assert _drain(queues["pp"]) == []
+
+
+def test_false_terminal_reopen_redrives_import_when_probe_resolves_folder(queues):
+    """When the downloader history still resolves the completed folder, a
+    reopened #742 row is re-driven through PP (real import) in the SAME
+    replay pass instead of being quarantined."""
+    rkey = journal.release_key("743", "nzb.su", nzbname="Stranded.002.cbz")
+    _issue_row("743")
+    _insert_journal(
+        rkey,
+        journal.POST_PROCESSED,
+        payload={
+            "issueid": "743",
+            "provider": "nzb.su",
+            "nzbname": "Stranded.002.cbz",
+            "download_info": {"nzo_id": "nzo743"},
+        },
+        issueid="743",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    probes = _probe({"status": True, "location": "/downloads/Stranded.002", "name": "Stranded.002.cbz"})
+    summary = recovery.replay_pipeline(probes=probes)
+
+    assert summary["reopened_false_terminal"] == 1
+    row = _journal_row(rkey)
+    assert row["stage"] == journal.DOWNLOADED
+    items = _drain(queues["pp"])
+    assert len(items) == 1
+    assert items[0]["nzb_folder"] == "/downloads/Stranded.002"
+    assert items[0]["journal_release_key"] == rkey
+
+
+def test_legit_post_processed_with_placement_is_left_terminal(queues):
+    """A genuinely-imported row (Location written by placement) must NEVER be
+    reopened — the backfill is scoped to rows the library contradicts."""
+    rkey = journal.release_key("744", "nzb.su", nzbname="Placed.001.cbz")
+    _issue_row("744", status="Downloaded", location="Placed 001 (2026).cbz")
+    _insert_journal(
+        rkey,
+        journal.POST_PROCESSED,
+        payload={"issueid": "744", "provider": "nzb.su", "nzbname": "Placed.001.cbz"},
+        issueid="744",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    summary = recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert summary["reopened_false_terminal"] == 0
+    assert _journal_row(rkey)["stage"] == journal.POST_PROCESSED
+    assert _drain(queues["pp"]) == []
+
+
+def test_post_processed_oneoff_is_left_terminal(queues):
+    """A synthetic-HIGHCOUNT one-off has no library row by design — placement
+    is unverifiable, so the backfill must leave it terminal."""
+    rkey = "oneoff|nzb.su|OneOff.cbz|disc1"
+    _insert_journal(
+        rkey,
+        journal.POST_PROCESSED,
+        payload={"issueid": "900001", "provider": "nzb.su", "nzbname": "OneOff.cbz"},
+        issueid="900001",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    summary = recovery.replay_pipeline(probes=_probe("unreachable"))
+
+    assert summary["reopened_false_terminal"] == 0
+    assert _journal_row(rkey)["stage"] == journal.POST_PROCESSED
+
+
+def test_post_processed_with_operator_intent_status_is_left_terminal(queues):
+    """An issue the operator has since set to Ignored/Skipped/Archived is an
+    explicit decision — the backfill must not resurrect the download."""
+    rkey = journal.release_key("745i", "nzb.su", nzbname="Ignored.001.cbz")
+    _issue_row("745i", status="Ignored")
+    _insert_journal(
+        rkey,
+        journal.POST_PROCESSED,
+        payload={"issueid": "745i", "provider": "nzb.su", "nzbname": "Ignored.001.cbz"},
+        issueid="745i",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    summary = recovery.replay_pipeline(probes=_probe("unreachable"))
+
+    assert summary["reopened_false_terminal"] == 0
+    assert _journal_row(rkey)["stage"] == journal.POST_PROCESSED
+
+
+def test_post_processed_with_no_library_row_is_left_terminal(queues):
+    """The library no longer tracks the issue (series removed): nothing to
+    recover into, so the row stays terminal."""
+    rkey = journal.release_key("746", "nzb.su", nzbname="Deleted.001.cbz")
+    _insert_journal(
+        rkey,
+        journal.POST_PROCESSED,
+        payload={"issueid": "746", "provider": "nzb.su", "nzbname": "Deleted.001.cbz"},
+        issueid="746",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    summary = recovery.replay_pipeline(probes=_probe("unreachable"))
+
+    assert summary["reopened_false_terminal"] == 0
+    assert _journal_row(rkey)["stage"] == journal.POST_PROCESSED
+
+
+def test_backfill_is_idempotent_across_restarts(queues):
+    """Second boot after the quarantine: the row is manual_review, not
+    post_processed — the backfill must not touch it again."""
+    rkey = journal.release_key("747", "nzb.su", nzbname="Stranded.003.cbz")
+    _issue_row("747")
+    _insert_journal(
+        rkey,
+        journal.POST_PROCESSED,
+        payload={"issueid": "747", "provider": "nzb.su", "nzbname": "Stranded.003.cbz"},
+        issueid="747",
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+
+    first = recovery.replay_pipeline(probes=_probe("unreachable"))
+    assert first["reopened_false_terminal"] == 1
+    assert _journal_row(rkey)["stage"] == journal.MANUAL_REVIEW
+
+    second = recovery.replay_pipeline(probes=_probe("unreachable"))
+    assert second["reopened_false_terminal"] == 0
+    assert _journal_row(rkey)["stage"] == journal.MANUAL_REVIEW
+
+
+def test_reopen_false_terminal_only_demotes_post_processed():
+    """journal.reopen_false_terminal is the single sanctioned backward write:
+    gated on stage == post_processed exactly — failed / manual_review / open
+    rows and absent keys are all no-ops."""
+    done = _insert_journal("j742-done|p", journal.POST_PROCESSED, issueid="800", provider="p")
+    assert journal.reopen_false_terminal(done["release_key"]) is True
+    row = journal.read_one(done["release_key"])
+    assert row["stage"] == journal.SNATCHED
+    assert row["stage_rank"] == journal.stage_rank(journal.SNATCHED)
+
+    failed = _insert_journal("j742-failed|p", journal.FAILED, issueid="801", provider="p")
+    review = _insert_journal("j742-review|p", journal.MANUAL_REVIEW, issueid="802", provider="p")
+    open_row = _insert_journal("j742-open|p", journal.DOWNLOADED, issueid="803", provider="p")
+    assert journal.reopen_false_terminal(failed["release_key"]) is False
+    assert journal.reopen_false_terminal(review["release_key"]) is False
+    assert journal.reopen_false_terminal(open_row["release_key"]) is False
+    assert journal.reopen_false_terminal("j742-absent|p") is False
+    assert journal.read_one(failed["release_key"])["stage"] == journal.FAILED
+    assert journal.read_one(review["release_key"])["stage"] == journal.MANUAL_REVIEW
+    assert journal.read_one(open_row["release_key"])["stage"] == journal.DOWNLOADED
 
 
 def test_done_signal_without_placement_absent_probe_enqueues_pp_not_done(queues):


### PR DESCRIPTION
Closes #742.

Rows the pre-#736 recovery falsely terminalized to `post_processed` were permanently stuck — terminal rows are invisible to `read_open()`, so no startup ever revisited them while the files sat stranded in the download directory. Startup recovery now reopens exactly those rows and re-evaluates them under the #736 placement contract in the same pass.

- New idempotent backfill in `replay_pipeline()` runs before the open-obligation snapshot: terminal `post_processed` rows that the library contradicts (no `Location`, no Downloaded/Post-Processed status, issue still tracked, no operator-intent status such as Ignored/Skipped/Archived, not a one-off) are demoted back to `snatched` and re-driven — real import when the completed folder resolves, otherwise Needs attention with `done_signal_without_library_placement`.
- `journal.reopen_false_terminal()` is the single sanctioned backward write in the stage lattice, gated on the stage being exactly `post_processed`, so failed/manual_review/cancelled terminals and open rows are untouchable and the write is race-safe against concurrent re-snatches.
- 15 new tests (repro → quarantine, same-pass re-drive, every leave-terminal guard, restart idempotency, demotion gate); full unit suite 2694 passed; `npm run lint` fully green; operator-facing patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqNd5NhTi3kx5e8foaPvyx