### PR TITLE
fix(downloads): let a failed download reach failed-handling from InterDir

### DIFF
--- a/.changeset/failed-download-handling-and-search-alternatives.md
+++ b/.changeset/failed-download-handling-and-search-alternatives.md
@@ -1,0 +1,7 @@
+---
+"comicarr": patch
+---
+
+Failed downloads now reach failed-handling instead of parking in Needs Attention. A download NZBGet reported as failed sits in `InterDir`, outside the configured post-processing roots, so the command was rejected on its path before anything looked at the failed flag. The grab was never marked failed, the failed-download checker never tripped, and the same broken release was re-grabbed on every later search while the issue stayed stuck in Needs Attention with no way to clear it. Failed downloads are still path-sanitised, and successful ones are still confined to the configured roots.
+
+A previously failed release no longer rejects every alternative for the same issue. Every candidate the provider returned was checked against the *first* candidate's release id, so one failed release discarded the whole result set and the issue stayed Wanted with nothing to show for the search. Each candidate is now judged on its own, and the release that is actually snatched is the one recorded against the issue — so post-processing can match the download back to it.

--- a/comicarr/app/downloads/pp_commands.py
+++ b/comicarr/app/downloads/pp_commands.py
@@ -85,9 +85,27 @@ def _validate_basename(value):
     return name
 
 
+def _is_boolean_flag(value):
+    """True when the value is one of the explicit boolean forms the boundary accepts.
+
+    Type-aware on purpose. ``bool`` subclasses ``int`` and numeric types compare
+    across themselves, so ``1.0 == 1 == True``; a plain membership test against
+    ``(None, True, False, 0, 1, "0", "1")`` therefore admits ``1.0`` and ``0.0``.
+    """
+    if value is None or isinstance(value, bool):
+        return True
+    if isinstance(value, int):  # bool is already handled above
+        return value in (0, 1)
+    return value in ("0", "1")
+
+
 def _is_failed_download(value):
     """True only for an explicit failed flag; anything else gets full validation."""
-    return value in (True, 1, "1")
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):  # bool is already handled above
+        return value == 1
+    return value == "1"
 
 
 def validate_postprocess_item(item, roots=None, require_exists=True):
@@ -96,7 +114,13 @@ def validate_postprocess_item(item, roots=None, require_exists=True):
         raise PostProcessCommandError("post-processing command must be an object")
     command = dict(item)
     command["nzb_name"] = _validate_basename(command.get("nzb_name"))
-    if _is_failed_download(command.get("failed")):
+    # Prove the flags are boolean before anything branches on them, so an
+    # unsupported form is reported as itself rather than as a path rejection.
+    for key in ("failed", "apicall", "ddl", "oneoff"):
+        if key in command and not _is_boolean_flag(command[key]):
+            raise PostProcessCommandError("%s must be boolean" % key)
+    failed = _is_failed_download(command.get("failed"))
+    if failed:
         # A failed download is never imported from this folder. It routes to
         # failed-download handling, which only needs to know the release failed
         # so it can look for a different one. Its folder legitimately sits
@@ -113,9 +137,14 @@ def validate_postprocess_item(item, roots=None, require_exists=True):
         command["nzb_folder"] = str(
             validate_mapped_path(command.get("nzb_folder"), roots=roots, require_exists=require_exists)
         )
-    for key in ("failed", "apicall", "ddl", "oneoff"):
-        if key in command and command[key] not in (None, True, False, 0, 1, "0", "1"):
-            raise PostProcessCommandError("%s must be boolean" % key)
+    if "failed" in command:
+        # Normalize to a real bool. process.Process.post_process() only rewrites
+        # the string forms and then branches on `failed is False` / `is True`,
+        # so an integer 1 would match neither branch: no PostProcessor, no
+        # FailedProcessor, and the item silently does nothing. Canonicalizing
+        # here — the one place the command is proven safe — means every accepted
+        # truthy form actually reaches failed-download handling.
+        command["failed"] = failed
     for key in ("issueid", "comicid"):
         if key in command and command[key] is not None and not str(command[key]).strip():
             raise PostProcessCommandError("%s cannot be blank" % key)

--- a/comicarr/app/downloads/pp_commands.py
+++ b/comicarr/app/downloads/pp_commands.py
@@ -85,15 +85,34 @@ def _validate_basename(value):
     return name
 
 
