### PR TITLE
fix(search): snatch manga volume releases found by searchforissue

### DIFF
--- a/.changeset/manga-volume-search.md
+++ b/.changeset/manga-volume-search.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Manga series tracked by volume now actually grab the releases they find. A volume-numbered series would run every search, receive the correct results from the provider, and snatch none of them — five separate gates each discarded the release, so the series sat permanently Wanted with nothing to show for it. Volume searches now query the volume name the way the RSS path already did, match results against the real series name, and accept a release on its volume number rather than demanding an issue number the release never carries. Half volumes such as v01.5 keep their fraction instead of being searched and matched as v01.

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -30,6 +30,7 @@ from comicarr.app.downloads import queries as dl_queries
 from comicarr.app.downloads.completed_path import resolve_completed_download_file
 from comicarr.app.downloads.ddl_commands import DDLCommand, DDLCommandError
 from comicarr.app.downloads.pp_commands import PostProcessCommandError, configured_roots, validate_postprocess_item
+from comicarr.app.manga.ledger import is_volume_target, volume_numbers_match
 from comicarr.downloaders import mediafire, mega, pixeldrain
 from comicarr.tables import annuals, comics, ddl_info, issues, storyarcs, weekly
 
@@ -983,13 +984,10 @@ def _pack_row_matches(row, int_iss, iss_item, kind):
     chapter = row.get("ChapterNumber")
     if kind == "volume":
         if volume not in (None, ""):
-            try:
-                return int(float(volume)) == int(iss_item)
-            except (TypeError, ValueError):
-                return False
+            return volume_numbers_match(volume, iss_item)
         if chapter not in (None, ""):
             return False
-    elif volume not in (None, "") and chapter in (None, ""):
+    elif is_volume_target(chapter, volume):
         return False
     return row["Int_IssueNumber"] == int_iss
 

--- a/comicarr/app/manga/acquisition.py
+++ b/comicarr/app/manga/acquisition.py
@@ -154,10 +154,17 @@ def search_plan_for_series(series, issues):
 
 
 def _pad_volume(number):
+    # Keeps the fraction, the same way _pad_chapter does. Half volumes are
+    # real ("v01.5"), and truncating one to "v01" searches the wrong volume --
+    # the exact volume comparison in _pack_row_matches then rejects the 1 it
+    # got against the 1.5 it wanted, so the row can never snatch.
     try:
-        return "%02d" % int(float(number))
+        value = float(number)
     except (TypeError, ValueError):
         return str(number) if number not in (None, "") else None
+    if value == int(value):
+        return "%02d" % int(value)
+    return "%02d.%s" % (int(value), str(round(value % 1, 1))[2:])
 
 
 def _pad_chapter(number):

--- a/comicarr/app/manga/acquisition.py
+++ b/comicarr/app/manga/acquisition.py
@@ -9,6 +9,8 @@
 
 """What automatic search should enqueue for a manga Series."""
 
+from decimal import Decimal, InvalidOperation
+
 from comicarr.app.manga.ledger import last_released_volume, normalize_volume_number
 
 MONITOR_MODES = frozenset({"blended", "volumes", "chapters"})
@@ -153,28 +155,42 @@ def search_plan_for_series(series, issues):
     )
 
 
-def _pad_volume(number):
-    # Keeps the fraction, the same way _pad_chapter does. Half volumes are
-    # real ("v01.5"), and truncating one to "v01" searches the wrong volume --
-    # the exact volume comparison in _pack_row_matches then rejects the 1 it
-    # got against the 1.5 it wanted, so the row can never snatch.
+def _pad_number(number, width):
+    """Zero-pad a volume or chapter number, keeping its fraction EXACTLY.
+
+    Half instalments are real ("v01.5", "c001.5"), and truncating one searches
+    the wrong book -- the exact comparison in _pack_row_matches then rejects
+    the 1 it got against the 1.5 it wanted, so the row can never snatch.
+
+    The fraction is carried as text rather than through float arithmetic.
+    `round(value % 1, 1)` keeps only ONE fractional digit, so it silently
+    rewrote the number it was meant to preserve: 1.25 searched "v01.2" and
+    1.75 searched "v01.8" -- not a truncation of the wanted volume but a
+    DIFFERENT one, which the same exact comparison then rejects.
+
+    A non-numeric value is returned as given: some series number instalments
+    in ways no padding rule can improve on, and inventing one would be worse
+    than leaving it alone.
+    """
+    if number in (None, ""):
+        return None
+    text = str(number).strip()
     try:
-        value = float(number)
-    except (TypeError, ValueError):
-        return str(number) if number not in (None, "") else None
-    if value == int(value):
-        return "%02d" % int(value)
-    return "%02d.%s" % (int(value), str(round(value % 1, 1))[2:])
+        value = Decimal(text)
+    except (InvalidOperation, TypeError, ValueError):
+        return text
+    if value == value.to_integral_value():
+        return "%0*d" % (width, int(value))
+    whole, _, fraction = format(value, "f").partition(".")
+    return "%0*d.%s" % (width, int(whole), fraction)
+
+
+def _pad_volume(number):
+    return _pad_number(number, 2)
 
 
 def _pad_chapter(number):
-    try:
-        value = float(number)
-    except (TypeError, ValueError):
-        return str(number) if number not in (None, "") else None
-    if value == int(value):
-        return "%03d" % int(value)
-    return "%03d.%s" % (int(value), str(round(value % 1, 1))[2:])
+    return _pad_number(number, 3)
 
 
 def _as_float(value):

--- a/comicarr/app/manga/ledger.py
+++ b/comicarr/app/manga/ledger.py
@@ -15,6 +15,7 @@ Owning a volume covers only the chapters that mapping actually lists.
 """
 
 import re
+from decimal import Decimal, InvalidOperation
 
 from comicarr.app.acquisition.models import Fulfillment
 
@@ -64,11 +65,31 @@ def volume_numbers_match(left, right):
     Returns False whenever either side has no usable volume, so a parse
     failure can never be read as a match and claim an arbitrary volume.
     """
-    left_value = normalize_volume_number(_strip_volume_marker(left))
-    right_value = normalize_volume_number(_strip_volume_marker(right))
+    left_value = _exact_volume(_strip_volume_marker(left))
+    right_value = _exact_volume(_strip_volume_marker(right))
     if left_value is None or right_value is None:
         return False
     return left_value == right_value
+
+
+def _exact_volume(value):
+    """A volume reference as an exact number, or None when it is not one.
+
+    normalize_volume_number is a DISPLAY normaliser: it preserves arbitrary
+    text and formats floats to six significant digits. Comparing through it
+    therefore made "TPB" equal "TPB" -- two releases with no volume at all
+    reading as the same volume -- and "1.0000001" equal "1". Neither is a
+    volume identity, and the contract above says so.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return Decimal(text).normalize()
+    except (InvalidOperation, TypeError, ValueError):
+        return None
 
 
 def _strip_volume_marker(value):

--- a/comicarr/app/manga/ledger.py
+++ b/comicarr/app/manga/ledger.py
@@ -14,10 +14,15 @@ chapters and volume→chapter containment come from unfiltered `/aggregate`.
 Owning a volume covers only the chapters that mapping actually lists.
 """
 
+import re
+
 from comicarr.app.acquisition.models import Fulfillment
 
 _OPERATOR_FIELDS = ("Status", "AcquisitionIntent", "Location", "status", "acquisitionIntent", "location")
 _NON_VOLUME = frozenset({"", "none", "null", "unknown"})
+# Only strips a marker that actually introduces a number, so "vTPB" is left
+# alone and never compares equal to a real volume.
+_VOLUME_MARKER = re.compile(r"^v(?:ol(?:ume)?)?\.?\s*(?=\d)", re.IGNORECASE)
 
 
 def normalize_volume_number(value):
@@ -34,6 +39,42 @@ def normalize_volume_number(value):
     if number.is_integer():
         return str(int(number))
     return format(number, "g")
