### PR TITLE
feat: Support Telegram forum topic targets in TELEGRAM_USERID

### DIFF
--- a/.changeset/telegram-forum-topics.md
+++ b/.changeset/telegram-forum-topics.md
@@ -1,0 +1,5 @@
+---
+"comicarr": minor
+---
+
+Telegram notifications can now post into a specific forum topic instead of a supergroup's General thread. In **Settings → Notifications**, append the topic ID to the chat ID in **User/Chat ID**, for example `-1007356238347:15`, and every notification Comicarr sends — text and cover images alike — lands in that topic. A plain chat ID or `@username` keeps working exactly as before, and a value whose suffix is not a topic number is still treated as an ordinary chat ID rather than being split.

--- a/comicarr/notifiers.py
+++ b/comicarr/notifiers.py
@@ -338,7 +338,8 @@ def _parse_telegram_target(userid):
     if ":" not in raw:
         return raw, None
     chat_id, topic_id = raw.rsplit(":", 1)
-    if topic_id.isdigit():
+    # isdigit() accepts non-decimal Unicode digits that int() rejects, so gate on ASCII.
+    if topic_id.isascii() and topic_id.isdigit():
         return chat_id, int(topic_id)
     return raw, None
 
@@ -488,9 +489,7 @@ class SLACK:
         else:
             pass
 
-        payload = {
-            "text": attachment_text
-        }
+        payload = {"text": attachment_text}
 
         response = None
         try:

--- a/comicarr/notifiers.py
+++ b/comicarr/notifiers.py
@@ -330,20 +330,37 @@ class PUSHBULLET:
         return self.notify(prline="Test Message", prline2="Release the Ninjas!")
 
 
+def _parse_telegram_target(userid):
+    """Split ``chat_id:topic_id`` targets used for forum topics (#787)."""
+    if userid is None:
+        return None, None
+    raw = str(userid).strip()
+    if ":" not in raw:
+        return raw, None
+    chat_id, topic_id = raw.rsplit(":", 1)
+    if topic_id.isdigit():
+        return chat_id, int(topic_id)
+    return raw, None
+
+
 class TELEGRAM:
     def __init__(self, test_userid=None, test_token=None):
         self.TELEGRAM_API = "https://api.telegram.org/bot%s/%s"
-        if test_userid is None:
-            self.userid = comicarr.CONFIG.TELEGRAM_USERID
-        else:
-            self.userid = test_userid
+        raw_userid = comicarr.CONFIG.TELEGRAM_USERID if test_userid is None else test_userid
+        self.userid, self.message_thread_id = _parse_telegram_target(raw_userid)
         if test_token is None:
             self.token = comicarr.CONFIG.TELEGRAM_TOKEN
         else:
             self.token = test_token
 
+    def _payload(self, **fields):
+        payload = dict(fields)
+        if self.message_thread_id is not None:
+            payload["message_thread_id"] = self.message_thread_id
+        return payload
+
     def notify(self, message, imageFile=None):
-        payload = {"chat_id": self.userid, "text": message}
+        payload = self._payload(chat_id=self.userid, text=message)
         sendMethod = "sendMessage"
         files = None
 
@@ -351,7 +368,7 @@ class TELEGRAM:
             # Construct message
             try:
                 files = {"photo": base64.b64decode(imageFile)}
-                payload = {"chat_id": self.userid, "caption": message}
+                payload = self._payload(chat_id=self.userid, caption=message)
                 sendMethod = "sendPhoto"
             except Exception as e:
                 logger.info("Telegram notify failed to decode image: " + str(e))
@@ -472,14 +489,6 @@ class SLACK:
             pass
 
         payload = {
-            #            "text": text,
-            #            "attachments": [
-            #                {
-            #                    "color": "#36a64f",
-            #                    "text": attachment_text
-            #                }
-            #            ]
-            # FIX: #1861 move notif from attachment to msg body - bbq
             "text": attachment_text
         }
 
@@ -490,7 +499,6 @@ class SLACK:
             logger.info(module + "Slack notify failed: " + str(e))
             return False
 
