### PR TITLE
fix(recovery): close a post_processing obligation that is provably fulfilled

### DIFF
--- a/.changeset/recovery-fulfilled-obligation.md
+++ b/.changeset/recovery-fulfilled-obligation.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Post-processing no longer stalls on downloads that were already filed. A journal row left at `post_processing` after its file had actually moved was re-driven at every startup and could never finish, because the folder it wanted to import from was already empty. Those stuck obligations held post-processing state, so Folder Monitor lost its lock on every sweep and stopped importing anything at all. Recovery now checks the library for the file before re-driving: when the issue reads Downloaded and its location resolves to a real file under the series folder, the move demonstrably happened, so the row is closed instead of retried. Anything it cannot verify is re-driven exactly as before.

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -551,7 +551,7 @@ def _obligation_already_fulfilled(row):
     return has_verified_library_file(series.get("ComicLocation"), issue.get("Location"))
 
 
-def finalize_post_processing(row, payload=None):
+def finalize_post_processing(row, payload=None, already_fulfilled=None):
     """Resolve a row already inside post-processing. The `moved` marker is the
     discriminator for whether the destructive move committed — there is NO
     SOURCE probe anywhere on this path (a surviving source is undecidable in
@@ -589,7 +589,9 @@ def finalize_post_processing(row, payload=None):
         return "moved-finish-dbfacts"
 
     if stage == journal.POST_PROCESSING:
-        if _obligation_already_fulfilled(row):
+        if already_fulfilled is None:
+            already_fulfilled = _obligation_already_fulfilled(row)
+        if already_fulfilled:
             _finish_db_facts_only(rkey, row, payload)
             logger.info(
                 "[RECOVERY] %s was `post_processing`, but its issue is already "
@@ -729,16 +731,23 @@ def _resolve_row(snapshot_row, probes=None, pp_cap=None):
     if cur_stage == journal.MOVED:
         return finalize_post_processing(row, payload=payload)
     if cur_stage == journal.POST_PROCESSING:
-        if pp_cap is not None and pp_cap.get("count", 0) >= _MAX_INLINE_PP_REDRIVE_PER_PASS:
-            logger.warn(
-                "[RECOVERY] %s is `post_processing` but the inline PP re-drive "
-                "cap (%d) for this replay pass is reached — DEFERRING; it "
-                "resumes next startup (replay is idempotent/re-runnable)." % (rkey, _MAX_INLINE_PP_REDRIVE_PER_PASS)
-            )
-            return "skip-pp-cap-deferred"
-        if pp_cap is not None:
-            pp_cap["count"] = pp_cap.get("count", 0) + 1
-        return finalize_post_processing(row, payload=payload)
+        # A provably-fulfilled obligation costs only the same DB facts as
+        # `moved`, so — per this cap's own contract — it is NOT charged to the
+        # INLINE re-drive budget. Otherwise a backlog of already-done rows
+        # would need one restart per five to drain.
+        already_fulfilled = _obligation_already_fulfilled(row)
+        if not already_fulfilled:
+            if pp_cap is not None and pp_cap.get("count", 0) >= _MAX_INLINE_PP_REDRIVE_PER_PASS:
+                logger.warn(
+                    "[RECOVERY] %s is `post_processing` but the inline PP re-drive "
+                    "cap (%d) for this replay pass is reached — DEFERRING; it "
+                    "resumes next startup (replay is idempotent/re-runnable)."
+                    % (rkey, _MAX_INLINE_PP_REDRIVE_PER_PASS)
+                )
+                return "skip-pp-cap-deferred"
+            if pp_cap is not None:
+                pp_cap["count"] = pp_cap.get("count", 0) + 1
+        return finalize_post_processing(row, payload=payload, already_fulfilled=already_fulfilled)
 
     if cur_stage == journal.DOWNLOADED:
         item = _pp_item_from_row(row, payload)

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -32,16 +32,18 @@ never aborting the loop.
 """
 
 import time
+import traceback
 
 from sqlalchemy import and_, delete, or_, select
 
 import comicarr
 from comicarr import db, logger
