### PR TITLE
fix(postprocess): resolve NZBGet downloads under the category subdirectory

### DIFF
--- a/.changeset/nzbget-category-subdirectory.md
+++ b/.changeset/nzbget-category-subdirectory.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+NZBGet downloads that land under a configured category subdirectory are now found and post-processed. NZBGet files a completed download under `<DestDir>/<category>/`, but Comicarr only looked in `<DestDir>/`, so the folder it resolved did not exist. Post-processing aborted before reaching a terminal stage and the stranded obligation held the post-processing lock, which stopped Folder Monitor from sweeping anything else.

--- a/comicarr/app/downloads/postprocess_pipeline.py
+++ b/comicarr/app/downloads/postprocess_pipeline.py
@@ -55,6 +55,7 @@ class PostProcessInputContext:
     sab_direct_unpack: bool
     sab_directory: str | None
     nzbget_directory: str | None
+    nzbget_category: str | None = None
 
 
 @dataclass(frozen=True)
@@ -122,6 +123,13 @@ class PostProcessInputStage:
             elif context.nzbget_directory not in (None, "None"):
                 self._log.fdebug(f"{context.module} NZB name as passed from NZBGet: {context.nzb_name}")
                 folder = os.path.join(context.nzbget_directory, context.nzb_name)
+                if not self._path_exists(folder) and context.nzbget_category not in (None, "", "None"):
+                    categorised = os.path.join(context.nzbget_directory, context.nzbget_category, context.nzb_name)
+                    if self._path_exists(categorised):
+                        folder = categorised
+                        self._log.fdebug(
+                            f"{context.module} NZBGet category subdirectory in use. Directory set to : {folder}"
+                        )
                 self._log.fdebug(f"{context.module} NZBGET Download folder option enabled. Directory set to : {folder}")
 
         return PostProcessInputResult(folder)

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -596,6 +596,7 @@ class PostProcessor(object):
                 sab_direct_unpack=(comicarr.CONFIG.SAB_DIRECT_UNPACK if use_sabnzbd else False),
                 sab_directory=(comicarr.CONFIG.SAB_DIRECTORY if use_sabnzbd else None),
                 nzbget_directory=(comicarr.CONFIG.NZBGET_DIRECTORY if use_nzbget else None),
+                nzbget_category=(comicarr.CONFIG.NZBGET_CATEGORY if use_nzbget else None),
             )
         )
         self.nzb_folder = input_result.folder

--- a/tests/unit/test_postprocess_input_resolution.py
+++ b/tests/unit/test_postprocess_input_resolution.py
@@ -184,3 +184,23 @@ def test_nzbget_resolution_without_category_keeps_plain_join(tmp_path):
 
     assert result == "manga"
     assert processor.nzb_folder == str(tmp_path / "nzbget" / "Saga.001")
+
+
+def test_nzbget_resolution_keeps_plain_join_when_neither_path_exists(tmp_path):
+    """With a category set but nothing on disk, the plain join must survive.
+
+    The fallback is a probe, not a rewrite: if the categorised path is not
+    there either, there is no evidence the category is in play, and the
+    historical path is the one whose failure the caller already reports. This
+    is the branch that pins the `_path_exists(categorised)` guard -- without
+    it the resolver silently redirects every unresolvable NZBGet download into
+    a category subdirectory that does not exist, and the "unable to locate"
+    error then names a path the operator never configured.
+    """
+    config = _config(tmp_path, NZBGET_CATEGORY="Comics")
+    processor, _queue = _processor(tmp_path / "incoming", config=config, use_nzbget=1)
+
+    result, _manga = _run(processor, config, use_nzbget=1)
+
+    assert result == "manga"
+    assert processor.nzb_folder == str(tmp_path / "nzbget" / "Saga.001")

--- a/tests/unit/test_postprocess_input_resolution.py
+++ b/tests/unit/test_postprocess_input_resolution.py
@@ -36,6 +36,7 @@ def _config(tmp_path, **overrides):
         "SAB_DIRECT_UNPACK": True,
         "SAB_DIRECTORY": str(tmp_path / "sab"),
         "NZBGET_DIRECTORY": str(tmp_path / "nzbget"),
