### PR TITLE
fix(manga): stop the store-date gate and a title parse from discarding correct volume releases

### DIFF
--- a/.changeset/manga-volume-date-and-title.md
+++ b/.changeset/manga-volume-date-and-title.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Correct manga volume releases are no longer thrown away by the store-date check or by a misread title. Digital manga is routinely posted before its street date and ComicVine store dates for volumes run weeks late, so a correct release was rejected for a date that says nothing about a volume — street dates disambiguate periodical issue numbers, which recycle across runs, and volume numbers do not. The date check is now skipped on a volume pass only; chapter passes and comics keep it. Separately, a trailing volume label is no longer read as part of the series title, so a release like "<series> v20" stops looking like a different series — this only applies when the label names the volume that was actually detected, so a series genuinely titled with a trailing number is left alone.

--- a/comicarr/app/downloads/service.py
+++ b/comicarr/app/downloads/service.py
@@ -30,6 +30,7 @@ from comicarr.app.downloads import queries as dl_queries
 from comicarr.app.downloads.completed_path import resolve_completed_download_file
 from comicarr.app.downloads.ddl_commands import DDLCommand, DDLCommandError
 from comicarr.app.downloads.pp_commands import PostProcessCommandError, configured_roots, validate_postprocess_item
+from comicarr.app.manga.ledger import is_volume_target, volume_numbers_match
 from comicarr.downloaders import mediafire, mega, pixeldrain
 from comicarr.tables import annuals, comics, ddl_info, issues, storyarcs, weekly
 
@@ -983,13 +984,10 @@ def _pack_row_matches(row, int_iss, iss_item, kind):
     chapter = row.get("ChapterNumber")
     if kind == "volume":
         if volume not in (None, ""):
-            try:
-                return int(float(volume)) == int(iss_item)
-            except (TypeError, ValueError):
-                return False
+            return volume_numbers_match(volume, iss_item)
         if chapter not in (None, ""):
             return False
-    elif volume not in (None, "") and chapter in (None, ""):
+    elif is_volume_target(chapter, volume):
         return False
     return row["Int_IssueNumber"] == int_iss
 

--- a/comicarr/app/manga/ledger.py
+++ b/comicarr/app/manga/ledger.py
@@ -14,10 +14,15 @@ chapters and volume→chapter containment come from unfiltered `/aggregate`.
 Owning a volume covers only the chapters that mapping actually lists.
 """
 
+import re
+
 from comicarr.app.acquisition.models import Fulfillment
 
 _OPERATOR_FIELDS = ("Status", "AcquisitionIntent", "Location", "status", "acquisitionIntent", "location")
 _NON_VOLUME = frozenset({"", "none", "null", "unknown"})
+# Only strips a marker that actually introduces a number, so "vTPB" is left
+# alone and never compares equal to a real volume.
+_VOLUME_MARKER = re.compile(r"^v(?:ol(?:ume)?)?\.?\s*(?=\d)", re.IGNORECASE)
 
 
 def normalize_volume_number(value):
@@ -34,6 +39,42 @@ def normalize_volume_number(value):
     if number.is_integer():
         return str(int(number))
     return format(number, "g")
+
+
+def is_volume_target(chapter_number, volume_number):
+    """Is this pair a volume rather than a chapter?
+
+    The single owner of the volume-vs-chapter rule: a volume has a volume
+    number and no chapter number. Stated once because getting it wrong in
+    either direction is silently destructive — a chapter treated as a volume
+    lets a pack claim "chapter 7" as "volume 7", and a volume treated as a
+    chapter is searched as ``c001`` and never matches a ``v01`` release.
+    """
+    return volume_number not in (None, "") and chapter_number in (None, "")
+
+
+def volume_numbers_match(left, right):
+    """Do two volume references denote the same volume?
+
+    The same volume is written differently everywhere it appears: a release
+    says ``v01``, the ledger stores ``1``, a pack range yields the integer 1.
+    Both sides are stripped of a leading volume marker and canonicalised
+    through :func:`normalize_volume_number` before comparison.
+
+    Returns False whenever either side has no usable volume, so a parse
+    failure can never be read as a match and claim an arbitrary volume.
+    """
+    left_value = normalize_volume_number(_strip_volume_marker(left))
+    right_value = normalize_volume_number(_strip_volume_marker(right))
+    if left_value is None or right_value is None:
+        return False
+    return left_value == right_value
+
+
+def _strip_volume_marker(value):
+    if value is None:
+        return None
+    return _VOLUME_MARKER.sub("", str(value).strip())
 
 
 def chapter_id(comic_id, chapter_number):

--- a/comicarr/filechecker.py
+++ b/comicarr/filechecker.py
@@ -34,9 +34,7 @@ if "windows" not in platform.system().lower():
     from pwd import getpwnam
 
 
-_TRAILING_VOLUME_LABEL = re.compile(
-    r"[\s._-]*\b(?:v|vol|vols|volume)\.?\s*0*(\d+)\s*$", re.IGNORECASE
-)
+_TRAILING_VOLUME_LABEL = re.compile(r"[\s._-]*\b(?:v|vol|vols|volume)\.?\s*0*(\d+)\s*$", re.IGNORECASE)
 
 
 def strip_trailing_volume_label(series_name, volume_number):

--- a/comicarr/filechecker.py
+++ b/comicarr/filechecker.py
@@ -34,7 +34,11 @@ if "windows" not in platform.system().lower():
     from pwd import getpwnam
 
 
-_TRAILING_VOLUME_LABEL = re.compile(r"[\s._-]*\b(?:v|vol|vols|volume)\.?\s*0*(\d+)\s*$", re.IGNORECASE)
+# `\s*\.?\s*` rather than `\.?\s*`: the token walker splits `Vol.33` into
+# `Vol .33`, moving the separator dot AFTER the space, so a pattern that only
+# allowed the dot to come first matched the short form and missed the very
+# long form this exists to catch.
+_TRAILING_VOLUME_LABEL = re.compile(r"[\s._-]*\b(?:v|vol|vols|volume)\s*\.?\s*0*(\d+)\s*$", re.IGNORECASE)
 
 
 def strip_trailing_volume_label(series_name, volume_number):
@@ -1743,6 +1747,12 @@ class FileChecker(object):
                 "annual_comicid": annual_comicid,
                 "scangroup": series_info["scangroup"],
                 "booktype": series_info["booktype"],
+                # Carried through so a caller can tell a volume file from a
+                # chapter file. series_volume cannot answer that: it defaults
+                # to v1 when the filename had no volume token, which makes a
+                # chapter file indistinguishable from a genuine volume 1.
+                "manga_chapter": series_info.get("manga_chapter"),
+                "manga_volume": series_info.get("manga_volume"),
             }
 
         else:

--- a/comicarr/filechecker.py
+++ b/comicarr/filechecker.py
@@ -34,6 +34,43 @@ if "windows" not in platform.system().lower():
     from pwd import getpwnam
 
 
+_TRAILING_VOLUME_LABEL = re.compile(
+    r"[\s._-]*\b(?:v|vol|vols|volume)\.?\s*0*(\d+)\s*$", re.IGNORECASE
+)
+
+
+def strip_trailing_volume_label(series_name, volume_number):
+    """Drop a trailing volume label that was already read off as the volume.
+
+    A volume label belongs to the volume, not to the title: "Series v03" and
+    "Series Vol.3" name the same series. The token walker removes the short
+    form, so "One-Punch Man v33 ..." parses as "One-Punch Man" -- but the long
+    form can survive it, leaving "One-Punch Man Vol 33" as the series name,
+    which then matches no series at all.
+
+    Only a label whose number is the volume that was actually detected is
+    removed, so a series legitimately titled with a trailing number is left
+    alone, and so is any trailing text that is not a volume label.
+    """
+    if not series_name or volume_number is None:
+        return series_name
+
+    match = _TRAILING_VOLUME_LABEL.search(series_name)
+    if not match:
+        return series_name
+
+    try:
+        if int(match.group(1)) != int(str(volume_number).strip()):
+            return series_name
+    except (TypeError, ValueError):
+        return series_name
+
+    stripped = series_name[: match.start()].strip()
+    # Never strip the title away entirely: a file whose whole name is a volume
+    # label has no series to recover, and an empty name matches everything.
+    return stripped or series_name
+
+
 class FileChecker(object):
     def __init__(
         self,
@@ -1331,6 +1368,21 @@ class FileChecker(object):
             alt_series = re.sub("f11", "&", alt_series)
             alt_series = re.sub("g11", "'", alt_series)
             alt_series = re.sub("h11", "@", alt_series)
+
+        # The token walker truncates the title at the volume position it found,
+        # but it does not always find the long form ("Vol.33"), and the manga
+        # volume regex that does find it only overrides series_volume. Without
+        # this the label stays in the title and the series matches nothing.
+        detected_volume = manga_volume
+        if detected_volume is None and len(volume_found) > 0:
+            detected_volume = volume_found.get("volume")
+        volume_label_stripped = strip_trailing_volume_label(series_name, detected_volume)
+        if volume_label_stripped != series_name:
+            logger.fdebug(
+                "[VOLUME-LABEL] volume %s is already the volume, removing it from the series title: %s -> %s"
+                % (detected_volume, series_name, volume_label_stripped)
+            )
+            series_name = volume_label_stripped
 
         if series_name.endswith("-"):
             series_name = series_name[:-1].strip()

--- a/comicarr/manga_parser.py
+++ b/comicarr/manga_parser.py
@@ -109,6 +109,43 @@ _PATTERNS = [
 ]
 
 
+# Every pattern above anchors its number at the end of the stem, but scene
+# releases append metadata groups after it -- "Series v20 (2020) (Digital)
+# (Group)".  Stripping those lets the same patterns see the volume/chapter
+# token they were written for.
+_PAT_TRAILING_TAGS = re.compile(r"(?:\s*[\(\[][^()\[\]]*[\)\]])+\s*$")
+
+
+def strip_trailing_tags(stem):
+    """Return ``stem`` without its trailing ``(...)``/``[...]`` tag groups.
+
+    Returns the stem unchanged when it does not end in a tag group.
+    """
+    return _PAT_TRAILING_TAGS.sub("", stem).strip()
+
+
+def _match_patterns(stem):
+    """Match ``stem`` against ``_PATTERNS``, returning ``(match, pattern)``.
+
+    The full stem is tried first, so any filename that already parsed keeps
+    its existing result.  Only when nothing matches is the stem retried with
+    trailing release tags removed.
+    """
+    for pattern in _PATTERNS:
+        m = pattern.match(stem)
+        if m:
+            return m, pattern
+
+    stripped = strip_trailing_tags(stem)
+    if stripped and stripped != stem:
+        for pattern in _PATTERNS:
+            m = pattern.match(stripped)
+            if m:
+                return m, pattern
+
+    return None, None
+
+
 def parse_manga_filename(
     filename,
     series_name=None,
@@ -159,13 +196,12 @@ def parse_manga_filename(
         volume_count=volume_count,
         chapter_count=chapter_count,
     )
-    for pattern in _PATTERNS:
-        m = pattern.match(stem)
-        if m:
-            result = _build_result(m)
-            if result is not None and pattern is _PAT_BARE_NUMBER:
-                return apply_bare_number(result, resolved_mode)
-            return result
+    m, pattern = _match_patterns(stem)
+    if m:
+        result = _build_result(m)
+        if result is not None and pattern is _PAT_BARE_NUMBER:
+            return apply_bare_number(result, resolved_mode)
+        return result
 
     if series_name:
         chapter = parse_manga_chapter_number(filename)
@@ -192,11 +228,9 @@ def parse_manga_chapter_number(filename):
     if not stem or len(stem) > 512:
         return None
 
-    for pattern in _PATTERNS:
-        m = pattern.match(stem)
-        if m:
-            groups = m.groupdict()
-            return _to_chapter_number(groups.get("chapter"))
+    m, _pattern = _match_patterns(stem)
+    if m:
+        return _to_chapter_number(m.groupdict().get("chapter"))
 
     return _parse_chapter_only_stem(stem)
 

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -77,25 +77,64 @@ def log_scan_summary(module, filename, candidate_count, selected_items, annual_c
     )
 
 
+_COLLECTED_TYPES = ("TPB", "HC", "GN")
+
+
+def numbered_by_volume(watch_values):
+    """Return whether this series names its files by volume rather than issue.
+
+    Collected editions and One-Shots have always been named this way, which is
+    why the scan exempts them from every check that assumes a file carries an
+    issue number: the weekly-pull cross-check, the "no issue number" rejection,
+    and the fallback that defaults a missing number to 1.
+
+    Manga belongs with them. In a periodical ``vNN`` names *which run* of the
+    series a release belongs to; in manga it names *which book*. A manga volume
+    file therefore carries no issue number at all, so applying the periodical
+    checks to it rejects a perfectly good file.
+
+    Rows built without the manga flag -- story arcs and one-offs assembled from
+    tables that do not carry it -- read as comics, which is the prior behaviour.
+    """
+    if watch_values.get("IsManga"):
+        return True
+    return watch_values["Type"] in _COLLECTED_TYPES + ("One-Shot",)
+
+
+def volume_match_settles_year(watch_values, volume_matched):
+    """Return whether a matched volume makes the filename's year irrelevant.
+
+    The year check exists because periodical issue numbers repeat across runs,
+    so ``Batman 1`` needs a year to say *which* Batman 1. A manga volume number
+    does not repeat -- there is one volume 1 -- so once it matches, the year
+    cannot be evidence of a wrong file.
+
+    It is routinely a mismatch, too: a provider dates the licensed English
+    printing while the release is labelled with the volume's original year. For
+    One-Punch Man v01 those are 2015 and 2014, and the file was rejected for it.
+
+    Deliberately manga-only. A collected edition's year mismatch can still mean
+    the wrong edition, so periodical and TPB behaviour is untouched.
+    """
+    return bool(volume_matched) and bool(watch_values.get("IsManga"))
+
+
 def volume_identifies_file(watch_values):
-    """Return whether this series numbers its files by volume rather than issue.
+    """Return whether a scanned file is located by volume rather than issue.
 
-    Collected editions (TPB/HC/GN spanning more than one entry) and One-Shots
-    have always been numbered this way, so a scanned file is located by the
-    ``vNN`` token in its name rather than by an issue number.
+    This is :func:`numbered_by_volume` qualified by the run length, because a
+    collected edition only numbers *files* by volume when the run actually has
+    volumes to distinguish: TPB/HC/GN spanning more than one entry, or a
+    One-Shot standing alone.
 
-    Manga joins them for a different reason. In a periodical, ``vNN`` names
-    *which run* of the series a release belongs to; in manga it names *which
-    book*, so the volume is the file's identity exactly as an issue number is
-    elsewhere. A manga volume file carries no issue number at all, so without
-    this the scan derives no number for it, matches it against every issue in
-    the series, and selects none of them.
+    Manga is not qualified that way. Volume 1 of a one-volume manga is still
+    identified by its volume, so the run length says nothing useful here.
     """
     if watch_values.get("IsManga"):
         return True
     series_type = watch_values["Type"]
     total = watch_values["Total"]
