### PR TITLE
fix: Resolve zero-padding prefix totally so post-processing cannot crash

### DIFF
--- a/.changeset/postprocess-zero-padding-crash.md
+++ b/.changeset/postprocess-zero-padding-crash.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Fix post-processing failing for every numeric issue when zero-padding was enabled but no padding level was set. Completed downloads (reported against SABnzbd, but affecting all download routes) crashed with `postprocess_error:UnboundLocalError`, landed in needs-attention, and retrying the import failed the same way with only "No rows could be resolved" shown. An unset or unrecognized padding level now means no padding, so imports proceed. Post-processing failures also now log the full error and traceback instead of just the error's name, so the log tells you what actually went wrong.

--- a/comicarr/app/common/numbers.py
+++ b/comicarr/app/common/numbers.py
@@ -350,6 +350,22 @@ def issuedigits(issnum, issue_exceptions=None, log=None):
     return int_issnum
 
 
+def zero_suppression_prefix(zero_level, zero_level_n):
+    """Resolve the issue-number zero-padding prefix from config.
+
+    Total over every input: an unset or unrecognized ``zero_level_n`` means
+    no padding, never an error (issue #796 — ZERO_LEVEL enabled with
+    ZERO_LEVEL_N at its unset default raised UnboundLocalError downstream).
+    """
+    if not zero_level:
+        return ""
+    if zero_level_n == "0x":
+        return "0"
+    if zero_level_n == "00x":
+        return "00"
+    return ""
+
+
 def sizeof_fmt(num, suffix="B"):
     """Format byte size with binary suffix (e.g., KiB, MiB, GiB)."""
     for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -18,6 +18,7 @@ import datetime
 import os
 import re
 import time
+import traceback
 import zipfile
 
 import rarfile
@@ -1976,7 +1977,10 @@ def _run_owned_postprocess(item):
                 comicarr.APILOCK.release()
             except RuntimeError:
                 pass
-        logger.error("[DOWNLOADS-PP] Owned post-processing failed; item quarantined: %s" % type(e).__name__)
+        logger.error(
+            "[DOWNLOADS-PP] Owned post-processing failed; item quarantined: %s: %s\n%s"
+            % (type(e).__name__, e, traceback.format_exc())
+        )
         return "failed", None
     finally:
         controller.release_lease(lease.lease_id)

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -32,6 +32,7 @@ from sqlalchemy import Integer, and_, delete, func, inspect, or_, select
 
 import comicarr
 from comicarr import db, filechecker, getimage, helpers, logger, notifiers, series_kind, updater, weeklypull