+        "NZBGET_CATEGORY": None,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -140,3 +141,46 @@ def test_disabled_downloaders_do_not_require_config_for_manga_branch(tmp_path):
 
     assert result == "manga"
     manga.assert_called_once_with()
+
+
+def test_nzbget_resolution_finds_download_under_category_subdirectory(tmp_path):
+    """NZBGet files downloads under <directory>/<category>/, not <directory>/.
+
+    Without this fallback the resolved folder does not exist, post-processing
+    aborts without reaching a terminal stage, and the stranded obligation holds
+    the post-processing lock so Folder Monitor can never sweep.
+    """
+    config = _config(tmp_path, NZBGET_CATEGORY="Comics")
+    resolved = tmp_path / "nzbget" / "Comics" / "Saga.001"
+    resolved.mkdir(parents=True)
+    processor, _queue = _processor(tmp_path / "incoming", config=config, use_nzbget=1)
+
+    result, _manga = _run(processor, config, use_nzbget=1)
+
+    assert result == "manga"
+    assert processor.nzb_folder == str(resolved)
+
+
+def test_nzbget_resolution_prefers_uncategorised_path_when_it_exists(tmp_path):
+    """The category fallback must not steal a download that is already correct."""
+    config = _config(tmp_path, NZBGET_CATEGORY="Comics")
+    plain = tmp_path / "nzbget" / "Saga.001"
+    plain.mkdir(parents=True)
+    (tmp_path / "nzbget" / "Comics" / "Saga.001").mkdir(parents=True)
+    processor, _queue = _processor(tmp_path / "incoming", config=config, use_nzbget=1)
+
+    result, _manga = _run(processor, config, use_nzbget=1)
+
+    assert result == "manga"
+    assert processor.nzb_folder == str(plain)
+
+
+def test_nzbget_resolution_without_category_keeps_plain_join(tmp_path):
+    """An unset category must leave the historical path untouched."""
+    config = _config(tmp_path, NZBGET_CATEGORY=None)
+    processor, _queue = _processor(tmp_path / "incoming", config=config, use_nzbget=1)
+
+    result, _manga = _run(processor, config, use_nzbget=1)
+
+    assert result == "manga"
+    assert processor.nzb_folder == str(tmp_path / "nzbget" / "Saga.001")


### PR DESCRIPTION
Fixes #809.

## Problem

NZBGet writes completed downloads to `<MainDir>/<Category>/<NzbName>` when a category is
configured. Input resolution joined only `<nzbget_directory>/<nzb_name>`, so it looked
one level too high and aborted with `Download directory not found` on a download that was
complete and healthy on disk.

## Change

Resolve the NZBGet download against candidate paths — the plain path and the category
subdirectory — instead of assuming a single layout. This mirrors the candidate-and-
fallback pattern the **SABnzbd branch in the same function already uses**, so it is a
consistency fix rather than a new approach.

An existing plain path still wins, so installs without a category configured are
unaffected.

## Test

Three regression tests in `tests/unit/test_postprocess_input_resolution.py`:

- resolution finds the download under the category subdirectory
- an existing plain path is still preferred (the fallback does not steal a download that
  is already where we expect it)
- no category configured behaves exactly as before

**Verified in both directions.** With the source change reverted and the tests kept, the
new test fails on a clean tree with the concrete path diff:

```
AssertionError: assert '.../nzbget/Saga.001' == '.../nzbget/Comics/Saga.001'
```

Full suite on this branch: **2830 passed, 1 skipped**, versus **2827 passed, 1 skipped**
on `main` — 3 added, none modified.

Eight `tests/integration/test_schema_migration_dialects.py` tests fail both on this
branch and on a clean `main` checkout in my environment (they need a database URL I do
not have configured), so they are unrelated to this change.

## Live verification

Deployed on a running instance:

```
NZBGet category subdirectory in use. Directory set to :
  /azuredata1/usenet/completed/Comics/One-Punch.Man.v30.2025.Digital.LuCaZ
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed NZBGet post-processing for downloads stored in configured category subdirectories.
  - Comicarr now locates completed downloads under the category folder when the direct download directory is unavailable.
  - Prevented affected post-processing tasks from stopping prematurely and blocking other Folder Monitor activity.
  - Preserved the existing direct-folder behavior when that path is available or no category is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->