+from comicarr.app.acquisition.evidence import has_verified_library_file
 from comicarr.app.attention import ManualReview, record
 from comicarr.app.downloads import journal, recovery_classify
 from comicarr.app.downloads.ddl_commands import DDLCommand, DDLCommandError
 from comicarr.app.downloads.pp_commands import PostProcessCommandError, validate_postprocess_item
-from comicarr.tables import ddl_info, nzblog, pipeline_journal, snatched, storyarcs
+from comicarr.tables import comics, ddl_info, issues, nzblog, pipeline_journal, snatched, storyarcs
 
 _ENQUEUE_THROTTLE_SECONDS = 0.05
 
@@ -468,22 +470,107 @@ def _resume_item_from_row(row, payload):
     return "nzb", item
 
 
+def _finish_db_facts_only(rkey, row, payload):
+    """Close an obligation whose physical move already committed: delete its
+    nzblog anchor and advance the journal to `post_processed`, in ONE atomic
+    begin(). Touches DB facts only — never re-imports or re-moves."""
+    issueid = row.get("issueid")
+    provider = row.get("provider")
+    story_arc = None
+    if isinstance(payload, dict) and "mode" in payload:
+        story_arc = payload.get("mode") == "story_arc"
+    if story_arc is None:
+        story_arc = _is_story_arc_obligation(issueid)
+    nzbname = (payload or {}).get("nzbname") if isinstance(payload, dict) else None
+    with db.get_engine().begin() as conn:
+        if story_arc is False:
+            id_pred = nzblog.c.IssueID == str(issueid)
+        elif story_arc is True:
+            id_pred = or_(
+                nzblog.c.IssueID == str(issueid),
+                nzblog.c.IssueID == "S" + str(issueid),
+            )
+        else:
+            if nzbname:
+                id_pred = and_(
+                    or_(
+                        nzblog.c.IssueID == str(issueid),
+                        nzblog.c.IssueID == "S" + str(issueid),
+                    ),
+                    nzblog.c.NZBName == nzbname,
+                )
+            else:
+                id_pred = nzblog.c.IssueID == str(issueid)
+        stmt = delete(nzblog).where(id_pred)
+        if provider:
+            stmt = stmt.where(nzblog.c.PROVIDER == provider)
+        conn.execute(stmt)
+        journal.record_transition(
+            rkey,
+            journal.POST_PROCESSED,
+            payload=payload,
+            conn=conn,
+            issueid=issueid,
+            provider=provider,
+        )
+
+
+def _obligation_already_fulfilled(row):
+    """Return whether this obligation's work is provably ALREADY DONE.
+
+    True only when the obligation's own issue row is `Downloaded` AND its
+    `Location` resolves to an existing file beneath its series root — the
+    shared `has_verified_library_file` evidence gate.
+
+    This is a DESTINATION probe, which is decidable, and is deliberately not
+    the source probe `finalize_post_processing` forbids: a surviving source is
+    undecidable under copy/hardlink/softlink FILE_OPTS, but a verified file in
+    the library proves the move committed in EVERY mode. Fails CLOSED — any
+    missing id, unreadable row, or unresolvable path returns False and the
+    caller re-drives exactly as before.
+    """
+    issueid = row.get("issueid")
+    if not issueid:
+        return False
+    try:
+        issue = db.select_one(
+            select(issues.c.Status, issues.c.Location, issues.c.ComicID).where(issues.c.IssueID == str(issueid))
+        )
+    except Exception as e:
+        logger.warn("[RECOVERY] fulfillment lookup failed for issue %s: %s" % (issueid, e))
+        return False
+    if not issue or issue.get("Status") != "Downloaded":
+        return False
+    try:
+        series = db.select_one(select(comics.c.ComicLocation).where(comics.c.ComicID == str(issue.get("ComicID"))))
+    except Exception as e:
+        logger.warn("[RECOVERY] fulfillment series lookup failed for issue %s: %s" % (issueid, e))
+        return False
+    if not series:
+        return False
+    return has_verified_library_file(series.get("ComicLocation"), issue.get("Location"))
+
+
 def finalize_post_processing(row, payload=None):