-        # Error logging
         sent_successfuly = True
         if not response.status_code == 200:
             logger.info(
@@ -567,7 +575,6 @@ class MATTERMOST:
             logger.info(module + "Mattermost notify failed: " + str(e))
             return False
 
-        # Error logging
         sent_successfuly = True
         if not response.status_code == 200:
             logger.info(
@@ -598,7 +605,6 @@ class DISCORD:
             module = ""
         module += "[NOTIFIER]"
 
-        # Setup discord variables
         payload = {}
         timestamp = str(datetime.utcnow())
 
@@ -613,20 +619,15 @@ class DISCORD:
                 snatched_text = "%s: %s" % (attachment_text, snatched_nzb)
                 if all([sent_to is not None, prov is not None]):
                     snatched_text += " from %s and %s" % (prov, sent_to)
-                    # If sent_to is not None, split it by whitespace into a list
                     sent_to_split = sent_to.split()
                     if "DDL" in sent_to:
                         sent_to = "DDL"
-                    # If client is in this string, that's a torrent client. Get second to last word.
                     elif "client" in sent_to:
-                        # This should be the name of our torrent client
                         sent_to = sent_to_split[len(sent_to_split) - 2]
-                    # If neither DDL nor client are in the string, it's an nzb. Get last word.
                     else:
                         sent_to = sent_to_split[len(sent_to_split) - 1]
                 elif sent_to is None:
                     snatched_text += " from %s" % prov
-                # Separate series and issue numbers
                 split_snatched_nzb = snatched_nzb.split()
                 issue = split_snatched_nzb[len(split_snatched_nzb) - 1]
                 split_snatched_nzb.pop()
@@ -647,7 +648,6 @@ class DISCORD:
                         "timestamp": timestamp,
                     }
                 ]
-            # If error is in the message
             elif "error" in attachment_text.lower():
                 payload["content"] = attachment_text
                 payload["embeds"] = [
@@ -659,17 +659,14 @@ class DISCORD:
                         "timestamp": timestamp,
                     }
                 ]
-            # If snatched or error is not in the message, it's a download and post-process
             else:
                 logger.info("attachment_text:%s" % (attachment_text,))
-                # extract series and issue number
                 series_num = attachment_text[41:]
                 series_num_split = series_num.split()
                 issue = series_num_split[len(series_num_split) - 1]
                 series_num_split.pop()
                 series = " ".join(map(str, series_num_split))
 
-                # If there's an image file, put it in
                 if imageFile is not None:
                     payload["content"] = attachment_text
                     payload["embeds"] = [
@@ -681,9 +678,7 @@ class DISCORD:
                                 {"name": "Series", "value": series, "inline": "true"},
                                 {"name": "Issue", "value": issue, "inline": "true"},
                             ],
-                            "image": {
-                                "url": "attachment://image.jpg",
-                            },
+                            "image": {"url": "attachment://image.jpg"},
                             "timestamp": timestamp,
                         }
                     ]
@@ -720,7 +715,6 @@ class DISCORD:
             except Exception as e:
                 logger.info(module + "Discord notify failed: " + str(e))
 
-        # Error logging
         if response is None:
             return False
         sent_successfuly = True
@@ -794,7 +788,6 @@ class GOTIFY:
             logger.info(module + "Gotify notify failed: " + str(e))
             return False
 
