### PR TITLE
fix: Clarify directory setting descriptions on the General settings tab

### DIFF
--- a/.changeset/directory-settings-help-text.md
+++ b/.changeset/directory-settings-help-text.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Clarify the directory descriptions on the General settings tab. Destination Directory is now described as the root of your organized library where new series folders are created and downloads are filed, and Comic/Manga Directory as the existing folders scanned by library import, matching what each setting actually does.

--- a/frontend/src/components/settings/GeneralTab.tsx
+++ b/frontend/src/components/settings/GeneralTab.tsx
@@ -54,28 +54,28 @@ export function GeneralTab({ config, formData, onChange }: GeneralTabProps) {
           value={config.comic_dir}
           type="text"
           readOnly
-          helpText="Location where your comic library is stored"
+          helpText="Existing comic folder scanned by library import; imported series stay in place here"
         />
         <SettingField
           label="Destination Directory"
           value={config.destination_dir}
           type="text"
           readOnly
-          helpText="Default destination for downloaded comics"
+          helpText="Root of your organized comic library — new series folders are created here and downloads are filed into them"
         />
         <SettingField
           label="Manga Directory"
           value={config.manga_dir}
           type="text"
           readOnly
-          helpText="Location where your manga library is stored"
+          helpText="Existing manga folder scanned by library import; imported series stay in place here"
         />
         <SettingField
           label="Manga Destination Directory"
           value={config.manga_destination_dir}
           type="text"
           readOnly
-          helpText="Default destination for downloaded manga (falls back to Manga Directory, then Destination Directory)"
+          helpText="Root of your organized manga library (falls back to Manga Directory, then Destination Directory)"
         />
         <SettingField
           label="Import Directory"


### PR DESCRIPTION
Settings: Clarify directory descriptions on the General tab

The help text for the four directory settings now describes what each setting actually does, fixing the docs/UI contradiction reported in #778.

- Destination Directory (and Manga Destination Directory) are now described as the root of the organized library where new series folders are created and downloads are filed — not a staging area for downloads.
- Comic Directory and Manga Directory are now described as the existing folders scanned by library import, noting that imported series stay in place.
- Adds a patch changeset since the settings screen text is operator-visible.

Fixes #778 (UI half — the comicarr.com docs update for `MANGA_DESTINATION_DIR` lives in the website repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7tzQJp3j9S47nAyNksqtr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified General settings help text for comic and manga directories.
  * Explained the difference between existing library folders and destination folders for organized downloads.
  * Documented the fallback order for the Manga Destination Directory setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->