-    """Resolve a row already inside post-processing using the `moved` marker
-    as the SOLE discriminator — NO file probe anywhere on this path (a probe
-    is undecidable in copy/hardlink/softlink FILE_OPTS modes where the source
-    is never deleted):
+    """Resolve a row already inside post-processing. The `moved` marker is the
+    discriminator for whether the destructive move committed — there is NO
+    SOURCE probe anywhere on this path (a surviving source is undecidable in
+    copy/hardlink/softlink FILE_OPTS modes, where it is never deleted):
 
       * stage `moved`           -> the destructive move physically committed
         (source may already be gone). Finish the DB facts ONLY — mirror the
         U9 atomic block (single begin(): nzblog-delete + journal
         post_processed). NEVER re-import / re-move.
-      * stage `post_processing` -> the move did NOT commit (source intact).
-        Re-drive PP in FULL by invoking process.Process DIRECTLY, threading
-        the authoritative release_key so the postprocessor markers advance
-        THIS row. NOT via PP_QUEUE: the U4 claim is a downloaded ->
-        post_processing advance and a row already at post_processing would
-        LOSE that claim and be dropped — so the finalizer bypasses it.
+      * stage `post_processing` -> the move did not record a marker. Before
+        re-driving, check `_obligation_already_fulfilled`: a DESTINATION probe
+        (issue `Downloaded` + verified file under the series root) proves the
+        move committed and only the marker write was lost, so finish the DB
+        facts exactly like `moved`. Without that proof, re-drive PP in FULL by
+        invoking process.Process DIRECTLY, threading the authoritative
+        release_key so the postprocessor markers advance THIS row. NOT via
+        PP_QUEUE: the U4 claim is a downloaded -> post_processing advance and a
+        row already at post_processing would LOSE that claim and be dropped —
+        so the finalizer bypasses it.
 
     Returns a short string describing the action taken (for logging/tests).
     """
@@ -493,45 +580,7 @@ def finalize_post_processing(row, payload=None):
         payload = journal.load_payload(row.get("payload_json"))
 
     if stage == journal.MOVED:
-        issueid = row.get("issueid")
-        provider = row.get("provider")
-        story_arc = None
-        if isinstance(payload, dict) and "mode" in payload:
-            story_arc = payload.get("mode") == "story_arc"
-        if story_arc is None:
-            story_arc = _is_story_arc_obligation(issueid)
-        nzbname = (payload or {}).get("nzbname") if isinstance(payload, dict) else None
-        with db.get_engine().begin() as conn:
-            if story_arc is False:
-                id_pred = nzblog.c.IssueID == str(issueid)
-            elif story_arc is True:
-                id_pred = or_(
-                    nzblog.c.IssueID == str(issueid),
-                    nzblog.c.IssueID == "S" + str(issueid),
-                )
-            else:
-                if nzbname:
-                    id_pred = and_(
-                        or_(
-                            nzblog.c.IssueID == str(issueid),
-                            nzblog.c.IssueID == "S" + str(issueid),
-                        ),
-                        nzblog.c.NZBName == nzbname,
-                    )
-                else:
-                    id_pred = nzblog.c.IssueID == str(issueid)
-            stmt = delete(nzblog).where(id_pred)
-            if provider:
-                stmt = stmt.where(nzblog.c.PROVIDER == provider)
-            conn.execute(stmt)
-            journal.record_transition(
-                rkey,
-                journal.POST_PROCESSED,
-                payload=payload,
-                conn=conn,
-                issueid=issueid,
-                provider=provider,
-            )
+        _finish_db_facts_only(rkey, row, payload)
         logger.info(
             "[RECOVERY] %s was `moved` (physical move committed) — finished DB "
             "facts only (nzblog-delete + journal post_processed); did NOT "
@@ -540,6 +589,17 @@ def finalize_post_processing(row, payload=None):
         return "moved-finish-dbfacts"
 
     if stage == journal.POST_PROCESSING:
+        if _obligation_already_fulfilled(row):
+            _finish_db_facts_only(rkey, row, payload)
+            logger.info(
+                "[RECOVERY] %s was `post_processing`, but its issue is already "
+                "`Downloaded` with a verified file under the series root — the "
+                "move committed and only the marker was lost. Finished DB facts "
+                "only (nzblog-delete + journal post_processed); did NOT "
+                "re-drive." % rkey
+            )
+            return "post_processing-already-fulfilled"
+
         item = _pp_item_from_row(row, payload or {})
         from comicarr.app.downloads.service import _configured_postprocess_roots
 
@@ -610,7 +670,10 @@ def finalize_post_processing(row, payload=None):
                     provider=row.get("provider"),
                 )
             )
-            logger.error("[RECOVERY] %s PP redrive failed and was quarantined: %s" % (rkey, type(e).__name__))
+            logger.error(
+                "[RECOVERY] %s PP redrive failed and was quarantined: %s: %s\n%s"
+                % (rkey, type(e).__name__, e, traceback.format_exc())
+            )
             return "post_processing-manual-review"
         return "post_processing-redrive"
 

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -481,7 +481,15 @@ def _finish_db_facts_only(rkey, row, payload):
         story_arc = payload.get("mode") == "story_arc"
     if story_arc is None:
         story_arc = _is_story_arc_obligation(issueid)
-    nzbname = (payload or {}).get("nzbname") if isinstance(payload, dict) else None
+    # Journal payloads persist the release name under EITHER spelling --
+    # `_PAYLOAD_KEYS` carries both `nzbname` and `nzb_name`, and the PP seam
+    # writes `nzb_name`. Reading only one of them leaves the unknown-story-arc
+    # fallback below without a name, which narrows the delete to the unprefixed
+    # IssueID and strands the `S<issueid>` anchor while the row still advances
+    # to `post_processed`.
+    nzbname = None
+    if isinstance(payload, dict):
+        nzbname = payload.get("nzbname") or payload.get("nzb_name")
     with db.get_engine().begin() as conn:
         if story_arc is False:
             id_pred = nzblog.c.IssueID == str(issueid)
@@ -741,8 +749,7 @@ def _resolve_row(snapshot_row, probes=None, pp_cap=None):
                 logger.warn(
                     "[RECOVERY] %s is `post_processing` but the inline PP re-drive "
                     "cap (%d) for this replay pass is reached — DEFERRING; it "
-                    "resumes next startup (replay is idempotent/re-runnable)."
-                    % (rkey, _MAX_INLINE_PP_REDRIVE_PER_PASS)
+                    "resumes next startup (replay is idempotent/re-runnable)." % (rkey, _MAX_INLINE_PP_REDRIVE_PER_PASS)
                 )
                 return "skip-pp-cap-deferred"
             if pp_cap is not None:

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -31,6 +31,7 @@ import comicarr
 from comicarr.app.acquisition.maintenance import ensure_acquisition_schema
 from comicarr.app.attention import RecordOutcome
 from comicarr.app.downloads import journal, recovery, recovery_classify
+from comicarr.app.downloads.recovery import _MAX_INLINE_PP_REDRIVE_PER_PASS
 from comicarr.db import get_engine, shutdown_engine
 from comicarr.tables import comics, ddl_info, issues, metadata, nzblog, pipeline_journal, snatched, storyarcs
 
@@ -1695,3 +1696,44 @@ def test_post_processing_with_file_outside_series_root_still_redrives(queues, tm
     recovery.replay_pipeline(probes=_probe("complete"))
 
     assert calls.get("ran") is True
+
+
+def test_fulfilled_backlog_larger_than_the_cap_drains_in_one_pass(queues, tmp_path, monkeypatch):
+    """The inline cap exists to bound expensive re-drives. A provably
+    fulfilled row costs only the same DB facts as `moved`, so it must not be
+    charged to that budget — otherwise a backlog of already-done rows needs
+    one restart per five to clear."""
+    keys = []
+    for n in range(_MAX_INLINE_PP_REDRIVE_PER_PASS + 3):
+        issueid = "95%d" % n
+        _placed_issue(tmp_path, issueid, "Series v%02d.cbz" % n)
+        keys.append(_pp_obligation(tmp_path, issueid, "Series.v%02d.cbz" % n))
+    _forbid_reimport(monkeypatch)
+
+    summary = recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert summary["actions"].get("skip-pp-cap-deferred") is None
+    assert all(_journal_row(k)["stage"] == journal.POST_PROCESSED for k in keys)
+
+
+def test_unfulfilled_rows_are_still_capped(queues, tmp_path, monkeypatch):
+    """The cap still bounds real re-drives: with no placement evidence, only
+    _MAX_INLINE_PP_REDRIVE_PER_PASS rows run and the rest defer."""
+    for n in range(_MAX_INLINE_PP_REDRIVE_PER_PASS + 3):
+        _pp_obligation(tmp_path, "96%d" % n, "Nope.v%02d.cbz" % n)
+    ran = {"count": 0}
+    import comicarr.process as process_mod
+
+    class _FakeProc:
+        def __init__(self, *a, **k):
+            pass
+
+        def post_process(self):
+            ran["count"] += 1
+
+    monkeypatch.setattr(process_mod, "Process", _FakeProc)
+
+    summary = recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert ran["count"] == _MAX_INLINE_PP_REDRIVE_PER_PASS
+    assert summary["actions"].get("skip-pp-cap-deferred") == 3

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -32,7 +32,7 @@ from comicarr.app.acquisition.maintenance import ensure_acquisition_schema
 from comicarr.app.attention import RecordOutcome
 from comicarr.app.downloads import journal, recovery, recovery_classify
 from comicarr.db import get_engine, shutdown_engine
-from comicarr.tables import ddl_info, issues, metadata, nzblog, pipeline_journal, snatched, storyarcs
+from comicarr.tables import comics, ddl_info, issues, metadata, nzblog, pipeline_journal, snatched, storyarcs
 
 
 @pytest.fixture(autouse=True)
@@ -1561,3 +1561,137 @@ def test_done_signal_without_placement_absent_probe_enqueues_pp_not_done(queues)
     assert row["stage"] == journal.DOWNLOADED
     assert summary["actions"].get("done-check") is None
     assert len(_drain(queues["pp"])) == 1
+
+
+# ===========================================================================
+# A `post_processing` row whose work is PROVABLY already done must self-heal.
+#
+# The inverse of the #734 rule above, through the SAME evidence gate: #734
+# says absent placement evidence must never be promoted to post_processed;
+# this says positive placement evidence (issue `Downloaded` + a verified file
+# under the series root) proves the move committed and only the marker write
+# was lost — so recovery finishes the DB facts instead of re-driving PP
+# forever against a source folder it already emptied.
+# ===========================================================================
+
+
+def _placed_issue(tmp_path, issueid, filename, *, status="Downloaded", create=True, location=None):
+    """Create a comics row with a real series root plus an issue row, and
+    (optionally) the placed file itself. Returns the series root."""
+    root = tmp_path / ("series-%s" % issueid)
+    root.mkdir(exist_ok=True)
+    if create:
+        (root / filename).write_bytes(b"cbz")
+    with get_engine().begin() as conn:
+        conn.execute(comics.insert().values(ComicID="C%s" % issueid, ComicLocation=str(root)))
+        conn.execute(
+            issues.insert().values(
+                IssueID=issueid,
+                ComicID="C%s" % issueid,
+                Status=status,
+                Location=str(root / filename) if location is None else location,
+            )
+        )
+    return root
+
+
+def _pp_obligation(tmp_path, issueid, name):
+    rkey = journal.release_key(issueid, "nzb.su", nzbname=name)
+    _insert_journal(
+        rkey,
+        journal.POST_PROCESSING,
+        payload={
+            "issueid": issueid,
+            "comicid": "C%s" % issueid,
+            "nzb_name": name,
+            "nzb_folder": _artifact_folder(tmp_path, "src-%s" % issueid),
+        },
+        issueid=issueid,
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+    return rkey
+
+
+def _forbid_reimport(monkeypatch):
+    import comicarr.process as process_mod
+
+    monkeypatch.setattr(
+        process_mod,
+        "Process",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not re-drive a fulfilled obligation")),
+    )
+
+
+def _capture_reimport(monkeypatch):
+    calls = {}
+    import comicarr.process as process_mod
+
+    class _FakeProc:
+        def __init__(self, *a, journal_release_key=None, **k):
+            calls["rkey"] = journal_release_key
+
+        def post_process(self):
+            calls["ran"] = True
+
+    monkeypatch.setattr(process_mod, "Process", _FakeProc)
+    return calls
+
+
+def test_post_processing_with_verified_placement_finishes_without_redrive(queues, tmp_path, monkeypatch):
+    """The file is already in the library and the issue reads Downloaded, so
+    the move committed — recovery must close the obligation with DB facts
+    only, exactly as it does for a `moved` row, and never re-import."""
+    _placed_issue(tmp_path, "901", "Series v01.cbz")
+    rkey = _pp_obligation(tmp_path, "901", "Series.v01.cbz")
+    with get_engine().begin() as conn:
+        conn.execute(nzblog.insert().values(IssueID="901", PROVIDER="nzb.su", NZBName="Series.v01.cbz"))
+    _forbid_reimport(monkeypatch)
+
+    summary = recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert _journal_row(rkey)["stage"] == journal.POST_PROCESSED
+    assert summary["actions"].get("post_processing-already-fulfilled") == 1
+    with get_engine().connect() as conn:
+        assert conn.execute(select(nzblog).where(nzblog.c.IssueID == "901")).fetchall() == []
+    assert _drain(queues["pp"]) == []
+
+
+def test_post_processing_not_downloaded_still_redrives(queues, tmp_path, monkeypatch):
+    """A placed-looking file is not enough: until the issue row itself reads
+    Downloaded the obligation is unproven, so the pre-existing re-drive must
+    still run."""
+    _placed_issue(tmp_path, "902", "Series v02.cbz", status="Snatched")
+    rkey = _pp_obligation(tmp_path, "902", "Series.v02.cbz")
+    calls = _capture_reimport(monkeypatch)
+
+    recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert calls.get("ran") is True
+    assert calls["rkey"] == rkey
+
+
+def test_post_processing_with_missing_file_still_redrives(queues, tmp_path, monkeypatch):
+    """A Downloaded row whose Location does not exist on disk is NOT evidence
+    — the check fails closed and the obligation is re-driven."""
+    _placed_issue(tmp_path, "903", "Series v03.cbz", create=False)
+    _pp_obligation(tmp_path, "903", "Series.v03.cbz")
+    calls = _capture_reimport(monkeypatch)
+
+    recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert calls.get("ran") is True
+
+
+def test_post_processing_with_file_outside_series_root_still_redrives(queues, tmp_path, monkeypatch):
+    """A file that exists but resolves OUTSIDE the series root proves nothing
+    about this series, so it must not close the obligation."""
+    stray = tmp_path / "stray.cbz"
+    stray.write_bytes(b"cbz")
+    _placed_issue(tmp_path, "904", "Series v04.cbz", create=False, location=str(stray))
+    _pp_obligation(tmp_path, "904", "Series.v04.cbz")
+    calls = _capture_reimport(monkeypatch)
+
+    recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert calls.get("ran") is True

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -1737,3 +1737,28 @@ def test_unfulfilled_rows_are_still_capped(queues, tmp_path, monkeypatch):
 
     assert ran["count"] == _MAX_INLINE_PP_REDRIVE_PER_PASS
     assert summary["actions"].get("skip-pp-cap-deferred") == 3
+
+
+def test_unanswerable_story_arc_clears_the_S_anchor_from_nzb_name(queues, tmp_path, monkeypatch):
+    """When the story-arc discriminator cannot answer, the fallback narrows the
+    nzblog delete by release NAME so it can safely clear both the plain and the
+    `S<issueid>` anchor. The PP seam writes that name as `nzb_name`, so reading
+    only `nzbname` left the fallback nameless, deleted just the unprefixed row,
+    and still advanced the journal to `post_processed` — stranding the `S`
+    anchor with no obligation left to clean it up."""
+    _placed_issue(tmp_path, "902", "Arc v01.cbz")
+    rkey = _pp_obligation(tmp_path, "902", "Arc.v01.cbz")
+    with get_engine().begin() as conn:
+        conn.execute(nzblog.insert().values(IssueID="902", PROVIDER="nzb.su", NZBName="Arc.v01.cbz"))
+        conn.execute(nzblog.insert().values(IssueID="S902", PROVIDER="nzb.su", NZBName="Arc.v01.cbz"))
+    # the discriminator's own unanswerable case: no issueid, or the lookup raised
+    monkeypatch.setattr(recovery, "_is_story_arc_obligation", lambda issueid: None)
+    _forbid_reimport(monkeypatch)
+
+    summary = recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert _journal_row(rkey)["stage"] == journal.POST_PROCESSED
+    assert summary["actions"].get("post_processing-already-fulfilled") == 1
+    with get_engine().connect() as conn:
+        left = conn.execute(select(nzblog.c.IssueID).where(nzblog.c.IssueID.in_(["902", "S902"]))).fetchall()
+    assert left == [], "story-arc S anchor was stranded: %r" % (left,)


### PR DESCRIPTION
Fixes #810.

## Problem

A journal row left at `post_processing` after its file move committed is re-driven at
every startup and can never terminalize, because the source folder is already empty. The
open obligations hold post-processing state, so the folder monitor loses `APILOCK` on
every sweep and stops importing entirely.

## Change

Two commits:

| Commit | Change |
|---|---|
| `close a post_processing obligation that is provably fulfilled` | check destination evidence before re-driving |
| `do not charge a fulfilled obligation to the PP re-drive cap` | resolve fulfilled rows before the cap test |

**Destination, not source.** The function's existing constraint forbids probing the
source path, because under copy/hardlink/softlink `FILE_OPTS` a surviving source proves
nothing. That constraint is preserved. A verified file **in the library**, on the other
hand, proves the move committed under every mode — so when the obligation's own issue row
reads `Downloaded` and its `Location` resolves beneath the series root, recovery finishes
the DB facts exactly as the `moved` branch does and skips the re-import.

It reuses the existing shared placement-evidence gate rather than adding a second
predicate, and it is the positive-direction counterpart of the existing rule that absent
placement evidence must never be promoted to `post_processed`.

**Fails closed.** Any missing id, unreadable row, or unresolvable path re-drives exactly
as before.

**Second commit — the cap.** The inline re-drive cap exists to bound expensive re-drives.
A fulfilled row costs only the cheap DB facts the `moved` path already performs, which
the cap's own contract exempts, so it is now resolved before the cap test and not
charged. Real re-drives stay capped; a test pins that a fulfilled backlog larger than the
cap drains in a single pass.

## Test

Six regression tests in `tests/unit/test_recovery_replay.py`, alongside the existing
`#734` cases that assert the inverse rule.

**Verified in both directions.** With the source reverted and the tests kept, two fail on
a clean tree with the exact production symptom:

```
test_post_processing_with_verified_placement_finishes_without_redrive
    AssertionError: assert 'manual_review' == 'post_processed'

test_fulfilled_backlog_larger_than_the_cap_drains_in_one_pass
    AssertionError: assert 3 is None      # skip-pp-cap-deferred
```

The remaining four are guards asserting preserved re-drive behaviour, so they correctly
pass on both sides.

Full suite on this branch: **2833 passed, 1 skipped**, versus **2827 passed, 1 skipped**
on `main` — 6 added, none modified.

Eight `tests/integration/test_schema_migration_dialects.py` tests fail both on this
branch and on a clean `main` checkout in my environment (they need a database URL I do
not have configured), so they are unrelated to this change.

## Live verification

Deployed on a running instance with 8 stranded rows. Startup recovery cleared all of them
in a single pass, with no re-drive and no manual intervention:

```
[RECOVERY] <key> was `post_processing`, but its issue is already `Downloaded`
with a verified file under the series root — the move committed and only the
marker was lost. Finished DB facts only; did NOT re-drive.
   ... x8 ...
Startup recovery replay complete:
  {'actions': {'unknown-unchanged': 1, 'post_processing-already-fulfilled': 8}}
```

`post_processing` rows went 8 → 0, `post_processed` 107 → 115, with no
`skip-pp-cap-deferred`. The `[FOLDER-CHECK] Unable to initiate folder monitor` message
that had repeated every 5 minutes stopped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup recovery for downloads that were already completed successfully.
  * Prevented unnecessary reprocessing when a verified file is already available in the correct series location.
  * Ensured recovery backlogs can finish without incorrectly consuming retry limits.
  * Preserved retry behavior for downloads that cannot be verified as complete.
  * Added more detailed diagnostics when post-processing recovery fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->