### PR TITLE
Forward opened issues to Comicarr webhook

### DIFF
--- a/.github/workflows/forward-issues-webhook.yml
+++ b/.github/workflows/forward-issues-webhook.yml
@@ -1,0 +1,40 @@
+name: Forward issues to Comicarr
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  forward:
+    name: POST opened issue to Comicarr webhook
+    if: github.repository == 'frankieramirez/comicarr'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Forward issue payload
+        uses: actions/github-script@v7
+        env:
+          COMICARR_WEBHOOK_URL: ${{ secrets.COMICARR_WEBHOOK_URL }}
+          COMICARR_WEBHOOK_KEY: ${{ secrets.COMICARR_WEBHOOK_KEY }}
+        with:
+          script: |
+            const url = process.env.COMICARR_WEBHOOK_URL
+            const key = process.env.COMICARR_WEBHOOK_KEY
+            if (!url || !key) {
+              throw new Error('Missing COMICARR_WEBHOOK_URL or COMICARR_WEBHOOK_KEY repo secret')
+            }
+            const res = await fetch(url, {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${key}`,
+                'Content-Type': 'application/json',
+                'X-GitHub-Event': 'issues',
+                'X-GitHub-Delivery': context.payload.issue?.node_id || context.runId.toString(),
+              },
+              body: JSON.stringify(context.payload),
+            })
+            if (!res.ok) {
+              throw new Error(`Webhook responded ${res.status}`)
+            }


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that POSTs newly opened issues to the Comicarr bot webhook with `Authorization: Bearer`.
- Native GitHub webhooks cannot send that header (they 401). This Action is the bridge so scoped bugs can auto-PR and questions stay questions.

## Secrets
Already on the repo:
- `COMICARR_WEBHOOK_URL`
- `COMICARR_WEBHOOK_KEY`

## Test plan
- [ ] Merge this PR
- [ ] Open a test issue (or wait for a real one)
- [ ] Confirm the Action run is green
- [ ] Confirm Comicarr wakes on opened issues (questions stay questions; scoped bugs get a cloud agent PR)
- [ ] Optional: remove the native GitHub webhook on Settings → Webhooks if it is still 401ing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic forwarding of newly opened issue details to a configured Comicarr webhook.
  * Added validation and error reporting when webhook configuration is missing or the request fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->