-    return (series_type in ("TPB", "HC", "GN") and total > 1) or (series_type == "One-Shot" and total == 1)
+    return (series_type in _COLLECTED_TYPES and total > 1) or (series_type == "One-Shot" and total == 1)
 
 
 def summarize_scan_matches(normal_items, arc_items):
@@ -1384,27 +1423,13 @@ class PostProcessor(object):
                             temploc = just_the_digits.replace("_", " ")
                             temploc = re.sub("[\\#']", "", temploc)
                         else:
-                            if any(
-                                [
-                                    cs["WatchValues"]["Type"] == "TPB",
-                                    cs["WatchValues"]["Type"] == "GN",
-                                    cs["WatchValues"]["Type"] == "HC",
-                                    cs["WatchValues"]["Type"] == "One-Shot",
-                                ]
-                            ):
+                            if numbered_by_volume(cs["WatchValues"]):
                                 temploc = "1"
                             else:
                                 temploc = None
                         datematch = "False"
 
-                        if temploc is None and all(
-                            [
-                                cs["WatchValues"]["Type"] != "TPB",
-                                cs["WatchValues"]["Type"] != "GN",
-                                cs["WatchValues"]["Type"] != "HC",
-                                cs["WatchValues"]["Type"] != "One-Shot",
-                            ]
-                        ):
+                        if temploc is None and not numbered_by_volume(cs["WatchValues"]):
                             logger.info(
                                 "this should have an issue number to match to this particular series: %s"
                                 % cs["ComicID"]
@@ -1662,14 +1687,9 @@ class PostProcessor(object):
                                             alts = x["AS_Alt"]
                                     alt_listing = [True if x.lower() == dynamic_seriesname else False for x in alts]
 
-                                    if any([cs["DynamicName"] == dynamic_seriesname, alt_listing]) and all(
-                                        [
-                                            cs["WatchValues"]["Type"] != "TPB",
-                                            cs["WatchValues"]["Type"] != "GN",
-                                            cs["WatchValues"]["Type"] != "HC",
-                                            cs["WatchValues"]["Type"] != "One-Shot",
-                                        ]
-                                    ):
+                                    if any(
+                                        [cs["DynamicName"] == dynamic_seriesname, alt_listing]
+                                    ) and not numbered_by_volume(cs["WatchValues"]):
                                         logger.fdebug(
                                             "name match exact : %s - %s" % (cs["DynamicName"], dynamic_seriesname)
                                         )
@@ -1798,15 +1818,7 @@ class PostProcessor(object):
                                 else:
                                     logger.fdebug("not a match")
 
-                                if all(
-                                    [
-                                        second_check is False,
-                                        cs["WatchValues"]["Type"] != "TPB",
-                                        cs["WatchValues"]["Type"] != "GN",
-                                        cs["WatchValues"]["Type"] != "HC",
-                                        cs["WatchValues"]["Type"] != "One-Shot",
-                                    ]
-                                ):
+                                if second_check is False and not numbered_by_volume(cs["WatchValues"]):
                                     logger.fdebug(
                                         "%s %s in filename don't match up to what's in the dB for %s [%s]. This is a wrong match. Continuing..."
                                         % (
@@ -1927,6 +1939,13 @@ class PostProcessor(object):
                                     logger.fdebug(
                                         "%s[LONE-VOLUME/NO YEAR][MATCH] Only Volume on watchlist matches, no year present in filename. Assuming match based on volume and title."
                                         % module
+                                    )
+                                    datematch = "True"
+
+                                if datematch == "False" and volume_match_settles_year(cs["WatchValues"], lonevol):
+                                    logger.fdebug(
+                                        "%s[MANGA][VOLUME MATCH] Volume %s matched, so the year in the filename (%s) does not decide this file. Assuming match based on volume and title."
+                                        % (module, watchmatch["series_volume"], watchmatch["issue_year"])
                                     )
                                     datematch = "True"
 
@@ -2080,6 +2099,7 @@ class PostProcessor(object):
                                     "Publisher": av["IssuePublisher"],
                                     "Total": int(av["TotalIssues"]),
                                     "Type": av["Type"],
+                                    "IsManga": series_kind.is_manga(av),
                                     "IsArc": True,
                                 },
                             }
@@ -2119,18 +2139,7 @@ class PostProcessor(object):
                                 nm += 1
                             else:
                                 try:
-                                    if (
-                                        any(
-                                            [
-                                                v[i]["WatchValues"]["Type"] == "TPB",
-                                                v[i]["WatchValues"]["Type"] == "GN",
-                                                v[i]["WatchValues"]["Type"] == "HC",
-                                            ]
-                                        )
-                                        and v[i]["WatchValues"]["Total"] > 1
-                                    ) or all(
-                                        [v[i]["WatchValues"]["Type"] == "One-Shot", v[i]["WatchValues"]["Total"] == 1]
-                                    ):
+                                    if volume_identifies_file(v[i]["WatchValues"]):
                                         if arcmatch["series_volume"] is not None:
                                             just_the_digits = re.sub("[^0-9]", "", arcmatch["series_volume"]).strip()
                                         else:
@@ -2149,14 +2158,7 @@ class PostProcessor(object):
                                     temploc = just_the_digits.replace("_", " ")
                                     temploc = re.sub("[\\#']", "", temploc)
                                 else:
-                                    if any(
-                                        [
-                                            v[i]["WatchValues"]["Type"] == "TPB",
-                                            v[i]["WatchValues"]["Type"] == "GN",
-                                            v[i]["WatchValues"]["Type"] == "HC",
-                                            v[i]["WatchValues"]["Type"] == "One-Shot",
-                                        ]
-                                    ):
+                                    if numbered_by_volume(v[i]["WatchValues"]):
                                         temploc = "1"
                                     else:
                                         temploc = None
@@ -2678,6 +2680,7 @@ class PostProcessor(object):
                                             "Total": 0,
                                             "Type": ofl["format"],
                                             "ComicID": ofl["ComicID"],
+                                            "IsManga": series_kind.is_manga(ofl),
                                             "IsArc": False,
                                         },
                                     }
@@ -2696,7 +2699,7 @@ class PostProcessor(object):
                                     continue
                                 else:
                                     try:
-                                        if ofv["WatchValues"]["Type"] is not None and ofv["WatchValues"]["Total"] > 1:
+                                        if volume_identifies_file(ofv["WatchValues"]):
                                             if watchmatch["series_volume"] is not None:
                                                 just_the_digits = re.sub(
                                                     "[^0-9]", "", watchmatch["series_volume"]

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -77,6 +77,27 @@ def log_scan_summary(module, filename, candidate_count, selected_items, annual_c
     )
 
 
+def volume_identifies_file(watch_values):
+    """Return whether this series numbers its files by volume rather than issue.
+
+    Collected editions (TPB/HC/GN spanning more than one entry) and One-Shots
+    have always been numbered this way, so a scanned file is located by the
+    ``vNN`` token in its name rather than by an issue number.
+
+    Manga joins them for a different reason. In a periodical, ``vNN`` names
+    *which run* of the series a release belongs to; in manga it names *which
+    book*, so the volume is the file's identity exactly as an issue number is
+    elsewhere. A manga volume file carries no issue number at all, so without
+    this the scan derives no number for it, matches it against every issue in
+    the series, and selects none of them.
+    """
+    if watch_values.get("IsManga"):
+        return True
+    series_type = watch_values["Type"]
+    total = watch_values["Total"]
+    return (series_type in ("TPB", "HC", "GN") and total > 1) or (series_type == "One-Shot" and total == 1)
+
+
 def summarize_scan_matches(normal_items, arc_items):
     """Build summary fields from the matches selected for one input file."""
     selected_items = normal_items + arc_items
@@ -1174,6 +1195,7 @@ class PostProcessor(object):
                     wv_seriesyear = wv["ComicYear"]
                     wv_comicversion = wv["ComicVersion"]
                     wv_publisher = wv["ComicPublisher"]
+                    wv_is_manga = series_kind.is_manga(wv)
                     wv_total = int(wv["Total"])
                     wv_agerating = wv["AgeRating"]
                     wv_latestissue = wv["LatestIssue"]
@@ -1323,6 +1345,7 @@ class PostProcessor(object):
                                 "Publisher": wv_publisher,
                                 "Total": wv_total,
                                 "ComicID": wv_comicid,
+                                "IsManga": wv_is_manga,
                                 "IsArc": False,
                             },
                         }
@@ -1342,16 +1365,7 @@ class PostProcessor(object):
                         continue
                     else:
                         try:
