### PR TITLE
fix: Fall back to cached weekly pull data when upstream is down (#786)

### DIFF
--- a/.changeset/weekly-pull-cached-fallback.md
+++ b/.changeset/weekly-pull-cached-fallback.md
@@ -2,4 +2,4 @@
 "comicarr": patch
 ---
 
-Keep showing your pull list when the upstream release site is down. Comicarr now falls back to the pull-list data it already has stored for that week and polls your watchlist against it, instead of failing the whole update and leaving the week blank. A failed check for the previous week no longer aborts the current week's update either. If there is no stored data for the week, the update still reports a failure as before.
+Keep showing your pull list when the upstream release site is down. Comicarr now falls back to the pull-list data it already has stored for that week and polls your watchlist against it, instead of failing the whole update and leaving the week blank. A failed check for the previous week no longer aborts the current week's update either. When upstream says how soon to retry, the next pull-list check is moved up to match (never sooner than a minute, never honored beyond an hour) so fresh data arrives as soon as the site is back. If there is no stored data for the week at all, the update still reports a failure as before.

--- a/.changeset/weekly-pull-cached-fallback.md
+++ b/.changeset/weekly-pull-cached-fallback.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Keep showing your pull list when the upstream release site is down. Comicarr now falls back to the pull-list data it already has stored for that week and polls your watchlist against it, instead of failing the whole update and leaving the week blank. A failed check for the previous week no longer aborts the current week's update either. If there is no stored data for the week, the update still reports a failure as before.

--- a/comicarr/locg.py
+++ b/comicarr/locg.py
@@ -19,6 +19,7 @@
 
 import datetime
 import re
+from email.utils import parsedate_to_datetime
 
 import requests
 from sqlalchemy import and_, delete
@@ -31,7 +32,8 @@ from comicarr.tables import weekly
 # Cloudflare fronts the pull-list host and answers for it whenever the origin
 # is unhealthy, so these arrive as ordinary responses rather than as request
 # exceptions. They say the upstream is unwell, not that the request was wrong,
-# and are transient — the next scheduled run is the retry.
+# and are transient — callers may honor the accompanying Retry-After hint to
+# retry sooner than the next scheduled run.
 CLOUDFLARE_ORIGIN_ERRORS = {
     "520": "returned an unknown error",
     "521": "is down",
@@ -49,6 +51,24 @@ def _retry_advice(retry_after):
     if value.isdigit():
         return " Upstream asked us to retry in %s seconds." % value
     return " Upstream asked us to retry after %s." % value
+
+
+def _retry_after_seconds(retry_after):
+    """Parse a Retry-After header into whole seconds from now, or None."""
+    value = str(retry_after or "").strip()
+    if not value:
+        return None
+    if value.isdigit():
+        seconds = int(value)
+    else:
+        try:
+            retry_at = parsedate_to_datetime(value)
+        except (TypeError, ValueError):
+            return None
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=datetime.timezone.utc)
+        seconds = int((retry_at - datetime.datetime.now(datetime.timezone.utc)).total_seconds())
+    return seconds if seconds > 0 else None
 
 
 def locg(pulldate=None, weeknumber=None, year=None):
@@ -110,7 +130,11 @@ def locg(pulldate=None, weeknumber=None, year=None):
             )
         )
         comicarr.BACKENDSTATUS_WS = "down"
-        return {"status": "failure"}
+        failure = {"status": "failure"}
+        retry_after = _retry_after_seconds(r.headers.get("Retry-After"))
+        if retry_after is not None:
+            failure["retry_after"] = retry_after
+        return failure
     elif str(r.status_code) == "999" or str(r.status_code) == "111":
         logger.warn(
             "[%s] Unable to retrieve data from site - this is a site.specific issue [%s]" % (r.status_code, pulldate)

--- a/comicarr/weeklypull.py
+++ b/comicarr/weeklypull.py
@@ -29,11 +29,26 @@ import time
 import traceback
 
 import sqlalchemy
-from sqlalchemy import delete, select, text
+from sqlalchemy import and_, delete, select, text
 
 import comicarr
 from comicarr import db, helpers, importer, locg, logger, mb, newpull, updater
 from comicarr.tables import annuals, comics, futureupcoming, issues, weekly
+
+
+def _weekly_pull_has_data(weeknumber, year):
+    """Return True if the weekly table already holds cached rows for the given week."""
+    try:
+        stmt = select(weekly.c.SHIPDATE).where(
+            and_(
+                weekly.c.weeknumber == int(weeknumber),
+                weekly.c.year == int(year),
+            )
+        )
+        return db.select_one(stmt) is not None
+    except Exception as e:
+        logger.fdebug("[PULL-LIST] Unable to check for cached pull-list data: %s" % e)
+        return False
 
 
 def pullit(forcecheck=None, weeknumber=None, year=None):
@@ -136,6 +151,20 @@ def pullit(forcecheck=None, weeknumber=None, year=None):
                     "[PULL-LIST] Unable to retrieve weekly pull-list. Pull list for week %s, %s may be stale."
                     % (weeknumber_mod, year_mod)
                 )
