### PR TITLE
Fix cloud agent environment.json ports schema

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -12,5 +12,14 @@
       "command": "npm --prefix frontend run dev:vite"
     }
   ],
-  "ports": [8090, 5173]
+  "ports": [
+    {
+      "name": "backend",
+      "port": 8090
+    },
+    {
+      "name": "frontend",
+      "port": 5173
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Cloud agent launches fail because `.cursor/environment.json` has `"ports": [8090, 5173]` (bare numbers).
- The current schema expects objects: `{ "name": "...", "port": 8090 }`.
- Backend stays 8090, frontend/vite stays 5173.

This unblocks auto-PRs on scoped bugs (including #826).

## Test plan
- [ ] Merge
- [ ] Launch a cloud agent on comicarr and confirm it starts
- [ ] Retry the #826 Location fix agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development environment configuration by labeling the backend and frontend ports for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->