-                            if (
-                                any(
-                                    [
-                                        cs["WatchValues"]["Type"] == "TPB",
-                                        cs["WatchValues"]["Type"] == "HC",
-                                        cs["WatchValues"]["Type"] == "GN",
-                                    ]
-                                )
-                                and cs["WatchValues"]["Total"] > 1
-                            ) or all([cs["WatchValues"]["Type"] == "One-Shot", cs["WatchValues"]["Total"] == 1]):
+                            if volume_identifies_file(cs["WatchValues"]):
                                 if watchmatch["series_volume"] is not None:
                                     just_the_digits = re.sub("[^0-9]", "", watchmatch["series_volume"]).strip()
                                 else:

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -41,6 +41,7 @@ from comicarr.app.downloads.postprocess_pipeline import (
     PostProcessJournalStage,
 )
 from comicarr.app.downloads.pp_commands import safe_walk
+from comicarr.app.manga.ledger import is_volume_target
 from comicarr.config import get_manga_destination
 from comicarr.tables import (
     annuals,
@@ -119,19 +120,35 @@ def volume_match_settles_year(watch_values, volume_matched):
     return bool(volume_matched) and bool(watch_values.get("IsManga"))
 
 
-def volume_identifies_file(watch_values):
-    """Return whether a scanned file is located by volume rather than issue.
+def volume_identifies_file(watch_values, parsed_file=None):
+    """Return whether THIS scanned file is located by volume rather than issue.
 
     This is :func:`numbered_by_volume` qualified by the run length, because a
     collected edition only numbers *files* by volume when the run actually has
     volumes to distinguish: TPB/HC/GN spanning more than one entry, or a
     One-Shot standing alone.
 
-    Manga is not qualified that way. Volume 1 of a one-volume manga is still
-    identified by its volume, so the run length says nothing useful here.
+    Manga is not qualified that way -- volume 1 of a one-volume manga is still
+    identified by its volume, so the run length says nothing useful. It is
+    qualified per FILE instead, because a manga series holds both kinds: a
+    volume file is located by its volume and a chapter file by its chapter,
+    and the series cannot say which one is in hand.
+
+    That has to be read off the parsed file's own volume/chapter tokens,
+    through the shared ``is_volume_target`` rule. It cannot be read off
+    ``series_volume``, which FileChecker defaults to ``v1`` whenever the
+    filename carried no volume token -- so answering the series-level question
+    for every manga file sent ``Chainsaw Man c181`` down the volume branch,
+    where the defaulted ``1`` was looked up as an issue number and marked
+    chapter 1 Downloaded. ``Series v33`` landed on chapter 33 the same way.
+
+    Callers pass the matchIT result. Omitting it answers the series-level
+    question only, and for manga that is never a safe default -- so it says
+    False rather than claiming a volume the file may not have.
     """
     if watch_values.get("IsManga"):
-        return True
+        parsed = parsed_file or {}
+        return is_volume_target(parsed.get("manga_chapter"), parsed.get("manga_volume"))
     series_type = watch_values["Type"]
     total = watch_values["Total"]
     return (series_type in _COLLECTED_TYPES and total > 1) or (series_type == "One-Shot" and total == 1)
@@ -1404,7 +1421,7 @@ class PostProcessor(object):
                         continue
                     else:
                         try:
-                            if volume_identifies_file(cs["WatchValues"]):
+                            if volume_identifies_file(cs["WatchValues"], watchmatch):
                                 if watchmatch["series_volume"] is not None:
                                     just_the_digits = re.sub("[^0-9]", "", watchmatch["series_volume"]).strip()
                                 else:
@@ -1659,6 +1676,15 @@ class PostProcessor(object):
                                 datematch = "False"
                                 lonevol = False
                                 watch_values = cs["WatchValues"]
+                                # Did the file's own BOOK VOLUME locate this row?
+                                # volume_identifies_file is what selected the volume
+                                # token as the lookup number, and reaching here means
+                                # that number matched an issue row. lonevol cannot
+                                # answer this: it asks whether the filename's volume
+                                # equals the watchlist ComicVersion, which MangaDex
+                                # leaves unset -- so it reads as 1, true for v01 and
+                                # false for every later volume of the same series.
+                                book_volume_matched = volume_identifies_file(watch_values, watchmatch)
                                 second_check = False
                                 if watch_values["LatestIssueInt"] >= fcdigit:
                                     logger.fdebug(
@@ -1942,7 +1968,9 @@ class PostProcessor(object):
                                     )
                                     datematch = "True"
 
-                                if datematch == "False" and volume_match_settles_year(cs["WatchValues"], lonevol):
+                                if datematch == "False" and volume_match_settles_year(
+                                    cs["WatchValues"], book_volume_matched
+                                ):
                                     logger.fdebug(
                                         "%s[MANGA][VOLUME MATCH] Volume %s matched, so the year in the filename (%s) does not decide this file. Assuming match based on volume and title."
                                         % (module, watchmatch["series_volume"], watchmatch["issue_year"])
@@ -2139,7 +2167,7 @@ class PostProcessor(object):
                                 nm += 1
                             else:
                                 try:
-                                    if volume_identifies_file(v[i]["WatchValues"]):
+                                    if volume_identifies_file(v[i]["WatchValues"], arcmatch):
                                         if arcmatch["series_volume"] is not None:
                                             just_the_digits = re.sub("[^0-9]", "", arcmatch["series_volume"]).strip()
                                         else:
@@ -2699,7 +2727,7 @@ class PostProcessor(object):
                                     continue
                                 else:
                                     try:
-                                        if volume_identifies_file(ofv["WatchValues"]):
+                                        if volume_identifies_file(ofv["WatchValues"], watchmatch):
                                             if watchmatch["series_volume"] is not None:
                                                 just_the_digits = re.sub(
                                                     "[^0-9]", "", watchmatch["series_volume"]

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -2567,9 +2567,7 @@ def searchforissue(
                     content_type = "manga" if series_kind.is_manga(comic) else "comic"
                     if content_type == "manga":
                         manga_row = db.select_one(
-                            select(issues.c.ChapterNumber, issues.c.VolumeNumber).where(
-                                issues.c.IssueID == issueid
-                            )
+                            select(issues.c.ChapterNumber, issues.c.VolumeNumber).where(issues.c.IssueID == issueid)
                         )
                         # Best-effort enrichment: a Series whose ledger row is
                         # missing or does not carry these columns must still be
@@ -2647,12 +2645,8 @@ def searchforissue(
                     booktype=booktype,
                     ignore_booktype=ignore_booktype,
                     content_type=content_type,
-                    chapter_number=(
-                        None if manga_chapter_number in (None, "") else str(manga_chapter_number)
-                    ),
-                    volume_number=(
-                        None if manga_volume_number in (None, "") else str(manga_volume_number)
-                    ),
+                    chapter_number=(None if manga_chapter_number in (None, "") else str(manga_chapter_number)),
+                    volume_number=(None if manga_volume_number in (None, "") else str(manga_volume_number)),
                 )
                 if manual is True:
                     comicarr.SEARCHLOCK.release()
@@ -4318,7 +4312,7 @@ def manga_volume_search_terms(series_name, chapter_num, volume_num):
 
     if not is_volume_target(chapter_num, volume_num):
         return {}
-    return {term: series_name for term in _build_manga_search_terms(series_name, chapter_num, volume_num)}
+    return dict.fromkeys(_build_manga_search_terms(series_name, chapter_num, volume_num), series_name)
 
 
 def get_findcomiciss(IssueNumber):

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -4281,11 +4281,6 @@ def searchforissue_checker(issueid, storedate, issuedate, digitaldate, info):
         return {"status": False, "reason": "invalid issueid"}
 
 
-def _is_volume_target(chapter_num, volume_num):
-    """A target is a volume iff it has a volume number and no chapter number."""
-    return volume_num not in (None, "") and chapter_num in (None, "")
-
-
 def _build_manga_search_terms(series_name, chapter_num, volume_num):
     """Build manga-specific search query variations.
 
@@ -4294,8 +4289,9 @@ def _build_manga_search_terms(series_name, chapter_num, volume_num):
     which kind to look for.
     """
     from comicarr.app.manga.acquisition import search_terms_for_target
+    from comicarr.app.manga.ledger import is_volume_target
 
-    if _is_volume_target(chapter_num, volume_num):
+    if is_volume_target(chapter_num, volume_num):
         return search_terms_for_target(series_name, {"kind": "volume", "number": volume_num})
     return search_terms_for_target(series_name, {"kind": "chapter", "number": chapter_num})
 
@@ -4318,7 +4314,9 @@ def manga_volume_search_terms(series_name, chapter_num, volume_num):
 
     Chapter terms are excluded: they keep the normal issue-number handling.
     """
-    if not _is_volume_target(chapter_num, volume_num):
+    from comicarr.app.manga.ledger import is_volume_target
+
+    if not is_volume_target(chapter_num, volume_num):
         return {}
     return {term: series_name for term in _build_manga_search_terms(series_name, chapter_num, volume_num)}
 

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -316,6 +316,7 @@ def search_init(
         logger.fdebug("Story-ARC: %s" % SARC)
         logger.fdebug("IssueArcID: %s" % IssueArcID)
 
+    manga_volume_terms = set()
     if content_type == "manga":
         logger.fdebug("[SEARCH-MANGA] Manga content detected for %s" % ComicName)
         manga_terms = _build_manga_search_terms(ComicName, chapter_number, volume_number)
@@ -326,6 +327,7 @@ def search_init(
                 AlternateSearch = manga_alt_str + "##" + AlternateSearch
             else:
                 AlternateSearch = manga_alt_str
+            manga_volume_terms = manga_volume_search_terms(ComicName, chapter_number, volume_number)
 
     provider_list = provider_order(initial_run=True)
     if content_type == "manga":
@@ -665,6 +667,7 @@ def search_init(
                     "ignore_booktype": ignore_booktype,
                     "smode": smode,
                     "allow_packs": allow_packs,
+                    "manga_volume_terms": manga_volume_terms,
                     "findit": findit,
                 }
 
@@ -972,6 +975,7 @@ def NZB_SEARCH(
     chktpb=0,
     ignore_booktype=False,
     smode=None,
+    manga_volume_terms=None,
 ):
 
     if _allow_packs_enabled(allow_packs) and comicarr.CONFIG.ENABLE_TORRENT_SEARCH:
@@ -1137,7 +1141,16 @@ def NZB_SEARCH(
             findloop = 99
             break
 
-        if IssueNumber is not None:
+        if IssueNumber is not None and ComicName in (manga_volume_terms or ()):
+            # Manga VOLUME target. comsrc is already the volume search name
+            # ("<series> v01"), and volume releases are published without an
+            # issue number -- "One-Punch Man v01 (2014) (Digital)" -- so
+            # appending one gives "<series> v01 001" and matches nothing.
+            # Search the volume name as-is, the way the TPB pass does.
+            comsearch = comsrc
+            issdig = ""
+            mod_isssearch = ""
+        elif IssueNumber is not None:
             if cmloopit == 3:
                 comsearch = comsrc + "%2000" + str(isssearch)
                 issdig = "00"
@@ -4149,6 +4162,7 @@ def search_the_matrix(scarios):
         ignore_booktype=scarios["ignore_booktype"],
         smode=scarios["smode"],
         allow_packs=scarios.get("allow_packs"),
+        manga_volume_terms=scarios.get("manga_volume_terms"),
     )
 
 
@@ -4261,6 +4275,11 @@ def searchforissue_checker(issueid, storedate, issuedate, digitaldate, info):
         return {"status": False, "reason": "invalid issueid"}
 
 
+def _is_volume_target(chapter_num, volume_num):
+    """A target is a volume iff it has a volume number and no chapter number."""
+    return volume_num not in (None, "") and chapter_num in (None, "")
+
+
 def _build_manga_search_terms(series_name, chapter_num, volume_num):
     """Build manga-specific search query variations.
 
@@ -4270,9 +4289,24 @@ def _build_manga_search_terms(series_name, chapter_num, volume_num):
     """
     from comicarr.app.manga.acquisition import search_terms_for_target
 
-    if volume_num not in (None, "") and chapter_num in (None, ""):
+    if _is_volume_target(chapter_num, volume_num):
         return search_terms_for_target(series_name, {"kind": "volume", "number": volume_num})
     return search_terms_for_target(series_name, {"kind": "chapter", "number": chapter_num})
+
+
+def manga_volume_search_terms(series_name, chapter_num, volume_num):
+    """The generated manga terms that are VOLUME targets, as a set.
+
+    NZB_SEARCH takes this to decide which alternate names must be searched
+    bare. A volume term already carries its number in the search name
+    ("<series> v01") and volume releases are published without an issue number
+    -- "One-Punch Man v01 (2014) (Digital)" -- so appending one yields
+    "<series> v01 001", which matches nothing. Chapter terms are excluded:
+    they keep the normal issue-number handling.
+    """
+    if not _is_volume_target(chapter_num, volume_num):
+        return set()
+    return set(_build_manga_search_terms(series_name, chapter_num, volume_num))
 
 
 def get_findcomiciss(IssueNumber):

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -2505,6 +2505,8 @@ def searchforissue(
                 allow_packs = False
                 ComicID = result["ComicID"]
                 content_type = "comic"
+                manga_chapter_number = None
+                manga_volume_number = None
                 if smode == "story_arc":
                     ComicName = result["ComicName"]
                     Comicname_filesafe = helpers.filesafe(ComicName)
@@ -2544,6 +2546,20 @@ def searchforissue(
                 else:
                     comic = db.select_one(select(comics).where(comics.c.ComicID == ComicID))
                     content_type = "manga" if series_kind.is_manga(comic) else "comic"
+                    if content_type == "manga":
+                        manga_row = db.select_one(
+                            select(issues.c.ChapterNumber, issues.c.VolumeNumber).where(
+                                issues.c.IssueID == issueid
+                            )
+                        )
+                        # Best-effort enrichment: a Series whose ledger row is
+                        # missing or does not carry these columns must still be
+                        # searched (by issue number), never fail outright.
+                        manga_keys = set(manga_row.keys()) if manga_row is not None else set()
+                        if "ChapterNumber" in manga_keys:
+                            manga_chapter_number = manga_row["ChapterNumber"]
+                        if "VolumeNumber" in manga_keys:
+                            manga_volume_number = manga_row["VolumeNumber"]
                     if smode == "want_ann":
                         ComicName = result["ReleaseComicName"]
                         Comicname_filesafe = None
@@ -2612,6 +2628,12 @@ def searchforissue(
                     booktype=booktype,
                     ignore_booktype=ignore_booktype,
                     content_type=content_type,
+                    chapter_number=(
+                        None if manga_chapter_number in (None, "") else str(manga_chapter_number)
+                    ),
+                    volume_number=(
+                        None if manga_volume_number in (None, "") else str(manga_volume_number)
+                    ),
                 )
                 if manual is True:
                     comicarr.SEARCHLOCK.release()

--- a/comicarr/search.py
+++ b/comicarr/search.py
@@ -1096,8 +1096,14 @@ def NZB_SEARCH(
     foundc["lastrun"] = provider_stat["lastrun"]
     done = False
 
+    # Set only when this pass is searching a manga volume term. Carries the
+    # real series name, because the term itself ("<series> v01") is a query
+    # rather than a name and would fail every series comparison.
+    manga_match_name = (manga_volume_terms or {}).get(ComicName)
+
     is_info = {
         "ComicName": ComicName,
+        "manga_match_name": manga_match_name,
         "nzbprov": nzbprov,
         "RSS": RSS,
         "UseFuzzy": UseFuzzy,
@@ -4295,18 +4301,26 @@ def _build_manga_search_terms(series_name, chapter_num, volume_num):
 
 
 def manga_volume_search_terms(series_name, chapter_num, volume_num):
-    """The generated manga terms that are VOLUME targets, as a set.
+    """Map each generated VOLUME search term to the real series name.
 
-    NZB_SEARCH takes this to decide which alternate names must be searched
-    bare. A volume term already carries its number in the search name
-    ("<series> v01") and volume releases are published without an issue number
-    -- "One-Punch Man v01 (2014) (Digital)" -- so appending one yields
-    "<series> v01 001", which matches nothing. Chapter terms are excluded:
-    they keep the normal issue-number handling.
+    Volume terms are injected into AlternateSearch so gen_altnames() hands them
+    to NZB_SEARCH as a ComicName, and that creates two problems this mapping
+    solves at once:
+
+      * The term already carries its number ("<series> v01") and volume
+        releases are published without an issue number -- "One-Punch Man v01
+        (2014) (Digital)" -- so NZB_SEARCH must not append one. Membership
+        answers "is this pass a volume search?".
+      * AlternateSearch means "another NAME for this series", but a volume term
+        is a query, not a name. The release still parses as the plain series
+        name, so the matcher must compare against the value here rather than
+        the volume-suffixed term, or every result is a series mismatch.
+
+    Chapter terms are excluded: they keep the normal issue-number handling.
     """
     if not _is_volume_target(chapter_num, volume_num):
-        return set()
-    return set(_build_manga_search_terms(series_name, chapter_num, volume_num))
+        return {}
+    return {term: series_name for term in _build_manga_search_terms(series_name, chapter_num, volume_num)}
 
 
 def get_findcomiciss(IssueNumber):

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -162,6 +162,24 @@ def report_provider_failure(provider, code, detail):
         collector["failure"](str(provider), str(code), str(detail))
 
 
+def manga_volume_satisfies(found_volume, wanted_number):
+    """Does a matched manga volume satisfy the ledger row being searched?
+
+    A manga volume release carries no issue number -- "One-Punch Man v01 (2014)
+    (Digital)" -- so the issue-number arms can never accept it. The volume IS
+    the unit being acquired, so the release satisfies the row when the two
+    volume numbers agree. Compared numerically, since the release writes "v01"
+    and the ledger stores "1".
+    """
+    if found_volume in (None, "") or wanted_number in (None, ""):
+        return False
+    found_digits = re.sub(r"[^0-9]", "", str(found_volume))
+    wanted_digits = re.sub(r"[^0-9]", "", str(wanted_number))
+    if not found_digits or not wanted_digits:
+        return False
+    return int(found_digits) == int(wanted_digits)
+
+
 class search_check(object):
     def __init__(self):
         pass
@@ -320,6 +338,7 @@ class search_check(object):
             # parses as the plain series name, so comparing against the query
             # would fail every result. Match against the real name instead.
             match_name = is_info.get("manga_match_name") or ComicName
+            manga_volume_pass = bool(is_info.get("manga_match_name"))
             nzbprov = is_info["nzbprov"]
             RSS = is_info["RSS"]
             UseFuzzy = is_info["UseFuzzy"]
@@ -1126,6 +1145,16 @@ class search_check(object):
                     or all([cmloopit == 4, findcomiciss is None, pc_in is None])
                     or all([cmloopit == 4, findcomiciss is None, pc_in == 1])
                     or all([cmloopit == 4, findcomiciss == 1, pc_in is None])
+                    or all(
+                        [
+                            manga_volume_pass,
+                            pc_in is None,
+                            manga_volume_satisfies(
+                                filecomic.get("volume") or filecomic.get("series_volume"),
+                                findcomiciss,
+                            ),
+                        ]
+                    )
                 ):
                     nowrite = False
                     logger.info(

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -316,6 +316,10 @@ class search_check(object):
     def _match_entry(self, entry, is_info):
         if is_info:
             ComicName = is_info["ComicName"]
+            # A manga volume pass searches "<series> v01", but the release
+            # parses as the plain series name, so comparing against the query
+            # would fail every result. Match against the real name instead.
+            match_name = is_info.get("manga_match_name") or ComicName
             nzbprov = is_info["nzbprov"]
             RSS = is_info["RSS"]
             UseFuzzy = is_info["UseFuzzy"]
@@ -665,7 +669,7 @@ class search_check(object):
                     "parse_status": "success",
                 }
             else:
-                p_comic = filechecker.FileChecker(file=ComicTitle, watchcomic=ComicName)
+                p_comic = filechecker.FileChecker(file=ComicTitle, watchcomic=match_name)
                 parsed_comic = p_comic.listFiles()
 
         logger.fdebug("parsed_info: %s" % parsed_comic)
@@ -692,7 +696,7 @@ class search_check(object):
             or re.sub("None", "issue", str(booktype)) in parsed_comic["booktype"]
         ):
             try:
-                fcomic = filechecker.FileChecker(watchcomic=ComicName)
+                fcomic = filechecker.FileChecker(watchcomic=match_name)
                 filecomic = fcomic.matchIT(parsed_comic)
             except Exception as e:
                 logger.error("[PARSE-ERROR]: %s" % e)

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -166,18 +166,16 @@ def manga_volume_satisfies(found_volume, wanted_number):
     """Does a matched manga volume satisfy the ledger row being searched?
 
     A manga volume release carries no issue number -- "One-Punch Man v01 (2014)
-    (Digital)" -- so the issue-number arms can never accept it. The volume IS
-    the unit being acquired, so the release satisfies the row when the two
-    volume numbers agree. Compared numerically, since the release writes "v01"
-    and the ledger stores "1".
+    (Digital)" -- so the issue-number acceptance arms can never accept it. The
+    volume IS the unit being acquired, so the release satisfies the row when
+    the two volume numbers agree.
+
+    The comparison itself belongs to the ledger, which already owns what a
+    volume number means; this only names the acceptance question.
     """
-    if found_volume in (None, "") or wanted_number in (None, ""):
-        return False
-    found_digits = re.sub(r"[^0-9]", "", str(found_volume))
-    wanted_digits = re.sub(r"[^0-9]", "", str(wanted_number))
-    if not found_digits or not wanted_digits:
-        return False
-    return int(found_digits) == int(wanted_digits)
+    from comicarr.app.manga.ledger import volume_numbers_match
+
+    return volume_numbers_match(found_volume, wanted_number)
 
 
 class search_check(object):

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -892,7 +892,20 @@ class search_check(object):
             logger.fdebug("SCVersion: %s" % S_ComicVersion)
             logger.fdebug("ComicYear: %s" % ComicYear)
 
-            if all(
+            if manga_volume_pass and manga_volume_satisfies(fndcomicversion, findcomiciss):
+                # "vNN" means different things in the two formats. In a comic
+                # release it is which RUN of the series this is (Amazing
+                # Spider-Man v2), which is why the arms below compare it to the
+                # series' ComicVersion or year. In manga it is which BOOK --
+                # volume 30 of one continuous series -- so the only meaningful
+                # comparison is against the volume being searched for.
+                #
+                # Without this, a manga volume matches only when the series'
+                # ComicVersion happens to equal the volume number, i.e. volume 1
+                # of a v1 series, and every later volume is discarded with
+                # "Versions wrong" despite being the exact release requested.
+                logger.fdebug("[MANGA] volume %s matches the volume searched for" % fndcomicversion)
+            elif all(
                 [
                     annualize is True,
                     parsed_comic["issue_number"] is not None,

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -484,8 +484,25 @@ class search_check(object):
                     logger.fdebug("Invalid date found. Unable to continue - skipping result. Error returned: %s" % e)
                     _reject("invalid.pubdate_missing", cause=e)
 
-        if UseFuzzy == "1":
-            logger.fdebug("Year has been fuzzied for this series, ignoring store date comparison entirely.")
+        if UseFuzzy == "1" or manga_volume_pass:
+            if manga_volume_pass:
+                # The store-date comparison exists because a periodical's issue
+                # NUMBER recycles across runs -- #6 of a 2016 run and #6 of a
+                # 1998 one are both "6" -- so the street date is the tiebreak.
+                # A volume number does not recycle, and manga_volume_satisfies()
+                # below still has to match it, so here the date adds no
+                # disambiguation and only subtracts: digital manga is routinely
+                # posted BEFORE the street date ComicVine records (which for a
+                # manga volume is often weeks late), and the gate then throws
+                # away the one correct file. Observed: "One-Punch Man v06 (2015)
+                # (Digital) (BlackManta-Empire)", posted 2016-04-13, rejected
+                # against a store date of 2016-04-27.
+                logger.fdebug(
+                    "[MANGA] Volume pass - the volume number identifies the book,"
+                    " ignoring store date comparison entirely."
+                )
+            else:
+                logger.fdebug("Year has been fuzzied for this series, ignoring store date comparison entirely.")
             postdate_int = None
             issuedate_int = None
         else:

--- a/comicarr/search_filer.py
+++ b/comicarr/search_filer.py
@@ -779,7 +779,14 @@ class search_check(object):
                 logger.fdebug("[Vx] Version detected as %s" % parsed_comic["series_volume"])
                 vers4vol = parsed_comic["series_volume"]
                 fndcomicversion = parsed_comic["series_volume"]
-            elif parsed_comic["series_volume"][1:].isdigit() and len(parsed_comic["series_volume"]) < 4:
+            # Digits AFTER the v, matching the two arms above. Measuring the
+            # whole string here made `v100` 4 characters, so it failed `< 4`
+            # although its 3 digits are plainly a volume and not a year. It
+            # then matched no arm at all, left fndcomicversion None and lost
+            # the year bypass -- One Piece v100, labelled 2021 against a 1997
+            # series year, was rejected for it. Four digits after the v is
+            # still a year, and is still claimed by the [Vxxxx] arm above.
+            elif parsed_comic["series_volume"][1:].isdigit() and len(parsed_comic["series_volume"][1:]) < 4:
                 logger.fdebug("[Vxxx] Version detected as %s" % parsed_comic["series_volume"])
                 vers4vol = parsed_comic["series_volume"]
                 fndcomicversion = parsed_comic["series_volume"]

--- a/tests/unit/test_filechecker_volume_label.py
+++ b/tests/unit/test_filechecker_volume_label.py
@@ -1,0 +1,95 @@
+#  Copyright (C) 2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+"""A volume label belongs to the volume, not to the series title.
+
+The token walker truncates a parsed title at the volume position it found, but
+it does not always find the long form. `Series Vol.33` then kept the label in
+the title and matched no series at all, while `Series v33` -- the same release,
+named the short way -- parsed correctly.
+"""
+
+import pytest
+
+
+def _strip(series_name, volume_number):
+    from comicarr.filechecker import strip_trailing_volume_label
+
+    return strip_trailing_volume_label(series_name, volume_number)
+
+
+class TestStripTrailingVolumeLabel:
+    @pytest.mark.parametrize(
+        "series_name",
+        [
+            "One-Punch Man Vol 33",
+            "One-Punch Man Vol.33",
+            "One-Punch Man Vol33",
+            "One-Punch Man vol. 33",
+            "One-Punch Man Volume 33",
+            "One-Punch Man v33",
+            "One-Punch Man-v33",
+            "One-Punch Man v033",
+        ],
+    )
+    def test_every_spelling_of_the_label_is_removed(self, series_name):
+        assert _strip(series_name, "33") == "One-Punch Man"
+
+    def test_a_zero_padded_detected_volume_still_matches(self):
+        assert _strip("One-Punch Man v06", "06") == "One-Punch Man"
+
+    def test_a_label_for_a_different_volume_is_left_alone(self):
+        """The number must be the volume that was actually detected."""
+        assert _strip("Some Series Vol 2", "33") == "Some Series Vol 2"
+
+    def test_a_trailing_number_that_is_not_a_label_is_left_alone(self):
+        assert _strip("Fantastic Four 4", "4") == "Fantastic Four 4"
+        assert _strip("District 9", "9") == "District 9"
+
+    def test_a_label_that_is_not_at_the_end_is_left_alone(self):
+        assert _strip("Heavy Metal Volume 5 Special", "5") == "Heavy Metal Volume 5 Special"
+
+    def test_no_detected_volume_means_nothing_is_removed(self):
+        assert _strip("One-Punch Man Vol 33", None) == "One-Punch Man Vol 33"
+
+    def test_a_title_that_is_only_a_label_is_kept(self):
+        """Stripping it away would leave a name that matches every series."""
+        assert _strip("Vol 33", "33") == "Vol 33"
+
+    def test_a_non_numeric_detected_volume_is_ignored(self):
+        assert _strip("One-Punch Man Vol 33", "unknown") == "One-Punch Man Vol 33"
+
+    def test_an_empty_series_name_is_returned_unchanged(self):
+        assert _strip("", "33") == ""
+        assert _strip(None, "33") is None
+
+
+class TestVolumeLabelWiring:
+    """The helper is only useful if parseit consults it."""
+
+    @staticmethod
+    def _source():
+        import inspect
+
+        from comicarr.filechecker import FileChecker
+
+        return inspect.getsource(FileChecker.parseit)
+
+    def test_parseit_strips_the_label_from_the_series_title(self):
+        assert "strip_trailing_volume_label(series_name, detected_volume)" in self._source(), (
+            "parseit no longer removes an already-detected volume label from the "
+            "series title; a 'Series Vol.NN' release will match no series"
+        )
+
+    def test_the_manga_volume_regex_result_is_used_when_the_walker_missed_it(self):
+        src = self._source()
+        assert "detected_volume = manga_volume" in src, (
+            "the long-form label is only found by the manga volume regex, so that "
+            "is the value the strip has to be driven by"
+        )

--- a/tests/unit/test_filechecker_volume_label.py
+++ b/tests/unit/test_filechecker_volume_label.py
@@ -70,26 +70,66 @@ class TestStripTrailingVolumeLabel:
         assert _strip(None, "33") is None
 
 
-class TestVolumeLabelWiring:
-    """The helper is only useful if parseit consults it."""
+def _parse(filename):
+    """Parse one filename the way the scan does, and return the result."""
+    from unittest.mock import MagicMock
 
-    @staticmethod
-    def _source():
-        import inspect
+    import comicarr
+    from comicarr.filechecker import FileChecker
 
-        from comicarr.filechecker import FileChecker
+    if comicarr.LOG_LEVEL is None:
+        comicarr.LOG_LEVEL = 0
+    config = MagicMock()
+    config.IGNORE_SEARCH_WORDS = []
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(comicarr, "CONFIG", config)
+        return FileChecker(dir="/tmp", file=filename, justparse=True).listFiles()
 
-        return inspect.getsource(FileChecker.parseit)
 
-    def test_parseit_strips_the_label_from_the_series_title(self):
-        assert "strip_trailing_volume_label(series_name, detected_volume)" in self._source(), (
-            "parseit no longer removes an already-detected volume label from the "
-            "series title; a 'Series Vol.NN' release will match no series"
+class TestVolumeLabelParsing:
+    """What the parse actually produces, rather than what parseit's source says.
+
+    Asserting on the source text of parseit passed while the behaviour was
+    still broken: the call was present, but the regex behind it did not match
+    the long form, so `One-Punch Man Vol.33` parsed as the series
+    `'One-Punch Man Vol .33'` and matched nothing.
+    """
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "One-Punch Man Vol.33 (2014) (Digital).cbz",
+            "One-Punch Man Vol 33 (2014) (Digital).cbz",
+            "One-Punch Man Volume 33 (2014) (Digital).cbz",
+            "One-Punch Man v33 (2014) (Digital).cbz",
+            "One-Punch Man v033 (2014) (Digital).cbz",
+        ],
+    )
+    def test_the_label_never_reaches_the_series_title(self, filename):
+        from comicarr.app.manga.ledger import volume_numbers_match
+
+        parsed = _parse(filename)
+
+        assert parsed["series_name"] == "One-Punch Man", (
+            "the volume label survived into the series title, which matches no series"
         )
+        # Compared through the ledger rule rather than by string: the parse
+        # keeps whatever padding the filename used (`v033`), and normalising
+        # that is the ledger's job, not the parser's.
+        assert volume_numbers_match(parsed["series_volume"], "33"), "the volume was not read off as the volume"
 
-    def test_the_manga_volume_regex_result_is_used_when_the_walker_missed_it(self):
-        src = self._source()
-        assert "detected_volume = manga_volume" in src, (
-            "the long-form label is only found by the manga volume regex, so that "
-            "is the value the strip has to be driven by"
-        )
+    def test_a_short_and_a_long_form_of_one_release_parse_alike(self):
+        """The whole point: the same release named two ways is one release."""
+        short = _parse("One-Punch Man v06 (2014).cbz")
+        long_form = _parse("One-Punch Man Vol.06 (2014).cbz")
+
+        assert short["series_name"] == long_form["series_name"] == "One-Punch Man"
+        assert short["series_volume"] == long_form["series_volume"] == "v06"
+
+    def test_a_chapter_file_keeps_its_number_and_claims_no_volume(self):
+        """Control: the strip must not invent a volume for a numbered chapter."""
+        parsed = _parse("Chainsaw Man 165.cbz")
+
+        assert parsed["series_name"] == "Chainsaw Man"
+        assert parsed["issue_number"] == "165"
+        assert parsed["series_volume"] is None

--- a/tests/unit/test_manga_ledger.py
+++ b/tests/unit/test_manga_ledger.py
@@ -16,10 +16,12 @@ from comicarr.app.manga.ledger import (
     blended_progress,
     chapter_id,
     covers_to_volume_rows,
+    is_volume_target,
     last_released_volume,
     merge_refresh_row,
     normalize_volume_number,
     volume_id,
+    volume_numbers_match,
 )
 
 
@@ -115,6 +117,45 @@ def test_covered_fulfillment_is_not_have_and_is_not_searchable():
     )
     assert decision.eligible is False
     assert decision.reason == "covered"
+
+
+def test_is_volume_target_requires_a_volume_and_no_chapter():
+    """The single owner of the volume-vs-chapter rule, used by search and packs."""
+    assert is_volume_target(None, "1") is True
+    assert is_volume_target("", "1") is True
+    # A chapter that happens to know its volume is still a chapter -- this is
+    # what stops a volume pack claiming "chapter 7" as "volume 7".
+    assert is_volume_target("7", "1") is False
+    assert is_volume_target("7", None) is False
+    assert is_volume_target(None, None) is False
+
+
+def test_volume_numbers_match_across_the_spellings_in_use():
+    """A release writes "v01", the ledger stores "1", a pack yields int 1."""
+    assert volume_numbers_match("v01", "1") is True
+    assert volume_numbers_match("Vol. 3", 3) is True
+    assert volume_numbers_match("01", 1) is True
+    assert volume_numbers_match("v02", "1") is False
+
+
+def test_volume_numbers_match_never_matches_on_missing_or_unparsable_data():
+    """Returning False on junk keeps a parse failure from claiming a volume."""
+    assert volume_numbers_match(None, "1") is False
+    assert volume_numbers_match("v01", None) is False
+    assert volume_numbers_match("", "") is False
+    assert volume_numbers_match("none", "1") is False
+    # "v" is only stripped when it introduces a number, so this stays unequal.
+    assert volume_numbers_match("vTPB", "1") is False
+
+
+def test_volume_numbers_match_keeps_fractional_volumes_distinct():
+    """A fractional volume is its own volume, not a truncation of the integer.
+
+    normalize_volume_number() already models fractional volumes, so 1.5 must
+    not collapse into 1 the way an int(float(...)) comparison would.
+    """
+    assert volume_numbers_match("1.5", "1") is False
+    assert volume_numbers_match("1.5", "1.5") is True
 
 
 def test_normalize_volume_number_treats_none_sentinel_as_absent():

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -326,12 +326,26 @@ def test_folder_scan_numbers_a_watchlisted_manga_series_by_volume():
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
     }
     assert "volume_identifies_file" in called, "the folder scan no longer consults the volume predicate"
+    assert "numbered_by_volume" in called, "the scan's issue-number checks no longer consult the exemption"
 
-    watch_value_keys = {
+    watch_value_keys = [
         key.value
         for node in ast.walk(tree)
         if isinstance(node, ast.Dict)
         for key in node.keys
         if isinstance(key, ast.Constant) and isinstance(key.value, str)
-    }
-    assert "IsManga" in watch_value_keys, "WatchValues no longer carries the manga signal"
+    ]
+    assert watch_value_keys.count("IsManga") == watch_value_keys.count("IsArc"), (
+        "every WatchValues row must carry the manga signal, not just the watchlist one"
+    )
+
+
+def test_the_volume_numbered_type_list_has_a_single_owner():
+    """The scan tested a hardcoded TPB/GN/HC/One-Shot list in eight places.
+
+    Each copy silently omitted manga, so a manga volume file failed a different
+    check depending on which copy it reached. The list now lives in one tuple.
+    """
+    pp_path = Path(__file__).resolve().parents[2] / "comicarr" / "postprocessor.py"
+    source = pp_path.read_text(encoding="utf-8")
+    assert source.count('"TPB"') == 1, "the volume-numbered type list has been duplicated again"

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -18,7 +18,7 @@ from comicarr.app.manga.acquisition import search_plan_for_series
 from comicarr.app.manga.parse import parse_in_series_context, parse_kwargs_for_series
 from comicarr.app.manga.sync import arm_manga_sync_job, next_interval_run
 from comicarr.rsscheck import mangaCheck
-from comicarr.search import _build_manga_search_terms
+from comicarr.search import _build_manga_search_terms, manga_volume_search_terms
 
 _INIT_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "__init__.py"
 _SEARCH_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "search.py"
@@ -29,6 +29,12 @@ def _is_search_init(func):
     if isinstance(func, ast.Name):
         return func.id == "search_init"
     return isinstance(func, ast.Attribute) and func.attr == "search_init"
+
+
+def _is_search_init_or_nzb(func):
+    """Match a call to either search_init(...) or NZB_SEARCH(...)."""
+    name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+    return name in {"search_init", "NZB_SEARCH"}
 
 
 def _search_init_call_keywords(function_name, path):
@@ -208,6 +214,47 @@ def test_searchforissue_passes_manga_numbers_to_search_init():
         assert "content_type" in keywords
         assert "chapter_number" in keywords
         assert "volume_number" in keywords
+
+
+def test_manga_volume_search_terms_marks_only_volume_targets():
+    """Volume terms are searched bare; chapter terms keep the issue number."""
+    volume = manga_volume_search_terms("One-Punch Man", None, "1")
+    assert volume == {"One-Punch Man v01"}
+
+    # A chapter target must NOT be marked -- "<series> c001" is a real search
+    # whose issue-number handling is unchanged.
+    assert manga_volume_search_terms("One Piece", "1161", None) == set()
+    # Neither number available: nothing to search bare.
+    assert manga_volume_search_terms("One Piece", None, None) == set()
+
+
+def test_nzb_search_accepts_and_receives_manga_volume_terms():
+    """The bare-volume signal must reach NZB_SEARCH, or the suffix is appended.
+
+    NZB_SEARCH builds "<series>%20<issue>" for anything with an IssueNumber. A
+    manga volume target already carries its number in the name, so without this
+    parameter the query becomes "<series> v01 001" and matches nothing.
+    """
+    tree = ast.parse(_SEARCH_PATH.read_text(encoding="utf-8"))
+    signature = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "NZB_SEARCH"
+    )
+    assert "manga_volume_terms" in {arg.arg for arg in signature.args.kwonlyargs + signature.args.args}
+
+    handoff = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "search_the_matrix"
+    )
+    passed = {
+        kw.arg
+        for call in ast.walk(handoff)
+        if isinstance(call, ast.Call) and _is_search_init_or_nzb(call.func)
+        for kw in call.keywords
+    }
+    assert "manga_volume_terms" in passed
 
 
 def test_manga_rss_path_passes_manga_numbers_to_search_init():

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -246,6 +246,23 @@ def test_manga_volume_satisfies_defers_to_the_ledger_comparison():
     assert manga_volume_satisfies(None, "1") is False
 
 
+def test_manga_volume_arm_precedes_the_comic_version_comparison():
+    """The manga reading of "vNN" must win before the comic-version arms run.
+
+    Those arms compare the release's vNN to the series' ComicVersion/year,
+    which is the comic meaning (which RUN this is). For manga it is which BOOK,
+    so a later volume is otherwise discarded as "Versions wrong" -- only volume
+    1 of a v1 series would ever slip through.
+    """
+    filer_path = Path(__file__).resolve().parents[2] / "comicarr" / "search_filer.py"
+    source = filer_path.read_text(encoding="utf-8")
+    manga_arm = source.index("if manga_volume_pass and manga_volume_satisfies(")
+    versions_wrong = source.index('logger.fdebug("Versions wrong. Ignoring possible match.")')
+    assert manga_arm < versions_wrong
+    # It must be the opening `if`, not an `elif` reached after a comic arm.
+    assert "\n            if manga_volume_pass and manga_volume_satisfies(" in source
+
+
 def test_match_entry_prefers_the_manga_match_name():
     """search_filer must compare against manga_match_name when it is set."""
     filer_path = Path(__file__).resolve().parents[2] / "comicarr" / "search_filer.py"

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -19,6 +19,7 @@ from comicarr.app.manga.parse import parse_in_series_context, parse_kwargs_for_s
 from comicarr.app.manga.sync import arm_manga_sync_job, next_interval_run
 from comicarr.rsscheck import mangaCheck
 from comicarr.search import _build_manga_search_terms, manga_volume_search_terms
+from comicarr.app.manga.ledger import volume_numbers_match
 from comicarr.search_filer import manga_volume_satisfies
 
 _INIT_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "__init__.py"
@@ -233,21 +234,16 @@ def test_manga_volume_search_terms_maps_volume_targets_to_the_real_name():
     assert manga_volume_search_terms("One Piece", None, None) == {}
 
 
-def test_manga_volume_satisfies_compares_volumes_numerically():
-    """A volume release has no issue number, so acceptance turns on the volume.
+def test_manga_volume_satisfies_defers_to_the_ledger_comparison():
+    """Acceptance asks the ledger; it does not carry its own volume rules.
 
-    The release writes "v01" and the ledger stores "1"; both must be read as
-    the same volume or nothing is ever snatched.
+    The spellings and edge cases are covered once, in test_manga_ledger.py.
+    This only pins that acceptance uses that comparison -- a second copy here
+    is exactly how the two would drift apart.
     """
-    assert manga_volume_satisfies("v01", "1") is True
-    assert manga_volume_satisfies("v1", 1) is True
-    assert manga_volume_satisfies("v12", "12") is True
-    assert manga_volume_satisfies("v02", "1") is False
-    # Never accept on missing data -- that would snatch an arbitrary volume.
+    assert manga_volume_satisfies("v01", "1") is volume_numbers_match("v01", "1")
+    assert manga_volume_satisfies("v02", "1") is volume_numbers_match("v02", "1")
     assert manga_volume_satisfies(None, "1") is False
-    assert manga_volume_satisfies("v01", None) is False
-    assert manga_volume_satisfies("", "") is False
-    assert manga_volume_satisfies("vTPB", "1") is False
 
 
 def test_match_entry_prefers_the_manga_match_name():

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -19,6 +19,7 @@ from comicarr.app.manga.parse import parse_in_series_context, parse_kwargs_for_s
 from comicarr.app.manga.sync import arm_manga_sync_job, next_interval_run
 from comicarr.rsscheck import mangaCheck
 from comicarr.search import _build_manga_search_terms, manga_volume_search_terms
+from comicarr.search_filer import manga_volume_satisfies
 
 _INIT_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "__init__.py"
 _SEARCH_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "search.py"
@@ -230,6 +231,23 @@ def test_manga_volume_search_terms_maps_volume_targets_to_the_real_name():
     assert manga_volume_search_terms("One Piece", "1161", None) == {}
     # Neither number available: nothing to search bare.
     assert manga_volume_search_terms("One Piece", None, None) == {}
+
+
+def test_manga_volume_satisfies_compares_volumes_numerically():
+    """A volume release has no issue number, so acceptance turns on the volume.
+
+    The release writes "v01" and the ledger stores "1"; both must be read as
+    the same volume or nothing is ever snatched.
+    """
+    assert manga_volume_satisfies("v01", "1") is True
+    assert manga_volume_satisfies("v1", 1) is True
+    assert manga_volume_satisfies("v12", "12") is True
+    assert manga_volume_satisfies("v02", "1") is False
+    # Never accept on missing data -- that would snatch an arbitrary volume.
+    assert manga_volume_satisfies(None, "1") is False
+    assert manga_volume_satisfies("v01", None) is False
+    assert manga_volume_satisfies("", "") is False
+    assert manga_volume_satisfies("vTPB", "1") is False
 
 
 def test_match_entry_prefers_the_manga_match_name():

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -216,16 +216,30 @@ def test_searchforissue_passes_manga_numbers_to_search_init():
         assert "volume_number" in keywords
 
 
-def test_manga_volume_search_terms_marks_only_volume_targets():
-    """Volume terms are searched bare; chapter terms keep the issue number."""
+def test_manga_volume_search_terms_maps_volume_targets_to_the_real_name():
+    """Volume terms search bare AND match against the unsuffixed series name."""
     volume = manga_volume_search_terms("One-Punch Man", None, "1")
-    assert volume == {"One-Punch Man v01"}
+    assert volume == {"One-Punch Man v01": "One-Punch Man"}
+    # The mapped value is what the matcher compares against: the release
+    # "One-Punch Man v01 (2014) (Digital)" parses as "One-Punch Man", so
+    # comparing against the query term would fail every result.
+    assert volume["One-Punch Man v01"] == "One-Punch Man"
 
     # A chapter target must NOT be marked -- "<series> c001" is a real search
     # whose issue-number handling is unchanged.
-    assert manga_volume_search_terms("One Piece", "1161", None) == set()
+    assert manga_volume_search_terms("One Piece", "1161", None) == {}
     # Neither number available: nothing to search bare.
-    assert manga_volume_search_terms("One Piece", None, None) == set()
+    assert manga_volume_search_terms("One Piece", None, None) == {}
+
+
+def test_match_entry_prefers_the_manga_match_name():
+    """search_filer must compare against manga_match_name when it is set."""
+    filer_path = Path(__file__).resolve().parents[2] / "comicarr" / "search_filer.py"
+    source = filer_path.read_text(encoding="utf-8")
+    assert 'is_info.get("manga_match_name")' in source
+    # Both the parse and the match must use it, or the series comparison fails.
+    assert source.count("watchcomic=match_name") == 2
+    assert "watchcomic=ComicName" not in source
 
 
 def test_nzb_search_accepts_and_receives_manga_volume_terms():

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -309,3 +309,29 @@ def test_manga_rss_path_passes_manga_numbers_to_search_init():
     assert calls, "mangaCheck() no longer calls search_init()"
     for keywords in calls:
         assert {"content_type", "chapter_number", "volume_number"} <= keywords
+
+
+def test_folder_scan_numbers_a_watchlisted_manga_series_by_volume():
+    """The folder scan must ask whether a series is numbered by volume.
+
+    Deriving the number inline meant a manga series fell through to the issue
+    branch, so a volume file yielded no number and matched no issue.
+    """
+    pp_path = Path(__file__).resolve().parents[2] / "comicarr" / "postprocessor.py"
+    tree = ast.parse(pp_path.read_text(encoding="utf-8"))
+
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "volume_identifies_file" in called, "the folder scan no longer consults the volume predicate"
+
+    watch_value_keys = {
+        key.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Dict)
+        for key in node.keys
+        if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    }
+    assert "IsManga" in watch_value_keys, "WatchValues no longer carries the manga signal"

--- a/tests/unit/test_manga_live_paths.py
+++ b/tests/unit/test_manga_live_paths.py
@@ -21,6 +21,33 @@ from comicarr.rsscheck import mangaCheck
 from comicarr.search import _build_manga_search_terms
 
 _INIT_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "__init__.py"
+_SEARCH_PATH = Path(__file__).resolve().parents[2] / "comicarr" / "search.py"
+
+
+def _is_search_init(func):
+    """Match both `search_init(...)` and `search.search_init(...)` call forms."""
+    if isinstance(func, ast.Name):
+        return func.id == "search_init"
+    return isinstance(func, ast.Attribute) and func.attr == "search_init"
+
+
+def _search_init_call_keywords(function_name, path):
+    """Keyword names passed to every search_init() call inside `function_name`.
+
+    search_init() is reached only through provider configuration and a global
+    search lock, so the wiring is asserted from source instead -- the same
+    approach test_init_arms_manga_sync_after_pause() takes.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != function_name:
+            continue
+        return [
+            {kw.arg for kw in call.keywords}
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call) and _is_search_init(call.func)
+        ]
+    raise AssertionError("%s not found in %s" % (function_name, path.name))
 
 
 def test_next_interval_run_fires_now_when_overdue():
@@ -164,3 +191,29 @@ def test_parse_kwargs_auto_passes_folder_bare_numbers():
     assert kwargs["bare_number_mode"] == "auto"
     assert kwargs["bare_numbers"] == ["1", "2"]
     assert kwargs["volume_count"] == 72
+
+
+def test_searchforissue_passes_manga_numbers_to_search_init():
+    """searchforissue() must supply the numbers manga search terms are built from.
+
+    search_init() turns chapter_number/volume_number into "<series> v01" or
+    "<series> c001" via _build_manga_search_terms(). Omit them and that helper
+    receives (None, None) and returns [], so a manga Series is searched by
+    issue number and volume-named releases are never queried -- silently, with
+    no [SEARCH-MANGA] line to show for it.
+    """
+    calls = _search_init_call_keywords("searchforissue", _SEARCH_PATH)
+    assert calls, "searchforissue() no longer calls search_init()"
+    for keywords in calls:
+        assert "content_type" in keywords
+        assert "chapter_number" in keywords
+        assert "volume_number" in keywords
+
+
+def test_manga_rss_path_passes_manga_numbers_to_search_init():
+    """The RSS lane already honours the contract; it guards against regression."""
+    rss_path = Path(__file__).resolve().parents[2] / "comicarr" / "rsscheck.py"
+    calls = _search_init_call_keywords("mangaCheck", rss_path)
+    assert calls, "mangaCheck() no longer calls search_init()"
+    for keywords in calls:
+        assert {"content_type", "chapter_number", "volume_number"} <= keywords

--- a/tests/unit/test_manga_parser.py
+++ b/tests/unit/test_manga_parser.py
@@ -409,3 +409,73 @@ class TestResultStructure:
         # When absent, volume_number should be None
         result = parse_manga_filename("Bleach 100.cbz")
         assert result["volume_number"] is None
+
+
+class TestTrailingReleaseTags:
+    """Scene releases append metadata groups after the volume/chapter token.
+
+    Every pattern anchors its number at the end of the stem, so a name like
+    "Series v20 (2020) (Digital) (Group)" parsed as None and post-processing
+    could not match the file to any ledger row.
+    """
+
+    def test_volume_with_trailing_tags(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("One-Punch Man v20 (2020) (Digital) (LuCaZ).cbz")
+        assert result is not None
+        assert result["series_name"] == "One-Punch Man"
+        assert result["volume_number"] == 20
+        assert result["chapter_number"] is None
+
+    def test_volume_with_many_trailing_tags(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("One-Punch Man v16 (2019) (F) (digital) (aKraa).cbz")
+        assert result is not None
+        assert result["series_name"] == "One-Punch Man"
+        assert result["volume_number"] == 16
+
+    def test_trailing_bracket_group_is_stripped(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Bleach v7 [Digital] [Group].cbz")
+        assert result is not None
+        assert result["series_name"] == "Bleach"
+        assert result["volume_number"] == 7
+
+    def test_chapter_with_trailing_tags(self):
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("Chainsaw Man c181 (2023) (Digital).cbz")
+        assert result is not None
+        assert result["series_name"] == "Chainsaw Man"
+        assert result["chapter_number"] == 181.0
+
+    def test_chapter_number_helper_also_sees_tagged_names(self):
+        """parse_manga_chapter_number shares the pattern loop and must agree."""
+        from comicarr.manga_parser import parse_manga_chapter_number
+
+        assert parse_manga_chapter_number("Chainsaw Man c181 (2023) (Digital).cbz") == 181.0
+
+    def test_full_stem_match_wins_over_stripping(self):
+        """A name that already parses keeps its trailing (vNN)/[quality] captures."""
+        from comicarr.manga_parser import parse_manga_filename
+
+        result = parse_manga_filename("[Group] Series - c001 (v03) [HQ].cbz")
+        assert result is not None
+        assert result["volume_number"] == 3
+        assert result["quality"] == "HQ"
+        assert result["group"] == "Group"
+
+    def test_tags_without_a_number_stay_unparseable(self):
+        """Stripping must not invent a match where there is no volume/chapter."""
+        from comicarr.manga_parser import parse_manga_filename
+
+        assert parse_manga_filename("One-Punch Man (2014) (Digital).cbz") is None
+
+    def test_strip_trailing_tags_leaves_untagged_stems_alone(self):
+        from comicarr.manga_parser import strip_trailing_tags
+
+        assert strip_trailing_tags("One-Punch Man v20") == "One-Punch Man v20"
+        assert strip_trailing_tags("One-Punch Man v20 (2020) (LuCaZ)") == "One-Punch Man v20"

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -695,12 +695,56 @@ class TestVolumeIdentifiesFile:
     the series and selects none of them.
     """
 
-    def test_manga_series_is_identified_by_volume(self):
-        assert volume_identifies_file({"Type": "Digital", "Total": 33, "IsManga": True}) is True
+    def test_manga_volume_file_is_identified_by_volume(self):
+        assert (
+            volume_identifies_file(
+                {"Type": "Digital", "Total": 33, "IsManga": True},
+                {"manga_volume": "33", "manga_chapter": None},
+            )
+            is True
+        )
 
     def test_manga_arm_does_not_depend_on_the_series_length(self):
         """A single-volume manga is still numbered by volume."""
-        assert volume_identifies_file({"Type": "Digital", "Total": 1, "IsManga": True}) is True
+        assert (
+            volume_identifies_file(
+                {"Type": "Digital", "Total": 1, "IsManga": True},
+                {"manga_volume": "1", "manga_chapter": None},
+            )
+            is True
+        )
+
+    def test_manga_chapter_file_is_not_identified_by_volume(self):
+        """A manga series holds both kinds; only the file says which is in hand.
+
+        `Chainsaw Man c181` went down the volume branch, where series_volume's
+        `v1` default was looked up as an issue number and marked chapter 1
+        Downloaded. `Series v33` landed on chapter 33 the same way.
+        """
+        assert (
+            volume_identifies_file(
+                {"Type": "Digital", "Total": 200, "IsManga": True},
+                {"manga_volume": None, "manga_chapter": "181"},
+            )
+            is False
+        )
+
+    def test_manga_file_carrying_both_is_a_chapter(self):
+        """A MangaDex chapter file also names its containing volume."""
+        assert (
+            volume_identifies_file(
+                {"Type": "Digital", "Total": 200, "IsManga": True},
+                {"manga_volume": "18", "manga_chapter": "181"},
+            )
+            is False
+        )
+
+    def test_manga_file_with_no_tokens_claims_no_volume(self):
+        """Fails closed -- never falls back to the defaulted series_volume."""
+        assert (
+            volume_identifies_file({"Type": "Digital", "Total": 33, "IsManga": True}, {"series_volume": "v1"}) is False
+        )
+        assert volume_identifies_file({"Type": "Digital", "Total": 33, "IsManga": True}, None) is False
 
     def test_comic_series_of_the_same_type_is_still_identified_by_issue(self):
         assert volume_identifies_file({"Type": "Digital", "Total": 33, "IsManga": False}) is False
@@ -769,3 +813,26 @@ class TestVolumeMatchSettlesYear:
     def test_collected_editions_are_not_covered(self):
         """A TPB year mismatch can still mean the wrong edition."""
         assert volume_match_settles_year({"Type": "TPB", "Total": 5}, True) is False
+
+    @pytest.mark.parametrize("volume", ["1", "6", "20", "100"])
+    def test_every_volume_of_a_mangadex_series_settles_its_year(self, volume):
+        """Not just v01.
+
+        The scan used to feed this `lonevol`, which asks whether the
+        filename's volume equals the watchlist ComicVersion. MangaDex leaves
+        ComicVersion unset, so it reads as 1 -- true for v01 and false for
+        every later volume. One-Punch Man v06 dated 2014 against a 2015 ledger
+        year was still rejected. It is now fed the file-level volume match,
+        which does not depend on ComicVersion at all.
+        """
+        watch_values = {"IsManga": True, "Type": "Digital", "Total": 200, "ComicVersion": None}
+        parsed = {"manga_volume": volume, "manga_chapter": None}
+
+        assert volume_match_settles_year(watch_values, volume_identifies_file(watch_values, parsed)) is True
+
+    def test_a_chapter_file_does_not_settle_its_year(self):
+        """The widening must stop at volumes: a chapter still answers to its year."""
+        watch_values = {"IsManga": True, "Type": "Digital", "Total": 200, "ComicVersion": None}
+        parsed = {"manga_volume": None, "manga_chapter": "181"}
+
+        assert volume_match_settles_year(watch_values, volume_identifies_file(watch_values, parsed)) is False

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -35,7 +35,12 @@ from tests.conftest import placement_result
 if comicarr.LOG_LEVEL is None:
     comicarr.LOG_LEVEL = 0
 
-from comicarr.postprocessor import PostProcessor, log_scan_summary, summarize_scan_matches
+from comicarr.postprocessor import (
+    PostProcessor,
+    log_scan_summary,
+    summarize_scan_matches,
+    volume_identifies_file,
+)
 
 
 def test_scan_summary_emits_one_bounded_line_without_candidate_chatter():
@@ -678,3 +683,35 @@ class TestProcessMangaChapterMatch:
 
         result = mock_queue.put.call_args[0][0]
         assert "0 files matched" in result[0]["self.log"]
+
+
+class TestVolumeIdentifiesFile:
+    """Which series number their scanned files by volume rather than issue.
+
+    A manga volume file carries no issue number, so without a volume arm the
+    folder scan derives no number, compares the file against every issue in
+    the series and selects none of them.
+    """
+
+    def test_manga_series_is_identified_by_volume(self):
+        assert volume_identifies_file({"Type": "Digital", "Total": 33, "IsManga": True}) is True
+
+    def test_manga_arm_does_not_depend_on_the_series_length(self):
+        """A single-volume manga is still numbered by volume."""
+        assert volume_identifies_file({"Type": "Digital", "Total": 1, "IsManga": True}) is True
+
+    def test_comic_series_of_the_same_type_is_still_identified_by_issue(self):
+        assert volume_identifies_file({"Type": "Digital", "Total": 33, "IsManga": False}) is False
+
+    @pytest.mark.parametrize("series_type", ["TPB", "HC", "GN"])
+    def test_collected_editions_keep_their_volume_numbering(self, series_type):
+        assert volume_identifies_file({"Type": series_type, "Total": 5, "IsManga": False}) is True
+        assert volume_identifies_file({"Type": series_type, "Total": 1, "IsManga": False}) is False
+
+    def test_one_shots_keep_their_volume_numbering(self):
+        assert volume_identifies_file({"Type": "One-Shot", "Total": 1, "IsManga": False}) is True
+        assert volume_identifies_file({"Type": "One-Shot", "Total": 2, "IsManga": False}) is False
+
+    def test_a_row_without_the_manga_flag_is_read_as_a_comic(self):
+        """One-off rows build WatchValues without IsManga and must not raise."""
+        assert volume_identifies_file({"Type": "Digital", "Total": 0}) is False

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -38,8 +38,10 @@ if comicarr.LOG_LEVEL is None:
 from comicarr.postprocessor import (
     PostProcessor,
     log_scan_summary,
+    numbered_by_volume,
     summarize_scan_matches,
     volume_identifies_file,
+    volume_match_settles_year,
 )
 
 
@@ -715,3 +717,55 @@ class TestVolumeIdentifiesFile:
     def test_a_row_without_the_manga_flag_is_read_as_a_comic(self):
         """One-off rows build WatchValues without IsManga and must not raise."""
         assert volume_identifies_file({"Type": "Digital", "Total": 0}) is False
+
+
+class TestNumberedByVolume:
+    """Which series are exempt from the checks that assume an issue number.
+
+    The weekly-pull cross-check, the "no issue number" rejection and the
+    default-to-1 fallback all skip series whose files are named by volume.
+    Manga must be exempt for the same reason collected editions are.
+    """
+
+    def test_manga_series_is_exempt(self):
+        assert numbered_by_volume({"Type": "Digital", "Total": 33, "IsManga": True}) is True
+
+    def test_comic_series_of_the_same_type_is_not_exempt(self):
+        assert numbered_by_volume({"Type": "Digital", "Total": 33, "IsManga": False}) is False
+
+    @pytest.mark.parametrize("series_type", ["TPB", "HC", "GN", "One-Shot"])
+    def test_collected_editions_stay_exempt_regardless_of_run_length(self, series_type):
+        """Exemption is a property of the type alone, unlike locating a file."""
+        assert numbered_by_volume({"Type": series_type, "Total": 1, "IsManga": False}) is True
+        assert numbered_by_volume({"Type": series_type, "Total": 9, "IsManga": False}) is True
+
+    def test_a_single_entry_tpb_is_exempt_but_is_not_located_by_volume(self):
+        """The two predicates deliberately disagree here; that split is the point."""
+        watch_values = {"Type": "TPB", "Total": 1, "IsManga": False}
+        assert numbered_by_volume(watch_values) is True
+        assert volume_identifies_file(watch_values) is False
+
+    def test_a_row_without_the_manga_flag_is_read_as_a_comic(self):
+        assert numbered_by_volume({"Type": "Digital", "Total": 0}) is False
+
+
+class TestVolumeMatchSettlesYear:
+    """A matched manga volume makes the filename's year irrelevant.
+
+    Providers date the licensed English printing while releases carry the
+    volume's original year, so the two routinely disagree by a year.
+    """
+
+    def test_matched_manga_volume_overrides_a_year_mismatch(self):
+        assert volume_match_settles_year({"IsManga": True}, True) is True
+
+    def test_an_unmatched_volume_never_overrides_the_year(self):
+        """Without a volume match there is no identity to trust instead."""
+        assert volume_match_settles_year({"IsManga": True}, False) is False
+
+    def test_a_comic_year_mismatch_still_decides(self):
+        assert volume_match_settles_year({"IsManga": False}, True) is False
+
+    def test_collected_editions_are_not_covered(self):
+        """A TPB year mismatch can still mean the wrong edition."""
+        assert volume_match_settles_year({"Type": "TPB", "Total": 5}, True) is False

--- a/tests/unit/test_search_filer.py
+++ b/tests/unit/test_search_filer.py
@@ -314,6 +314,47 @@ def test_datetime_rejection_does_not_fall_through_to_disagreeing_integer_compari
     assert _reason(evaluation) == "rejected.before_reference_date"
 
 
+class TestStoreDateGateOnAMangaVolumePass:
+    """A volume number identifies the book; a street date cannot improve on it.
+
+    The store-date comparison is a periodical tiebreak: an issue NUMBER recycles
+    across runs, so the street date says which run a result belongs to. A volume
+    number does not recycle, and digital manga is routinely posted before the
+    street date ComicVine records -- so on a volume pass the gate only discards
+    correct files.
+    """
+
+    _EARLY = dict(
+        UseFuzzy="0",
+        StoreDate="2024-02-01",
+        IssueDate="2024-02-01",
+        digitaldate="2024-02-01",
+    )
+
+    @staticmethod
+    def _evaluate(**info):
+        return search_filer.search_check().evaluate_entry(
+            _entry(pubdate="Wed, 10 Jan 2024 12:00:00 +0000"),
+            _info(**info),
+        )
+
+    def test_a_volume_pass_survives_a_pubdate_before_the_store_date(self):
+        """The real rejection: OPM v06 posted 2016-04-13, store date 2016-04-27."""
+        evaluation = self._evaluate(manga_match_name="Example Series", **self._EARLY)
+        assert _reason(evaluation) != "rejected.before_reference_date"
+
+    def test_a_periodical_with_the_same_dates_is_STILL_rejected(self):
+        """Control: this must stay a rejection, or the gate is disabled, not scoped."""
+        evaluation = self._evaluate(**self._EARLY)
+        assert _reason(evaluation) == "rejected.before_reference_date"
+
+    def test_the_exemption_needs_the_volume_pass_not_merely_a_manga_series(self):
+        """manga_match_name is set only by the volume pass; a chapter pass keeps
+        normal issue-number handling and so keeps the date tiebreak."""
+        evaluation = self._evaluate(manga_match_name=None, booktype="Manga", **self._EARLY)
+        assert _reason(evaluation) == "rejected.before_reference_date"
+
+
 @pytest.mark.parametrize(
     ("parsed", "matched", "match_error", "info", "reason_code"),
     [

--- a/tests/unit/test_search_filer.py
+++ b/tests/unit/test_search_filer.py
@@ -533,9 +533,7 @@ def test_numberless_series_pack_is_not_detected_for_print_series(monkeypatch):
 
 
 def test_non_ddl_issue_range_pack_is_accepted_for_print_series(monkeypatch):
-    monkeypatch.setattr(
-        search_filer.helpers, "issue_find_ids", lambda *_args, **_kwargs: {"valid": True, "issues": []}
-    )
+    monkeypatch.setattr(search_filer.helpers, "issue_find_ids", lambda *_args, **_kwargs: {"valid": True, "issues": []})
     info = _info(allow_packs=True)
     entry = _entry(title="Example Series #1-10 (2024)")
 
@@ -670,3 +668,58 @@ def test_first_result_preserves_preference_and_last_fallback(monkeypatch):
     process.reset_mock(side_effect=True)
     process.side_effect = candidates[:2]
     assert checker.check_for_first_result([1, 2], {}, prefer_pack=False)["name"] == "last-pack"
+
+
+class TestMangaVolumeAcceptanceArm:
+    """The volume-number acceptance arm, driven through evaluate_entry.
+
+    The store-date tests above cannot reach it: they stub justthedigits as 1,
+    so they accept via `intIss == comintIss` and the arm never runs. A volume
+    release carries no issue digits at all, which is precisely the shape that
+    reaches this arm.
+    """
+
+    @staticmethod
+    def _evaluate(monkeypatch, *, volume, wanted, series_volume=None):
+        _install_parser(
+            monkeypatch,
+            parsed=_parsed(series_volume=series_volume or "v%s" % volume, issue_number=None, booktype="TPB"),
+            # No issue digits: a volume release has none, so pc_in is None,
+            # and the volume itself is what the arm compares against.
+            matched=_matched(
+                justthedigits=None,
+                booktype="TPB",
+                volume=series_volume or "v%s" % volume,
+                series_volume=series_volume or "v%s" % volume,
+            ),
+        )
+        return search_filer.search_check().evaluate_entry(
+            _entry(title="Example Series v%s (2024)" % volume),
+            _info(
+                manga_match_name="Example Series",
+                findcomiciss=wanted,
+                IssueNumber=wanted,
+                cmloopit=3,
+                UseFuzzy="0",
+                booktype="TPB",
+            ),
+        )
+
+    def test_the_wanted_volume_is_accepted(self, monkeypatch):
+        evaluation = self._evaluate(monkeypatch, volume="06", wanted="6")
+        assert _reason(evaluation) is None or "rejected" not in str(_reason(evaluation))
+
+    def test_a_different_volume_is_rejected(self, monkeypatch):
+        """The arm must discriminate, not wave every volume through."""
+        evaluation = self._evaluate(monkeypatch, volume="07", wanted="6")
+        assert "rejected" in str(_reason(evaluation))
+
+    def test_a_three_digit_volume_is_still_read_as_a_volume(self, monkeypatch):
+        """v100 is 3 digits after the v, so it is a volume and not a year.
+
+        The version arm measured the whole `v100` string against `< 4`, so it
+        matched no arm, left fndcomicversion None and lost the year bypass --
+        One Piece v100 labelled 2021 against a 1997 series year was rejected.
+        """
+        evaluation = self._evaluate(monkeypatch, volume="100", wanted="100")
+        assert _reason(evaluation) is None or "rejected" not in str(_reason(evaluation))


### PR DESCRIPTION
Fixes #820.

> **Builds on #815 and #816.** This branch carries both of those PRs' commits as prerequisites — the date gate lives in code #815 touches, and the parser change lives in code #816 touches. Only the **last two** commits are new here; once both merge, this diff reduces to those two.

## Change — two commits

### 1. `fix(manga): do not store-date gate a volume pass`

Take the same exit `UseFuzzy` already takes, **scoped to the volume pass** — `manga_match_name` is set only there, so a chapter pass keeps normal issue-number handling and keeps the tiebreak.

The reasoning is that the store date is a *periodical* disambiguator: issue numbers recycle across runs, so the street date says which run a result belongs to. Volume numbers do not recycle, and `manga_volume_satisfies()` already has to match the volume, so on a volume pass the date adds nothing — while actively rejecting correct releases, because digital manga is routinely posted before the street date and ComicVine store dates for manga volumes run weeks late.

Tests cover the fix and, **as controls**, that a periodical with identical dates and a manga series that is *not* on a volume pass both stay rejected. The gate is scoped, not disabled.

### 2. `fix(parse): a volume label is the volume, not part of the series title`

`strip_trailing_volume_label()` removes a trailing label **whose number is the volume that was actually detected**.

Requiring the numbers to agree is what keeps it safe. All of these are left alone:

- a series legitimately titled with a trailing number (`District 9`)
- a label naming a *different* volume than the one detected
- a label that is not at the end
- a title consisting of nothing but a label — stripping that would leave a name matching every series

## Test

| | |
|---|---|
| Full suite on this branch | **2889 passed, 8 failed, 1 skipped** |
| Clean `main` baseline | **2827 passed, 8 failed, 1 skipped** |
| New tests, source reverted | **19 failed, 41 passed** |

The 8 failures are identical on both sides: `tests/integration/test_schema_migration_dialects.py`, which needs a database URL not available in this environment.

The reverted run gives genuine assertion failures; the 41 that still pass include the scoping controls above, which assert *preserved* rejection behaviour and therefore correctly pass on both sides.

## Reading order

If you are reviewing the manga work as a set, this reads after #815 and #816 — those make a volume release findable and importable; this stops two later gates from discarding one that was found correctly.