+                if _weekly_pull_has_data(weeknumber_mod, year_mod):
+                    logger.info(
+                        "[PULL-LIST] Falling back to the cached pull-list already stored for week %s, %s."
+                        % (weeknumber_mod, year_mod)
+                    )
+                    comicarr.PULLNEW = "no"
+                    new_pullcheck(weeknumber_mod, year_mod)
+                    continue
+                if x == 1:
+                    logger.fdebug(
+                        "[PULL-LIST] No cached pull-list for the previous week %s, %s - continuing on to the current week."
+                        % (weeknumber_mod, year_mod)
+                    )
+                    continue
                 return {"status": "failure"}
                 # comicarr.PULLBYFILE = pull_the_file(newrl)
                 # break

--- a/comicarr/weeklypull.py
+++ b/comicarr/weeklypull.py
@@ -102,6 +102,7 @@ def pullit(forcecheck=None, weeknumber=None, year=None):
         weekly_info = helpers.weekly_info()
         current_weeknumber = weekly_info["weeknumber"]
         weekly_info["year"]
+        retry_hint = None
         for x in [1, 2]:
             # for now we'll query WS twice - once for the previous week & once for the current week
             # but only when requesting data for the current week. This is done in order to make sure that
@@ -151,6 +152,7 @@ def pullit(forcecheck=None, weeknumber=None, year=None):
                     "[PULL-LIST] Unable to retrieve weekly pull-list. Pull list for week %s, %s may be stale."
                     % (weeknumber_mod, year_mod)
                 )
+                retry_hint = chk_locg.get("retry_after") or retry_hint
                 if _weekly_pull_has_data(weeknumber_mod, year_mod):
                     logger.info(
                         "[PULL-LIST] Falling back to the cached pull-list already stored for week %s, %s."
@@ -165,9 +167,15 @@ def pullit(forcecheck=None, weeknumber=None, year=None):
                         % (weeknumber_mod, year_mod)
                     )
                     continue
+                if retry_hint:
+                    return {"status": "failure", "retry_after": retry_hint}
                 return {"status": "failure"}
                 # comicarr.PULLBYFILE = pull_the_file(newrl)
                 # break
+        if retry_hint:
+            # A pass served stale cached data; surface upstream's hint so the
+            # scheduler can retry sooner than the regular interval.
+            return {"status": "success", "retry_after": retry_hint}
         return {"status": "success"}
 
     else:

--- a/comicarr/weeklypull.py
+++ b/comicarr/weeklypull.py
@@ -47,7 +47,7 @@ def _weekly_pull_has_data(weeknumber, year):
         )
         return db.select_one(stmt) is not None
     except Exception as e:
-        logger.fdebug("[PULL-LIST] Unable to check for cached pull-list data: %s" % e)
+        logger.warn("[PULL-LIST] Unable to check for cached pull-list data: %s" % e)
         return False
 
 

--- a/comicarr/weeklypullit.py
+++ b/comicarr/weeklypullit.py
@@ -71,6 +71,42 @@ def _restore_manual_next_run():
         logger.error("[WEEKLY] Could not restore scheduled refresh time: %s" % e)
 
 