+from comicarr.app.common.numbers import zero_suppression_prefix
 from comicarr.app.common.placement import OnExisting, Outcome, Purpose, place
 from comicarr.app.downloads.postprocess_pipeline import (
     PostProcessContext,
@@ -3430,8 +3431,8 @@ class PostProcessor(object):
                         OComicname = oneinfo["COMIC"]
                         OIssue = oneinfo["ISSUE"]
                         OPublisher = oneinfo["PUBLISHER"]
-                        OSeriesYear = oneoff["SHIPDATE"][:4]
-                        OSeriesVolume = oneoff["volume"]
+                        OSeriesYear = oneinfo["SHIPDATE"][:4]
+                        OSeriesVolume = oneinfo["volume"]
 
                     ppinfo.append(
                         {
@@ -4670,15 +4671,7 @@ class PostProcessor(object):
             issueno = iss
 
         # issue zero-suppression here
-        if comicarr.CONFIG.ZERO_LEVEL is False:
-            zeroadd = ""
-        else:
-            if any([comicarr.CONFIG.ZERO_LEVEL_N == "none", comicarr.CONFIG.ZERO_LEVEL is None]):
-                zeroadd = ""
-            elif comicarr.CONFIG.ZERO_LEVEL_N == "0x":
-                zeroadd = "0"
-            elif comicarr.CONFIG.ZERO_LEVEL_N == "00x":
-                zeroadd = "00"
+        zeroadd = zero_suppression_prefix(comicarr.CONFIG.ZERO_LEVEL, comicarr.CONFIG.ZERO_LEVEL_N)
 
         logger.fdebug("%s Zero Suppression set to : %s" % (module, comicarr.CONFIG.ZERO_LEVEL_N))
 

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -4720,15 +4720,9 @@ class PostProcessor(object):
                 )
             elif int(issueno) >= 10 and int(issueno) < 100:
                 logger.fdebug("issue detected greater than 10, but less than 100")
-                if any(
-                    [
-                        comicarr.CONFIG.ZERO_LEVEL_N == "none",
-                        comicarr.CONFIG.ZERO_LEVEL_N is None,
-                        comicarr.CONFIG.ZERO_LEVEL is False,
-                    ]
-                ):
-                    zeroadd = ""
-                else:
+                # two-digit issues take at most one leading zero; keep the
+                # helper's no-padding fallback for unrecognized levels
+                if zeroadd == "00":
                     zeroadd = "0"
                 if "." in iss:
                     if int(iss_decval) > 0:

--- a/tests/unit/test_zero_suppression.py
+++ b/tests/unit/test_zero_suppression.py
@@ -1,0 +1,50 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Regression tests for issue #796: zero-suppression prefix resolution.
+
+Post-processing raised UnboundLocalError for every numeric issue when
+ZERO_LEVEL was enabled but ZERO_LEVEL_N was unset (its registry default),
+because the guard checked ``ZERO_LEVEL is None`` instead of
+``ZERO_LEVEL_N is None``.
+"""
+
+import pytest
+
+from comicarr.app.common.numbers import zero_suppression_prefix
+
+
+class TestZeroSuppressionPrefix:
+    def test_disabled_returns_empty(self):
+        assert zero_suppression_prefix(False, "00x") == ""
+
+    @pytest.mark.parametrize("level_n", [None, "none"])
+    def test_enabled_with_unset_or_none_returns_empty(self, level_n):
+        # The #796 case: ZERO_LEVEL enabled, ZERO_LEVEL_N never configured.
+        assert zero_suppression_prefix(True, level_n) == ""
+
+    def test_single_zero_padding(self):
+        assert zero_suppression_prefix(True, "0x") == "0"
+
+    def test_double_zero_padding(self):
+        assert zero_suppression_prefix(True, "00x") == "00"
+
+    def test_unknown_value_is_total_not_an_error(self):
+        assert zero_suppression_prefix(True, "banana") == ""
+
+    def test_zero_level_none_treated_as_disabled(self):
+        assert zero_suppression_prefix(None, "00x") == ""


### PR DESCRIPTION
Fixes #796.

## Root cause

The zero-suppression block in `postprocessor.py` guarded on `ZERO_LEVEL is None` where the sibling implementation in `filers.py` correctly guards on `ZERO_LEVEL_N is None`. With **zero-padding enabled but the padding level unset** (its registry default — no UI sets it), `zeroadd` was never assigned, so post-processing every numeric issue raised `UnboundLocalError`. Each completed download (reported against SABnzbd, but any route is affected) quarantined to needs-attention as `postprocess_error:UnboundLocalError`, and retrying the import failed the same way behind the generic "No rows could be resolved" envelope.

## Changes

- Extract the prefix resolution into `comicarr.app.common.numbers.zero_suppression_prefix`, total over every input (unset or unrecognized level → no padding, never a crash), and use it at the crashing site.
- Fix the adjacent `oneoff`/`oneinfo` typo in the one-off weekly branch, which raised `NameError` on that path — same defect class, found by the same used-before-assignment scan.
- Log the full error and traceback when owned post-processing quarantines an item, instead of only the exception class name — this is why the reporter had "no further indication in logs".
- Regression tests (`tests/unit/test_zero_suppression.py`) including the exact #796 configuration, plus an operator-facing patch changeset.

## Verification

- Full backend unit suite: **2813 passed**.
- `npm run lint` passes end to end (modern lane, all guards, backend, generated types, frontend).
- Re-ran `pylint --enable=used-before-assignment,undefined-variable`: both fixed sites are clean. Two remaining flags were deliberately left: `manual_arclist` (false positive — the legacy `except NameError` guard catches `UnboundLocalError`) and `grdst` (latent story-arc one-off edge, out of scope here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed comic imports that could crash when zero-padding was enabled without a valid padding level.
  - Unset or unrecognized padding settings now proceed without padding.
  - Fixed one-off pull-list processing errors.
  - Improved post-processing failure logs with complete error details and tracebacks.
  - Prevented failed retries from obscuring the original import error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->