+
+
+def is_volume_target(chapter_number, volume_number):
+    """Is this pair a volume rather than a chapter?
+
+    The single owner of the volume-vs-chapter rule: a volume has a volume
+    number and no chapter number. Stated once because getting it wrong in
+    either direction is silently destructive — a chapter treated as a volume
+    lets a pack claim "chapter 7" as "volume 7", and a volume treated as a
+    chapter is searched as ``c001`` and never matches a ``v01`` release.
+    """
+    return volume_number not in (None, "") and chapter_number in (None, "")
+
+
+def volume_numbers_match(left, right):
+    """Do two volume references denote the same volume?
+
+    The same volume is written differently everywhere it appears: a release
+    says ``v01``, the ledger stores ``1``, a pack range yields the integer 1.
+    Both sides are stripped of a leading volume marker and canonicalised
+    through :func:`normalize_volume_number` before comparison.
+
+    Returns False whenever either side has no usable volume, so a parse
+    failure can never be read as a match and claim an arbitrary volume.
+    """
+    left_value = normalize_volume_number(_strip_volume_marker(left))
+    right_value = normalize_volume_number(_strip_volume_marker(right))
+    if left_value is None or right_value is None:
+        return False
+    return left_value == right_value
+
+
+def _strip_volume_marker(value):
+    if value is None:
+        return None
+    return _VOLUME_MARKER.sub("", str(value).strip())
 
 
 def chapter_id(comic_id, chapter_number):

--- a/comicarr/filechecker.py
+++ b/comicarr/filechecker.py
@@ -357,7 +357,10 @@ class FileChecker(object):
             manga_chapter = manga_chapter_match.group(1)
             logger.fdebug("[MANGA] Chapter detected: %s" % manga_chapter)
 
-        manga_volume_match = re.search(r"(?:v(?:ol(?:ume)?)?\.?\s*)(\d+)", modfilename, re.IGNORECASE)
+        # Captures the fraction like the chapter pattern above: a "v01.5" file
+        # that reports its volume as "01" is compared against the ledger's 1.5
+        # and rejected, so the half volume never imports.
+        manga_volume_match = re.search(r"(?:v(?:ol(?:ume)?)?\.?\s*)(\d+(?:\.\d+)?)", modfilename, re.IGNORECASE)
         if manga_volume_match:
             manga_volume = manga_volume_match.group(1)
             logger.fdebug("[MANGA] Volume detected: %s" % manga_volume)

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -2567,9 +2567,7 @@ def searchforissue(
                     content_type = "manga" if series_kind.is_manga(comic) else "comic"
                     if content_type == "manga":
                         manga_row = db.select_one(
-                            select(issues.c.ChapterNumber, issues.c.VolumeNumber).where(
-                                issues.c.IssueID == issueid
-                            )
+                            select(issues.c.ChapterNumber, issues.c.VolumeNumber).where(issues.c.IssueID == issueid)
                         )
                         # Best-effort enrichment: a Series whose ledger row is
                         # missing or does not carry these columns must still be
@@ -2647,12 +2645,8 @@ def searchforissue(
                     booktype=booktype,
                     ignore_booktype=ignore_booktype,
                     content_type=content_type,
-                    chapter_number=(
-                        None if manga_chapter_number in (None, "") else str(manga_chapter_number)
-                    ),
-                    volume_number=(
-                        None if manga_volume_number in (None, "") else str(manga_volume_number)
-                    ),
+                    chapter_number=(None if manga_chapter_number in (None, "") else str(manga_chapter_number)),
+                    volume_number=(None if manga_volume_number in (None, "") else str(manga_volume_number)),
                 )
                 if manual is True:
                     comicarr.SEARCHLOCK.release()
@@ -4318,7 +4312,7 @@ def manga_volume_search_terms(series_name, chapter_num, volume_num):
 
     if not is_volume_target(chapter_num, volume_num):
         return {}
-    return {term: series_name for term in _build_manga_search_terms(series_name, chapter_num, volume_num)}
+    return dict.fromkeys(_build_manga_search_terms(series_name, chapter_num, volume_num), series_name)
 
 
 def get_findcomiciss(IssueNumber):

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -4281,11 +4281,6 @@ def searchforissue_checker(issueid, storedate, issuedate, digitaldate, info):
         return {"status": False, "reason": "invalid issueid"}
 
 
-def _is_volume_target(chapter_num, volume_num):
-    """A target is a volume iff it has a volume number and no chapter number."""
-    return volume_num not in (None, "") and chapter_num in (None, "")
-
-
 def _build_manga_search_terms(series_name, chapter_num, volume_num):
     """Build manga-specific search query variations.
 
@@ -4294,8 +4289,9 @@ def _build_manga_search_terms(series_name, chapter_num, volume_num):
     which kind to look for.
     """
     from comicarr.app.manga.acquisition import search_terms_for_target
+    from comicarr.app.manga.ledger import is_volume_target
 
-    if _is_volume_target(chapter_num, volume_num):
+    if is_volume_target(chapter_num, volume_num):
         return search_terms_for_target(series_name, {"kind": "volume", "number": volume_num})
     return search_terms_for_target(series_name, {"kind": "chapter", "number": chapter_num})
 
@@ -4318,7 +4314,9 @@ def manga_volume_search_terms(series_name, chapter_num, volume_num):
 
     Chapter terms are excluded: they keep the normal issue-number handling.
     """
-    if not _is_volume_target(chapter_num, volume_num):
+    from comicarr.app.manga.ledger import is_volume_target
+
+    if not is_volume_target(chapter_num, volume_num):
         return {}
     return {term: series_name for term in _build_manga_search_terms(series_name, chapter_num, volume_num)}
 

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -316,6 +316,7 @@ def search_init(
         logger.fdebug("Story-ARC: %s" % SARC)
         logger.fdebug("IssueArcID: %s" % IssueArcID)
 
+    manga_volume_terms = set()
     if content_type == "manga":
         logger.fdebug("[SEARCH-MANGA] Manga content detected for %s" % ComicName)
         manga_terms = _build_manga_search_terms(ComicName, chapter_number, volume_number)
@@ -326,6 +327,7 @@ def search_init(
                 AlternateSearch = manga_alt_str + "##" + AlternateSearch
             else:
                 AlternateSearch = manga_alt_str
+            manga_volume_terms = manga_volume_search_terms(ComicName, chapter_number, volume_number)
 
     provider_list = provider_order(initial_run=True)
     if content_type == "manga":
@@ -665,6 +667,7 @@ def search_init(
                     "ignore_booktype": ignore_booktype,
                     "smode": smode,
                     "allow_packs": allow_packs,
+                    "manga_volume_terms": manga_volume_terms,
                     "findit": findit,
                 }
 
@@ -972,6 +975,7 @@ def NZB_SEARCH(
     chktpb=0,
     ignore_booktype=False,
     smode=None,
+    manga_volume_terms=None,
 ):
 
     if _allow_packs_enabled(allow_packs) and comicarr.CONFIG.ENABLE_TORRENT_SEARCH:
@@ -1137,7 +1141,16 @@ def NZB_SEARCH(
             findloop = 99
             break
 
-        if IssueNumber is not None:
+        if IssueNumber is not None and ComicName in (manga_volume_terms or ()):
+            # Manga VOLUME target. comsrc is already the volume search name
+            # ("<series> v01"), and volume releases are published without an
+            # issue number -- "One-Punch Man v01 (2014) (Digital)" -- so
+            # appending one gives "<series> v01 001" and matches nothing.
+            # Search the volume name as-is, the way the TPB pass does.
+            comsearch = comsrc
+            issdig = ""
+            mod_isssearch = ""
+        elif IssueNumber is not None:
             if cmloopit == 3:
                 comsearch = comsrc + "%2000" + str(isssearch)
                 issdig = "00"
@@ -4149,6 +4162,7 @@ def search_the_matrix(scarios):
         ignore_booktype=scarios["ignore_booktype"],
         smode=scarios["smode"],
         allow_packs=scarios.get("allow_packs"),
+        manga_volume_terms=scarios.get("manga_volume_terms"),
     )
 
 
@@ -4261,6 +4275,11 @@ def searchforissue_checker(issueid, storedate, issuedate, digitaldate, info):
         return {"status": False, "reason": "invalid issueid"}
 
 
+def _is_volume_target(chapter_num, volume_num):
+    """A target is a volume iff it has a volume number and no chapter number."""
+    return volume_num not in (None, "") and chapter_num in (None, "")
+
+
 def _build_manga_search_terms(series_name, chapter_num, volume_num):
     """Build manga-specific search query variations.
 
@@ -4270,9 +4289,24 @@ def _build_manga_search_terms(series_name, chapter_num, volume_num):
     """
     from comicarr.app.manga.acquisition import search_terms_for_target
 
-    if volume_num not in (None, "") and chapter_num in (None, ""):
+    if _is_volume_target(chapter_num, volume_num):
         return search_terms_for_target(series_name, {"kind": "volume", "number": volume_num})
     return search_terms_for_target(series_name, {"kind": "chapter", "number": chapter_num})
+
+
+def manga_volume_search_terms(series_name, chapter_num, volume_num):
+    """The generated manga terms that are VOLUME targets, as a set.
+
+    NZB_SEARCH takes this to decide which alternate names must be searched
+    bare. A volume term already carries its number in the search name
+    ("<series> v01") and volume releases are published without an issue number
+    -- "One-Punch Man v01 (2014) (Digital)" -- so appending one yields
+    "<series> v01 001", which matches nothing. Chapter terms are excluded:
+    they keep the normal issue-number handling.
+    """
+    if not _is_volume_target(chapter_num, volume_num):
+        return set()
+    return set(_build_manga_search_terms(series_name, chapter_num, volume_num))
 
 
 def get_findcomiciss(IssueNumber):

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -2505,6 +2505,8 @@ def searchforissue(
                 allow_packs = False
                 ComicID = result["ComicID"]
                 content_type = "comic"
+                manga_chapter_number = None
+                manga_volume_number = None
                 if smode == "story_arc":
                     ComicName = result["ComicName"]
                     Comicname_filesafe = helpers.filesafe(ComicName)
@@ -2544,6 +2546,20 @@ def searchforissue(
                 else:
                     comic = db.select_one(select(comics).where(comics.c.ComicID == ComicID))
                     content_type = "manga" if series_kind.is_manga(comic) else "comic"
+                    if content_type == "manga":
+                        manga_row = db.select_one(
+                            select(issues.c.ChapterNumber, issues.c.VolumeNumber).where(
+                                issues.c.IssueID == issueid
+                            )
+                        )
+                        # Best-effort enrichment: a Series whose ledger row is
+                        # missing or does not carry these columns must still be
+                        # searched (by issue number), never fail outright.
+                        manga_keys = set(manga_row.keys()) if manga_row is not None else set()
+                        if "ChapterNumber" in manga_keys:
+                            manga_chapter_number = manga_row["ChapterNumber"]
+                        if "VolumeNumber" in manga_keys:
+                            manga_volume_number = manga_row["VolumeNumber"]
                     if smode == "want_ann":
                         ComicName = result["ReleaseComicName"]
                         Comicname_filesafe = None
@@ -2612,6 +2628,12 @@ def searchforissue(
                     booktype=booktype,
                     ignore_booktype=ignore_booktype,
                     content_type=content_type,
+                    chapter_number=(
+                        None if manga_chapter_number in (None, "") else str(manga_chapter_number)
+                    ),
+                    volume_number=(
+                        None if manga_volume_number in (None, "") else str(manga_volume_number)
+                    ),
                 )
                 if manual is True:
                     comicarr.SEARCHLOCK.release()

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -316,18 +316,28 @@ def search_init(
         logger.fdebug("Story-ARC: %s" % SARC)
         logger.fdebug("IssueArcID: %s" % IssueArcID)
 
-    manga_volume_terms = set()
+    from comicarr.app.manga.ledger import is_volume_target
+
+    manga_volume_terms = {}
+    manga_volume_target = content_type == "manga" and is_volume_target(chapter_number, volume_number)
     if content_type == "manga":
         logger.fdebug("[SEARCH-MANGA] Manga content detected for %s" % ComicName)
-        manga_terms = _build_manga_search_terms(ComicName, chapter_number, volume_number)
-        if manga_terms:
-            manga_alt_str = "##".join(manga_terms)
-            logger.fdebug("[SEARCH-MANGA] Generated %d search variations: %s" % (len(manga_terms), manga_terms))
-            if AlternateSearch and AlternateSearch != "None":
-                AlternateSearch = manga_alt_str + "##" + AlternateSearch
-            else:
-                AlternateSearch = manga_alt_str
-            manga_volume_terms = manga_volume_search_terms(ComicName, chapter_number, volume_number)
+        # A VOLUME target deliberately does not go through AlternateSearch.
+        # gen_altnames() splits that string on `!` and `#`, which shreds a term
+        # like "Gantz! v01", and whatever survived would be ordered AFTER the
+        # bare series name -- whose pass appends the issue number, so a
+        # same-numbered CHAPTER release ("One-Punch Man 030") wins on the first
+        # hit and the v30 pass never runs. Volume terms are built from the
+        # finished name list instead, below.
+        if not manga_volume_target:
+            manga_terms = _build_manga_search_terms(ComicName, chapter_number, volume_number)
+            if manga_terms:
+                manga_alt_str = "##".join(manga_terms)
+                logger.fdebug("[SEARCH-MANGA] Generated %d search variations: %s" % (len(manga_terms), manga_terms))
+                if AlternateSearch and AlternateSearch != "None":
+                    AlternateSearch = manga_alt_str + "##" + AlternateSearch
+                else:
+                    AlternateSearch = manga_alt_str
 
     provider_list = provider_order(initial_run=True)
     if content_type == "manga":
@@ -674,7 +684,11 @@ def search_init(
                 if searchmode == "rss":
                     logger.info("RSS searchmode enabled for %s" % ComicName)
                     scarios["RSS"] = "yes"
-                    for xx in gen_altnames(ComicName, AlternateSearch, filesafe, smode):
+                    altnames = gen_altnames(ComicName, AlternateSearch, filesafe, smode)
+                    if manga_volume_target:
+                        altnames, manga_volume_terms = manga_volume_altnames(altnames, volume_number)
+                        scarios["manga_volume_terms"] = manga_volume_terms
+                    for xx in altnames:
                         logger.info("comicname searched for: %s" % ComicName)
                         if all([findit["status"] is False, not provider_blocked]):
                             scarios["ComicName"] = xx["ComicName"]
@@ -696,6 +710,9 @@ def search_init(
                         ]
                     else:
                         altnames = gen_altnames(ComicName, AlternateSearch, filesafe, smode)
+                    if manga_volume_target:
+                        altnames, manga_volume_terms = manga_volume_altnames(altnames, volume_number)
+                        scarios["manga_volume_terms"] = manga_volume_terms
                     for xx in altnames:
                         logger.info("comicname searched for: %s" % ComicName)
                         if all([findit["status"] is False, not provider_blocked]):
@@ -4288,6 +4305,39 @@ def _build_manga_search_terms(series_name, chapter_num, volume_num):
     if is_volume_target(chapter_num, volume_num):
         return search_terms_for_target(series_name, {"kind": "volume", "number": volume_num})
     return search_terms_for_target(series_name, {"kind": "chapter", "number": chapter_num})
+
+
+def manga_volume_altnames(altnames, volume_num):
+    """Rewrite a finished name list into VOLUME queries.
+
+    Takes the list gen_altnames() produced -- the series name plus every
+    alternate, already split and de-duplicated -- and replaces each entry with
+    its volume query, so no pass is left searching a bare name with an issue
+    number appended. Alternate titles keep their coverage: each one gets its
+    own "<alt> vNN" rather than being dropped.
+
+    Returns ``(entries, terms)`` where ``terms`` maps each query back to the
+    name the release will actually parse as, which is what the matcher has to
+    compare against -- "<series> v01" is a query, never a series name.
+
+    Falls back to the original list when no term can be built (an unusable
+    volume number), so a series is never left unsearchable.
+    """
+    from comicarr.app.manga.acquisition import search_terms_for_target
+
+    entries = []
+    terms = {}
+    for entry in altnames or ():
+        name = entry.get("unaltered_ComicName") or entry.get("ComicName")
+        for term in search_terms_for_target(name, {"kind": "volume", "number": volume_num}):
+            if term in terms:
+                continue
+            terms[term] = name
+            entries.append({"ComicName": term, "unaltered_ComicName": term})
+    if not entries:
+        return list(altnames or ()), {}
+    logger.fdebug("[SEARCH-MANGA] Volume queries: %s" % ([e["ComicName"] for e in entries],))
+    return entries, terms
 
 
 def manga_volume_search_terms(series_name, chapter_num, volume_num):

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -1096,8 +1096,14 @@ def NZB_SEARCH(
     foundc["lastrun"] = provider_stat["lastrun"]
     done = False
 
+    # Set only when this pass is searching a manga volume term. Carries the
+    # real series name, because the term itself ("<series> v01") is a query
+    # rather than a name and would fail every series comparison.
+    manga_match_name = (manga_volume_terms or {}).get(ComicName)
+
     is_info = {
         "ComicName": ComicName,
+        "manga_match_name": manga_match_name,
         "nzbprov": nzbprov,
         "RSS": RSS,
         "UseFuzzy": UseFuzzy,
@@ -4295,18 +4301,26 @@ def _build_manga_search_terms(series_name, chapter_num, volume_num):
 
 
 def manga_volume_search_terms(series_name, chapter_num, volume_num):
-    """The generated manga terms that are VOLUME targets, as a set.
+    """Map each generated VOLUME search term to the real series name.
 
-    NZB_SEARCH takes this to decide which alternate names must be searched
-    bare. A volume term already carries its number in the search name
-    ("<series> v01") and volume releases are published without an issue number
-    -- "One-Punch Man v01 (2014) (Digital)" -- so appending one yields
-    "<series> v01 001", which matches nothing. Chapter terms are excluded:
-    they keep the normal issue-number handling.
+    Volume terms are injected into AlternateSearch so gen_altnames() hands them
+    to NZB_SEARCH as a ComicName, and that creates two problems this mapping
+    solves at once:
+
+      * The term already carries its number ("<series> v01") and volume
+        releases are published without an issue number -- "One-Punch Man v01
+        (2014) (Digital)" -- so NZB_SEARCH must not append one. Membership
+        answers "is this pass a volume search?".
+      * AlternateSearch means "another NAME for this series", but a volume term
+        is a query, not a name. The release still parses as the plain series
+        name, so the matcher must compare against the value here rather than
+        the volume-suffixed term, or every result is a series mismatch.
+
+    Chapter terms are excluded: they keep the normal issue-number handling.
     """
     if not _is_volume_target(chapter_num, volume_num):
-        return set()
-    return set(_build_manga_search_terms(series_name, chapter_num, volume_num))
+        return {}
+    return {term: series_name for term in _build_manga_search_terms(series_name, chapter_num, volume_num)}
 
 
 def get_findcomiciss(IssueNumber):

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -1078,7 +1078,10 @@ def NZB_SEARCH(
 
     cm = re.sub("\\bthe\\b", "", cm.lower())
 
-    cm = re.sub(r"[\&\:\?\,]", "", str(cm))
+    # '#' joins the strip list because it is not merely awkward in a query, it
+    # TERMINATES the URL: everything after it is the fragment, so the apikey and
+    # every later parameter appended below never reach the provider.
+    cm = re.sub(r"[\&\:\?\,\#]", "", str(cm))
     cm = re.sub(r"\s+", " ", cm)
     cm = re.sub(" ", "%20", str(cm))
     cm = re.sub("'", "%27", str(cm))

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -162,6 +162,24 @@ def report_provider_failure(provider, code, detail):
         collector["failure"](str(provider), str(code), str(detail))
 
 
+def manga_volume_satisfies(found_volume, wanted_number):
+    """Does a matched manga volume satisfy the ledger row being searched?
+
+    A manga volume release carries no issue number -- "One-Punch Man v01 (2014)
+    (Digital)" -- so the issue-number arms can never accept it. The volume IS
+    the unit being acquired, so the release satisfies the row when the two
+    volume numbers agree. Compared numerically, since the release writes "v01"
+    and the ledger stores "1".
+    """
+    if found_volume in (None, "") or wanted_number in (None, ""):
+        return False
+    found_digits = re.sub(r"[^0-9]", "", str(found_volume))
+    wanted_digits = re.sub(r"[^0-9]", "", str(wanted_number))
+    if not found_digits or not wanted_digits:
+        return False
+    return int(found_digits) == int(wanted_digits)
+
+
 class search_check(object):
     def __init__(self):
         pass
@@ -320,6 +338,7 @@ class search_check(object):
             # parses as the plain series name, so comparing against the query
             # would fail every result. Match against the real name instead.
             match_name = is_info.get("manga_match_name") or ComicName
+            manga_volume_pass = bool(is_info.get("manga_match_name"))
             nzbprov = is_info["nzbprov"]
             RSS = is_info["RSS"]
             UseFuzzy = is_info["UseFuzzy"]
@@ -1126,6 +1145,16 @@ class search_check(object):
                     or all([cmloopit == 4, findcomiciss is None, pc_in is None])
                     or all([cmloopit == 4, findcomiciss is None, pc_in == 1])
                     or all([cmloopit == 4, findcomiciss == 1, pc_in is None])
+                    or all(
+                        [
+                            manga_volume_pass,
+                            pc_in is None,
+                            manga_volume_satisfies(
+                                filecomic.get("volume") or filecomic.get("series_volume"),
+                                findcomiciss,
+                            ),
+                        ]
+                    )
                 ):
                     nowrite = False
                     logger.info(

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -316,6 +316,10 @@ class search_check(object):
     def _match_entry(self, entry, is_info):
         if is_info:
             ComicName = is_info["ComicName"]
+            # A manga volume pass searches "<series> v01", but the release
+            # parses as the plain series name, so comparing against the query
+            # would fail every result. Match against the real name instead.
+            match_name = is_info.get("manga_match_name") or ComicName
             nzbprov = is_info["nzbprov"]
             RSS = is_info["RSS"]
             UseFuzzy = is_info["UseFuzzy"]
@@ -665,7 +669,7 @@ class search_check(object):
                     "parse_status": "success",
                 }
             else:
-                p_comic = filechecker.FileChecker(file=ComicTitle, watchcomic=ComicName)
+                p_comic = filechecker.FileChecker(file=ComicTitle, watchcomic=match_name)
                 parsed_comic = p_comic.listFiles()
 
         logger.fdebug("parsed_info: %s" % parsed_comic)
@@ -692,7 +696,7 @@ class search_check(object):
             or re.sub("None", "issue", str(booktype)) in parsed_comic["booktype"]
         ):
             try:
-                fcomic = filechecker.FileChecker(watchcomic=ComicName)
+                fcomic = filechecker.FileChecker(watchcomic=match_name)
                 filecomic = fcomic.matchIT(parsed_comic)
             except Exception as e:
                 logger.error("[PARSE-ERROR]: %s" % e)

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -166,18 +166,16 @@ def manga_volume_satisfies(found_volume, wanted_number):
     """Does a matched manga volume satisfy the ledger row being searched?
 
     A manga volume release carries no issue number -- "One-Punch Man v01 (2014)
-    (Digital)" -- so the issue-number arms can never accept it. The volume IS
-    the unit being acquired, so the release satisfies the row when the two
-    volume numbers agree. Compared numerically, since the release writes "v01"
-    and the ledger stores "1".
+    (Digital)" -- so the issue-number acceptance arms can never accept it. The
+    volume IS the unit being acquired, so the release satisfies the row when
+    the two volume numbers agree.
+
+    The comparison itself belongs to the ledger, which already owns what a
+    volume number means; this only names the acceptance question.
     """
-    if found_volume in (None, "") or wanted_number in (None, ""):
-        return False
-    found_digits = re.sub(r"[^0-9]", "", str(found_volume))
-    wanted_digits = re.sub(r"[^0-9]", "", str(wanted_number))
-    if not found_digits or not wanted_digits:
-        return False
-    return int(found_digits) == int(wanted_digits)
+    from comicarr.app.manga.ledger import volume_numbers_match
+
+    return volume_numbers_match(found_volume, wanted_number)
 
 
 class search_check(object):

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -892,7 +892,14 @@ class search_check(object):
             logger.fdebug("SCVersion: %s" % S_ComicVersion)
             logger.fdebug("ComicYear: %s" % ComicYear)
 