+def _honor_upstream_retry(retry_after):
+    """Move the weekly job's next run earlier when upstream asked for a sooner retry.
+
+    Only ever pulls the schedule forward - a hint later than the regular next
+    run is ignored, as is anything beyond an hour, where the normal interval
+    is the better retry anyway.
+    """
+    try:
+        seconds = int(retry_after)
+    except (TypeError, ValueError):
+        return
+    if seconds <= 0 or seconds > 3600:
+        return
+    seconds = max(seconds, 60)
+    try:
+        scheduler = _get_weekly_runtime_value("scheduler", "SCHED")
+        job = scheduler.get_job("weekly") if scheduler is not None else None
+        if job is None:
+            return
+        next_run = getattr(job, "next_run_time", None)
+        if next_run is not None and next_run.tzinfo is not None:
+            now = datetime.datetime.now(tz=next_run.tzinfo)
+        else:
+            now = datetime.datetime.utcnow()
+        retry_at = now + datetime.timedelta(seconds=seconds)
+        if next_run is not None and next_run <= retry_at:
+            return
+        job.modify(next_run_time=retry_at)
+        logger.info(
+            "[WEEKLY] Upstream asked for a retry in %s seconds - next pull-list check moved up to %s."
+            % (seconds, retry_at.strftime("%Y-%m-%d %H:%M:%S"))
+        )
+    except Exception as e:
+        logger.error("[WEEKLY] Could not honor upstream retry request: %s" % e)
+
+
 class Weekly:
     def __init__(self):
         pass
@@ -84,14 +120,18 @@ class Weekly:
                 write=True, job="Weekly Pullist", current_run=helpers.utctimestamp(), status="Running"
             )
             _set_weekly_runtime_value("weekly_status", "WEEKLY_STATUS", "Running")
+            retry_hint = None
             try:
                 pull_result = weeklypull.pullit()
-                if isinstance(pull_result, dict) and pull_result.get("status") == "failure":
-                    raise RuntimeError("Weekly pull source reported a failure")
+                if isinstance(pull_result, dict):
+                    retry_hint = pull_result.get("retry_after")
+                    if pull_result.get("status") == "failure":
+                        raise RuntimeError("Weekly pull source reported a failure")
                 weeklypull.future_check()
             except Exception as e:
                 logger.error("[WEEKLY] Pull-list refresh failed: %s" % e)
                 _restore_manual_next_run()