+def _is_failed_download(value):
+    """True only for an explicit failed flag; anything else gets full validation."""
+    return value in (True, 1, "1")
+
+
 def validate_postprocess_item(item, roots=None, require_exists=True):
     """Return a normalized copy after validating the PP side-effect boundary."""
     if not isinstance(item, dict):
         raise PostProcessCommandError("post-processing command must be an object")
     command = dict(item)
     command["nzb_name"] = _validate_basename(command.get("nzb_name"))
-    command["nzb_folder"] = str(
-        validate_mapped_path(command.get("nzb_folder"), roots=roots, require_exists=require_exists)
-    )
+    if _is_failed_download(command.get("failed")):
+        # A failed download is never imported from this folder. It routes to
+        # failed-download handling, which only needs to know the release failed
+        # so it can look for a different one. Its folder legitimately sits
+        # outside the post-processing roots: NZBGet leaves a FAILURE/* item
+        # under InterDir, so the folder reported here is InterDir's parent
+        # rather than the completed-download root.
+        #
+        # Requiring containment rejects the command before the failed path ever
+        # runs, so the release parks in manual_review, the failure is never
+        # recorded, and the identical release is grabbed again on every
+        # subsequent search. Sanitize the path, but do not require containment.
+        command["nzb_folder"] = str(_canonical_path(command.get("nzb_folder"), "nzb_folder"))
+    else:
+        command["nzb_folder"] = str(
+            validate_mapped_path(command.get("nzb_folder"), roots=roots, require_exists=require_exists)
+        )
     for key in ("failed", "apicall", "ddl", "oneoff"):
         if key in command and command[key] not in (None, True, False, 0, 1, "0", "1"):
             raise PostProcessCommandError("%s must be boolean" % key)

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -1514,21 +1514,29 @@ def verification(verified_matches, is_info):
     done = False
     verified_index = 0
     if verified_matches != "no results":
-        for verified in verified_matches:
+        # verified_index has to track the candidate actually in hand: the post-loop
+        # block reads verified_matches[verified_index] for the pack check, the nzbid
+        # it hands nzblog(), and the snatch notification. search_filer also emits
+        # alt_match entries with downloadit=False into this same list, and those were
+        # skipped without advancing the index -- so any candidate sent after one of
+        # them was logged under an earlier entry's nzbid.
+        for verified_index, verified in enumerate(verified_matches):
             if verified["downloadit"]:
                 try:
                     if verified["chkit"]:
                         helpers.checkthe_id(ComicID, verified["chkit"])
                 except Exception:
                     pass
-                nzbname = nzbname_create(is_info["nzbprov"], info=verified_matches, title=verified["ComicTitle"])
+                # nzbname_create() reads ComicName, IssueNumber and comyear off
+                # info[0] for the blackhole name, so it needs the candidate being
+                # tried for the same reason searcher() below does.
+                nzbname = nzbname_create(is_info["nzbprov"], info=[verified], title=verified["ComicTitle"])
                 if nzbname is None:
                     logger.error(
                         "[NZBPROVIDER = NONE] Encountered an error using given "
                         "provider with requested information: %s. You have a blank "
                         "entry most likely in your newznabs, fix it & restart Comicarr" % verified
                     )
-                    verified_index += 1
                     continue
                 try:
                     links = {"id": verified["entry"]["id"], "link": verified["entry"]["link"]}
@@ -1561,7 +1569,6 @@ def verification(verified_matches, is_info):
                     ]
                 ):
                     is_info["foundc"]["status"] = False
-                    verified_index += 1
                     continue
                 elif any(
                     [
@@ -1573,7 +1580,6 @@ def verification(verified_matches, is_info):
                     ]
                 ):
                     is_info["foundc"]["status"] = False
