### PR TITLE
fix: Fire one live query per provider in interactive release search

### DIFF
--- a/.changeset/interactive-search-single-pass.md
+++ b/.changeset/interactive-search-single-pass.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Interactive release search ("Review missing" and the per-issue search icon) now answers in a fraction of the time. It used to run through the same retry machinery as the automatic search — an RSS cache pass, up to three zero-padded issue-number query variants per provider, and a 30-second courtesy wait between provider queries — which multiplied across a series review into minutes of dead time and was the main reason review sessions hit the 10-minute timeout. The interactive flow now fires one live query per provider (plus the bare-title pass that pack discovery needs) with no waits in between; a provider that objects to the pace shows up as a provider failure on the sheet instead of stalling the whole session. The automatic "Search all missing" flow keeps its retries and rate-limit backoff unchanged.

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -351,11 +351,19 @@ def search_init(
     searchcnt = 0
     srchloop = 1
 
+    # Interactive review: the operator is watching, so the retry layers built
+    # for unattended search only delay the result sheet (#768). Skip the RSS
+    # cache pass and (below) run one numbered query per provider.
+    interactive = search_filer.interactive_collection_active()
+
     if rsschecker:
         if comicarr.CONFIG.ENABLE_RSS:
             searchcnt = 1  # rss-only
         else:
             searchcnt = 1  # if it's not enabled, don't even bother.
+    elif interactive:
+        searchcnt = 2
+        srchloop = 2  # straight to API, no RSS pass
     else:
         if comicarr.CONFIG.ENABLE_RSS:
             searchcnt = 2  # rss first, then api on non-matches
@@ -741,7 +749,12 @@ def search_init(
                     # don't think this is needed as we do the check_time btwn searches now
                     pass
 
-                tmp_cmloopit -= 1
+                if interactive:
+                    # One numbered query per provider; keep only the
+                    # bare-title pack pass that pack discovery needs (#744).
+                    tmp_cmloopit = 0 if (pack_title_pass and tmp_cmloopit > 0) else -1
+                else:
+                    tmp_cmloopit -= 1
 
             search_filer.report_provider_complete(progress_provider)
             prov_count += 1
@@ -1373,19 +1386,8 @@ def NZB_SEARCH(
                     logger.fdebug("[SSL: %s] Search URL: %s" % (verify, logsearch))
 
                     # check search time here
-                    if localbypass is False and foundc["lastrun"] != 0:
-                        diff = check_time(foundc["lastrun"])
-                        if diff < pause_the_search:
-                            logger.warn(
-                                "[PROVIDER-SEARCH-DELAY][%s] Waiting %s seconds before we search again..."
-                                % (nzbprov, (pause_the_search - int(diff)))
-                            )
-                            time.sleep(pause_the_search - int(diff))
-                        else:
-                            logger.fdebug(
-                                "[PROVIDER-SEARCH-DELAY][%s] Last search took place %s seconds ago. We're clear..."
-                                % (nzbprov, int(diff))
-                            )
+                    if localbypass is False:
+                        _honour_search_delay(nzbprov, pause_the_search, foundc["lastrun"])
 
                     try:
                         r = get_http_session().get(findurl, params=payload, verify=verify, headers=headers, timeout=30)
@@ -4407,6 +4409,35 @@ def check_the_search_delay(manual=False):
         logger.warn("Check Search Delay - invalid numerical given. Force-setting to 30 seconds.")
         pause_the_search = 30
     return pause_the_search
+
+
+def _honour_search_delay(nzbprov, pause_the_search, lastrun):
+    """Sleep out the remainder of a provider's backoff window.
+
+    Interactive review never blocks on the window (#768): the operator is
+    waiting on the session, and a provider that objects to the pace answers
+    with an error that surfaces as a provider failure instead.
+    """
+
+    if lastrun == 0:
+        return
+    diff = check_time(lastrun)
+    if diff >= pause_the_search:
+        logger.fdebug(
+            "[PROVIDER-SEARCH-DELAY][%s] Last search took place %s seconds ago. We're clear..." % (nzbprov, int(diff))
+        )
+        return
+    if search_filer.interactive_collection_active():
+        logger.fdebug(
+            "[PROVIDER-SEARCH-DELAY][%s] Interactive search - skipping the remaining %s second backoff."
+            % (nzbprov, (pause_the_search - int(diff)))
+        )
+        return
+    logger.warn(
+        "[PROVIDER-SEARCH-DELAY][%s] Waiting %s seconds before we search again..."
+        % (nzbprov, (pause_the_search - int(diff)))
+    )
+    time.sleep(pause_the_search - int(diff))
 
 
 def search_the_matrix(scarios):

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -752,6 +752,10 @@ def search_init(
                 if interactive:
                     # One numbered query per provider; keep only the
                     # bare-title pack pass that pack discovery needs (#744).
+                    # Alternate names still each get their query above:
+                    # they are distinct titles (aliases, manga chapter
+                    # forms), not padding retries, and dropping them would
+                    # hide results a manual review exists to surface.
                     tmp_cmloopit = 0 if (pack_title_pass and tmp_cmloopit > 0) else -1
                 else:
                     tmp_cmloopit -= 1

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -139,6 +139,17 @@ def interactive_collection(*, on_evaluations, on_provider_complete, on_provider_
         _INTERACTIVE_COLLECTOR.reset(token)
 
 
+def interactive_collection_active():
+    """True while an Interactive-search worker is collecting in this context.
+
+    The legacy search pipeline consults this to drop the retry layers built
+    for unattended search — RSS pass, issue-number variants, backoff sleeps —
+    when an operator is watching the results arrive (#768).
+    """
+
+    return _INTERACTIVE_COLLECTOR.get() is not None
+
+
 def report_provider_complete(provider):
     collector = _INTERACTIVE_COLLECTOR.get()
     if collector:

--- a/tests/unit/test_interactive_search_single_pass.py
+++ b/tests/unit/test_interactive_search_single_pass.py
@@ -1,0 +1,148 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""Interactive review collection fires one live query per provider (#768).
+
+The automatic search flow retries on purpose: RSS cache first, then padded
+issue-number variants, with a backoff sleep between provider queries. When an
+operator is reviewing results interactively, those layers only add latency, so
+collection runs exactly one numbered API query per provider (plus the
+bare-title pack pass that pack discovery depends on, #744) and never sleeps.
+"""
+
+import time
+import types
+
+import pytest
+
+import comicarr
+from comicarr import search, search_filer
+
+
+def _noop_collection():
+    return search_filer.interactive_collection(
+        on_evaluations=lambda values: None,
+        on_provider_complete=lambda provider: None,
+        on_provider_failure=lambda provider, code, detail: None,
+    )
+
+
+def test_interactive_collection_active_only_inside_context():
+    assert search_filer.interactive_collection_active() is False
+    with _noop_collection():
+        assert search_filer.interactive_collection_active() is True
+    assert search_filer.interactive_collection_active() is False
+
+
+@pytest.fixture
+def search_env(monkeypatch):
+    calls = []
+
+    def fake_matrix(scarios):
+        calls.append({"cmloopit": scarios["cmloopit"], "RSS": scarios["RSS"]})
+        return {"status": False, "lastrun": 0}
+
+    monkeypatch.setattr(
+        comicarr,
+        "CONFIG",
+        types.SimpleNamespace(
+            ENABLE_RSS=True,
+            ENABLE_TORRENT_SEARCH=True,
+            SEARCH_DELAY=None,
+            USENET_RETENTION=None,
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(comicarr, "COMICINFO", [], raising=False)
+    monkeypatch.setattr(search, "search_the_matrix", fake_matrix)
+    monkeypatch.setattr(search, "last_run_check", lambda **kwargs: {})
+    monkeypatch.setattr(
+        search,
+        "provider_order",
+        lambda initial_run=False: {
+            "prov_order": ["torznab"],
+            "torznab_info": [{"provider": "torznab", "info": ("nyaa", "https://nyaa.test", "0", "key", "8020")}],
+            "newznab_info": [],
+            "totalproviders": 1,
+        },
+    )
+    monkeypatch.setattr(search.helpers, "get_issue_title", lambda *args, **kwargs: None)
+    monkeypatch.setattr(search.helpers, "block_provider_check", lambda *args, **kwargs: False)
+    return calls
+
+
+def _run_search_init(allow_packs=1):
+    return search.search_init(
+        "Example Series",
+        "2",
+        "2024",
+        "2024",
+        None,
+        "2024-01-01",
+        "2024-01-01",
+        "issue-1",
+        smode=None,
+        ComicID="comic-1",
+        allow_packs=allow_packs,
+        manual=True,
+        booktype=None,
+    )
+
+
+def test_automatic_search_keeps_rss_and_variant_passes(search_env):
+    _run_search_init()
+
+    rss_passes = [call for call in search_env if call["RSS"] == "yes"]
+    api_passes = [call for call in search_env if call["RSS"] == "no"]
+    assert rss_passes, "automatic search must still run the RSS cache pass"
+    assert [call["cmloopit"] for call in api_passes] == [3, 2, 1, 0]
+
+
+def test_interactive_search_runs_single_query_plus_pack_pass(search_env):
+    with _noop_collection():
+        _run_search_init()
+
+    assert all(call["RSS"] == "no" for call in search_env), "interactive search must not run the RSS pass"
+    assert [call["cmloopit"] for call in search_env] == [3, 0]
+
+
+def test_interactive_search_without_packs_runs_exactly_one_query(search_env):
+    with _noop_collection():
+        _run_search_init(allow_packs=0)
+
+    assert [call["cmloopit"] for call in search_env] == [3]
+
+
+def test_search_delay_sleeps_for_automatic_search(monkeypatch):
+    slept = []
+    monkeypatch.setattr(search.time, "sleep", lambda seconds: slept.append(seconds))
+
+    search._honour_search_delay("nyaa", 30, time.time())
+
+    assert len(slept) == 1
+
+
+def test_search_delay_never_sleeps_for_interactive_search(monkeypatch):
+    slept = []
+    monkeypatch.setattr(search.time, "sleep", lambda seconds: slept.append(seconds))
+
+    with _noop_collection():
+        search._honour_search_delay("nyaa", 30, time.time())
+
+    assert slept == []
+
+
+def test_search_delay_noop_outside_backoff_window(monkeypatch):
+    slept = []
+    monkeypatch.setattr(search.time, "sleep", lambda seconds: slept.append(seconds))
+
+    search._honour_search_delay("nyaa", 30, 0)
+    search._honour_search_delay("nyaa", 30, time.time() - 3600)
+
+    assert slept == []

--- a/tests/unit/test_interactive_search_single_pass.py
+++ b/tests/unit/test_interactive_search_single_pass.py
@@ -45,7 +45,7 @@ def search_env(monkeypatch):
     calls = []
 
     def fake_matrix(scarios):
-        calls.append({"cmloopit": scarios["cmloopit"], "RSS": scarios["RSS"]})
+        calls.append({"cmloopit": scarios["cmloopit"], "RSS": scarios["RSS"], "ComicName": scarios["ComicName"]})
         return {"status": False, "lastrun": 0}
 
     monkeypatch.setattr(
@@ -77,7 +77,7 @@ def search_env(monkeypatch):
     return calls
 
 
-def _run_search_init(allow_packs=1):
+def _run_search_init(allow_packs=1, alternate_search=None):
     return search.search_init(
         "Example Series",
         "2",
@@ -87,6 +87,7 @@ def _run_search_init(allow_packs=1):
         "2024-01-01",
         "2024-01-01",
         "issue-1",
+        AlternateSearch=alternate_search,
         smode=None,
         ComicID="comic-1",
         allow_packs=allow_packs,
@@ -117,6 +118,19 @@ def test_interactive_search_without_packs_runs_exactly_one_query(search_env):
         _run_search_init(allow_packs=0)
 
     assert [call["cmloopit"] for call in search_env] == [3]
+
+
+def test_interactive_search_keeps_alternate_names_but_stays_bounded(search_env):
+    # Alternate names are distinct titles (aliases, manga chapter forms), not
+    # padding retries: each still gets its own query, so total interactive
+    # queries per provider are bounded at names x passes (at most two passes).
+    with _noop_collection():
+        _run_search_init(alternate_search="Alias One##Alias Two")
+
+    assert [call["cmloopit"] for call in search_env] == [3, 3, 3, 0, 0, 0]
+    names = [call["ComicName"] for call in search_env]
+    assert names[:3] == ["Example Series", "Alias One", "Alias Two"]
+    assert names[3:] == ["Example Series", "Alias One", "Alias Two"]
 
 
 def test_search_delay_sleeps_for_automatic_search(monkeypatch):


### PR DESCRIPTION
## Summary

"Review missing" and the per-issue search icon called `searchforissue(manual=True)` and inherited the automatic-search retry machinery: an RSS cache pass, up to three zero-padded issue-number query variants per provider, and a 30-second backoff sleep between provider queries. Multiplied across up to 8 series targets, that dead time was the main reason interactive sessions blew the 10-minute TTL (#768, #766).

Interactive collection workers already scope themselves with `search_filer.interactive_collection()`, so a new `interactive_collection_active()` predicate lets the legacy pipeline drop those layers only in that context:

- `search_init` skips the RSS pass and runs a single numbered query per provider, keeping only the bare-title pack pass that pack discovery depends on (#744).
- The backoff sleep, extracted into `_honour_search_delay()`, never blocks an interactive session. A provider that objects to the pace surfaces as a provider failure on the sheet through the existing error handling instead of stalling the whole session.
- Automatic "Search all missing" and RSS flows keep every retry layer and the rate-limit backoff unchanged.

One deliberate deviation from the issue's letter: configured alternate names (and generated manga chapter-form terms) still each get their query. They are distinct titles, not padding retries, and dropping them would hide results in the manga scenario that motivated the issue. Interactive queries per provider are bounded at names × at-most-two passes; the decision is documented at the seam and pinned by a test.

Closes #768. Also answers #769: the per-target sequencing stays, but the per-target cost drops to one live query per provider with no sleeps.

## Testing

- 8 new tests in `tests/unit/test_interactive_search_single_pass.py` covering the predicate, the pass plan (with and without packs, with alternate names), and the delay skip
- Full backend unit suite passes (2763)
- All lint lanes pass; CodeRabbit review run twice, remaining finding is a formatting preference `ruff format` disagrees with

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iSsiiqcx5EXAckcTMGdyA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Interactive searches now return results faster by using one live query per provider without retry delays.
  * Pack discovery continues to include the necessary bare-title search.
  * Automatic “Search all missing” searches retain their existing retries, RSS checks, and rate-limit handling.
  * Alternate titles continue to receive dedicated searches within the streamlined interactive flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->