### PR TITLE
fix(search): try each candidate as itself, not as the first result

### DIFF
--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -1514,21 +1514,29 @@ def verification(verified_matches, is_info):
     done = False
     verified_index = 0
     if verified_matches != "no results":
-        for verified in verified_matches:
+        # verified_index has to track the candidate actually in hand: the post-loop
+        # block reads verified_matches[verified_index] for the pack check, the nzbid
+        # it hands nzblog(), and the snatch notification. search_filer also emits
+        # alt_match entries with downloadit=False into this same list, and those were
+        # skipped without advancing the index -- so any candidate sent after one of
+        # them was logged under an earlier entry's nzbid.
+        for verified_index, verified in enumerate(verified_matches):
             if verified["downloadit"]:
                 try:
                     if verified["chkit"]:
                         helpers.checkthe_id(ComicID, verified["chkit"])
                 except Exception:
                     pass
-                nzbname = nzbname_create(is_info["nzbprov"], info=verified_matches, title=verified["ComicTitle"])
+                # nzbname_create() reads ComicName, IssueNumber and comyear off
+                # info[0] for the blackhole name, so it needs the candidate being
+                # tried for the same reason searcher() below does.
+                nzbname = nzbname_create(is_info["nzbprov"], info=[verified], title=verified["ComicTitle"])
                 if nzbname is None:
                     logger.error(
                         "[NZBPROVIDER = NONE] Encountered an error using given "
                         "provider with requested information: %s. You have a blank "
                         "entry most likely in your newznabs, fix it & restart Comicarr" % verified
                     )
-                    verified_index += 1
                     continue
                 try:
                     links = {"id": verified["entry"]["id"], "link": verified["entry"]["link"]}
@@ -1561,7 +1569,6 @@ def verification(verified_matches, is_info):
                     ]
                 ):
                     is_info["foundc"]["status"] = False
-                    verified_index += 1
                     continue
                 elif any(
                     [
@@ -1573,7 +1580,6 @@ def verification(verified_matches, is_info):
                     ]
                 ):
                     is_info["foundc"]["status"] = False