-        # Error logging
         sent_successfuly = True
         if not response.status_code == 200:
             logger.info(
@@ -837,8 +830,6 @@ class MATRIX:
                 snatched_text += " from %s" % prov
             attachment_text = snatched_text
 
-        # Matrix Client-Server API endpoint for sending messages
-        # Using a transaction ID based on timestamp for idempotency
         txn_id = str(int(time.time() * 1000))
         url = f"{self.homeserver.rstrip('/')}/_matrix/client/r0/rooms/{self.room_id}/send/m.room.message/{txn_id}"
 

--- a/frontend/src/components/settings/NotificationsTab.tsx
+++ b/frontend/src/components/settings/NotificationsTab.tsx
@@ -52,7 +52,8 @@ export function NotificationsTab({
               label="User/Chat ID"
               value={formData.telegram_userid || ""}
               onChange={(v) => onChange("telegram_userid", v as string)}
-              helpText="Your Telegram user or chat ID"
+              helpText="Your Telegram user or chat ID. To post into a forum topic, append the topic ID."
+              placeholder="-1007356238347 or -1007356238347:15"
             />
             <SettingField
               label="Notify on snatch"

--- a/tests/unit/notifiers/test_telegram.py
+++ b/tests/unit/notifiers/test_telegram.py
@@ -21,6 +21,23 @@ class TestTelegramInit:
         assert telegram.userid == "-1007356238347"
         assert telegram.message_thread_id == 15
 
+    @pytest.mark.parametrize("userid", ["some:host", "-1007356238347:", "-1007356238347:15a"])
+    def test_init_keeps_non_numeric_suffix_as_chat_id(
+        self, notifiers_module, mock_notifier_config, userid
+    ):
+        """A colon whose suffix is not a topic ID is left alone, preserving old behaviour."""
+        telegram = notifiers_module.TELEGRAM(test_userid=userid)
+
+        assert telegram.userid == userid
+        assert telegram.message_thread_id is None
+
+    def test_init_ignores_non_ascii_digit_suffix(self, notifiers_module, mock_notifier_config):
+        """str.isdigit() accepts Unicode digits int() rejects; those must not raise."""
+        telegram = notifiers_module.TELEGRAM(test_userid="-1007356238347:²")
+
+        assert telegram.userid == "-1007356238347:²"
+        assert telegram.message_thread_id is None
+
     def test_init_test_params_override_config(
         self, notifiers_module, mock_notifier_config
     ):
@@ -105,6 +122,53 @@ class TestTelegramNotify:
         assert "multipart/form-data" in responses.calls[0].request.headers.get(
             "Content-Type", ""
         )
+
+    @responses.activate
+    def test_notify_with_image_includes_message_thread_id(
+        self, notifiers_module, mock_notifier_config, sample_image_base64
+    ):
+        """sendPhoto encodes the topic ID as multipart form data, not JSON."""
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_telegram_token/sendPhoto",
+            json={"ok": True, "result": {}},
+            status=200,
+        )
+
+        telegram = notifiers_module.TELEGRAM(test_userid="-1007356238347:15")
+        result = telegram.notify("Test message with image", imageFile=sample_image_base64)
+
+        assert result is True
+        assert len(responses.calls) == 1
+
+        body = responses.calls[0].request.body
+        if isinstance(body, bytes):
+            body = body.decode("utf-8", errors="replace")
+        assert 'name="message_thread_id"' in body
+        assert 'name="chat_id"' in body
+        # The field value follows the multipart headers, before the next boundary.
+        thread_part = body.split('name="message_thread_id"')[1]
+        assert thread_part.split("--")[0].strip() == "15"
+
+    @responses.activate
+    def test_notify_omits_message_thread_id_without_topic(
+        self, notifiers_module, mock_notifier_config
+    ):
+        """A plain chat ID must not send message_thread_id at all."""
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_telegram_token/sendMessage",
+            json={"ok": True, "result": {}},
+            status=200,
+        )
+
+        telegram = notifiers_module.TELEGRAM()
+        assert telegram.notify("Test message") is True
+
+        import json
+
+        request_body = json.loads(responses.calls[0].request.body)
+        assert "message_thread_id" not in request_body
 
     @responses.activate
     def test_notify_image_decode_error_falls_back_to_text(

--- a/tests/unit/notifiers/test_telegram.py
+++ b/tests/unit/notifiers/test_telegram.py
@@ -13,6 +13,13 @@ class TestTelegramInit:
 
         assert telegram.userid == "123456789"
         assert telegram.token == "test_telegram_token"
+        assert telegram.message_thread_id is None
+
+    def test_init_parses_forum_topic_from_userid(self, notifiers_module, mock_notifier_config):
+        telegram = notifiers_module.TELEGRAM(test_userid="-1007356238347:15")
+
+        assert telegram.userid == "-1007356238347"
+        assert telegram.message_thread_id == 15
 
     def test_init_test_params_override_config(
         self, notifiers_module, mock_notifier_config
@@ -58,6 +65,24 @@ class TestTelegramNotify:
         request_body = json.loads(responses.calls[0].request.body)
         assert request_body["chat_id"] == "123456789"
         assert request_body["text"] == "Test message"
+
+    @responses.activate
+    def test_notify_forum_topic_includes_message_thread_id(self, notifiers_module, mock_notifier_config):
+        responses.add(
+            responses.POST,
+            "https://api.telegram.org/bottest_telegram_token/sendMessage",
+            json={"ok": True, "result": {}},
+            status=200,
+        )
+
+        telegram = notifiers_module.TELEGRAM(test_userid="-1007356238347:15")
+        assert telegram.notify("Test message") is True
+
+        import json
+
+        request_body = json.loads(responses.calls[0].request.body)
+        assert request_body["chat_id"] == "-1007356238347"
+        assert request_body["message_thread_id"] == 15
 
     @responses.activate
     def test_notify_with_image(


### PR DESCRIPTION
## Summary

Support Telegram forum topic targets in `TELEGRAM_USERID` using the `-1007356238347:15` format.

Closes #787

## Changes

- Parse `:topic_id` suffix from chat ID and send `message_thread_id` in Telegram API payloads

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [ ] No app release impact; no changeset needed (omit rather than "No user-visible behaviour changes.")

## Testing

- [x] Tests pass locally (`pytest tests/unit/notifiers/test_telegram.py -v`)
- [ ] Frontend builds (`cd frontend && npm run build`)
- [ ] Backend lint/format (`ruff check comicarr/` and `ruff format --check comicarr/`)
- [ ] Frontend lint/format (`cd frontend && npm run lint && npm run format:check`)
- [ ] Or one-shot: `npm run lint` (from repo root; requires `uv` + `frontend/node_modules`)
- [ ] Manually tested (describe what you tested):

## Additional Notes

No issue comments posted per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram notifications can now be sent directly to specific forum topics by appending a topic ID to the chat ID.
  * Text and image notifications support forum topic delivery.
  * Existing chat IDs and usernames continue to work as before.
  * Updated notification settings guidance and examples.

* **Bug Fixes**
  * Invalid or non-numeric topic suffixes are handled safely as regular chat IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->