+                _honor_upstream_retry(retry_hint)
                 helpers.job_management(
                     write=True,
                     job="Weekly Pullist",
@@ -104,6 +144,7 @@ class Weekly:
                 raise
 
             _restore_manual_next_run()
+            _honor_upstream_retry(retry_hint)
             helpers.job_management(
                 write=True, job="Weekly Pullist", last_run_completed=helpers.utctimestamp(), status="Waiting"
             )

--- a/tests/unit/test_weekly_pull_fallback.py
+++ b/tests/unit/test_weekly_pull_fallback.py
@@ -52,3 +52,45 @@ def test_pullit_still_fails_without_cached_week(monkeypatch):
         result = weeklypull.pullit()
 
     assert result == {"status": "failure"}
+
+
+def test_pullit_surfaces_retry_hint_when_serving_cached_week(monkeypatch):
+    config = MagicMock()
+    config.ALT_PULL = 2
+    config.CACHE_DIR = "/tmp"
+    monkeypatch.setattr(comicarr, "CONFIG", config)
+    monkeypatch.setattr(
+        weeklypull.helpers,
+        "weekly_info",
+        lambda: {"weeknumber": 33, "year": 2026, "prev_weeknumber": 32, "prev_year": 2026},
+    )
+    monkeypatch.setattr(weeklypull, "_weekly_pull_has_data", lambda week, year: week == 33 and year == 2026)
+    monkeypatch.setattr(weeklypull.locg, "locg", lambda **kwargs: {"status": "failure", "retry_after": 120})
+    monkeypatch.setattr(weeklypull, "new_pullcheck", MagicMock())
+    monkeypatch.setattr(weeklypull.time, "sleep", lambda *_args: None)
+
+    with patch.object(weeklypull.db, "select_one", return_value={"SHIPDATE": "20260827"}):
+        result = weeklypull.pullit()
+
+    assert result == {"status": "success", "retry_after": 120}
+
+
+def test_pullit_surfaces_retry_hint_on_failure(monkeypatch):
+    config = MagicMock()
+    config.ALT_PULL = 2
+    config.CACHE_DIR = "/tmp"
+    monkeypatch.setattr(comicarr, "CONFIG", config)
+    monkeypatch.setattr(
+        weeklypull.helpers,
+        "weekly_info",
+        lambda: {"weeknumber": 33, "year": 2026, "prev_weeknumber": 32, "prev_year": 2026},
+    )
+    monkeypatch.setattr(weeklypull, "_weekly_pull_has_data", lambda *_args: False)
+    monkeypatch.setattr(weeklypull.locg, "locg", lambda **kwargs: {"status": "failure", "retry_after": 120})
+    monkeypatch.setattr(weeklypull, "new_pullcheck", MagicMock())
+    monkeypatch.setattr(weeklypull.time, "sleep", lambda *_args: None)
+
+    with patch.object(weeklypull.db, "select_one", return_value={"SHIPDATE": "20260827"}):
+        result = weeklypull.pullit()
+
+    assert result == {"status": "failure", "retry_after": 120}

--- a/tests/unit/test_weekly_pull_fallback.py
+++ b/tests/unit/test_weekly_pull_fallback.py
@@ -1,13 +1,57 @@
 #  Copyright (C) 2026 Comicarr contributors
 #
 #  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
 
 """Weekly pull-list upstream outage fallback tests."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+from sqlalchemy import insert
+
 import comicarr
-from comicarr import weeklypull
+from comicarr import db, weeklypull
+from comicarr.tables import metadata, weekly
+
+
+@pytest.fixture
+def weekly_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(comicarr, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(comicarr, "CONFIG", SimpleNamespace())
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    db.shutdown_engine()
+    engine = db.get_engine()
+    metadata.create_all(engine)
+    yield engine
+    db.shutdown_engine()
+
+
+def test_weekly_pull_has_data_runs_the_real_query(weekly_db):
+    with weekly_db.begin() as conn:
+        conn.execute(
+            insert(weekly),
+            [
+                {
+                    "COMIC": "Cached title",
+                    "ISSUE": "1",
+                    "ComicID": "cached",
+                    "IssueID": "cached-1",
+                    "SHIPDATE": "20260827",
+                    "weeknumber": "33",
+                    "year": "2026",
+                }
+            ],
+        )
+
+    assert weeklypull._weekly_pull_has_data(33, 2026) is True
+    assert weeklypull._weekly_pull_has_data("33", "2026") is True
+    assert weeklypull._weekly_pull_has_data(34, 2026) is False
 
 
 def test_pullit_uses_cached_week_when_upstream_fails(monkeypatch):

--- a/tests/unit/test_weekly_pull_fallback.py
+++ b/tests/unit/test_weekly_pull_fallback.py
@@ -1,0 +1,54 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+
+"""Weekly pull-list upstream outage fallback tests."""
+
+from unittest.mock import MagicMock, patch
+
+import comicarr
+from comicarr import weeklypull
+
+
+def test_pullit_uses_cached_week_when_upstream_fails(monkeypatch):
+    config = MagicMock()
+    config.ALT_PULL = 2
+    config.CACHE_DIR = "/tmp"
+    monkeypatch.setattr(comicarr, "CONFIG", config)
+    monkeypatch.setattr(
+        weeklypull.helpers,
+        "weekly_info",
+        lambda: {"weeknumber": 33, "year": 2026, "prev_weeknumber": 32, "prev_year": 2026},
+    )
+    monkeypatch.setattr(weeklypull, "_weekly_pull_has_data", lambda week, year: week == 33 and year == 2026)
+    monkeypatch.setattr(weeklypull.locg, "locg", lambda **kwargs: {"status": "failure"})
+    new_pullcheck = MagicMock()
+    monkeypatch.setattr(weeklypull, "new_pullcheck", new_pullcheck)
+    monkeypatch.setattr(weeklypull.time, "sleep", lambda *_args: None)
+
+    with patch.object(weeklypull.db, "select_one", return_value={"SHIPDATE": "20260827"}):
+        result = weeklypull.pullit()
+
+    assert result == {"status": "success"}
+    new_pullcheck.assert_called_once_with(33, 2026)
+
+
+def test_pullit_still_fails_without_cached_week(monkeypatch):
+    config = MagicMock()
+    config.ALT_PULL = 2
+    config.CACHE_DIR = "/tmp"
+    monkeypatch.setattr(comicarr, "CONFIG", config)
+    monkeypatch.setattr(
+        weeklypull.helpers,
+        "weekly_info",
+        lambda: {"weeknumber": 33, "year": 2026, "prev_weeknumber": 32, "prev_year": 2026},
+    )
+    monkeypatch.setattr(weeklypull, "_weekly_pull_has_data", lambda *_args: False)
+    monkeypatch.setattr(weeklypull.locg, "locg", lambda **kwargs: {"status": "failure"})
+    monkeypatch.setattr(weeklypull, "new_pullcheck", MagicMock())
+    monkeypatch.setattr(weeklypull.time, "sleep", lambda *_args: None)
+
+    with patch.object(weeklypull.db, "select_one", return_value={"SHIPDATE": "20260827"}):
+        result = weeklypull.pullit()
+
+    assert result == {"status": "failure"}

--- a/tests/unit/test_weekly_retry_hint.py
+++ b/tests/unit/test_weekly_retry_hint.py
@@ -1,0 +1,74 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+
+"""Upstream Retry-After hint parsing and scheduler honoring tests."""
+
+import datetime
+from email.utils import format_datetime
+from unittest.mock import MagicMock
+
+from comicarr import locg, weeklypullit
+
+
+def test_retry_after_seconds_parses_delta_seconds():
+    assert locg._retry_after_seconds("120") == 120
+
+
+def test_retry_after_seconds_parses_http_date():
+    retry_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=300)
+    seconds = locg._retry_after_seconds(format_datetime(retry_at))
+    assert seconds is not None
+    assert 290 <= seconds <= 300
+
+
+def test_retry_after_seconds_rejects_garbage_and_past_dates():
+    assert locg._retry_after_seconds(None) is None
+    assert locg._retry_after_seconds("") is None
+    assert locg._retry_after_seconds("soon") is None
+    past = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+    assert locg._retry_after_seconds(format_datetime(past)) is None
+
+
+def _job_with_next_run(next_run):
+    job = MagicMock()
+    job.next_run_time = next_run
+    return job
+
+
+def test_honor_upstream_retry_moves_next_run_earlier(monkeypatch):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    job = _job_with_next_run(now + datetime.timedelta(hours=6))
+    scheduler = MagicMock()
+    scheduler.get_job.return_value = job
+    monkeypatch.setattr(weeklypullit, "_get_weekly_runtime_value", lambda *_args: scheduler)
+
+    weeklypullit._honor_upstream_retry(120)
+
+    job.modify.assert_called_once()
+    new_time = job.modify.call_args.kwargs["next_run_time"]
+    assert new_time < now + datetime.timedelta(minutes=5)
+
+
+def test_honor_upstream_retry_never_delays_a_sooner_schedule(monkeypatch):
+    now = datetime.datetime.now(datetime.timezone.utc)
+    job = _job_with_next_run(now + datetime.timedelta(seconds=30))
+    scheduler = MagicMock()
+    scheduler.get_job.return_value = job
+    monkeypatch.setattr(weeklypullit, "_get_weekly_runtime_value", lambda *_args: scheduler)
+
+    weeklypullit._honor_upstream_retry(120)
+
+    job.modify.assert_not_called()
+
+
+def test_honor_upstream_retry_ignores_bad_or_excessive_hints(monkeypatch):
+    scheduler = MagicMock()
+    monkeypatch.setattr(weeklypullit, "_get_weekly_runtime_value", lambda *_args: scheduler)
+
+    weeklypullit._honor_upstream_retry(None)
+    weeklypullit._honor_upstream_retry("soon")
+    weeklypullit._honor_upstream_retry(-5)
+    weeklypullit._honor_upstream_retry(7200)
+
+    scheduler.get_job.assert_not_called()

--- a/tests/unit/test_weekly_retry_hint.py
+++ b/tests/unit/test_weekly_retry_hint.py
@@ -1,6 +1,11 @@
 #  Copyright (C) 2026 Comicarr contributors
 #
 #  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
 
 """Upstream Retry-After hint parsing and scheduler honoring tests."""
 


### PR DESCRIPTION
## Summary

Fall back to cached weekly pull data when upstream is down, and honor upstream's Retry-After hint. Closes #786.

## Changes

- Add `_weekly_pull_has_data()` helper to detect existing local weekly rows for a week
- When the ALT_PULL=2 upstream fetch fails but cached data exists, poll the watchlist against the cached week instead of failing the refresh
- A failed previous-week supplemental query no longer aborts the current week's update
- `locg()` parses the Retry-After header (delta-seconds or HTTP date) on Cloudflare origin errors and surfaces it in the failure dict
- The weekly scheduler moves its next run earlier to match the hint — clamped to at least a minute, ignored beyond an hour, and never delaying an already-sooner schedule
- Unit tests for the fallback, no-cache failure, hint propagation, parsing, and scheduler honoring

## Release Impact

- [x] User-visible app change; changeset added (operator-facing, outcome-first prose)
- [ ] No app release impact; no changeset needed

## Testing

- [x] Tests pass locally (`pytest tests/unit` — 2799 passed)
- [x] Backend lint/format (`ruff check` and `ruff format --check` clean on changed files)
- [x] Contributor gates (`lint:guards` scripts all pass)
- [ ] Manually tested

## Screenshots

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKvYUucYhKNKLjnvZDSGSZ