### PR TITLE
fix(manga): mark a placed manga volume file against its issue row

### DIFF
--- a/.changeset/manga-volume-import-match.md
+++ b/.changeset/manga-volume-import-match.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Manga volume files now count towards Have instead of reporting "0 files matched". A volume file was placed into the series folder correctly and was perfectly readable, but nothing recorded it: the filename did not parse once release tags followed the volume number, and the scan then looked the file up by issue number, which a volume file does not have. Volumes are now matched on their volume number — so on MangaDex and MyAnimeList a v20 file no longer attaches itself to chapter 20 — and a chapter-numbered file is no longer filed as issue 1 on the strength of a volume it never stated. A year disagreement between the provider and the release, which is routine for licensed manga, no longer rejects a file whose volume already matched.

--- a/comicarr/manga_parser.py
+++ b/comicarr/manga_parser.py
@@ -109,6 +109,43 @@ _PATTERNS = [
 ]
 
 
+# Every pattern above anchors its number at the end of the stem, but scene
+# releases append metadata groups after it -- "Series v20 (2020) (Digital)
+# (Group)".  Stripping those lets the same patterns see the volume/chapter
+# token they were written for.
+_PAT_TRAILING_TAGS = re.compile(r"(?:\s*[\(\[][^()\[\]]*[\)\]])+\s*$")
+
+
+def strip_trailing_tags(stem):
+    """Return ``stem`` without its trailing ``(...)``/``[...]`` tag groups.
+
+    Returns the stem unchanged when it does not end in a tag group.
+    """
+    return _PAT_TRAILING_TAGS.sub("", stem).strip()
+
+
+def _match_patterns(stem):
+    """Match ``stem`` against ``_PATTERNS``, returning ``(match, pattern)``.
+
+    The full stem is tried first, so any filename that already parsed keeps
+    its existing result.  Only when nothing matches is the stem retried with
+    trailing release tags removed.
+    """
+    for pattern in _PATTERNS:
+        m = pattern.match(stem)
+        if m:
+            return m, pattern
+
+    stripped = strip_trailing_tags(stem)
+    if stripped and stripped != stem:
+        for pattern in _PATTERNS:
+            m = pattern.match(stripped)
+            if m:
+                return m, pattern
+
+    return None, None
+
+
 def parse_manga_filename(
     filename,
     series_name=None,
@@ -159,13 +196,12 @@ def parse_manga_filename(
         volume_count=volume_count,
         chapter_count=chapter_count,
     )
-    for pattern in _PATTERNS:
-        m = pattern.match(stem)
-        if m:
-            result = _build_result(m)
-            if result is not None and pattern is _PAT_BARE_NUMBER:
-                return apply_bare_number(result, resolved_mode)
-            return result
+    m, pattern = _match_patterns(stem)
+    if m:
+        result = _build_result(m)
+        if result is not None and pattern is _PAT_BARE_NUMBER:
+            return apply_bare_number(result, resolved_mode)
+        return result
 
     if series_name:
         chapter = parse_manga_chapter_number(filename)
@@ -192,11 +228,9 @@ def parse_manga_chapter_number(filename):
     if not stem or len(stem) > 512:
         return None
 
-    for pattern in _PATTERNS:
-        m = pattern.match(stem)
-        if m:
-            groups = m.groupdict()
-            return _to_chapter_number(groups.get("chapter"))
+    m, _pattern = _match_patterns(stem)
+    if m:
+        return _to_chapter_number(m.groupdict().get("chapter"))
 
     return _parse_chapter_only_stem(stem)
 

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -77,25 +77,64 @@ def log_scan_summary(module, filename, candidate_count, selected_items, annual_c
     )
 
 
+_COLLECTED_TYPES = ("TPB", "HC", "GN")
+
+
+def numbered_by_volume(watch_values):
+    """Return whether this series names its files by volume rather than issue.
+
+    Collected editions and One-Shots have always been named this way, which is
+    why the scan exempts them from every check that assumes a file carries an
+    issue number: the weekly-pull cross-check, the "no issue number" rejection,
+    and the fallback that defaults a missing number to 1.
+
+    Manga belongs with them. In a periodical ``vNN`` names *which run* of the
+    series a release belongs to; in manga it names *which book*. A manga volume
+    file therefore carries no issue number at all, so applying the periodical
+    checks to it rejects a perfectly good file.
+
+    Rows built without the manga flag -- story arcs and one-offs assembled from
+    tables that do not carry it -- read as comics, which is the prior behaviour.
+    """
+    if watch_values.get("IsManga"):
+        return True
+    return watch_values["Type"] in _COLLECTED_TYPES + ("One-Shot",)
+
+
+def volume_match_settles_year(watch_values, volume_matched):
+    """Return whether a matched volume makes the filename's year irrelevant.
+
+    The year check exists because periodical issue numbers repeat across runs,
+    so ``Batman 1`` needs a year to say *which* Batman 1. A manga volume number
+    does not repeat -- there is one volume 1 -- so once it matches, the year
+    cannot be evidence of a wrong file.
+
+    It is routinely a mismatch, too: a provider dates the licensed English
+    printing while the release is labelled with the volume's original year. For
+    One-Punch Man v01 those are 2015 and 2014, and the file was rejected for it.
+
+    Deliberately manga-only. A collected edition's year mismatch can still mean
+    the wrong edition, so periodical and TPB behaviour is untouched.
+    """
+    return bool(volume_matched) and bool(watch_values.get("IsManga"))
+
+
 def volume_identifies_file(watch_values):
-    """Return whether this series numbers its files by volume rather than issue.
+    """Return whether a scanned file is located by volume rather than issue.
 
-    Collected editions (TPB/HC/GN spanning more than one entry) and One-Shots
-    have always been numbered this way, so a scanned file is located by the
-    ``vNN`` token in its name rather than by an issue number.
+    This is :func:`numbered_by_volume` qualified by the run length, because a
+    collected edition only numbers *files* by volume when the run actually has
+    volumes to distinguish: TPB/HC/GN spanning more than one entry, or a
+    One-Shot standing alone.
 
-    Manga joins them for a different reason. In a periodical, ``vNN`` names
-    *which run* of the series a release belongs to; in manga it names *which
-    book*, so the volume is the file's identity exactly as an issue number is
-    elsewhere. A manga volume file carries no issue number at all, so without
-    this the scan derives no number for it, matches it against every issue in
-    the series, and selects none of them.
+    Manga is not qualified that way. Volume 1 of a one-volume manga is still
+    identified by its volume, so the run length says nothing useful here.
     """
     if watch_values.get("IsManga"):
         return True
     series_type = watch_values["Type"]
     total = watch_values["Total"]
-    return (series_type in ("TPB", "HC", "GN") and total > 1) or (series_type == "One-Shot" and total == 1)
+    return (series_type in _COLLECTED_TYPES and total > 1) or (series_type == "One-Shot" and total == 1)
 
 
 def summarize_scan_matches(normal_items, arc_items):
@@ -1384,27 +1423,13 @@ class PostProcessor(object):
                             temploc = just_the_digits.replace("_", " ")
                             temploc = re.sub("[\\#']", "", temploc)
                         else:
-                            if any(
-                                [
-                                    cs["WatchValues"]["Type"] == "TPB",
-                                    cs["WatchValues"]["Type"] == "GN",
-                                    cs["WatchValues"]["Type"] == "HC",
-                                    cs["WatchValues"]["Type"] == "One-Shot",
-                                ]
-                            ):
+                            if numbered_by_volume(cs["WatchValues"]):
                                 temploc = "1"
                             else:
                                 temploc = None
                         datematch = "False"
 
-                        if temploc is None and all(
-                            [
-                                cs["WatchValues"]["Type"] != "TPB",
-                                cs["WatchValues"]["Type"] != "GN",
-                                cs["WatchValues"]["Type"] != "HC",
-                                cs["WatchValues"]["Type"] != "One-Shot",
-                            ]
-                        ):
+                        if temploc is None and not numbered_by_volume(cs["WatchValues"]):
                             logger.info(
                                 "this should have an issue number to match to this particular series: %s"
                                 % cs["ComicID"]
@@ -1662,14 +1687,9 @@ class PostProcessor(object):
                                             alts = x["AS_Alt"]
                                     alt_listing = [True if x.lower() == dynamic_seriesname else False for x in alts]
 
-                                    if any([cs["DynamicName"] == dynamic_seriesname, alt_listing]) and all(
-                                        [
-                                            cs["WatchValues"]["Type"] != "TPB",
-                                            cs["WatchValues"]["Type"] != "GN",
-                                            cs["WatchValues"]["Type"] != "HC",
-                                            cs["WatchValues"]["Type"] != "One-Shot",
-                                        ]
-                                    ):
+                                    if any(
+                                        [cs["DynamicName"] == dynamic_seriesname, alt_listing]
+                                    ) and not numbered_by_volume(cs["WatchValues"]):
                                         logger.fdebug(
                                             "name match exact : %s - %s" % (cs["DynamicName"], dynamic_seriesname)
                                         )
@@ -1798,15 +1818,7 @@ class PostProcessor(object):
                                 else:
                                     logger.fdebug("not a match")
 
-                                if all(
-                                    [
-                                        second_check is False,
-                                        cs["WatchValues"]["Type"] != "TPB",
-                                        cs["WatchValues"]["Type"] != "GN",
-                                        cs["WatchValues"]["Type"] != "HC",
-                                        cs["WatchValues"]["Type"] != "One-Shot",
-                                    ]
-                                ):
+                                if second_check is False and not numbered_by_volume(cs["WatchValues"]):
                                     logger.fdebug(
                                         "%s %s in filename don't match up to what's in the dB for %s [%s]. This is a wrong match. Continuing..."
                                         % (
@@ -1927,6 +1939,13 @@ class PostProcessor(object):
                                     logger.fdebug(
                                         "%s[LONE-VOLUME/NO YEAR][MATCH] Only Volume on watchlist matches, no year present in filename. Assuming match based on volume and title."
                                         % module
+                                    )
+                                    datematch = "True"
+
+                                if datematch == "False" and volume_match_settles_year(cs["WatchValues"], lonevol):
+                                    logger.fdebug(
+                                        "%s[MANGA][VOLUME MATCH] Volume %s matched, so the year in the filename (%s) does not decide this file. Assuming match based on volume and title."
+                                        % (module, watchmatch["series_volume"], watchmatch["issue_year"])
                                     )
                                     datematch = "True"
 
@@ -2080,6 +2099,7 @@ class PostProcessor(object):
                                     "Publisher": av["IssuePublisher"],
                                     "Total": int(av["TotalIssues"]),
                                     "Type": av["Type"],
+                                    "IsManga": series_kind.is_manga(av),
                                     "IsArc": True,
                                 },
                             }
@@ -2119,18 +2139,7 @@ class PostProcessor(object):
                                 nm += 1
                             else:
                                 try:
-                                    if (
-                                        any(
-                                            [
-                                                v[i]["WatchValues"]["Type"] == "TPB",
-                                                v[i]["WatchValues"]["Type"] == "GN",
-                                                v[i]["WatchValues"]["Type"] == "HC",
-                                            ]
-                                        )
-                                        and v[i]["WatchValues"]["Total"] > 1
-                                    ) or all(
-                                        [v[i]["WatchValues"]["Type"] == "One-Shot", v[i]["WatchValues"]["Total"] == 1]
-                                    ):
+                                    if volume_identifies_file(v[i]["WatchValues"]):
                                         if arcmatch["series_volume"] is not None:
                                             just_the_digits = re.sub("[^0-9]", "", arcmatch["series_volume"]).strip()
                                         else:
@@ -2149,14 +2158,7 @@ class PostProcessor(object):
                                     temploc = just_the_digits.replace("_", " ")
                                     temploc = re.sub("[\\#']", "", temploc)
                                 else:
-                                    if any(
-                                        [
-                                            v[i]["WatchValues"]["Type"] == "TPB",
-                                            v[i]["WatchValues"]["Type"] == "GN",
-                                            v[i]["WatchValues"]["Type"] == "HC",
-                                            v[i]["WatchValues"]["Type"] == "One-Shot",
-                                        ]
-                                    ):
+                                    if numbered_by_volume(v[i]["WatchValues"]):
                                         temploc = "1"
                                     else:
                                         temploc = None
@@ -2678,6 +2680,7 @@ class PostProcessor(object):
                                             "Total": 0,
                                             "Type": ofl["format"],
                                             "ComicID": ofl["ComicID"],
+                                            "IsManga": series_kind.is_manga(ofl),
                                             "IsArc": False,
                                         },
                                     }
@@ -2696,7 +2699,7 @@ class PostProcessor(object):
                                     continue
                                 else:
                                     try:
-                                        if ofv["WatchValues"]["Type"] is not None and ofv["WatchValues"]["Total"] > 1:
+                                        if volume_identifies_file(ofv["WatchValues"]):
                                             if watchmatch["series_volume"] is not None:
                                                 just_the_digits = re.sub(
                                                     "[^0-9]", "", watchmatch["series_volume"]

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -77,6 +77,27 @@ def log_scan_summary(module, filename, candidate_count, selected_items, annual_c
     )
 
 
+def volume_identifies_file(watch_values):
+    """Return whether this series numbers its files by volume rather than issue.
+
+    Collected editions (TPB/HC/GN spanning more than one entry) and One-Shots
+    have always been numbered this way, so a scanned file is located by the
+    ``vNN`` token in its name rather than by an issue number.
+
+    Manga joins them for a different reason. In a periodical, ``vNN`` names
+    *which run* of the series a release belongs to; in manga it names *which
+    book*, so the volume is the file's identity exactly as an issue number is
+    elsewhere. A manga volume file carries no issue number at all, so without
+    this the scan derives no number for it, matches it against every issue in
+    the series, and selects none of them.
+    """
+    if watch_values.get("IsManga"):
+        return True
+    series_type = watch_values["Type"]
+    total = watch_values["Total"]
+    return (series_type in ("TPB", "HC", "GN") and total > 1) or (series_type == "One-Shot" and total == 1)
+
+
 def summarize_scan_matches(normal_items, arc_items):
     """Build summary fields from the matches selected for one input file."""
     selected_items = normal_items + arc_items
@@ -1174,6 +1195,7 @@ class PostProcessor(object):
                     wv_seriesyear = wv["ComicYear"]
                     wv_comicversion = wv["ComicVersion"]
                     wv_publisher = wv["ComicPublisher"]
+                    wv_is_manga = series_kind.is_manga(wv)
                     wv_total = int(wv["Total"])
                     wv_agerating = wv["AgeRating"]
                     wv_latestissue = wv["LatestIssue"]
@@ -1323,6 +1345,7 @@ class PostProcessor(object):
                                 "Publisher": wv_publisher,
                                 "Total": wv_total,
                                 "ComicID": wv_comicid,
+                                "IsManga": wv_is_manga,
                                 "IsArc": False,
                             },
                         }
@@ -1342,16 +1365,7 @@ class PostProcessor(object):
                         continue
                     else:
                         try:
-                            if (
-                                any(
-                                    [
-                                        cs["WatchValues"]["Type"] == "TPB",
-                                        cs["WatchValues"]["Type"] == "HC",
-                                        cs["WatchValues"]["Type"] == "GN",
-                                    ]
-                                )
-                                and cs["WatchValues"]["Total"] > 1
-                            ) or all([cs["WatchValues"]["Type"] == "One-Shot", cs["WatchValues"]["Total"] == 1]):
+                            if volume_identifies_file(cs["WatchValues"]):
                                 if watchmatch["series_volume"] is not None:
                                     just_the_digits = re.sub("[^0-9]", "", watchmatch["series_volume"]).strip()
                                 else:

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -41,6 +41,7 @@ from comicarr.app.downloads.postprocess_pipeline import (
     PostProcessJournalStage,
 )
 from comicarr.app.downloads.pp_commands import safe_walk
+from comicarr.app.manga.ledger import normalize_volume_number
 from comicarr.config import get_manga_destination
 from comicarr.tables import (
     annuals,
@@ -117,6 +118,70 @@ def volume_match_settles_year(watch_values, volume_matched):
     the wrong edition, so periodical and TPB behaviour is untouched.
     """
     return bool(volume_matched) and bool(watch_values.get("IsManga"))
+
+
+def volume_settles_year_for_match(watch_values, match):
+    """Return whether a volume match lets this file through a year mismatch.
+
+    Deliberately NOT keyed off ``lonevol``. That flag means "the filename's
+    volume digits equal ComicVersion", and manga has no ComicVersion -- the
+    scan defaults it to 1. So v01 slipped through by coincidence while v20
+    died on ``20 != 1``, which is the opposite of the intended rule.
+
+    The only question that matters here is whether the file was located by its
+    own volume: a real volume, not the "v1" FileChecker defaults onto a
+    chapter file.
+    """
+    volume_located = (
+        volume_identifies_file(watch_values)
+        and not chapter_named_file(match)
+        and (match or {}).get("series_volume") is not None
+    )
+    return volume_match_settles_year(watch_values, volume_located)
+
+
+def chapter_named_file(match):
+    """Return whether a scanned file is named by CHAPTER rather than volume.
+
+    FileChecker sets ``booktype`` to "manga" only when it actually found a
+    c/ch/chapter token, and then defaults a *missing* volume to "v1". So a
+    chapter file arrives carrying a volume it never stated, and locating it by
+    that volume files "Chainsaw Man c181 (2023).cbz" as issue 1.
+
+    A volume-named file keeps ``booktype`` "issue", so this reads the
+    distinction FileChecker already drew rather than re-deriving it.
+    """
+    return str((match or {}).get("booktype") or "").strip().lower() == "manga"
+
+
+def manga_volume_rows(comicid, series_volume):
+    """Resolve a manga VOLUME file to its rows via VolumeNumber.
+
+    MangaDex and MyAnimeList series store the CHAPTER in ``Int_IssueNumber``,
+    so looking a volume up in that column files "v20" against chapter 20 --
+    ticking Have on a row the file has nothing to do with. Volume rows carry
+    the volume in its own column, which is where rescan already matches them.
+
+    Returns ``None`` when the series has no volume rows at all -- the
+    ComicVine volumes-as-issues case, where ``Int_IssueNumber`` *is* the
+    volume and the caller's existing query is already correct.
+    """
+    digits = re.sub("[^0-9.]", "", str(series_volume or "")).strip()
+    wanted = normalize_volume_number(digits) if digits else None
+    if wanted is None:
+        return None
+    rows = db.select_all(
+        select(issues).where(
+            and_(
+                issues.c.ComicID == comicid,
+                issues.c.VolumeNumber.isnot(None),
+                issues.c.VolumeNumber != "",
+            )
+        )
+    )
+    if not rows:
+        return None
+    return [row for row in rows if normalize_volume_number(row.get("VolumeNumber")) == wanted]
 
 
 def volume_identifies_file(watch_values):
@@ -1404,7 +1469,10 @@ class PostProcessor(object):
                         continue
                     else:
                         try:
-                            if volume_identifies_file(cs["WatchValues"]):
+                            # A chapter-named file is excluded even for manga:
+                            # FileChecker handed it a defaulted "v1" it never
+                            # stated, and locating by that files c181 as issue 1.
+                            if volume_identifies_file(cs["WatchValues"]) and not chapter_named_file(watchmatch):
                                 if watchmatch["series_volume"] is not None:
                                     just_the_digits = re.sub("[^0-9]", "", watchmatch["series_volume"]).strip()
                                 else:
@@ -1473,11 +1541,25 @@ class PostProcessor(object):
                             annchk = "no"
                             if temploc is not None:
                                 fcdigit = helpers.issuedigits(temploc)
-                                issuechk = db.select_all(
-                                    select(issues).where(
-                                        and_(issues.c.ComicID == cs["ComicID"], issues.c.Int_IssueNumber == fcdigit)
+                                issuechk = None
+                                # A manga VOLUME resolves on VolumeNumber. On
+                                # MangaDex/MAL Int_IssueNumber holds the
+                                # chapter, so querying it here would file v20
+                                # against chapter 20. Returns None when the
+                                # series has no volume rows (ComicVine stores
+                                # volumes AS issues), and the query below is
+                                # then already the right one.
+                                if cs["WatchValues"].get("IsManga") and not chapter_named_file(watchmatch):
+                                    issuechk = manga_volume_rows(cs["ComicID"], watchmatch["series_volume"])
+                                if issuechk is None:
+                                    issuechk = db.select_all(
+                                        select(issues).where(
+                                            and_(
+                                                issues.c.ComicID == cs["ComicID"],
+                                                issues.c.Int_IssueNumber == fcdigit,
+                                            )
+                                        )
                                     )
-                                )
                             else:
                                 fcdigit = None
                                 issuechk = db.select_all(select(issues).where(issues.c.ComicID == cs["ComicID"]))
@@ -1942,7 +2024,9 @@ class PostProcessor(object):
                                     )
                                     datematch = "True"
 
-                                if datematch == "False" and volume_match_settles_year(cs["WatchValues"], lonevol):
+                                if datematch == "False" and volume_settles_year_for_match(
+                                    cs["WatchValues"], watchmatch
+                                ):
                                     logger.fdebug(
                                         "%s[MANGA][VOLUME MATCH] Volume %s matched, so the year in the filename (%s) does not decide this file. Assuming match based on volume and title."
                                         % (module, watchmatch["series_volume"], watchmatch["issue_year"])

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -164,3 +164,29 @@ def test_parse_kwargs_auto_passes_folder_bare_numbers():
     assert kwargs["bare_number_mode"] == "auto"
     assert kwargs["bare_numbers"] == ["1", "2"]
     assert kwargs["volume_count"] == 72
+
+
+def test_folder_scan_numbers_a_watchlisted_manga_series_by_volume():
+    """The folder scan must ask whether a series is numbered by volume.
+
+    Deriving the number inline meant a manga series fell through to the issue
+    branch, so a volume file yielded no number and matched no issue.
+    """
+    pp_path = Path(__file__).resolve().parents[2] / "comicarr" / "postprocessor.py"
+    tree = ast.parse(pp_path.read_text(encoding="utf-8"))
+
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "volume_identifies_file" in called, "the folder scan no longer consults the volume predicate"
+
+    watch_value_keys = {
+        key.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Dict)
+        for key in node.keys
+        if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    }
+    assert "IsManga" in watch_value_keys, "WatchValues no longer carries the manga signal"

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -182,6 +182,33 @@ def test_folder_scan_numbers_a_watchlisted_manga_series_by_volume():
     }
     assert "volume_identifies_file" in called, "the folder scan no longer consults the volume predicate"
     assert "numbered_by_volume" in called, "the scan's issue-number checks no longer consult the exemption"
+    # the year gate must actually be reached, and must be reached through the
+    # composed helper -- not handed a flag the scan computed for another purpose
+    assert "volume_settles_year_for_match" in called, "the scan no longer consults the volume year gate"
+    assert "chapter_named_file" in called, (
+        "the scan no longer distinguishes a chapter file from a volume file, so a "
+        "defaulted v1 will locate c181 as issue 1 again"
+    )
+    assert "manga_volume_rows" in called, (
+        "the scan no longer resolves a manga volume on VolumeNumber, so v20 will "
+        "attach to chapter 20 on MangaDex again"
+    )
+    assert "volume_match_settles_year" in called, "the volume year gate is defined but never called"
+
+    settles_year_args = [
+        node.args
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "volume_match_settles_year"
+    ]
+    assert settles_year_args, "volume_match_settles_year is never called"
+    for args in settles_year_args:
+        names = {arg.id for arg in args if isinstance(arg, ast.Name)}
+        assert "lonevol" not in names, (
+            "the year gate is keyed off lonevol again -- manga has no ComicVersion, "
+            "so that defaults to 1 and only v01 would pass"
+        )
 
     watch_value_keys = [
         key.value
@@ -200,7 +227,31 @@ def test_the_volume_numbered_type_list_has_a_single_owner():
 
     Each copy silently omitted manga, so a manga volume file failed a different
     check depending on which copy it reached. The list now lives in one tuple.
+
+    Asserted over the AST rather than the raw source: a source-text count is
+    blind to a duplicate written with single quotes, and fails on a mere
+    mention of TPB in a comment or docstring.
     """
     pp_path = Path(__file__).resolve().parents[2] / "comicarr" / "postprocessor.py"
-    source = pp_path.read_text(encoding="utf-8")
-    assert source.count('"TPB"') == 1, "the volume-numbered type list has been duplicated again"
+    tree = ast.parse(pp_path.read_text(encoding="utf-8"))
+
+    definitions = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "_COLLECTED_TYPES" for target in node.targets)
+    ]
+    assert len(definitions) == 1, "_COLLECTED_TYPES must be defined exactly once"
+
+    value = definitions[0].value
+    assert isinstance(value, ast.Tuple), "_COLLECTED_TYPES must stay a literal tuple"
+    assert [element.value for element in value.elts] == ["TPB", "HC", "GN"]
+
+    # and no other literal "TPB" may exist -- quote style is irrelevant to the
+    # AST, and a comment or docstring mentioning TPB is not a Constant of it
+    literals = [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value == "TPB"
+    ]
+    assert len(literals) == 1, "the volume-numbered type list has been duplicated again"

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -181,12 +181,26 @@ def test_folder_scan_numbers_a_watchlisted_manga_series_by_volume():
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
     }
     assert "volume_identifies_file" in called, "the folder scan no longer consults the volume predicate"
+    assert "numbered_by_volume" in called, "the scan's issue-number checks no longer consult the exemption"
 
-    watch_value_keys = {
+    watch_value_keys = [
         key.value
         for node in ast.walk(tree)
         if isinstance(node, ast.Dict)
         for key in node.keys
         if isinstance(key, ast.Constant) and isinstance(key.value, str)
-    }
-    assert "IsManga" in watch_value_keys, "WatchValues no longer carries the manga signal"
+    ]
+    assert watch_value_keys.count("IsManga") == watch_value_keys.count("IsArc"), (
+        "every WatchValues row must carry the manga signal, not just the watchlist one"
+    )
+
+
+def test_the_volume_numbered_type_list_has_a_single_owner():
+    """The scan tested a hardcoded TPB/GN/HC/One-Shot list in eight places.
+
+    Each copy silently omitted manga, so a manga volume file failed a different
+    check depending on which copy it reached. The list now lives in one tuple.
+    """
+    pp_path = Path(__file__).resolve().parents[2] / "comicarr" / "postprocessor.py"
+    source = pp_path.read_text(encoding="utf-8")
+    assert source.count('"TPB"') == 1, "the volume-numbered type list has been duplicated again"

--- a/tests/unit/test_manga_parser.py
+++ b/tests/unit/test_manga_parser.py
@@ -409,3 +409,73 @@ class TestResultStructure:
         # When absent, volume_number should be None
         result = parse_manga_filename("Bleach 100.cbz")
         assert result["volume_number"] is None
+
+
+class TestTrailingReleaseTags:
+    """Scene releases append metadata groups after the volume/chapter token.
+
+    Every pattern anchors its number at the end of the stem, so a name like
+    "Series v20 (2020) (Digital) (Group)" parsed as None and post-processing
+    could not match the file to any ledger row.
+    """
+
+    def test_volume_with_trailing_tags(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("One-Punch Man v20 (2020) (Digital) (LuCaZ).cbz")
+        assert result is not None
+        assert result["series_name"] == "One-Punch Man"
+        assert result["volume_number"] == 20
+        assert result["chapter_number"] is None
+
+    def test_volume_with_many_trailing_tags(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("One-Punch Man v16 (2019) (F) (digital) (aKraa).cbz")
+        assert result is not None
+        assert result["series_name"] == "One-Punch Man"
+        assert result["volume_number"] == 16
+
+    def test_trailing_bracket_group_is_stripped(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach v7 [Digital] [Group].cbz")
+        assert result is not None
+        assert result["series_name"] == "Bleach"
+        assert result["volume_number"] == 7
+
+    def test_chapter_with_trailing_tags(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Chainsaw Man c181 (2023) (Digital).cbz")
+        assert result is not None
+        assert result["series_name"] == "Chainsaw Man"
+        assert result["chapter_number"] == 181.0
+
+    def test_chapter_number_helper_also_sees_tagged_names(self):
+        """parse_manga_chapter_number shares the pattern loop and must agree."""
+        from comicarr.manga_parser import parse_manga_chapter_number
+
+        assert parse_manga_chapter_number("Chainsaw Man c181 (2023) (Digital).cbz") == 181.0
+
+    def test_full_stem_match_wins_over_stripping(self):
+        """A name that already parses keeps its trailing (vNN)/[quality] captures."""
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("[Group] Series - c001 (v03) [HQ].cbz")
+        assert result is not None
+        assert result["volume_number"] == 3
+        assert result["quality"] == "HQ"
+        assert result["group"] == "Group"
+
+    def test_tags_without_a_number_stay_unparseable(self):
+        """Stripping must not invent a match where there is no volume/chapter."""
+        from comicarr.manga_parser import parse_manga_filename
+
+        assert parse_manga_filename("One-Punch Man (2014) (Digital).cbz") is None
+
+    def test_strip_trailing_tags_leaves_untagged_stems_alone(self):
+        from comicarr.manga_parser import strip_trailing_tags
+
+        assert strip_trailing_tags("One-Punch Man v20") == "One-Punch Man v20"
+        assert strip_trailing_tags("One-Punch Man v20 (2020) (LuCaZ)") == "One-Punch Man v20"

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -37,11 +37,14 @@ if comicarr.LOG_LEVEL is None:
 
 from comicarr.postprocessor import (
     PostProcessor,
+    chapter_named_file,
     log_scan_summary,
+    manga_volume_rows,
     numbered_by_volume,
     summarize_scan_matches,
     volume_identifies_file,
     volume_match_settles_year,
+    volume_settles_year_for_match,
 )
 
 
@@ -769,3 +772,107 @@ class TestVolumeMatchSettlesYear:
     def test_collected_editions_are_not_covered(self):
         """A TPB year mismatch can still mean the wrong edition."""
         assert volume_match_settles_year({"Type": "TPB", "Total": 5}, True) is False
+
+
+class TestVolumeSettlesYearForMatch:
+    """The year gate as the folder scan actually reaches it.
+
+    The helper tests above supply `volume_matched` themselves, so they cannot
+    catch the scan deriving that flag wrongly. This drives the composed gate
+    with the watchmatch shapes FileChecker really produces.
+    """
+
+    def _manga(self):
+        return {"Type": "Digital", "Total": 33, "IsManga": True}
+
+    def test_v20_with_a_mismatched_year_is_settled_by_the_volume(self):
+        """The regression that keyed this off lonevol.
+
+        lonevol means "the filename's volume digits equal ComicVersion", and a
+        manga series has no ComicVersion so the scan defaults it to 1. v01
+        passed by coincidence; v20 failed on 20 != 1 and the file was rejected
+        for a year the provider and the release simply disagree about.
+        """
+        match = {"series_volume": "v20", "issue_year": "2014", "booktype": "issue"}
+
+        assert volume_settles_year_for_match(self._manga(), match) is True
+
+    def test_v01_is_settled_for_the_same_reason_and_not_by_accident(self):
+        match = {"series_volume": "v01", "issue_year": "2014", "booktype": "issue"}
+
+        assert volume_settles_year_for_match(self._manga(), match) is True
+
+    def test_a_chapter_file_is_not_settled_by_its_defaulted_volume(self):
+        """FileChecker defaults a missing volume to v1 on a chapter file.
+
+        Letting that stand in for a volume match would wave a chapter file
+        past the year check on evidence it never actually carried.
+        """
+        match = {"series_volume": "v1", "issue_year": "2023", "booktype": "manga"}
+
+        assert chapter_named_file(match) is True
+        assert volume_settles_year_for_match(self._manga(), match) is False
+
+    def test_a_file_with_no_volume_at_all_is_not_settled(self):
+        match = {"series_volume": None, "issue_year": "2014", "booktype": "issue"}
+
+        assert volume_settles_year_for_match(self._manga(), match) is False
+
+    def test_a_comic_series_keeps_its_year_check(self):
+        """Deliberately manga-only: a TPB year mismatch can mean a wrong edition."""
+        match = {"series_volume": "v20", "issue_year": "2014", "booktype": "issue"}
+
+        assert volume_settles_year_for_match({"Type": "TPB", "Total": 5, "IsManga": False}, match) is False
+        assert volume_match_settles_year({"Type": "TPB", "Total": 5, "IsManga": False}, True) is False
+
+
+class TestMangaVolumeRows:
+    """A manga VOLUME resolves on VolumeNumber, not Int_IssueNumber.
+
+    MangaDex and MyAnimeList store the CHAPTER in Int_IssueNumber. Looking a
+    volume up there files "v20" against chapter 20 -- the file lands on a row
+    it has nothing to do with, and Have ticks up on the wrong one.
+    """
+
+    def test_a_volume_file_matches_the_volume_row(self):
+        rows = [
+            {"IssueID": "md-csm-v20", "VolumeNumber": "20"},
+            {"IssueID": "md-csm-v21", "VolumeNumber": "21"},
+        ]
+        with patch("comicarr.postprocessor.db") as mock_db:
+            mock_db.select_all.return_value = rows
+
+            matched = manga_volume_rows("md-csm", "v20")
+
+        assert [row["IssueID"] for row in matched] == ["md-csm-v20"]
+
+    def test_zero_padding_and_the_v_marker_do_not_prevent_a_match(self):
+        rows = [{"IssueID": "md-csm-v01", "VolumeNumber": "1"}]
+        with patch("comicarr.postprocessor.db") as mock_db:
+            mock_db.select_all.return_value = rows
+
+            assert manga_volume_rows("md-csm", "v01") == rows
+
+    def test_a_series_with_no_volume_rows_defers_to_the_issue_query(self):
+        """ComicVine stores volumes AS issues, so Int_IssueNumber is correct there.
+
+        Returning None (rather than an empty list) is what tells the caller to
+        run its existing query instead of concluding nothing matched.
+        """
+        with patch("comicarr.postprocessor.db") as mock_db:
+            mock_db.select_all.return_value = []
+
+            assert manga_volume_rows("cv-123", "v20") is None
+
+    def test_an_unusable_volume_defers_without_querying(self):
+        with patch("comicarr.postprocessor.db") as mock_db:
+            assert manga_volume_rows("md-csm", None) is None
+            assert manga_volume_rows("md-csm", "v") is None
+            mock_db.select_all.assert_not_called()
+
+    def test_a_volume_with_no_matching_row_reports_no_match(self):
+        """An empty list is a real answer: the series has volumes, just not this one."""
+        with patch("comicarr.postprocessor.db") as mock_db:
+            mock_db.select_all.return_value = [{"IssueID": "md-csm-v01", "VolumeNumber": "1"}]
+
+            assert manga_volume_rows("md-csm", "v20") == []

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -35,7 +35,12 @@ from tests.conftest import placement_result
 if comicarr.LOG_LEVEL is None:
     comicarr.LOG_LEVEL = 0
 
-from comicarr.postprocessor import PostProcessor, log_scan_summary, summarize_scan_matches
+from comicarr.postprocessor import (
+    PostProcessor,
+    log_scan_summary,
+    summarize_scan_matches,
+    volume_identifies_file,
+)
 
 
 def test_scan_summary_emits_one_bounded_line_without_candidate_chatter():
@@ -678,3 +683,35 @@ class TestProcessMangaChapterMatch:
 
         result = mock_queue.put.call_args[0][0]
         assert "0 files matched" in result[0]["self.log"]
+
+
+class TestVolumeIdentifiesFile:
+    """Which series number their scanned files by volume rather than issue.
+
+    A manga volume file carries no issue number, so without a volume arm the
+    folder scan derives no number, compares the file against every issue in
+    the series and selects none of them.
+    """
+
+    def test_manga_series_is_identified_by_volume(self):
+        assert volume_identifies_file({"Type": "Digital", "Total": 33, "IsManga": True}) is True
+
+    def test_manga_arm_does_not_depend_on_the_series_length(self):
+        """A single-volume manga is still numbered by volume."""
+        assert volume_identifies_file({"Type": "Digital", "Total": 1, "IsManga": True}) is True
+
+    def test_comic_series_of_the_same_type_is_still_identified_by_issue(self):
+        assert volume_identifies_file({"Type": "Digital", "Total": 33, "IsManga": False}) is False
+
+    @pytest.mark.parametrize("series_type", ["TPB", "HC", "GN"])
+    def test_collected_editions_keep_their_volume_numbering(self, series_type):
+        assert volume_identifies_file({"Type": series_type, "Total": 5, "IsManga": False}) is True
+        assert volume_identifies_file({"Type": series_type, "Total": 1, "IsManga": False}) is False
+
+    def test_one_shots_keep_their_volume_numbering(self):
+        assert volume_identifies_file({"Type": "One-Shot", "Total": 1, "IsManga": False}) is True
+        assert volume_identifies_file({"Type": "One-Shot", "Total": 2, "IsManga": False}) is False
+
+    def test_a_row_without_the_manga_flag_is_read_as_a_comic(self):
+        """One-off rows build WatchValues without IsManga and must not raise."""
+        assert volume_identifies_file({"Type": "Digital", "Total": 0}) is False

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -38,8 +38,10 @@ if comicarr.LOG_LEVEL is None:
 from comicarr.postprocessor import (
     PostProcessor,
     log_scan_summary,
+    numbered_by_volume,
     summarize_scan_matches,
     volume_identifies_file,
+    volume_match_settles_year,
 )
 
 
@@ -715,3 +717,55 @@ class TestVolumeIdentifiesFile:
     def test_a_row_without_the_manga_flag_is_read_as_a_comic(self):
         """One-off rows build WatchValues without IsManga and must not raise."""
         assert volume_identifies_file({"Type": "Digital", "Total": 0}) is False
+
+
+class TestNumberedByVolume:
+    """Which series are exempt from the checks that assume an issue number.
+
+    The weekly-pull cross-check, the "no issue number" rejection and the
+    default-to-1 fallback all skip series whose files are named by volume.
+    Manga must be exempt for the same reason collected editions are.
+    """
+
+    def test_manga_series_is_exempt(self):
+        assert numbered_by_volume({"Type": "Digital", "Total": 33, "IsManga": True}) is True
+
+    def test_comic_series_of_the_same_type_is_not_exempt(self):
+        assert numbered_by_volume({"Type": "Digital", "Total": 33, "IsManga": False}) is False
+
+    @pytest.mark.parametrize("series_type", ["TPB", "HC", "GN", "One-Shot"])
+    def test_collected_editions_stay_exempt_regardless_of_run_length(self, series_type):
+        """Exemption is a property of the type alone, unlike locating a file."""
+        assert numbered_by_volume({"Type": series_type, "Total": 1, "IsManga": False}) is True
+        assert numbered_by_volume({"Type": series_type, "Total": 9, "IsManga": False}) is True
+
+    def test_a_single_entry_tpb_is_exempt_but_is_not_located_by_volume(self):
+        """The two predicates deliberately disagree here; that split is the point."""
+        watch_values = {"Type": "TPB", "Total": 1, "IsManga": False}
+        assert numbered_by_volume(watch_values) is True
+        assert volume_identifies_file(watch_values) is False
+
+    def test_a_row_without_the_manga_flag_is_read_as_a_comic(self):
+        assert numbered_by_volume({"Type": "Digital", "Total": 0}) is False
+
+
+class TestVolumeMatchSettlesYear:
+    """A matched manga volume makes the filename's year irrelevant.
+
+    Providers date the licensed English printing while releases carry the
+    volume's original year, so the two routinely disagree by a year.
+    """
+
+    def test_matched_manga_volume_overrides_a_year_mismatch(self):
+        assert volume_match_settles_year({"IsManga": True}, True) is True
+
+    def test_an_unmatched_volume_never_overrides_the_year(self):
+        """Without a volume match there is no identity to trust instead."""
+        assert volume_match_settles_year({"IsManga": True}, False) is False
+
+    def test_a_comic_year_mismatch_still_decides(self):
+        assert volume_match_settles_year({"IsManga": False}, True) is False
+
+    def test_collected_editions_are_not_covered(self):
+        """A TPB year mismatch can still mean the wrong edition."""
+        assert volume_match_settles_year({"Type": "TPB", "Total": 5}, True) is False


### PR DESCRIPTION
Fixes #812.

## Problem

Manga volume files are placed into the series folder correctly and are readable, but
Comicarr reports `0 files` and `Have` never rises. Three causes, all the same root: a
manga volume file is identified by its **volume**, and several paths identify a file by
its **issue number** only.

## Change

Three commits:

### 1. `parse volume/chapter tokens followed by release tags`

Every pattern anchors the number at the end of the stem (`\s*$`), so
`<series> v20 (2020) (Digital) (Group).cbz` does not parse and
`parse_manga_filename()` returns `None`.

Worth noting what this unblocks rather than adds: `_process_manga` and
`rescan_manga_series` **already have correct volume-matching branches**. They were simply
unreachable, because `parsed` was `None` before either branch ran.

Adds `strip_trailing_tags()` and a shared `_match_patterns()` helper that tries the full
stem first and retries the stripped stem only when nothing matched. Full-stem-first keeps
the change purely additive — `[Group] Series - c001 (v03) [HQ].cbz` still returns
`volume=3, quality='HQ'`, which stripping first would have eaten.

The identical `for pattern in _PATTERNS` loop existed in `parse_manga_chapter_number()`
too, so both entry points now route through the one helper rather than leaving the same
blindness in the second.

### 2 + 3. `number a watchlisted manga file by its volume during folder scan`, then `give the folder scan one owner for volume-numbered series`

The folder scan derived the identifying number inline from a hardcoded
`("TPB","HC","GN")` / `One-Shot` test, which manga is not in — so a volume file yielded
no number and matched no issue.

That tuple was tested in **seven** places: three number derivations plus four guards that
exempt collected editions from checks assuming an issue number. Every copy omitted manga,
so the first commit fixed one site and the failure simply moved to the next; the second
commit gives the fact one owner.

Two predicates over one tuple, because the sites need different questions:

| Predicate | Question | Sites |
|---|---|---|
| `numbered_by_volume()` | type alone — is this series exempt from issue-number checks? | the 4 guards |
| `volume_identifies_file()` | same, qualified by run length — is a file *located* by its volume? | the 3 derivations |

They deliberately disagree for a one-entry TPB (`exempt=True, locates=False`), which is
why they are separate — collapsing them into one would have silently changed TPB
handling.

The manga signal comes from the existing `series_kind.is_manga()`, which reconciles
`ContentType` with the provider prefix, rather than testing either directly. Rows built
without the flag read as comics, so nothing else changes.

The third commit also adds `volume_match_settles_year()`: for manga only, a matched
volume settles the year, because a volume number does not repeat across a series. A
collected edition's year mismatch can still mean the wrong edition, so comic behaviour is
untouched.

## Test

Thirty tests added across `tests/unit/test_manga_parser.py`,
`tests/unit/test_manga_postprocessor.py` and `tests/unit/test_manga_live_paths.py`.

Full suite on this branch: **2857 passed, 1 skipped**, versus **2827 passed, 1 skipped**
on `main` — 30 added, none modified.

Eight `tests/integration/test_schema_migration_dialects.py` tests fail both on this
branch and on a clean `main` checkout in my environment (they need a database URL I do
not have configured), so they are unrelated to this change.

**On proving these fail without the fix.** Reverting the source makes the manga test
modules fail at *import*, because they exercise helpers this PR introduces — that proves
the helpers are new, not that the fix works. The meaningful assertions are therefore the
AST wiring tests, which check that production code actually consults the predicates. Run
against a clean `main` checkout they report:

```
UPSTREAM postprocessor.py
  calls volume_identifies_file : False
  WatchValues carries IsManga  : False
  hardcoded '"TPB"' occurrences: 7
```

One of those tests asserts `source.count('"TPB"') == 1` directly, so it fails on `main`
with `assert 7 == 1` and guards the consolidation against future copies.

The parser commit has ordinary behavioural coverage: with its source reverted and its
tests kept, 6 of its 8 tests fail; the other 2 are guards asserting preserved behaviour
and correctly pass on both sides.

## Live verification

Deployed on a running instance. The same log file holds the before and after across two
builds of the same file:

```
before:  [Issue Year FAILURE] 2015 does NOT match ... 2014   -> selected=none
after:   [MANGA][VOLUME MATCH] Volume v01 matched, so the year in the
         filename (2014) does not decide this file            -> selected=71856
```

`Have` went 12 → 13 with no manual intervention, and a full reconcile marked 12 placed
files `Downloaded`, matching the reader's view of the folder exactly.

## Ordering

This PR is only reachable once a manga volume is actually snatched, so it is best read
after #815. The changes themselves are independent — this
branch applies cleanly to `main` on its own and its suite is green.
