### PR TITLE
fix: Keep the accepted verdict when series targets disagree on a pack

### DIFF
--- a/.changeset/series-review-verdict-merge.md
+++ b/.changeset/series-review-verdict-merge.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+"Review missing" no longer downgrades a grabbable pack to "Not a match" when the same release was found for several missing issues. When one issue's search rejected a pack (for example because that issue is outside the pack's range) and another issue's search accepted it, the review sheet could keep whichever verdict arrived first — hiding a pack you could grab, or anchoring the grab on an issue the pack does not contain. The accepted verdict now always wins, and the grab anchors on an issue the pack actually covers.

--- a/comicarr/app/search/interactive.py
+++ b/comicarr/app/search/interactive.py
@@ -301,13 +301,30 @@ def _union_satisfies(existing, incoming):
     existing.satisfies = merged
 
 
+def _verdict_rank(evaluation):
+    verdict = evaluation.verdict or {}
+    if verdict.get("accepted"):
+        return 0
+    if verdict.get("overrideable"):
+        return 1
+    return 2
+
+
 def _merge_series_evaluation(collected, evaluation):
     identity = _evaluation_identity(evaluation)
     existing = collected.get(identity)
-    if existing is not None:
-        _union_satisfies(existing, evaluation)
+    if existing is None:
+        collected[identity] = evaluation
         return
-    collected[identity] = evaluation
+    if _verdict_rank(evaluation) < _verdict_rank(existing):
+        # The same release can be rejected for one searched target (e.g. a
+        # pack that does not contain it) yet accepted for another. Keep the
+        # grabbable evaluation — its satisfies list leads, so the persisted
+        # anchor (satisfies[0]) stays a target the grab can revalidate against.
+        _union_satisfies(evaluation, existing)
+        collected[identity] = evaluation
+        return
+    _union_satisfies(existing, evaluation)
 
 
 def _order_series_evaluations(collected):

--- a/tests/unit/test_interactive_search_api.py
+++ b/tests/unit/test_interactive_search_api.py
@@ -821,6 +821,74 @@ def test_series_worker_searches_gap_starts_and_annotates_pack_coverage(engine, m
     assert titles.count("Example 001-010") == 1
 
 
+def test_series_worker_keeps_the_accepted_verdict_when_a_target_rejected_the_same_pack(engine, monkeypatch):
+    pending = interactive.create_pending_session(
+        engine,
+        actor="alice",
+        browser_session="browser-cookie",
+        entity_type="series",
+        entity_id="series-1",
+        series_id="series-1",
+        provider_total=1,
+    )
+
+    def _rejected_pack():
+        evaluation = _pack_evaluation()
+        evaluation.legacy_match = None
+        evaluation.verdict = {
+            "status": "rejected",
+            "accepted": False,
+            "overrideable": True,
+            "reason_code": "rejected.pack_issue_absent",
+            "reasons": [{"code": "rejected.pack_issue_absent", "message": "Pack does not contain the tracked item"}],
+            "match_kind": "none",
+        }
+        return evaluation
+
+    def manual_search(**kwargs):
+        evaluations = [_rejected_pack()] if kwargs["issueid"] == "i10" else [_pack_evaluation()]
+        interactive.search_filer._INTERACTIVE_COLLECTOR.get()["evaluations"](evaluations)
+        interactive.search_filer.report_provider_complete("DDL(GetComics)")
+        return []
+
+    monkeypatch.setattr(interactive.search, "searchforissue", manual_search)
+
+    interactive._collect(
+        session_id=pending["session_id"],
+        entity={
+            "entity_type": "series",
+            "entity_id": "series-1",
+            "series_id": "series-1",
+            "missing": _missing_items(),
+            "targets": [
+                {"entity_type": "issue", "entity_id": "i10", "issue_number": "10"},
+                {"entity_type": "issue", "entity_id": "i1", "issue_number": "1"},
+            ],
+        },
+        initial_failures=[],
+        provider_total=1,
+    )
+
+    result = read_session(
+        engine,
+        session_id=pending["session_id"],
+        actor="alice",
+        browser_session="browser-cookie",
+    )
+    assert result["state"] == "complete"
+    packs = [candidate for candidate in result["candidates"] if candidate["candidate"]["pack"]]
+    assert len(packs) == 1
+    # i10 rejected the pack first; i1's accepted evaluation must still win,
+    # and its own coverage must lead so the grab anchor is a covered issue.
+    assert packs[0]["verdict"]["accepted"] is True
+    assert packs[0]["satisfies"] == [
+        {"entity_type": "issue", "entity_id": "i1", "issue_number": "1"},
+        {"entity_type": "issue", "entity_id": "i2", "issue_number": "2"},
+        {"entity_type": "issue", "entity_id": "i3", "issue_number": "3"},
+        {"entity_type": "issue", "entity_id": "i10", "issue_number": "10"},
+    ]
+
+
 def test_series_grab_revalidates_against_the_pack_anchor_issue(engine, monkeypatch):
     pack = _pack_evaluation()
     pack.satisfies = [


### PR DESCRIPTION
## Summary

While investigating #746, tracing `_collect_series()` surfaced a real order-dependence bug in how series-scoped Interactive search merges the same release found by multiple targets.

A series search evaluates the same provider release once per searched target, and `_merge_series_evaluation` kept whichever evaluation arrived first, only unioning coverage. When an earlier target rejected a pack (`rejected.pack_issue_absent` — that target sits outside the pack's range) and a later target accepted it, two things went wrong:

- The sheet showed the pack as "Review needed"/rejected even though it was grabbable as-is.
- The persisted grab anchor (`satisfies[0]`) was the rejecting target — an issue the pack does not contain — so revalidation during the grab could not re-find the accepted match.

## Changes

- `_merge_series_evaluation` now prefers accepted over overrideable over rejected when the same provider item is seen by several targets, and the preferred evaluation's own coverage leads the `satisfies` union so the anchor stays an issue the pack actually covers.
- Regression test: a pack rejected by the first searched target and accepted by the second now surfaces as one accepted candidate whose coverage leads with the accepted evaluation's issues. Verified the test fails on `main`.

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [ ] No app release impact; no changeset needed

## Testing

- [x] Tests pass locally (`pytest tests/unit -v`)
- [x] Or one-shot: `npm run lint` (from repo root)
- [ ] Manually tested

## Additional Notes

This does not change the per-target collection strategy questioned in #746 — the near-redundant queries for a single contiguous missing run are #744's territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2tfNHhrms6vN3P7iUHb8i