-                    verified_index += 1
                     return is_info
 
                 searchresult["nzbid"]

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -1537,7 +1537,13 @@ def verification(verified_matches, is_info):
                 searchresult = searcher(
                     verified["nzbprov"],
                     nzbname,
-                    verified_matches,
+                    # searcher() reads every field off comicinfo[0], so it has to be
+                    # handed the candidate currently being tried. Passing the whole
+                    # verified_matches list pins it to the first candidate, so the
+                    # failed-release check (and the nzbid, size and title it logs)
+                    # describe candidate 0 no matter which one is in hand -- meaning
+                    # one previously-failed release rejects every alternative.
+                    [verified],
                     links,
                     verified["IssueID"],
                     verified["ComicID"],

--- a/tests/unit/test_search_verification_candidate.py
+++ b/tests/unit/test_search_verification_candidate.py
@@ -1,3 +1,12 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
 """verification() must hand searcher() the candidate it is currently trying.
 
 searcher() reads ComicName, nzbid, size, nzbtitle and friends off comicinfo[0].
@@ -10,14 +19,14 @@ alternative the provider offered.
 import comicarr.search as search
 
 
-def _candidate(nzbid, title):
+def _candidate(nzbid, title, downloadit=True, comyear="2011"):
     return {
-        "downloadit": True,
+        "downloadit": downloadit,
         "chkit": None,
         "ComicTitle": title,
         "nzbid": nzbid,
         "nzbtitle": title,
-        "comyear": "2011",
+        "comyear": comyear,
         "nzbprov": "NZBGeek",
         "tmpprov": "NZBGeek (newznab)",
         "IssueID": "1001",
@@ -91,3 +100,51 @@ def test_fallback_candidate_can_still_be_taken(monkeypatch):
 
     assert out["foundc"]["status"] is True
     assert out["foundc"]["info"]["nzbid"] == "minutemen-id"
+
+
+def test_skipped_candidate_does_not_misname_the_snatch(monkeypatch):
+    """A leading downloadit=False entry must not shift what gets logged.
+
+    search_filer emits alt_match entries with downloadit=False into the same
+    list. They are skipped without ever reaching searcher(), so the index used
+    by the post-loop block has to advance past them anyway -- otherwise the
+    accepted release is recorded under the skipped entry's nzbid and year, and
+    post-processing later cannot match the download back to the issue.
+    """
+    logged = {}
+    snatched = {}
+
+    def fake_searcher(nzbprov, nzbname, comicinfo, link, *a, **kw):
+        return {
+            "nzbid": comicinfo[0]["nzbid"],
+            "nzbname": "nzbname",
+            "sent_to": "NZBGet",
+            "alt_nzbname": None,
+            "SARC": None,
+        }
+
+    monkeypatch.setattr(search, "searcher", fake_searcher)
+    monkeypatch.setattr(search, "nzbname_create", lambda *a, **kw: "nzbname")
+    monkeypatch.setattr(search.updater, "nzblog", lambda *a, **kw: logged.update(kw))
+    monkeypatch.setattr(search.updater, "foundsearch", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        search, "notify_snatch", lambda sent_to, name, year, *a: snatched.update(year=year)
+    )
+
+    matches = [
+        _candidate("alt-id", "Invincible 085 (alt match)", downloadit=False, comyear="1999"),
+        _candidate("minutemen-id", "Invincible 085 (Minutemen-InnerDemons)"),
+    ]
+
+    info = _is_info()
+    info.update({"ComicName": "Invincible", "ComicYear": "2003", "IssueID": "1001",
+                 "ComicID": "17993", "SARC": None, "IssueArcID": None,
+                 "smode": "want", "oneoff": False, "IssueNumber": "85"})
+
+    out = search.verification(matches, info)
+
+    assert out["foundc"]["status"] is True
+    assert logged["id"] == "minutemen-id", (
+        "nzblog was given the skipped candidate's nzbid: %r" % (logged.get("id"),)
+    )
+    assert snatched["year"] == "2011"

--- a/tests/unit/test_search_verification_candidate.py
+++ b/tests/unit/test_search_verification_candidate.py
@@ -1,0 +1,93 @@
+"""verification() must hand searcher() the candidate it is currently trying.
+
+searcher() reads ComicName, nzbid, size, nzbtitle and friends off comicinfo[0].
+When verification() passed the whole verified_matches list, every candidate was
+described by candidate 0 -- so the failed-release check ran against candidate 0's
+nzbid for all of them, and a single previously-failed release rejected every
+alternative the provider offered.
+"""
+
+import comicarr.search as search
+
+
+def _candidate(nzbid, title):
+    return {
+        "downloadit": True,
+        "chkit": None,
+        "ComicTitle": title,
+        "nzbid": nzbid,
+        "nzbtitle": title,
+        "comyear": "2011",
+        "nzbprov": "NZBGeek",
+        "tmpprov": "NZBGeek (newznab)",
+        "IssueID": "1001",
+        "ComicID": "17993",
+        "newznab": None,
+        "torznab": None,
+        "provider_stat": {},
+        "pack": False,
+        "entry": {"id": nzbid, "link": "https://example.invalid/%s" % nzbid},
+    }
+
+
+def _is_info():
+    return {
+        "nzbprov": "NZBGeek",
+        "RSS": "no",
+        "foundc": {"status": False, "info": None},
+    }
+
+
+def test_each_candidate_is_described_by_itself(monkeypatch):
+    """The nzbid searcher() sees must advance with the candidate."""
+    seen = []
+
+    def fake_searcher(nzbprov, nzbname, comicinfo, link, *a, **kw):
+        seen.append(comicinfo[0]["nzbid"])
+        return "downloadchk-fail"  # force the loop on to the next candidate
+
+    monkeypatch.setattr(search, "searcher", fake_searcher)
+    monkeypatch.setattr(search, "nzbname_create", lambda *a, **kw: "nzbname")
+
+    matches = [_candidate("empire-id", "Invincible 085 (digital-Empire)"),
+               _candidate("minutemen-id", "Invincible 085 (Minutemen-InnerDemons)")]
+
+    search.verification(matches, _is_info())
+
+    assert seen == ["empire-id", "minutemen-id"], (
+        "second candidate was described by candidate 0: %r" % (seen,)
+    )
+
+
+def test_fallback_candidate_can_still_be_taken(monkeypatch):
+    """A failed first candidate must not stop the second from being sent."""
+
+    def fake_searcher(nzbprov, nzbname, comicinfo, link, *a, **kw):
+        if comicinfo[0]["nzbid"] == "empire-id":
+            return "downloadchk-fail"
+        return {
+            "nzbid": comicinfo[0]["nzbid"],
+            "nzbname": "nzbname",
+            "sent_to": "NZBGet",
+            "alt_nzbname": None,
+            "SARC": None,
+        }
+
+    monkeypatch.setattr(search, "searcher", fake_searcher)
+    monkeypatch.setattr(search, "nzbname_create", lambda *a, **kw: "nzbname")
+    monkeypatch.setattr(search.updater, "nzblog", lambda *a, **kw: None)
+    monkeypatch.setattr(search.updater, "foundsearch", lambda *a, **kw: None)
+    monkeypatch.setattr(search, "notify_snatch", lambda *a, **kw: None)
+
+    matches = [_candidate("empire-id", "Invincible 085 (digital-Empire)"),
+               _candidate("minutemen-id", "Invincible 085 (Minutemen-InnerDemons)")]
+
+    info = _is_info()
+    info.update({"ComicName": "Invincible", "ComicYear": "2003", "IssueID": "1001",
+                 "ComicID": "17993", "SARC": None, "IssueArcID": None,
+                 "smode": "want", "oneoff": False, "IssueNumber": "85"})
+
+    out = search.verification(matches, info)
+
+    assert out["foundc"]["status"] is True
+    assert out["foundc"]["info"]["nzbid"] == "minutemen-id"


### PR DESCRIPTION
Fixes #808.

### Problem

`verification()` loops over `verified_matches`, but passes the **whole list** into `searcher()`. `searcher()` reads every field it needs off `comicinfo[0]`:

```python
ComicName   = comicinfo[0]["ComicName"]
IssueNumber = comicinfo[0]["IssueNumber"]
nzbid       = comicinfo[0]["nzbid"]
...
```

So every candidate is described by candidate 0 — including `nzbid`, `size`, `nzbtitle` and `pack_numbers`.

The visible effect is in failed-download handling. `failed_check()` is called with candidate 0's `nzbid` for **every** candidate, so once a release is recorded in the `failed` table it rejects not only itself but every alternative the provider offered for that issue. The search then ends in `Could not find Issue N` while a perfectly good release sits in the same result set.

### Observed

Four distinct candidates matched for one issue, and all four were checked under the first candidate's guid:

```
_match_entry : title_id: ...guid=c2569165793b89a4a1f396377b266147
_match_entry : title_id: ...guid=66a98248e1252d915890382acd51fb99
_match_entry : title_id: ...guid=43cd0587987b2d4cde2f996724b5d157
_match_entry : title_id: ...guid=9925a0f01f4448a1b550d3c07217cd58
...
failed_check : prov : NZBGeek (newznab)[c2569165793b89a4a1f396377b266147]   x4
search_init  : Could not find Issue 85 of Invincible (2003) using NZBGeek [api]
```

The indexer had a well-seeded alternative release for that issue (candidate 2). It was never tried.

After the change, the id advances with the candidate and the fallback is taken:

```
searcher : nzbid: c2569165793b89a4a1f396377b266147
           [FAILED_DOWNLOAD_CHECKER] result has a status of FAIL ... continuing search
searcher : nzbid: 66a98248e1252d915890382acd51fb99
           [FAILED_DOWNLOAD_CHECKER] Successfully marked this download as Good
           This is not in the failed downloads list. Will continue with the download.
```

The issue downloaded and imported.

### Note on why this survived

It only bites once the `failed` table is non-empty. On an install where `markFailed()` never fires, `failed_check()` always returns `Good`, so the wrong id is harmless and invisible.

### Change

`verified_index` already tracks the current candidate for the code after the loop (`verified_matches[verified_index]["pack"]`, `["nzbid"]`, `["entry"]`, …). Only the `searcher()` call ignored it. Pass the candidate itself.

### Tests

`tests/unit/test_search_verification_candidate.py` — two cases, both of which fail on `main`:

- the `nzbid` seen by `searcher()` must advance with the candidate (on `main`: `['empire-id', 'empire-id']`)
- a failed first candidate must not prevent the second from being sent

Full unit suite passes (2816), `ruff` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release verification so each candidate is checked individually.
  * Correctly evaluates alternative candidates when the first release fails verification.

* **Tests**
  * Added coverage confirming candidate-specific checks and successful fallback to valid alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