-            if manga_volume_pass and manga_volume_satisfies(fndcomicversion, findcomiciss):
+            # fndcomicversion or the parsed volume: the version arms above only
+            # recognise an all-digit vNN, so a FRACTIONAL volume leaves
+            # fndcomicversion None even though FileChecker parsed `v01.5`
+            # perfectly well. The comparison then failed and the half volume
+            # this branch exists to accept was rejected before the post-gate
+            # fallback could run.
+            parsed_volume = fndcomicversion or parsed_comic.get("series_volume")
+            if manga_volume_pass and manga_volume_satisfies(parsed_volume, findcomiciss):
                 # "vNN" means different things in the two formats. In a comic
                 # release it is which RUN of the series this is (Amazing
                 # Spider-Man v2), which is why the arms below compare it to the

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -892,7 +892,20 @@ class search_check(object):
             logger.fdebug("SCVersion: %s" % S_ComicVersion)
             logger.fdebug("ComicYear: %s" % ComicYear)
 
-            if all(
+            if manga_volume_pass and manga_volume_satisfies(fndcomicversion, findcomiciss):
+                # "vNN" means different things in the two formats. In a comic
+                # release it is which RUN of the series this is (Amazing
+                # Spider-Man v2), which is why the arms below compare it to the
+                # series' ComicVersion or year. In manga it is which BOOK --
+                # volume 30 of one continuous series -- so the only meaningful
+                # comparison is against the volume being searched for.
+                #
+                # Without this, a manga volume matches only when the series'
+                # ComicVersion happens to equal the volume number, i.e. volume 1
+                # of a v1 series, and every later volume is discarded with
+                # "Versions wrong" despite being the exact release requested.
+                logger.fdebug("[MANGA] volume %s matches the volume searched for" % fndcomicversion)
+            elif all(
                 [
                     annualize is True,
                     parsed_comic["issue_number"] is not None,

--- a/tests/unit/test_manga_ledger.py
+++ b/tests/unit/test_manga_ledger.py
@@ -16,10 +16,12 @@ from comicarr.app.manga.ledger import (
     blended_progress,
     chapter_id,
     covers_to_volume_rows,
+    is_volume_target,
     last_released_volume,
     merge_refresh_row,
     normalize_volume_number,
     volume_id,
+    volume_numbers_match,
 )
 
 
@@ -115,6 +117,45 @@ def test_covered_fulfillment_is_not_have_and_is_not_searchable():
     )
     assert decision.eligible is False
     assert decision.reason == "covered"
+
+
+def test_is_volume_target_requires_a_volume_and_no_chapter():
+    """The single owner of the volume-vs-chapter rule, used by search and packs."""
+    assert is_volume_target(None, "1") is True
+    assert is_volume_target("", "1") is True
+    # A chapter that happens to know its volume is still a chapter -- this is
+    # what stops a volume pack claiming "chapter 7" as "volume 7".
+    assert is_volume_target("7", "1") is False
+    assert is_volume_target("7", None) is False
+    assert is_volume_target(None, None) is False
+
+
+def test_volume_numbers_match_across_the_spellings_in_use():
+    """A release writes "v01", the ledger stores "1", a pack yields int 1."""
+    assert volume_numbers_match("v01", "1") is True
+    assert volume_numbers_match("Vol. 3", 3) is True
+    assert volume_numbers_match("01", 1) is True
+    assert volume_numbers_match("v02", "1") is False
+
+
+def test_volume_numbers_match_never_matches_on_missing_or_unparsable_data():
+    """Returning False on junk keeps a parse failure from claiming a volume."""
+    assert volume_numbers_match(None, "1") is False
+    assert volume_numbers_match("v01", None) is False
+    assert volume_numbers_match("", "") is False
+    assert volume_numbers_match("none", "1") is False
+    # "v" is only stripped when it introduces a number, so this stays unequal.
+    assert volume_numbers_match("vTPB", "1") is False
+
+
+def test_volume_numbers_match_keeps_fractional_volumes_distinct():
+    """A fractional volume is its own volume, not a truncation of the integer.
+
+    normalize_volume_number() already models fractional volumes, so 1.5 must
+    not collapse into 1 the way an int(float(...)) comparison would.
+    """
+    assert volume_numbers_match("1.5", "1") is False
+    assert volume_numbers_match("1.5", "1.5") is True
 
 
 def test_normalize_volume_number_treats_none_sentinel_as_absent():

--- a/tests/unit/test_manga_ledger.py
+++ b/tests/unit/test_manga_ledger.py
@@ -162,3 +162,27 @@ def test_normalize_volume_number_treats_none_sentinel_as_absent():
     assert normalize_volume_number("1.0") == "1"
     assert normalize_volume_number("none") is None
     assert normalize_volume_number("") is None
+
+
+class TestVolumeNumbersMatchIsExact:
+    """The matcher's own contract: no usable volume on either side means False.
+
+    normalize_volume_number is a DISPLAY normaliser -- it preserves arbitrary
+    text and formats floats to six significant digits -- so comparing through
+    it made two non-volumes equal each other and lost precision.
+    """
+
+    def test_two_identical_non_volumes_do_not_match(self):
+        """"TPB" is not a volume, so a TPB does not satisfy another TPB."""
+        assert volume_numbers_match("TPB", "TPB") is False
+
+    def test_precision_is_not_rounded_away(self):
+        assert volume_numbers_match("1.0000001", "1") is False
+
+    def test_padding_and_markers_still_match(self):
+        assert volume_numbers_match("v01", "1") is True
+        assert volume_numbers_match("01", "1") is True
+        assert volume_numbers_match("v01.5", "1.5") is True
+
+    def test_a_different_volume_still_does_not_match(self):
+        assert volume_numbers_match("v01", "1.5") is False

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -11,19 +11,22 @@
 
 import ast
 import datetime
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from comicarr.app.manga.acquisition import search_plan_for_series
+import comicarr.search as search
+from comicarr.app.manga.acquisition import search_plan_for_series, search_terms_for_target
+from comicarr.app.manga.ledger import volume_numbers_match
 from comicarr.app.manga.parse import parse_in_series_context, parse_kwargs_for_series
 from comicarr.app.manga.sync import arm_manga_sync_job, next_interval_run
 from comicarr.rsscheck import mangaCheck
 from comicarr.search import _build_manga_search_terms, manga_volume_search_terms
-from comicarr.app.manga.ledger import volume_numbers_match
 from comicarr.search_filer import manga_volume_satisfies
 
 _INIT_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "__init__.py"
 _SEARCH_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "search.py"
+_FILECHECKER_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "filechecker.py"
 
 
 def _is_search_init(func):
@@ -281,17 +284,11 @@ def test_nzb_search_accepts_and_receives_manga_volume_terms():
     parameter the query becomes "<series> v01 001" and matches nothing.
     """
     tree = ast.parse(_SEARCH_PATH.read_text(encoding="utf-8"))
-    signature = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.FunctionDef) and node.name == "NZB_SEARCH"
-    )
+    signature = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "NZB_SEARCH")
     assert "manga_volume_terms" in {arg.arg for arg in signature.args.kwonlyargs + signature.args.args}
 
     handoff = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.FunctionDef) and node.name == "search_the_matrix"
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "search_the_matrix"
     )
     passed = {
         kw.arg
@@ -309,3 +306,110 @@ def test_manga_rss_path_passes_manga_numbers_to_search_init():
     assert calls, "mangaCheck() no longer calls search_init()"
     for keywords in calls:
         assert {"content_type", "chapter_number", "volume_number"} <= keywords
+
+
+def test_gen_altnames_shreds_a_volume_term_carried_in_alternatesearch():
+    """Characterises WHY volume terms cannot ride AlternateSearch.
+
+    gen_altnames() splits that string on `!` and `#` (and reads `!!` as an
+    alt-priority marker), so a series whose title contains one never survives
+    the round trip. This is the reason manga_volume_altnames() builds the terms
+    from the finished name list instead.
+    """
+    names = [x["ComicName"] for x in search.gen_altnames("Gantz!", "Gantz! v01", None, "want")]
+    assert "Gantz! v01" not in names
+
+
+def test_manga_volume_altnames_leaves_no_bare_name_to_search_by_issue_number():
+    """Every pass for a volume target must be a volume query.
+
+    NZB_SEARCH appends the issue number to any name that is not a volume term,
+    and search_the_matrix stops on the first hit -- so leaving the bare series
+    name in the list lets "One-Punch Man 030", a CHAPTER release, snatch the
+    volume 30 row before the v30 pass ever runs.
+    """
+    altnames = [
+        {"ComicName": "One-Punch Man", "unaltered_ComicName": "One-Punch Man"},
+        {"ComicName": "Onepunchman", "unaltered_ComicName": "Onepunchman"},
+    ]
+
+    entries, terms = search.manga_volume_altnames(altnames, "30")
+
+    assert [x["ComicName"] for x in entries] == ["One-Punch Man v30", "Onepunchman v30"]
+    # the bare name is gone -- nothing left that would append an issue number
+    assert "One-Punch Man" not in [x["ComicName"] for x in entries]
+    # alternates keep their coverage rather than being dropped
+    assert terms == {"One-Punch Man v30": "One-Punch Man", "Onepunchman v30": "Onepunchman"}
+
+
+def test_manga_volume_altnames_keeps_a_bang_title_unsplit():
+    """ "Gantz!" and "Working!!" must produce a usable volume term.
+
+    The term is what NZB_SEARCH looks up to decide this is a volume pass, and
+    what the matcher maps back to the real series name. A split term matches
+    neither, so the lookup silently misses and the pass reverts to an
+    issue-number search.
+    """
+    altnames = search.gen_altnames("Gantz!", None, None, "want")
+
+    entries, terms = search.manga_volume_altnames(altnames, "1")
+
+    assert [x["ComicName"] for x in entries] == ["Gantz! v01"]
+    assert terms["Gantz! v01"] == "Gantz!"
+
+
+def test_manga_volume_altnames_falls_back_when_no_term_can_be_built():
+    """An unusable volume number must not leave the series unsearchable."""
+    altnames = [{"ComicName": "Berserk", "unaltered_ComicName": "Berserk"}]
+
+    entries, terms = search.manga_volume_altnames(altnames, None)
+
+    assert entries == altnames
+    assert terms == {}
+
+
+def test_half_volume_keeps_its_fraction_through_search_and_match():
+    """A v01.5 release must be searched for, parsed, and accepted.
+
+    _pad_volume() used to truncate through int(), so a 1.5 volume searched
+    "v01" and then failed the exact volume comparison (1 against 1.5) -- the
+    row could never snatch.
+    """
+    assert search_terms_for_target("Kanojo", {"kind": "volume", "number": "1.5"}) == ["Kanojo v01.5"]
+    # whole volumes keep their existing zero-padded form
+    assert search_terms_for_target("Kanojo", {"kind": "volume", "number": "2"}) == ["Kanojo v02"]
+
+    assert volume_numbers_match("v01.5", "1.5") is True
+    # and the truncated form must NOT satisfy the half volume
+    assert volume_numbers_match("v01", "1.5") is False
+
+
+def test_filechecker_captures_a_fractional_manga_volume():
+    """The volume pattern must keep the fraction, as the chapter pattern does."""
+    pattern = re.compile(r"(?:v(?:ol(?:ume)?)?\.?\s*)(\d+(?:\.\d+)?)", re.IGNORECASE)
+    source = _FILECHECKER_PATH.read_text(encoding="utf-8")
+    assert pattern.pattern in source, "filechecker no longer uses the fractional volume pattern"
+
+    assert pattern.search("Kanojo v01.5 (2020) (Digital)").group(1) == "01.5"
+    assert pattern.search("Kanojo v01 (2020) (Digital)").group(1) == "01"
+    # an extension must not be read as a fraction
+    assert pattern.search("Kanojo v01.cbz").group(1) == "01"
+
+
+def test_search_init_wires_volume_queries_instead_of_alternatesearch():
+    """The wiring the two findings above depend on, asserted at the seam.
+
+    search_init() is reached only through provider configuration and a global
+    search lock, so this is asserted from source -- the same approach
+    test_manga_volume_arm_precedes_the_comic_version_comparison() takes.
+    """
+    source = _SEARCH_PATH.read_text(encoding="utf-8")
+
+    # both search loops (rss and api) rewrite the finished name list
+    rewrite = "altnames, manga_volume_terms = manga_volume_altnames(altnames, volume_number)"
+    assert source.count(rewrite) == 2, "a search loop still iterates un-rewritten altnames"
+
+    # the AlternateSearch injection is reachable only for a NON-volume target
+    guard = source.index("if not manga_volume_target:")
+    injection = source.index('AlternateSearch = manga_alt_str + "##" + AlternateSearch')
+    assert guard < injection, "volume terms are being injected into AlternateSearch again"

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -18,7 +18,7 @@ from comicarr.app.manga.acquisition import search_plan_for_series
 from comicarr.app.manga.parse import parse_in_series_context, parse_kwargs_for_series
 from comicarr.app.manga.sync import arm_manga_sync_job, next_interval_run
 from comicarr.rsscheck import mangaCheck
-from comicarr.search import _build_manga_search_terms
+from comicarr.search import _build_manga_search_terms, manga_volume_search_terms
 
 _INIT_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "__init__.py"
 _SEARCH_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "search.py"
@@ -29,6 +29,12 @@ def _is_search_init(func):
     if isinstance(func, ast.Name):
         return func.id == "search_init"
     return isinstance(func, ast.Attribute) and func.attr == "search_init"
+
+
+def _is_search_init_or_nzb(func):
+    """Match a call to either search_init(...) or NZB_SEARCH(...)."""
+    name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+    return name in {"search_init", "NZB_SEARCH"}
 
 
 def _search_init_call_keywords(function_name, path):
@@ -208,6 +214,47 @@ def test_searchforissue_passes_manga_numbers_to_search_init():
         assert "content_type" in keywords
         assert "chapter_number" in keywords
         assert "volume_number" in keywords
+
+
+def test_manga_volume_search_terms_marks_only_volume_targets():
+    """Volume terms are searched bare; chapter terms keep the issue number."""
+    volume = manga_volume_search_terms("One-Punch Man", None, "1")
+    assert volume == {"One-Punch Man v01"}
+
+    # A chapter target must NOT be marked -- "<series> c001" is a real search
+    # whose issue-number handling is unchanged.
+    assert manga_volume_search_terms("One Piece", "1161", None) == set()
+    # Neither number available: nothing to search bare.
+    assert manga_volume_search_terms("One Piece", None, None) == set()
+
+
+def test_nzb_search_accepts_and_receives_manga_volume_terms():
+    """The bare-volume signal must reach NZB_SEARCH, or the suffix is appended.
+
+    NZB_SEARCH builds "<series>%20<issue>" for anything with an IssueNumber. A
+    manga volume target already carries its number in the name, so without this
+    parameter the query becomes "<series> v01 001" and matches nothing.
+    """
+    tree = ast.parse(_SEARCH_PATH.read_text(encoding="utf-8"))
+    signature = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "NZB_SEARCH"
+    )
+    assert "manga_volume_terms" in {arg.arg for arg in signature.args.kwonlyargs + signature.args.args}
+
+    handoff = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "search_the_matrix"
+    )
+    passed = {
+        kw.arg
+        for call in ast.walk(handoff)
+        if isinstance(call, ast.Call) and _is_search_init_or_nzb(call.func)
+        for kw in call.keywords
+    }
+    assert "manga_volume_terms" in passed
 
 
 def test_manga_rss_path_passes_manga_numbers_to_search_init():

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -246,6 +246,23 @@ def test_manga_volume_satisfies_defers_to_the_ledger_comparison():
     assert manga_volume_satisfies(None, "1") is False
 
 
+def test_manga_volume_arm_precedes_the_comic_version_comparison():
+    """The manga reading of "vNN" must win before the comic-version arms run.
+
+    Those arms compare the release's vNN to the series' ComicVersion/year,
+    which is the comic meaning (which RUN this is). For manga it is which BOOK,
+    so a later volume is otherwise discarded as "Versions wrong" -- only volume
+    1 of a v1 series would ever slip through.
+    """
+    filer_path = Path(__file__).resolve().parents[2] / "comicarr" / "search_filer.py"
+    source = filer_path.read_text(encoding="utf-8")
+    manga_arm = source.index("if manga_volume_pass and manga_volume_satisfies(")
+    versions_wrong = source.index('logger.fdebug("Versions wrong. Ignoring possible match.")')
+    assert manga_arm < versions_wrong
+    # It must be the opening `if`, not an `elif` reached after a comic arm.
+    assert "\n            if manga_volume_pass and manga_volume_satisfies(" in source
+
+
 def test_match_entry_prefers_the_manga_match_name():
     """search_filer must compare against manga_match_name when it is set."""
     filer_path = Path(__file__).resolve().parents[2] / "comicarr" / "search_filer.py"

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -19,6 +19,7 @@ from comicarr.app.manga.parse import parse_in_series_context, parse_kwargs_for_s
 from comicarr.app.manga.sync import arm_manga_sync_job, next_interval_run
 from comicarr.rsscheck import mangaCheck
 from comicarr.search import _build_manga_search_terms, manga_volume_search_terms
+from comicarr.app.manga.ledger import volume_numbers_match
 from comicarr.search_filer import manga_volume_satisfies
 
 _INIT_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "__init__.py"
@@ -233,21 +234,16 @@ def test_manga_volume_search_terms_maps_volume_targets_to_the_real_name():
     assert manga_volume_search_terms("One Piece", None, None) == {}
 
 
-def test_manga_volume_satisfies_compares_volumes_numerically():
-    """A volume release has no issue number, so acceptance turns on the volume.
+def test_manga_volume_satisfies_defers_to_the_ledger_comparison():
+    """Acceptance asks the ledger; it does not carry its own volume rules.
 
-    The release writes "v01" and the ledger stores "1"; both must be read as
-    the same volume or nothing is ever snatched.
+    The spellings and edge cases are covered once, in test_manga_ledger.py.
+    This only pins that acceptance uses that comparison -- a second copy here
+    is exactly how the two would drift apart.
     """
-    assert manga_volume_satisfies("v01", "1") is True
-    assert manga_volume_satisfies("v1", 1) is True
-    assert manga_volume_satisfies("v12", "12") is True
-    assert manga_volume_satisfies("v02", "1") is False
-    # Never accept on missing data -- that would snatch an arbitrary volume.
+    assert manga_volume_satisfies("v01", "1") is volume_numbers_match("v01", "1")
+    assert manga_volume_satisfies("v02", "1") is volume_numbers_match("v02", "1")
     assert manga_volume_satisfies(None, "1") is False
-    assert manga_volume_satisfies("v01", None) is False
-    assert manga_volume_satisfies("", "") is False
-    assert manga_volume_satisfies("vTPB", "1") is False
 
 
 def test_match_entry_prefers_the_manga_match_name():

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -19,6 +19,7 @@ from comicarr.app.manga.parse import parse_in_series_context, parse_kwargs_for_s
 from comicarr.app.manga.sync import arm_manga_sync_job, next_interval_run
 from comicarr.rsscheck import mangaCheck
 from comicarr.search import _build_manga_search_terms, manga_volume_search_terms
+from comicarr.search_filer import manga_volume_satisfies
 
 _INIT_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "__init__.py"
 _SEARCH_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "search.py"
@@ -230,6 +231,23 @@ def test_manga_volume_search_terms_maps_volume_targets_to_the_real_name():
     assert manga_volume_search_terms("One Piece", "1161", None) == {}
     # Neither number available: nothing to search bare.
     assert manga_volume_search_terms("One Piece", None, None) == {}
+
+
+def test_manga_volume_satisfies_compares_volumes_numerically():
+    """A volume release has no issue number, so acceptance turns on the volume.
+
+    The release writes "v01" and the ledger stores "1"; both must be read as
+    the same volume or nothing is ever snatched.
+    """
+    assert manga_volume_satisfies("v01", "1") is True
+    assert manga_volume_satisfies("v1", 1) is True
+    assert manga_volume_satisfies("v12", "12") is True
+    assert manga_volume_satisfies("v02", "1") is False
+    # Never accept on missing data -- that would snatch an arbitrary volume.
+    assert manga_volume_satisfies(None, "1") is False
+    assert manga_volume_satisfies("v01", None) is False
+    assert manga_volume_satisfies("", "") is False
+    assert manga_volume_satisfies("vTPB", "1") is False
 
 
 def test_match_entry_prefers_the_manga_match_name():

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -413,3 +413,37 @@ def test_search_init_wires_volume_queries_instead_of_alternatesearch():
     guard = source.index("if not manga_volume_target:")
     injection = source.index('AlternateSearch = manga_alt_str + "##" + AlternateSearch')
     assert guard < injection, "volume terms are being injected into AlternateSearch again"
+
+
+def test_a_multi_digit_fraction_survives_padding():
+    """A volume/chapter fraction is carried as text, not through float rounding.
+
+    `round(value % 1, 1)` keeps only ONE fractional digit, so 1.25 searched
+    "v01.2" and 1.75 searched "v01.8" -- not truncations of the wanted volume
+    but DIFFERENT ones, which the exact comparison then rejects, so the row
+    could never snatch.
+    """
+    from comicarr.app.manga.acquisition import _pad_chapter, _pad_volume
+
+    assert _pad_volume("1.25") == "01.25"
+    assert _pad_volume("1.75") == "01.75"
+    assert _pad_volume("1.05") == "01.05"
+    assert _pad_chapter("1.25") == "001.25"
+    assert _pad_chapter("1.75") == "001.75"
+
+    # and the existing forms are unchanged
+    assert _pad_volume("1.5") == "01.5"
+    assert _pad_volume("2") == "02"
+    assert _pad_chapter("165") == "165"
+
+
+def test_a_fractional_volume_search_term_round_trips():
+    """The term that is searched must satisfy the volume that was wanted."""
+    from comicarr.app.manga.ledger import volume_numbers_match
+
+    (term,) = search_terms_for_target("Kanojo", {"kind": "volume", "number": "1.25"})
+
+    assert term == "Kanojo v01.25"
+    assert volume_numbers_match("v01.25", "1.25") is True
+    # the number the old rounding would have searched must NOT satisfy it
+    assert volume_numbers_match("v01.2", "1.25") is False

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -216,16 +216,30 @@ def test_searchforissue_passes_manga_numbers_to_search_init():
         assert "volume_number" in keywords
 
 
-def test_manga_volume_search_terms_marks_only_volume_targets():
-    """Volume terms are searched bare; chapter terms keep the issue number."""
+def test_manga_volume_search_terms_maps_volume_targets_to_the_real_name():
+    """Volume terms search bare AND match against the unsuffixed series name."""
     volume = manga_volume_search_terms("One-Punch Man", None, "1")
-    assert volume == {"One-Punch Man v01"}
+    assert volume == {"One-Punch Man v01": "One-Punch Man"}
+    # The mapped value is what the matcher compares against: the release
+    # "One-Punch Man v01 (2014) (Digital)" parses as "One-Punch Man", so
+    # comparing against the query term would fail every result.
+    assert volume["One-Punch Man v01"] == "One-Punch Man"
 
     # A chapter target must NOT be marked -- "<series> c001" is a real search
     # whose issue-number handling is unchanged.
-    assert manga_volume_search_terms("One Piece", "1161", None) == set()
+    assert manga_volume_search_terms("One Piece", "1161", None) == {}
     # Neither number available: nothing to search bare.
-    assert manga_volume_search_terms("One Piece", None, None) == set()
+    assert manga_volume_search_terms("One Piece", None, None) == {}
+
+
+def test_match_entry_prefers_the_manga_match_name():
+    """search_filer must compare against manga_match_name when it is set."""
+    filer_path = Path(__file__).resolve().parents[2] / "comicarr" / "search_filer.py"
+    source = filer_path.read_text(encoding="utf-8")
+    assert 'is_info.get("manga_match_name")' in source
+    # Both the parse and the match must use it, or the series comparison fails.
+    assert source.count("watchcomic=match_name") == 2
+    assert "watchcomic=ComicName" not in source
 
 
 def test_nzb_search_accepts_and_receives_manga_volume_terms():

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -21,6 +21,33 @@ from comicarr.rsscheck import mangaCheck
 from comicarr.search import _build_manga_search_terms
 
 _INIT_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "__init__.py"
+_SEARCH_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "search.py"
+
+
+def _is_search_init(func):
+    """Match both `search_init(...)` and `search.search_init(...)` call forms."""
+    if isinstance(func, ast.Name):
+        return func.id == "search_init"
+    return isinstance(func, ast.Attribute) and func.attr == "search_init"
+
+
+def _search_init_call_keywords(function_name, path):
+    """Keyword names passed to every search_init() call inside `function_name`.
+
+    search_init() is reached only through provider configuration and a global
+    search lock, so the wiring is asserted from source instead -- the same
+    approach test_init_arms_manga_sync_after_pause() takes.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != function_name:
+            continue
+        return [
+            {kw.arg for kw in call.keywords}
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call) and _is_search_init(call.func)
+        ]
+    raise AssertionError("%s not found in %s" % (function_name, path.name))
 
 
 def test_next_interval_run_fires_now_when_overdue():
@@ -164,3 +191,29 @@ def test_parse_kwargs_auto_passes_folder_bare_numbers():
     assert kwargs["bare_number_mode"] == "auto"
     assert kwargs["bare_numbers"] == ["1", "2"]
     assert kwargs["volume_count"] == 72
+
+
+def test_searchforissue_passes_manga_numbers_to_search_init():
+    """searchforissue() must supply the numbers manga search terms are built from.
+
+    search_init() turns chapter_number/volume_number into "<series> v01" or
+    "<series> c001" via _build_manga_search_terms(). Omit them and that helper
+    receives (None, None) and returns [], so a manga Series is searched by
+    issue number and volume-named releases are never queried -- silently, with
+    no [SEARCH-MANGA] line to show for it.
+    """
+    calls = _search_init_call_keywords("searchforissue", _SEARCH_PATH)
+    assert calls, "searchforissue() no longer calls search_init()"
+    for keywords in calls:
+        assert "content_type" in keywords
+        assert "chapter_number" in keywords
+        assert "volume_number" in keywords
+
+
+def test_manga_rss_path_passes_manga_numbers_to_search_init():
+    """The RSS lane already honours the contract; it guards against regression."""
+    rss_path = Path(__file__).resolve().parents[2] / "comicarr" / "rsscheck.py"
+    calls = _search_init_call_keywords("mangaCheck", rss_path)
+    assert calls, "mangaCheck() no longer calls search_init()"
+    for keywords in calls:
+        assert {"content_type", "chapter_number", "volume_number"} <= keywords


### PR DESCRIPTION
Fixes #811.

## Problem

A manga series tracked by volume runs every search, receives the correct releases from
the provider, and grabs none of them. Five gates each discard the release, producing the
identical symptom, so fixing one only exposes the next.

The RSS path already implements the manga contract correctly at `rsscheck.py:1762`.
`searchforissue()` calls the same `search_init()` and passes `content_type` but omits
`chapter_number` and `volume_number`, so `_build_manga_search_terms()` always receives
`(None, None)` and returns `[]`.

## Change

Six commits, one per gate plus one refactor:

| Commit | Gate |
|---|---|
| `pass manga chapter/volume numbers from searchforissue` | 1 — the numbers reach `search_init()`, as the RSS caller already does |
| `search manga volume targets without an issue-number suffix` | 2 — a volume target queries `<series> v01`, not `<series> v01 001` |
| `match manga volume results against the real series name` | 3 — carry the match name alongside the term so results compare against `<series>` |
| `accept a manga volume release on its volume number` | 4 — an acceptance arm for a release that carries no issue number |
| `give the volume rules one owner in the ledger` | refactor — see below |
| `read a manga release's vNN as the volume, not the series run` | 5 — a manga arm ahead of the `ComicVersion` comparison |

Each is narrowly gated on a manga volume pass; a comic search cannot reach any of them.
`manga_volume_satisfies()` returns `False` on missing or non-numeric data rather than
defaulting true, so a parse failure can never snatch an arbitrary volume.

## The refactor, and one intentional behaviour change

While adding gate 4 I found the same two facts already implemented in
`app/downloads/service.py::_pack_row_matches` — "is this target a volume?" and "do these
two volume numbers match?". Rather than leave a second copy, both now live in
`app/manga/ledger.py` beside `normalize_volume_number()`, which already owned what a
volume number means, and `_pack_row_matches` delegates to them.

**This changes two fractional-volume cases, and I would rather flag it than have a
reviewer find it:**

| Case | Before | After |
|---|---|---|
| `1.5` vs `1` | `True` (`int(float(...))` truncated) | `False` |
| `1.5` vs `1.5` | `False` (`int("1.5")` raised) | `True` |

Both look like corrections to me — `normalize_volume_number` already models fractional
volumes via `format(number, "g")`, so the truncating comparison was the odd one out.
Every integer case is unchanged, which is why the existing pack tests pass untouched. If
you would rather preserve the old comparison exactly, I am happy to keep the shared
helper and restore truncation.

## Test

Eleven tests added across `tests/unit/test_manga_ledger.py` and
`tests/unit/test_manga_live_paths.py`. The comparison cases live once, in the ledger
tests; the acceptance test only pins that acceptance defers to them, so the two cannot
drift.

Full suite on this branch: **2838 passed, 1 skipped**, versus **2827 passed, 1 skipped**
on `main` — 11 added, none modified.

Eight `tests/integration/test_schema_migration_dialects.py` tests fail both on this
branch and on a clean `main` checkout in my environment (they need a database URL I do
not have configured), so they are unrelated to this change.

**On asserting wiring by AST.** `searchforissue()` is ~900 lines behind provider config
and a global search lock, so invoking it in a unit test is impractical — but gate 1 *is*
a wiring omission, so the test parses the call site and asserts the keywords are passed.
The repo already uses this idiom in `test_init_arms_manga_sync_after_pause`. The same
assertion run against a clean `main` reports:

```
searchforissue -> search_init call sites: 1
  passes content_type: True | chapter_number: False | volume_number: False
```

## Live verification

Deployed on a running instance. Before, every query was issue form; after, the volume
term is generated and the release is snatched:

```
before:  Sending request to RSS for One-Punch Man : 001 (2015)
after:   I'm looking for One-Punch Man v01 issue: 1 (2015) using NZBGeek (newznab)
         [MANGA] volume v30 matches the volume searched for
         [UPDATER] Updated the status (Snatched) complete for One-Punch Man Issue: 1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manga volume-aware searching and release matching.
  * Volume searches now support alternate titles and volume-only queries.
  * Fractional volumes, such as `v01.5`, are preserved and matched accurately.

* **Bug Fixes**
  * Improved volume detection and comparison across common naming formats.
  * Prevented chapters from being incorrectly treated as volumes.
  * Improved matching for volume releases without issue numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->