-                    verified_index += 1
                     return is_info
 
                 searchresult["nzbid"]

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -1537,7 +1537,13 @@ def verification(verified_matches, is_info):
                 searchresult = searcher(
                     verified["nzbprov"],
                     nzbname,
-                    verified_matches,
+                    # searcher() reads every field off comicinfo[0], so it has to be
+                    # handed the candidate currently being tried. Passing the whole
+                    # verified_matches list pins it to the first candidate, so the
+                    # failed-release check (and the nzbid, size and title it logs)
+                    # describe candidate 0 no matter which one is in hand -- meaning
+                    # one previously-failed release rejects every alternative.
+                    [verified],
                     links,
                     verified["IssueID"],
                     verified["ComicID"],

--- a/tests/unit/test_download_processing_contracts.py
+++ b/tests/unit/test_download_processing_contracts.py
@@ -142,20 +142,47 @@ def test_failed_download_is_not_required_to_sit_under_a_postprocess_root(tmp_pat
     )
     assert command["nzb_folder"] == str(interdir_parent.resolve())
 
-    # "1" is the other explicit truthy form the command boundary accepts.
-    assert pp_commands.validate_postprocess_item(
-        {"nzb_name": "Saga.001.cbz", "nzb_folder": str(interdir_parent), "failed": "1"},
-        roots=[root],
-    )
+    # Every explicit truthy form the command boundary accepts, normalized to a
+    # real bool. process.Process.post_process() rewrites only the string forms
+    # and then branches on `failed is False` / `is True`, so an integer 1 left
+    # as-is would match neither branch: no PostProcessor, no FailedProcessor,
+    # and the item silently does nothing.
+    for failed in (True, 1, "1"):
+        command = pp_commands.validate_postprocess_item(
+            {"nzb_name": "Saga.001.cbz", "nzb_folder": str(interdir_parent), "failed": failed},
+            roots=[root],
+        )
+        assert command["failed"] is True
 
     # A successful download stays confined to the configured roots, and an
     # unset or false flag must not inherit the relaxed path.
-    for failed in (False, "0", None):
+    for failed in (False, 0, "0", None):
         with pytest.raises(pp_commands.PostProcessCommandError):
             pp_commands.validate_postprocess_item(
                 {"nzb_name": "Saga.001.cbz", "nzb_folder": str(interdir_parent), "failed": failed},
                 roots=[root],
             )
+
+    # A falsey flag is normalized the same way, so `failed is False` reaches the
+    # import path instead of falling through both branches.
+    for failed in (False, 0, "0", None):
+        command = pp_commands.validate_postprocess_item(
+            {"nzb_name": "Saga.001.cbz", "nzb_folder": str(root), "failed": failed},
+            roots=[root],
+        )
+        assert command["failed"] is False
+
+    # bool subclasses int and numeric types compare across themselves, so
+    # `1.0 == 1 == True`. A membership test would let a float take the relaxed
+    # path; an unsupported form must be rejected as a non-boolean flag, and be
+    # reported as itself rather than as a path rejection.
+    for key in ("failed", "apicall", "ddl", "oneoff"):
+        for value in (1.0, 0.0, 2, "true", "yes"):
+            with pytest.raises(pp_commands.PostProcessCommandError, match="%s must be boolean" % key):
+                pp_commands.validate_postprocess_item(
+                    {"nzb_name": "Saga.001.cbz", "nzb_folder": str(root), key: value},
+                    roots=[root],
+                )
 
     # Traversal sanitising still applies to a failed download.
     with pytest.raises(pp_commands.PostProcessCommandError):

--- a/tests/unit/test_download_processing_contracts.py
+++ b/tests/unit/test_download_processing_contracts.py
@@ -122,6 +122,49 @@ def test_postprocess_command_rejects_traversal_prefix_collision_and_symlink_esca
             )
 
 
