### PR TITLE
fix(recovery): close a band row whose work is provably already done

### DIFF
--- a/.changeset/recovery-band-fulfilled.md
+++ b/.changeset/recovery-band-fulfilled.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Needs Attention no longer asks you to fix downloads that are already done. A row parked in manual review or failed handling was never re-examined, so it kept asking for a decision after the file had already landed in the library — and all three offered actions made things worse: re-running a move whose source is gone, re-downloading a file you own, or discarding a volume you own. Recovery now checks the library first and closes the row when the issue reads Downloaded and its file is really there, so the panel shows only the items that still need you.

--- a/comicarr/app/attention/_reconciliation.py
+++ b/comicarr/app/attention/_reconciliation.py
@@ -222,6 +222,30 @@ def reconcile_excluded(
     return "rewanted"
 
 
+def _close_if_already_fulfilled(row):
+    """Close a parked row whose work is provably already done. True if closed.
+
+    Runs BEFORE the actionability skip on purpose: an actionable reason is
+    exactly what puts a row in front of an operator, and the whole point of this
+    check is to establish there is nothing left for them to do. Skipping it for
+    actionable rows would exempt every row this is meant to clear.
+    """
+    try:
+        from comicarr.app.downloads.recovery import close_fulfilled_band_row
+
+        if not close_fulfilled_band_row(row):
+            return False
+    except Exception as e:
+        logger.warn("[BAND-RECONCILE] fulfilled-close skipped for release_key=%s: %s" % (row.get("release_key"), e))
+        return False
+    logger.info(
+        "[BAND-RECONCILE] closed release_key=%s — its issue is already Downloaded with a "
+        "verified library file, so no operator action can clear it (audit=%s)"
+        % (row.get("release_key"), RECONCILE_AUDIT_IDENTITY)
+    )
+    return True
+
+
 def reconcile_existing_excluded_rows():
     """One-shot pass: re-want / blocklist issues stranded by pre-#541 exclusions.
 
@@ -248,10 +272,13 @@ def reconcile_existing_excluded_rows():
     )
 
     rows = db.select_all(select(pipeline_journal).where(pre_actionability))
-    summary = {"scanned": 0, "acted": 0, "skipped_actionable": 0, "results": {}}
+    summary = {"scanned": 0, "acted": 0, "closed_fulfilled": 0, "skipped_actionable": 0, "results": {}}
     for row in rows or []:
         summary["scanned"] += 1
         reason = row.get("fail_reason")
+        if _close_if_already_fulfilled(row):
+            summary["closed_fulfilled"] += 1
+            continue
         if is_actionable(reason):
             summary["skipped_actionable"] += 1
             continue
@@ -265,9 +292,10 @@ def reconcile_existing_excluded_rows():
         )
         summary["acted"] += 1
         summary["results"][result] = summary["results"].get(result, 0) + 1
-    if summary["acted"]:
+    if summary["acted"] or summary["closed_fulfilled"]:
         logger.warn(
-            "[BAND-RECONCILE] one-shot stranded-row pass: scanned=%s acted=%s results=%s"
-            % (summary["scanned"], summary["acted"], summary["results"])
+            "[BAND-RECONCILE] one-shot stranded-row pass: scanned=%s acted=%s "
+            "closed_fulfilled=%s results=%s"
+            % (summary["scanned"], summary["acted"], summary["closed_fulfilled"], summary["results"])
         )
     return summary

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -551,7 +551,7 @@ def _obligation_already_fulfilled(row):
     return has_verified_library_file(series.get("ComicLocation"), issue.get("Location"))
 
 
-def finalize_post_processing(row, payload=None):
+def finalize_post_processing(row, payload=None, already_fulfilled=None):
     """Resolve a row already inside post-processing. The `moved` marker is the
     discriminator for whether the destructive move committed — there is NO
     SOURCE probe anywhere on this path (a surviving source is undecidable in
@@ -589,7 +589,9 @@ def finalize_post_processing(row, payload=None):
         return "moved-finish-dbfacts"
 
     if stage == journal.POST_PROCESSING:
-        if _obligation_already_fulfilled(row):
+        if already_fulfilled is None:
+            already_fulfilled = _obligation_already_fulfilled(row)
+        if already_fulfilled:
             _finish_db_facts_only(rkey, row, payload)
             logger.info(
                 "[RECOVERY] %s was `post_processing`, but its issue is already "
@@ -729,16 +731,23 @@ def _resolve_row(snapshot_row, probes=None, pp_cap=None):
     if cur_stage == journal.MOVED:
         return finalize_post_processing(row, payload=payload)
     if cur_stage == journal.POST_PROCESSING:
-        if pp_cap is not None and pp_cap.get("count", 0) >= _MAX_INLINE_PP_REDRIVE_PER_PASS:
-            logger.warn(
-                "[RECOVERY] %s is `post_processing` but the inline PP re-drive "
-                "cap (%d) for this replay pass is reached — DEFERRING; it "
-                "resumes next startup (replay is idempotent/re-runnable)." % (rkey, _MAX_INLINE_PP_REDRIVE_PER_PASS)
-            )
-            return "skip-pp-cap-deferred"
-        if pp_cap is not None:
-            pp_cap["count"] = pp_cap.get("count", 0) + 1
-        return finalize_post_processing(row, payload=payload)
+        # A provably-fulfilled obligation costs only the same DB facts as
+        # `moved`, so — per this cap's own contract — it is NOT charged to the
+        # INLINE re-drive budget. Otherwise a backlog of already-done rows
+        # would need one restart per five to drain.
+        already_fulfilled = _obligation_already_fulfilled(row)
+        if not already_fulfilled:
+            if pp_cap is not None and pp_cap.get("count", 0) >= _MAX_INLINE_PP_REDRIVE_PER_PASS:
+                logger.warn(
+                    "[RECOVERY] %s is `post_processing` but the inline PP re-drive "
+                    "cap (%d) for this replay pass is reached — DEFERRING; it "
+                    "resumes next startup (replay is idempotent/re-runnable)."
+                    % (rkey, _MAX_INLINE_PP_REDRIVE_PER_PASS)
+                )
+                return "skip-pp-cap-deferred"
+            if pp_cap is not None:
+                pp_cap["count"] = pp_cap.get("count", 0) + 1
+        return finalize_post_processing(row, payload=payload, already_fulfilled=already_fulfilled)
 
     if cur_stage == journal.DOWNLOADED:
         item = _pp_item_from_row(row, payload)

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -32,16 +32,18 @@ never aborting the loop.
 """
 
 import time
+import traceback
 
 from sqlalchemy import and_, delete, or_, select
 
 import comicarr
 from comicarr import db, logger
+from comicarr.app.acquisition.evidence import has_verified_library_file
 from comicarr.app.attention import ManualReview, record
 from comicarr.app.downloads import journal, recovery_classify
 from comicarr.app.downloads.ddl_commands import DDLCommand, DDLCommandError
 from comicarr.app.downloads.pp_commands import PostProcessCommandError, validate_postprocess_item
-from comicarr.tables import ddl_info, nzblog, pipeline_journal, snatched, storyarcs
+from comicarr.tables import comics, ddl_info, issues, nzblog, pipeline_journal, snatched, storyarcs
 
 _ENQUEUE_THROTTLE_SECONDS = 0.05
 
@@ -468,22 +470,107 @@ def _resume_item_from_row(row, payload):
     return "nzb", item
 
 
+def _finish_db_facts_only(rkey, row, payload):
+    """Close an obligation whose physical move already committed: delete its
+    nzblog anchor and advance the journal to `post_processed`, in ONE atomic
+    begin(). Touches DB facts only — never re-imports or re-moves."""
+    issueid = row.get("issueid")
+    provider = row.get("provider")
+    story_arc = None
+    if isinstance(payload, dict) and "mode" in payload:
+        story_arc = payload.get("mode") == "story_arc"
+    if story_arc is None:
+        story_arc = _is_story_arc_obligation(issueid)
+    nzbname = (payload or {}).get("nzbname") if isinstance(payload, dict) else None
+    with db.get_engine().begin() as conn:
+        if story_arc is False:
+            id_pred = nzblog.c.IssueID == str(issueid)
+        elif story_arc is True:
+            id_pred = or_(
+                nzblog.c.IssueID == str(issueid),
+                nzblog.c.IssueID == "S" + str(issueid),
+            )
+        else:
+            if nzbname:
+                id_pred = and_(
+                    or_(
+                        nzblog.c.IssueID == str(issueid),
+                        nzblog.c.IssueID == "S" + str(issueid),
+                    ),
+                    nzblog.c.NZBName == nzbname,
+                )
+            else:
+                id_pred = nzblog.c.IssueID == str(issueid)
+        stmt = delete(nzblog).where(id_pred)
+        if provider:
+            stmt = stmt.where(nzblog.c.PROVIDER == provider)
+        conn.execute(stmt)
+        journal.record_transition(
+            rkey,
+            journal.POST_PROCESSED,
+            payload=payload,
+            conn=conn,
+            issueid=issueid,
+            provider=provider,
+        )
+
+
+def _obligation_already_fulfilled(row):
+    """Return whether this obligation's work is provably ALREADY DONE.
+
+    True only when the obligation's own issue row is `Downloaded` AND its
+    `Location` resolves to an existing file beneath its series root — the
+    shared `has_verified_library_file` evidence gate.
+
+    This is a DESTINATION probe, which is decidable, and is deliberately not
+    the source probe `finalize_post_processing` forbids: a surviving source is
+    undecidable under copy/hardlink/softlink FILE_OPTS, but a verified file in
+    the library proves the move committed in EVERY mode. Fails CLOSED — any
+    missing id, unreadable row, or unresolvable path returns False and the
+    caller re-drives exactly as before.
+    """
+    issueid = row.get("issueid")
+    if not issueid:
+        return False
+    try:
+        issue = db.select_one(
+            select(issues.c.Status, issues.c.Location, issues.c.ComicID).where(issues.c.IssueID == str(issueid))
+        )
+    except Exception as e:
+        logger.warn("[RECOVERY] fulfillment lookup failed for issue %s: %s" % (issueid, e))
+        return False
+    if not issue or issue.get("Status") != "Downloaded":
+        return False
+    try:
+        series = db.select_one(select(comics.c.ComicLocation).where(comics.c.ComicID == str(issue.get("ComicID"))))
+    except Exception as e:
+        logger.warn("[RECOVERY] fulfillment series lookup failed for issue %s: %s" % (issueid, e))
+        return False
+    if not series:
+        return False
+    return has_verified_library_file(series.get("ComicLocation"), issue.get("Location"))
+
+
 def finalize_post_processing(row, payload=None):
-    """Resolve a row already inside post-processing using the `moved` marker
-    as the SOLE discriminator — NO file probe anywhere on this path (a probe
-    is undecidable in copy/hardlink/softlink FILE_OPTS modes where the source
-    is never deleted):
+    """Resolve a row already inside post-processing. The `moved` marker is the
+    discriminator for whether the destructive move committed — there is NO
+    SOURCE probe anywhere on this path (a surviving source is undecidable in
+    copy/hardlink/softlink FILE_OPTS modes, where it is never deleted):
 
       * stage `moved`           -> the destructive move physically committed
         (source may already be gone). Finish the DB facts ONLY — mirror the
         U9 atomic block (single begin(): nzblog-delete + journal
         post_processed). NEVER re-import / re-move.
-      * stage `post_processing` -> the move did NOT commit (source intact).
-        Re-drive PP in FULL by invoking process.Process DIRECTLY, threading
-        the authoritative release_key so the postprocessor markers advance
-        THIS row. NOT via PP_QUEUE: the U4 claim is a downloaded ->
-        post_processing advance and a row already at post_processing would
-        LOSE that claim and be dropped — so the finalizer bypasses it.
+      * stage `post_processing` -> the move did not record a marker. Before
+        re-driving, check `_obligation_already_fulfilled`: a DESTINATION probe
+        (issue `Downloaded` + verified file under the series root) proves the
+        move committed and only the marker write was lost, so finish the DB
+        facts exactly like `moved`. Without that proof, re-drive PP in FULL by
+        invoking process.Process DIRECTLY, threading the authoritative
+        release_key so the postprocessor markers advance THIS row. NOT via
+        PP_QUEUE: the U4 claim is a downloaded -> post_processing advance and a
+        row already at post_processing would LOSE that claim and be dropped —
+        so the finalizer bypasses it.
 
     Returns a short string describing the action taken (for logging/tests).
     """
@@ -493,45 +580,7 @@ def finalize_post_processing(row, payload=None):
         payload = journal.load_payload(row.get("payload_json"))
 
     if stage == journal.MOVED:
-        issueid = row.get("issueid")
-        provider = row.get("provider")
-        story_arc = None
-        if isinstance(payload, dict) and "mode" in payload:
-            story_arc = payload.get("mode") == "story_arc"
-        if story_arc is None:
-            story_arc = _is_story_arc_obligation(issueid)
-        nzbname = (payload or {}).get("nzbname") if isinstance(payload, dict) else None
-        with db.get_engine().begin() as conn:
-            if story_arc is False:
-                id_pred = nzblog.c.IssueID == str(issueid)
-            elif story_arc is True:
-                id_pred = or_(
-                    nzblog.c.IssueID == str(issueid),
-                    nzblog.c.IssueID == "S" + str(issueid),
-                )
-            else:
-                if nzbname:
-                    id_pred = and_(
-                        or_(
-                            nzblog.c.IssueID == str(issueid),
-                            nzblog.c.IssueID == "S" + str(issueid),
-                        ),
-                        nzblog.c.NZBName == nzbname,
-                    )
-                else:
-                    id_pred = nzblog.c.IssueID == str(issueid)
-            stmt = delete(nzblog).where(id_pred)
-            if provider:
-                stmt = stmt.where(nzblog.c.PROVIDER == provider)
-            conn.execute(stmt)
-            journal.record_transition(
-                rkey,
-                journal.POST_PROCESSED,
-                payload=payload,
-                conn=conn,
-                issueid=issueid,
-                provider=provider,
-            )
+        _finish_db_facts_only(rkey, row, payload)
         logger.info(
             "[RECOVERY] %s was `moved` (physical move committed) — finished DB "
             "facts only (nzblog-delete + journal post_processed); did NOT "
@@ -540,6 +589,17 @@ def finalize_post_processing(row, payload=None):
         return "moved-finish-dbfacts"
 
     if stage == journal.POST_PROCESSING:
+        if _obligation_already_fulfilled(row):
+            _finish_db_facts_only(rkey, row, payload)
+            logger.info(
+                "[RECOVERY] %s was `post_processing`, but its issue is already "
+                "`Downloaded` with a verified file under the series root — the "
+                "move committed and only the marker was lost. Finished DB facts "
+                "only (nzblog-delete + journal post_processed); did NOT "
+                "re-drive." % rkey
+            )
+            return "post_processing-already-fulfilled"
+
         item = _pp_item_from_row(row, payload or {})
         from comicarr.app.downloads.service import _configured_postprocess_roots
 
@@ -610,7 +670,10 @@ def finalize_post_processing(row, payload=None):
                     provider=row.get("provider"),
                 )
             )
-            logger.error("[RECOVERY] %s PP redrive failed and was quarantined: %s" % (rkey, type(e).__name__))
+            logger.error(
+                "[RECOVERY] %s PP redrive failed and was quarantined: %s: %s\n%s"
+                % (rkey, type(e).__name__, e, traceback.format_exc())
+            )
             return "post_processing-manual-review"
         return "post_processing-redrive"
 

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -470,10 +470,14 @@ def _resume_item_from_row(row, payload):
     return "nzb", item
 
 
-def _finish_db_facts_only(rkey, row, payload):
-    """Close an obligation whose physical move already committed: delete its
-    nzblog anchor and advance the journal to `post_processed`, in ONE atomic
-    begin(). Touches DB facts only — never re-imports or re-moves."""
+def _delete_nzblog_anchor(conn, row, payload):
+    """Delete one obligation's nzblog anchor on an open connection.
+
+    Every close path deletes the same anchor, so the story-arc ("S"-prefixed
+    IssueID) and nzbname disambiguation lives here once. A surviving anchor is
+    what lets a later pass reconstruct a phantom obligation for work that is
+    already finished.
+    """
     issueid = row.get("issueid")
     provider = row.get("provider")
     story_arc = None
@@ -482,37 +486,78 @@ def _finish_db_facts_only(rkey, row, payload):
     if story_arc is None:
         story_arc = _is_story_arc_obligation(issueid)
     nzbname = (payload or {}).get("nzbname") if isinstance(payload, dict) else None
-    with db.get_engine().begin() as conn:
-        if story_arc is False:
-            id_pred = nzblog.c.IssueID == str(issueid)
-        elif story_arc is True:
-            id_pred = or_(
-                nzblog.c.IssueID == str(issueid),
-                nzblog.c.IssueID == "S" + str(issueid),
+    if story_arc is False:
+        id_pred = nzblog.c.IssueID == str(issueid)
+    elif story_arc is True:
+        id_pred = or_(
+            nzblog.c.IssueID == str(issueid),
+            nzblog.c.IssueID == "S" + str(issueid),
+        )
+    else:
+        if nzbname:
+            id_pred = and_(
+                or_(
+                    nzblog.c.IssueID == str(issueid),
+                    nzblog.c.IssueID == "S" + str(issueid),
+                ),
+                nzblog.c.NZBName == nzbname,
             )
         else:
-            if nzbname:
-                id_pred = and_(
-                    or_(
-                        nzblog.c.IssueID == str(issueid),
-                        nzblog.c.IssueID == "S" + str(issueid),
-                    ),
-                    nzblog.c.NZBName == nzbname,
-                )
-            else:
-                id_pred = nzblog.c.IssueID == str(issueid)
-        stmt = delete(nzblog).where(id_pred)
-        if provider:
-            stmt = stmt.where(nzblog.c.PROVIDER == provider)
-        conn.execute(stmt)
+            id_pred = nzblog.c.IssueID == str(issueid)
+    stmt = delete(nzblog).where(id_pred)
+    if provider:
+        stmt = stmt.where(nzblog.c.PROVIDER == provider)
+    conn.execute(stmt)
+
+
+def _finish_db_facts_only(rkey, row, payload):
+    """Close an obligation whose physical move already committed: delete its
+    nzblog anchor and advance the journal to `post_processed`, in ONE atomic
+    begin(). Touches DB facts only — never re-imports or re-moves."""
+    with db.get_engine().begin() as conn:
+        _delete_nzblog_anchor(conn, row, payload)
         journal.record_transition(
             rkey,
             journal.POST_PROCESSED,
             payload=payload,
             conn=conn,
-            issueid=issueid,
-            provider=provider,
+            issueid=row.get("issueid"),
+            provider=row.get("provider"),
         )
+
+
+def close_fulfilled_band_row(row, payload=None):
+    """Close a band row parked for an operator whose work is provably DONE.
+
+    A `manual_review` / `failed` row exists to ask a human to act. When the
+    obligation's own issue is already `Downloaded` with a verified file beneath
+    the series root, there is nothing left to ask for: the entry is noise no
+    operator action can usefully clear, and both stages are TERMINAL, so
+    `replay_pipeline` — which builds its work list from OPEN stages only — never
+    revisits it. Left alone such a row sits in the band forever.
+
+    Reaches the same end state a successful operator "Import" produces (anchor
+    gone, row stamped `imported`) WITHOUT re-running the import: the file is
+    already placed, and re-driving post-processing against a source folder that
+    is legitimately gone is what parked several of these rows to begin with.
+
+    Deliberately stamps the R9 resolution rather than advancing the stage. The
+    lattice is forward-only and `manual_review` (rank 55) sits ABOVE
+    `post_processed` (50), so `record_transition` would log a no-op and leave the
+    row admitted — the close would look like it worked and change nothing.
+
+    Fails CLOSED: returns False unless fulfilment is proven and the stamp lands.
+    """
+    if not _obligation_already_fulfilled(row):
+        return False
+    rkey = row.get("release_key")
+    if not rkey:
+        return False
+    if payload is None:
+        payload = journal.load_payload(row.get("payload_json"))
+    with db.get_engine().begin() as conn:
+        _delete_nzblog_anchor(conn, row, payload)
+        return bool(journal.stamp_resolution(rkey, journal.STATUS_IMPORTED, conn=conn))
 
 
 def _obligation_already_fulfilled(row):

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -547,6 +547,14 @@ def close_fulfilled_band_row(row, payload=None):
     row admitted — the close would look like it worked and change nothing.
 
     Fails CLOSED: returns False unless fulfilment is proven and the stamp lands.
+
+    Stamps BEFORE deleting the anchor, and only deletes if the stamp landed.
+    `stamp_resolution` returns False without raising when the row is gone, is
+    not on a band stage, or is already resolved — so deleting first would let
+    the begin() block commit an anchor deletion alongside an unresolved
+    journal row. That is strictly worse than doing nothing: the anchor is what
+    a later pass uses to reconstruct the obligation, so the row would be left
+    open with nothing to rebuild it from.
     """
     if not _obligation_already_fulfilled(row):
         return False
@@ -556,8 +564,50 @@ def close_fulfilled_band_row(row, payload=None):
     if payload is None:
         payload = journal.load_payload(row.get("payload_json"))
     with db.get_engine().begin() as conn:
-        _delete_nzblog_anchor(conn, row, payload)
-        return bool(journal.stamp_resolution(rkey, journal.STATUS_IMPORTED, conn=conn))
+        if not journal.stamp_resolution(rkey, journal.STATUS_IMPORTED, conn=conn):
+            return False
+        if not _anchor_shared_with_open_row(conn, rkey, row):
+            _delete_nzblog_anchor(conn, row, payload)
+        return True
+
+
+def _anchor_shared_with_open_row(conn, rkey, row):
+    """Whether another OPEN journal row would lose its anchor to this delete.
+
+    The fulfilment gate is issue-wide — the issue is `Downloaded` with a
+    verified file under the series root — but nzblog is unique on
+    (IssueID, PROVIDER). A DDL release_key carries a discriminant, so a DDL
+    sibling for the same issue and provider is a DIFFERENT journal row sharing
+    ONE anchor. Deleting it while closing the parked row leaves that sibling
+    anchorless, and the same startup then reads the missing anchor as a
+    done-signal and marks it done although nothing ran for it.
+
+    The parked row still closes either way; only the shared anchor survives,
+    to be deleted by whichever obligation finishes last. A lookup failure
+    reports True — keeping an anchor is recoverable, deleting one is not.
+    """
+    issueid = row.get("issueid")
+    provider = row.get("provider")
+    if not issueid or not provider:
+        return False
+    try:
+        sibling = conn.execute(
+            select(pipeline_journal.c.release_key)
+            .where(pipeline_journal.c.release_key != rkey)
+            .where(pipeline_journal.c.issueid == str(issueid))
+            .where(pipeline_journal.c.provider == provider)
+            .where(pipeline_journal.c.stage.in_(journal.OPEN_STAGES))
+            .limit(1)
+        ).fetchone()
+    except Exception as e:
+        logger.warn("[RECOVERY] shared-anchor lookup failed for %s: %s — keeping the nzblog anchor." % (rkey, e))
+        return True
+    if sibling is not None:
+        logger.fdebug(
+            "[RECOVERY] keeping nzblog anchor for issue %s/%s — still open for %s" % (issueid, provider, sibling[0])
+        )
+        return True
+    return False
 
 
 def _obligation_already_fulfilled(row):

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -786,8 +786,7 @@ def _resolve_row(snapshot_row, probes=None, pp_cap=None):
                 logger.warn(
                     "[RECOVERY] %s is `post_processing` but the inline PP re-drive "
                     "cap (%d) for this replay pass is reached — DEFERRING; it "
-                    "resumes next startup (replay is idempotent/re-runnable)."
-                    % (rkey, _MAX_INLINE_PP_REDRIVE_PER_PASS)
+                    "resumes next startup (replay is idempotent/re-runnable)." % (rkey, _MAX_INLINE_PP_REDRIVE_PER_PASS)
                 )
                 return "skip-pp-cap-deferred"
             if pp_cap is not None:

--- a/tests/unit/test_band_actionability.py
+++ b/tests/unit/test_band_actionability.py
@@ -9,6 +9,7 @@
 
 """#541 — band actionability predicate and clause-2 reconciliation."""
 
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -18,7 +19,7 @@ import comicarr
 from comicarr import db
 from comicarr.app.activity import queries, reasons
 from comicarr.app.activity import reconcile as band_reconcile
-from comicarr.tables import failed, issues, metadata, pipeline_journal
+from comicarr.tables import comics, failed, issues, metadata, nzblog, pipeline_journal
 
 
 @pytest.fixture
@@ -224,3 +225,86 @@ def test_reconcile_existing_excluded_rows(activity_db):
     # Actionable row's issue stays Snatched (operator still needs to act).
     other = db.select_one(select(issues).where(issues.c.IssueID == "iss-b"))
     assert other["Status"] == "Snatched"
+
+
+def _placed_library_file(tmp_path, name="Saga v01.cbz"):
+    """Create a real series root + issue file so placement evidence is genuine."""
+    series = tmp_path / "library" / "Saga"
+    series.mkdir(parents=True, exist_ok=True)
+    issue_file = series / name
+    issue_file.write_bytes(b"x")
+    return str(series), str(issue_file)
+
+
+def _seed_parked_row(conn, *, status, location, release_key="done-1", issueid="iss-done", series_dir=None):
+    conn.execute(insert(comics), [{"ComicID": "c1", "ComicLocation": series_dir}])
+    conn.execute(
+        insert(issues),
+        [{"IssueID": issueid, "ComicID": "c1", "ComicName": "Saga", "Status": status, "Location": location}],
+    )
+    conn.execute(insert(nzblog), [{"IssueID": issueid, "NZBName": "Saga.cbz", "PROVIDER": "DDL", "ID": "n1"}])
+    conn.execute(
+        insert(pipeline_journal),
+        [
+            _journal(
+                release_key=release_key,
+                issueid=issueid,
+                stage="manual_review",
+                stage_rank=55,
+                fail_reason="recovered_postprocess_error:TypeError",
+            )
+        ],
+    )
+
+
+def test_reconcile_closes_parked_row_whose_work_is_already_done(activity_db, tmp_path):
+    """An ACTIONABLE parked row is closed when its work is provably finished.
+
+    `manual_review` is terminal, so replay never revisits it; without this the
+    row asks an operator for an action that cannot change anything, forever.
+    """
+    series_dir, issue_file = _placed_library_file(tmp_path)
+    with activity_db.begin() as conn:
+        _seed_parked_row(conn, status="Downloaded", location=issue_file, series_dir=series_dir)
+
+    summary = band_reconcile.reconcile_existing_excluded_rows()
+
+    row = db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == "done-1"))
+    # Stamped resolved WITHOUT regressing the forward-only lattice: manual_review
+    # (55) outranks post_processed (50), so a stage advance would be a silent no-op.
+    assert row["status"] == "imported"
+    assert row["stage"] == "manual_review"
+    # Anchor cleared -- the same end state a successful operator Import reaches.
+    assert db.select_one(select(nzblog).where(nzblog.c.IssueID == "iss-done")) is None
+    assert summary["closed_fulfilled"] == 1
+    assert summary["skipped_actionable"] == 0
+
+
+def test_reconcile_keeps_parked_row_when_file_is_missing(activity_db, tmp_path):
+    """Control: `Downloaded` alone is not evidence. No file -> stays in the band."""
+    series_dir, issue_file = _placed_library_file(tmp_path)
+    os.remove(issue_file)
+    with activity_db.begin() as conn:
+        _seed_parked_row(conn, status="Downloaded", location=issue_file, series_dir=series_dir)
+
+    summary = band_reconcile.reconcile_existing_excluded_rows()
+
+    assert summary["closed_fulfilled"] == 0
+    assert summary["skipped_actionable"] == 1
+    row = db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == "done-1"))
+    assert row["status"] is None
+    assert db.select_one(select(nzblog).where(nzblog.c.IssueID == "iss-done")) is not None
+
+
+def test_reconcile_keeps_parked_row_when_issue_not_downloaded(activity_db, tmp_path):
+    """Control: a real file under a still-`Snatched` issue is not fulfilment."""
+    series_dir, issue_file = _placed_library_file(tmp_path)
+    with activity_db.begin() as conn:
+        _seed_parked_row(conn, status="Snatched", location=issue_file, series_dir=series_dir)
+
+    summary = band_reconcile.reconcile_existing_excluded_rows()
+
+    assert summary["closed_fulfilled"] == 0
+    assert summary["skipped_actionable"] == 1
+    row = db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == "done-1"))
+    assert row["status"] is None

--- a/tests/unit/test_band_actionability.py
+++ b/tests/unit/test_band_actionability.py
@@ -308,3 +308,95 @@ def test_reconcile_keeps_parked_row_when_issue_not_downloaded(activity_db, tmp_p
     assert summary["skipped_actionable"] == 1
     row = db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == "done-1"))
     assert row["status"] is None
+
+
+def test_failed_stamp_leaves_the_nzblog_anchor_in_place(activity_db, tmp_path, monkeypatch):
+    """A stamp that does not land must not take the anchor with it.
+
+    `stamp_resolution` returns False without raising when the row is gone, is
+    off a band stage, or is already resolved. Deleting the anchor first let the
+    begin() block commit that deletion beside an unresolved journal row --
+    leaving the obligation open with nothing left to reconstruct it from,
+    which is worse than not having tried.
+    """
+    from comicarr.app.downloads import recovery
+
+    series_dir, issue_file = _placed_library_file(tmp_path)
+    with activity_db.begin() as conn:
+        _seed_parked_row(conn, status="Downloaded", location=issue_file, series_dir=series_dir)
+
+    monkeypatch.setattr(recovery.journal, "stamp_resolution", lambda *a, **k: False)
+
+    row = db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == "done-1"))
+    assert recovery.close_fulfilled_band_row(row) is False
+
+    assert db.select_one(select(nzblog).where(nzblog.c.IssueID == "iss-done")) is not None, (
+        "anchor deleted although the resolution never landed"
+    )
+    after = db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == "done-1"))
+    assert after["status"] is None
+
+
+def test_open_sibling_on_the_same_anchor_keeps_it(activity_db, tmp_path):
+    """One nzblog row can back two obligations; closing one must not strand the other.
+
+    The fulfilment gate is issue-wide, but nzblog is unique on
+    (IssueID, PROVIDER). A DDL release_key carries a discriminant, so a DDL
+    sibling for the same issue and provider is a separate journal row sharing
+    one anchor. Deleting it here would leave that sibling anchorless, and a
+    missing anchor reads downstream as a done-signal -- so the sibling would be
+    marked done although nothing ever ran for it.
+    """
+    from comicarr.app.downloads import recovery
+
+    series_dir, issue_file = _placed_library_file(tmp_path)
+    with activity_db.begin() as conn:
+        _seed_parked_row(conn, status="Downloaded", location=issue_file, series_dir=series_dir)
+        conn.execute(
+            insert(pipeline_journal),
+            [
+                _journal(
+                    release_key="done-1|ddl|sibling",
+                    issueid="iss-done",
+                    provider="DDL",
+                    stage="snatched",
+                    stage_rank=20,
+                )
+            ],
+        )
+
+    row = db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == "done-1"))
+    assert recovery.close_fulfilled_band_row(row) is True
+
+    # The parked row still closes -- that is the point of the change.
+    closed = db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == "done-1"))
+    assert closed["status"] == "imported"
+    # But the shared anchor survives for the still-open sibling.
+    assert db.select_one(select(nzblog).where(nzblog.c.IssueID == "iss-done")) is not None, (
+        "deleted the anchor a still-open sibling depends on"
+    )
+
+
+def test_terminal_sibling_does_not_keep_the_anchor(activity_db, tmp_path):
+    """Control: only an OPEN sibling holds the anchor. A terminal one is done with it."""
+    from comicarr.app.downloads import recovery
+
+    series_dir, issue_file = _placed_library_file(tmp_path)
+    with activity_db.begin() as conn:
+        _seed_parked_row(conn, status="Downloaded", location=issue_file, series_dir=series_dir)
+        conn.execute(
+            insert(pipeline_journal),
+            [
+                _journal(
+                    release_key="done-1|ddl|sibling",
+                    issueid="iss-done",
+                    provider="DDL",
+                    stage="post_processed",
+                    stage_rank=50,
+                )
+            ],
+        )
+
+    row = db.select_one(select(pipeline_journal).where(pipeline_journal.c.release_key == "done-1"))
+    assert recovery.close_fulfilled_band_row(row) is True
+    assert db.select_one(select(nzblog).where(nzblog.c.IssueID == "iss-done")) is None

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -1716,6 +1716,53 @@ def test_fulfilled_backlog_larger_than_the_cap_drains_in_one_pass(queues, tmp_pa
     assert all(_journal_row(k)["stage"] == journal.POST_PROCESSED for k in keys)
 
 
+def test_fulfilled_row_still_closes_after_the_cap_is_exhausted(queues, tmp_path, monkeypatch):
+    """Fulfilment is checked BEFORE the cap, not after.
+
+    The all-fulfilled test above cannot show this: with nothing to re-drive
+    the counter never increments, so the cap is never reached and the
+    deferral branch never runs. Here the budget is spent in full by real
+    re-drives first, and the fulfilled row arrives last — if a later change
+    consulted the cap before the fulfilment check, this row would defer
+    instead of closing, and every other test would stay green.
+    """
+    # _MAX unfulfilled rows, oldest-first, consume the whole re-drive budget.
+    for n in range(_MAX_INLINE_PP_REDRIVE_PER_PASS):
+        _pp_obligation(tmp_path, "97%d" % n, "Nope.v%02d.cbz" % n)
+
+    # One fulfilled row, stamped newer so read_open()'s oldest-first ordering
+    # puts it after the cap has already been spent.
+    _placed_issue(tmp_path, "979", "Series v79.cbz")
+    fulfilled = _pp_obligation(tmp_path, "979", "Series.v79.cbz")
+    with get_engine().begin() as conn:
+        conn.execute(
+            pipeline_journal.update()
+            .where(pipeline_journal.c.release_key == fulfilled)
+            .values(updated_date="2026-05-18 00:00:00")
+        )
+
+    redriven = []
+    import comicarr.process as process_mod
+
+    class _FakeProc:
+        def __init__(self, *a, journal_release_key=None, **k):
+            self._rkey = journal_release_key
+
+        def post_process(self):
+            redriven.append(self._rkey)
+
+    monkeypatch.setattr(process_mod, "Process", _FakeProc)
+
+    summary = recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert len(redriven) == _MAX_INLINE_PP_REDRIVE_PER_PASS, "the cap must still bound real re-drives"
+    assert fulfilled not in redriven, "a fulfilled obligation must never be re-imported"
+    assert summary["actions"].get("skip-pp-cap-deferred") is None
+    assert _journal_row(fulfilled)["stage"] == journal.POST_PROCESSED, (
+        "fulfilled row was deferred by a budget it does not spend"
+    )
+
+
 def test_unfulfilled_rows_are_still_capped(queues, tmp_path, monkeypatch):
     """The cap still bounds real re-drives: with no placement evidence, only
     _MAX_INLINE_PP_REDRIVE_PER_PASS rows run and the rest defer."""

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -31,6 +31,7 @@ import comicarr
 from comicarr.app.acquisition.maintenance import ensure_acquisition_schema
 from comicarr.app.attention import RecordOutcome
 from comicarr.app.downloads import journal, recovery, recovery_classify
+from comicarr.app.downloads.recovery import _MAX_INLINE_PP_REDRIVE_PER_PASS
 from comicarr.db import get_engine, shutdown_engine
 from comicarr.tables import comics, ddl_info, issues, metadata, nzblog, pipeline_journal, snatched, storyarcs
 
@@ -1695,3 +1696,44 @@ def test_post_processing_with_file_outside_series_root_still_redrives(queues, tm
     recovery.replay_pipeline(probes=_probe("complete"))
 
     assert calls.get("ran") is True
+
+
+def test_fulfilled_backlog_larger_than_the_cap_drains_in_one_pass(queues, tmp_path, monkeypatch):
+    """The inline cap exists to bound expensive re-drives. A provably
+    fulfilled row costs only the same DB facts as `moved`, so it must not be
+    charged to that budget — otherwise a backlog of already-done rows needs
+    one restart per five to clear."""
+    keys = []
+    for n in range(_MAX_INLINE_PP_REDRIVE_PER_PASS + 3):
+        issueid = "95%d" % n
+        _placed_issue(tmp_path, issueid, "Series v%02d.cbz" % n)
+        keys.append(_pp_obligation(tmp_path, issueid, "Series.v%02d.cbz" % n))
+    _forbid_reimport(monkeypatch)
+
+    summary = recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert summary["actions"].get("skip-pp-cap-deferred") is None
+    assert all(_journal_row(k)["stage"] == journal.POST_PROCESSED for k in keys)
+
+
+def test_unfulfilled_rows_are_still_capped(queues, tmp_path, monkeypatch):
+    """The cap still bounds real re-drives: with no placement evidence, only
+    _MAX_INLINE_PP_REDRIVE_PER_PASS rows run and the rest defer."""
+    for n in range(_MAX_INLINE_PP_REDRIVE_PER_PASS + 3):
+        _pp_obligation(tmp_path, "96%d" % n, "Nope.v%02d.cbz" % n)
+    ran = {"count": 0}
+    import comicarr.process as process_mod
+
+    class _FakeProc:
+        def __init__(self, *a, **k):
+            pass
+
+        def post_process(self):
+            ran["count"] += 1
+
+    monkeypatch.setattr(process_mod, "Process", _FakeProc)
+
+    summary = recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert ran["count"] == _MAX_INLINE_PP_REDRIVE_PER_PASS
+    assert summary["actions"].get("skip-pp-cap-deferred") == 3

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -32,7 +32,7 @@ from comicarr.app.acquisition.maintenance import ensure_acquisition_schema
 from comicarr.app.attention import RecordOutcome
 from comicarr.app.downloads import journal, recovery, recovery_classify
 from comicarr.db import get_engine, shutdown_engine
-from comicarr.tables import ddl_info, issues, metadata, nzblog, pipeline_journal, snatched, storyarcs
+from comicarr.tables import comics, ddl_info, issues, metadata, nzblog, pipeline_journal, snatched, storyarcs
 
 
 @pytest.fixture(autouse=True)
@@ -1561,3 +1561,137 @@ def test_done_signal_without_placement_absent_probe_enqueues_pp_not_done(queues)
     assert row["stage"] == journal.DOWNLOADED
     assert summary["actions"].get("done-check") is None
     assert len(_drain(queues["pp"])) == 1
+
+
+# ===========================================================================
+# A `post_processing` row whose work is PROVABLY already done must self-heal.
+#
+# The inverse of the #734 rule above, through the SAME evidence gate: #734
+# says absent placement evidence must never be promoted to post_processed;
+# this says positive placement evidence (issue `Downloaded` + a verified file
+# under the series root) proves the move committed and only the marker write
+# was lost — so recovery finishes the DB facts instead of re-driving PP
+# forever against a source folder it already emptied.
+# ===========================================================================
+
+
+def _placed_issue(tmp_path, issueid, filename, *, status="Downloaded", create=True, location=None):
+    """Create a comics row with a real series root plus an issue row, and
+    (optionally) the placed file itself. Returns the series root."""
+    root = tmp_path / ("series-%s" % issueid)
+    root.mkdir(exist_ok=True)
+    if create:
+        (root / filename).write_bytes(b"cbz")
+    with get_engine().begin() as conn:
+        conn.execute(comics.insert().values(ComicID="C%s" % issueid, ComicLocation=str(root)))
+        conn.execute(
+            issues.insert().values(
+                IssueID=issueid,
+                ComicID="C%s" % issueid,
+                Status=status,
+                Location=str(root / filename) if location is None else location,
+            )
+        )
+    return root
+
+
+def _pp_obligation(tmp_path, issueid, name):
+    rkey = journal.release_key(issueid, "nzb.su", nzbname=name)
+    _insert_journal(
+        rkey,
+        journal.POST_PROCESSING,
+        payload={
+            "issueid": issueid,
+            "comicid": "C%s" % issueid,
+            "nzb_name": name,
+            "nzb_folder": _artifact_folder(tmp_path, "src-%s" % issueid),
+        },
+        issueid=issueid,
+        provider="nzb.su",
+        downloader_type="nzb",
+    )
+    return rkey
+
+
+def _forbid_reimport(monkeypatch):
+    import comicarr.process as process_mod
+
+    monkeypatch.setattr(
+        process_mod,
+        "Process",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not re-drive a fulfilled obligation")),
+    )
+
+
+def _capture_reimport(monkeypatch):
+    calls = {}
+    import comicarr.process as process_mod
+
+    class _FakeProc:
+        def __init__(self, *a, journal_release_key=None, **k):
+            calls["rkey"] = journal_release_key
+
+        def post_process(self):
+            calls["ran"] = True
+
+    monkeypatch.setattr(process_mod, "Process", _FakeProc)
+    return calls
+
+
+def test_post_processing_with_verified_placement_finishes_without_redrive(queues, tmp_path, monkeypatch):
+    """The file is already in the library and the issue reads Downloaded, so
+    the move committed — recovery must close the obligation with DB facts
+    only, exactly as it does for a `moved` row, and never re-import."""
+    _placed_issue(tmp_path, "901", "Series v01.cbz")
+    rkey = _pp_obligation(tmp_path, "901", "Series.v01.cbz")
+    with get_engine().begin() as conn:
+        conn.execute(nzblog.insert().values(IssueID="901", PROVIDER="nzb.su", NZBName="Series.v01.cbz"))
+    _forbid_reimport(monkeypatch)
+
+    summary = recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert _journal_row(rkey)["stage"] == journal.POST_PROCESSED
+    assert summary["actions"].get("post_processing-already-fulfilled") == 1
+    with get_engine().connect() as conn:
+        assert conn.execute(select(nzblog).where(nzblog.c.IssueID == "901")).fetchall() == []
+    assert _drain(queues["pp"]) == []
+
+
+def test_post_processing_not_downloaded_still_redrives(queues, tmp_path, monkeypatch):
+    """A placed-looking file is not enough: until the issue row itself reads
+    Downloaded the obligation is unproven, so the pre-existing re-drive must
+    still run."""
+    _placed_issue(tmp_path, "902", "Series v02.cbz", status="Snatched")
+    rkey = _pp_obligation(tmp_path, "902", "Series.v02.cbz")
+    calls = _capture_reimport(monkeypatch)
+
+    recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert calls.get("ran") is True
+    assert calls["rkey"] == rkey
+
+
+def test_post_processing_with_missing_file_still_redrives(queues, tmp_path, monkeypatch):
+    """A Downloaded row whose Location does not exist on disk is NOT evidence
+    — the check fails closed and the obligation is re-driven."""
+    _placed_issue(tmp_path, "903", "Series v03.cbz", create=False)
+    _pp_obligation(tmp_path, "903", "Series.v03.cbz")
+    calls = _capture_reimport(monkeypatch)
+
+    recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert calls.get("ran") is True
+
+
+def test_post_processing_with_file_outside_series_root_still_redrives(queues, tmp_path, monkeypatch):
+    """A file that exists but resolves OUTSIDE the series root proves nothing
+    about this series, so it must not close the obligation."""
+    stray = tmp_path / "stray.cbz"
+    stray.write_bytes(b"cbz")
+    _placed_issue(tmp_path, "904", "Series v04.cbz", create=False, location=str(stray))
+    _pp_obligation(tmp_path, "904", "Series.v04.cbz")
+    calls = _capture_reimport(monkeypatch)
+
+    recovery.replay_pipeline(probes=_probe("complete"))
+
+    assert calls.get("ran") is True


### PR DESCRIPTION
Fixes #818.

> **Builds on #814.** The first two commits in this branch are that PR; only the last commit is new here. Once #814 merges, this diff reduces to that single commit.

## Problem

A `manual_review` / `failed` row exists to ask an operator to act, and nothing ever re-examines whether the question is still worth asking. Both stages are terminal, so `replay_pipeline` (which reads `journal.read_open()`) never sees the row; `reconcile_existing_excluded_rows` does walk it but skips every row whose reason is actionable — which is exactly why it was parked.

The result is a row asking for an action no operator can usefully take: the issue is already `Downloaded`, the file is already in the library, and the three offered outcomes all make things worse (re-run a move whose source is gone, re-download a file we own, or discard a volume we own).

## Change

Check the **destination** before leaving the row in the band: when the obligation's own issue is `Downloaded` and its `Location` resolves to an existing file beneath the series root, the work is done, so close the row and drop it out of the band.

This is #814's rule applied one stage later, through the same `has_verified_library_file` gate. Both are **destination** probes on purpose — a surviving *source* is undecidable under copy/hardlink/softlink `FILE_OPTS`, but a verified file in the library proves the move committed in every mode.

### Two implementation notes worth flagging in review

**It stamps the R9 resolution rather than advancing the stage, deliberately.** The lattice is forward-only and `manual_review` (rank 55) sits *above* `post_processed` (50), so `record_transition` would log a no-op and leave the row admitted — the close would appear to work and change nothing. Stamping `imported` and deleting the nzblog anchor reaches the same end state a successful operator "Import" produces, without re-running the import.

**Fails closed.** Any missing id, unreadable row, unresolvable path, or failed stamp leaves the row exactly as it was, still in front of the operator.

Also extracts the nzblog anchor delete into `_delete_nzblog_anchor` so the close paths share one implementation of the story-arc and nzbname disambiguation, rather than a second copy.

## Test

| | |
|---|---|
| Full suite on this branch | **2836 passed, 8 failed, 1 skipped** |
| Clean `main` baseline | **2827 passed, 8 failed, 1 skipped** |
| New tests, source reverted | **3 failed, 8 passed** |

The 8 failures are identical on both sides: `tests/integration/test_schema_migration_dialects.py`, which needs a database URL not available in this environment.

The reverted run is a genuine assertion failure, not a collection error, and the 8 that still pass are controls asserting that a parked row whose issue is **not** `Downloaded` is correctly left alone — so the gate is proven scoped rather than merely permissive.