+def test_failed_download_is_not_required_to_sit_under_a_postprocess_root(tmp_path):
+    """A failed download must reach failed-handling even from outside the roots.
+
+    NZBGet leaves a FAILURE/* item under InterDir, so the folder reported for a
+    failed download is InterDir's parent rather than the completed-download
+    root. Requiring containment there rejects the command before the failed
+    path runs: the release parks in manual_review, the failure is never
+    recorded, and the identical release is re-grabbed on every later search.
+    """
+    root = tmp_path / "completed"
+    root.mkdir()
+    interdir_parent = tmp_path / "intermediate"
+    interdir_parent.mkdir()
+
+    command = pp_commands.validate_postprocess_item(
+        {"nzb_name": "Saga.001.cbz", "nzb_folder": str(interdir_parent), "failed": True},
+        roots=[root],
+    )
+    assert command["nzb_folder"] == str(interdir_parent.resolve())
+
+    # "1" is the other explicit truthy form the command boundary accepts.
+    assert pp_commands.validate_postprocess_item(
+        {"nzb_name": "Saga.001.cbz", "nzb_folder": str(interdir_parent), "failed": "1"},
+        roots=[root],
+    )
+
+    # A successful download stays confined to the configured roots, and an
+    # unset or false flag must not inherit the relaxed path.
+    for failed in (False, "0", None):
+        with pytest.raises(pp_commands.PostProcessCommandError):
+            pp_commands.validate_postprocess_item(
+                {"nzb_name": "Saga.001.cbz", "nzb_folder": str(interdir_parent), "failed": failed},
+                roots=[root],
+            )
+
+    # Traversal sanitising still applies to a failed download.
+    with pytest.raises(pp_commands.PostProcessCommandError):
+        pp_commands.validate_postprocess_item(
+            {"nzb_name": "Saga.001.cbz", "nzb_folder": str(interdir_parent) + "/../x", "failed": True},
+            roots=[root],
+        )
+
+
 def test_postprocess_worker_quarantines_owned_failure_and_continues(sqlite_ddl_db, monkeypatch, tmp_path):
     first = {
         "nzb_name": "First.cbz",

--- a/tests/unit/test_search_verification_candidate.py
+++ b/tests/unit/test_search_verification_candidate.py
@@ -1,3 +1,12 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
 """verification() must hand searcher() the candidate it is currently trying.
 
 searcher() reads ComicName, nzbid, size, nzbtitle and friends off comicinfo[0].
@@ -10,14 +19,14 @@ alternative the provider offered.
 import comicarr.search as search
 
 
-def _candidate(nzbid, title):
+def _candidate(nzbid, title, downloadit=True, comyear="2011"):
     return {
-        "downloadit": True,
+        "downloadit": downloadit,
         "chkit": None,
         "ComicTitle": title,
         "nzbid": nzbid,
         "nzbtitle": title,
-        "comyear": "2011",
+        "comyear": comyear,
         "nzbprov": "NZBGeek",
         "tmpprov": "NZBGeek (newznab)",
         "IssueID": "1001",
@@ -91,3 +100,51 @@ def test_fallback_candidate_can_still_be_taken(monkeypatch):
 
     assert out["foundc"]["status"] is True
     assert out["foundc"]["info"]["nzbid"] == "minutemen-id"
+
+
+def test_skipped_candidate_does_not_misname_the_snatch(monkeypatch):
+    """A leading downloadit=False entry must not shift what gets logged.
+
+    search_filer emits alt_match entries with downloadit=False into the same
+    list. They are skipped without ever reaching searcher(), so the index used
+    by the post-loop block has to advance past them anyway -- otherwise the
+    accepted release is recorded under the skipped entry's nzbid and year, and
+    post-processing later cannot match the download back to the issue.
+    """
+    logged = {}
+    snatched = {}
+
+    def fake_searcher(nzbprov, nzbname, comicinfo, link, *a, **kw):
+        return {
+            "nzbid": comicinfo[0]["nzbid"],
+            "nzbname": "nzbname",
+            "sent_to": "NZBGet",
+            "alt_nzbname": None,
+            "SARC": None,
+        }
+
+    monkeypatch.setattr(search, "searcher", fake_searcher)
+    monkeypatch.setattr(search, "nzbname_create", lambda *a, **kw: "nzbname")
+    monkeypatch.setattr(search.updater, "nzblog", lambda *a, **kw: logged.update(kw))
+    monkeypatch.setattr(search.updater, "foundsearch", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        search, "notify_snatch", lambda sent_to, name, year, *a: snatched.update(year=year)
+    )
+
+    matches = [
+        _candidate("alt-id", "Invincible 085 (alt match)", downloadit=False, comyear="1999"),
+        _candidate("minutemen-id", "Invincible 085 (Minutemen-InnerDemons)"),
+    ]
+
+    info = _is_info()
+    info.update({"ComicName": "Invincible", "ComicYear": "2003", "IssueID": "1001",
+                 "ComicID": "17993", "SARC": None, "IssueArcID": None,
+                 "smode": "want", "oneoff": False, "IssueNumber": "85"})
+
+    out = search.verification(matches, info)
+
+    assert out["foundc"]["status"] is True
+    assert logged["id"] == "minutemen-id", (
+        "nzblog was given the skipped candidate's nzbid: %r" % (logged.get("id"),)
+    )
+    assert snatched["year"] == "2011"

--- a/tests/unit/test_search_verification_candidate.py
+++ b/tests/unit/test_search_verification_candidate.py
@@ -1,0 +1,93 @@
+"""verification() must hand searcher() the candidate it is currently trying.
+
+searcher() reads ComicName, nzbid, size, nzbtitle and friends off comicinfo[0].
+When verification() passed the whole verified_matches list, every candidate was
+described by candidate 0 -- so the failed-release check ran against candidate 0's
+nzbid for all of them, and a single previously-failed release rejected every
+alternative the provider offered.
+"""
+
+import comicarr.search as search
+
+
+def _candidate(nzbid, title):
+    return {
+        "downloadit": True,
+        "chkit": None,
+        "ComicTitle": title,
+        "nzbid": nzbid,
+        "nzbtitle": title,
+        "comyear": "2011",
+        "nzbprov": "NZBGeek",
+        "tmpprov": "NZBGeek (newznab)",
+        "IssueID": "1001",
+        "ComicID": "17993",
+        "newznab": None,
+        "torznab": None,
+        "provider_stat": {},
+        "pack": False,
+        "entry": {"id": nzbid, "link": "https://example.invalid/%s" % nzbid},
+    }
+
+
+def _is_info():
+    return {
+        "nzbprov": "NZBGeek",
+        "RSS": "no",
+        "foundc": {"status": False, "info": None},
+    }
+
+
+def test_each_candidate_is_described_by_itself(monkeypatch):
+    """The nzbid searcher() sees must advance with the candidate."""
+    seen = []
+
+    def fake_searcher(nzbprov, nzbname, comicinfo, link, *a, **kw):
+        seen.append(comicinfo[0]["nzbid"])
+        return "downloadchk-fail"  # force the loop on to the next candidate
+
+    monkeypatch.setattr(search, "searcher", fake_searcher)
+    monkeypatch.setattr(search, "nzbname_create", lambda *a, **kw: "nzbname")
+
+    matches = [_candidate("empire-id", "Invincible 085 (digital-Empire)"),
+               _candidate("minutemen-id", "Invincible 085 (Minutemen-InnerDemons)")]
+
+    search.verification(matches, _is_info())
+
+    assert seen == ["empire-id", "minutemen-id"], (
+        "second candidate was described by candidate 0: %r" % (seen,)
+    )
+
+
+def test_fallback_candidate_can_still_be_taken(monkeypatch):
+    """A failed first candidate must not stop the second from being sent."""
+
+    def fake_searcher(nzbprov, nzbname, comicinfo, link, *a, **kw):
+        if comicinfo[0]["nzbid"] == "empire-id":
+            return "downloadchk-fail"
+        return {
+            "nzbid": comicinfo[0]["nzbid"],
+            "nzbname": "nzbname",
+            "sent_to": "NZBGet",
+            "alt_nzbname": None,
+            "SARC": None,
+        }
+
+    monkeypatch.setattr(search, "searcher", fake_searcher)
+    monkeypatch.setattr(search, "nzbname_create", lambda *a, **kw: "nzbname")
+    monkeypatch.setattr(search.updater, "nzblog", lambda *a, **kw: None)
+    monkeypatch.setattr(search.updater, "foundsearch", lambda *a, **kw: None)
+    monkeypatch.setattr(search, "notify_snatch", lambda *a, **kw: None)
+
+    matches = [_candidate("empire-id", "Invincible 085 (digital-Empire)"),
+               _candidate("minutemen-id", "Invincible 085 (Minutemen-InnerDemons)")]
+
+    info = _is_info()
+    info.update({"ComicName": "Invincible", "ComicYear": "2003", "IssueID": "1001",
+                 "ComicID": "17993", "SARC": None, "IssueArcID": None,
+                 "smode": "want", "oneoff": False, "IssueNumber": "85"})
+
+    out = search.verification(matches, info)
+
+    assert out["foundc"]["status"] is True
+    assert out["foundc"]["info"]["nzbid"] == "minutemen-id"


### PR DESCRIPTION
Fixes #805.

Two fixes an operator will notice, both on the path from a grab to a usable file. They ride together because the second is what makes the first recoverable: failed-handling is only useful if the follow-up search can actually find a different release.

Covered by one changeset, `.changeset/failed-download-handling-and-search-alternatives.md`.

---

## 1. A failed download never reached failed-handling

`validate_postprocess_item()` requires `nzb_folder` to sit under a configured post-processing root **before** anything inspects the `failed` flag. But a failed download's folder legitimately sits outside those roots: NZBGet leaves a `FAILURE/*` item under `InterDir`, and `nzbget.py` reports the folder as `DestDir`'s parent.

So the command is rejected:

```
[DOWNLOADS-PP] Rejected unsafe post-processing command:
    nzb_folder is outside configured post-processing roots
```

`PostProcessCommandError` propagates and the item is quarantined, so `process.py` — which routes `failed is True` to `FailedProcessor` — is never reached. Because `markFailed()` never runs, the `failed` table stays empty, `FAILED_DOWNLOAD_CHECKER` never trips, and the same release is re-grabbed on every later search. `manual_review` is terminal, so the row never self-heals.

**Change.** A failed download is never imported from that folder — it only needs to reach failed-handling so a different release can be found. Sanitize the path, but don't require containment.

Successful downloads are untouched and still confined to the configured roots. Traversal and separator sanitising still applies to both paths.

The `failed` flag is also now type-aware rather than a membership test, and is normalized to a bool at the command boundary. `bool` subclasses `int` and numeric types compare across themselves, so `1.0 == 1 == True` let a float take the relaxed branch; integer `1` was accepted at the boundary but then missed `Process.post_process()`'s identity check, which only rewrites the string forms — leaving the item stuck. `False` / `"0"` / `None` still get full containment validation.

## 2. One failed release rejected every alternative (`comicarr/search.py`)

`verification()` passed the whole `verified_matches` list to `searcher()`, which reads `ComicName`, `nzbid`, size and title off `comicinfo[0]`. So every candidate was described by candidate 0: the failed-release check ran against candidate 0's nzbid no matter which candidate was in hand, and once one release for an issue had failed, every alternative the provider offered was rejected too. The issue stayed Wanted with nothing to show for the search — the exact state fix 1 leaves an issue in.

Each candidate is now handed to `searcher()` as itself.

Making fallbacks reachable exposed a second defect in the same function, [raised in review](https://github.com/frankieramirez/comicarr/pull/807#discussion_r3909402591): `verified_index` only advanced inside the `downloadit` branch, but `search_filer` emits `alt_match` entries with `downloadit=False` into the same list. A skipped entry ahead of the accepted candidate left the index pointing at the earlier row, and the post-loop block reads `verified_matches[verified_index]` for the pack check, the nzbid it hands `nzblog()`, and the snatch year — so the accepted release was recorded under the wrong nzbid and post-processing could not match the download back to the issue. The index now comes from `enumerate()`. `nzbname_create()` reads `info[0]` for the blackhole name, the same shape as `searcher()`, so it gets the current candidate too.

> This is the same change as #807, cherry-picked here so the two fixes could be verified together on a live install. Happy to drop it from this branch and let #807 land on its own if you'd rather keep them separate — just say which you prefer.

## Tests

`test_failed_download_is_not_required_to_sit_under_a_postprocess_root` covers:

- a failed download from outside the roots is accepted
- both explicit truthy forms (`True`, `"1"`)
- `False` / `"0"` / `None` still get full containment validation
- traversal is still rejected for a failed download
- `1.0` and `0.0` are rejected; integer `1` is accepted and normalized

`test_search_verification_candidate.py` covers:

- each candidate is described by itself, not by candidate 0
- a failed first candidate does not stop the second from being sent
- a leading `downloadit=False` entry does not shift the nzbid handed to `nzblog()`

On `main` the first fails with the exact production error:

```
E   comicarr.app.downloads.pp_commands.PostProcessCommandError:
    nzb_folder is outside configured post-processing roots
```

and the indexing test fails with `nzblog was given the skipped candidate's nzbid: 'alt-id'`.

Full unit suite passes: **2817 passed**. `ruff check`, `ruff format --check` and `lint:guards` clean.

## Verified on a live install

Applied to `v0.38.2`, built and deployed against the reproducing install:

| | before | after |
|---|---|---|
| `nzb_folder is outside configured post-processing roots` | every attempt | 0 |
| `Initiating Failed Download handling` | 0 in all history | runs |
| `failed` table | 0 rows | records the release |
| `pipeline_journal` `manual_review/manual_review` | 7 | 0 |
| Needs-attention panel | 7 issues | empty |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of failed downloads whose folders are located outside configured post-processing directories.
  - Preserved security checks for non-failed downloads and path traversal attempts.
  - Download failure status is now recognized only for explicit failure values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
