### PR TITLE
fix: Repoint manga issue Location after metatag converts .cbr to .cbz

### DIFF
--- a/.changeset/manga-metatag-cbr-location.md
+++ b/.changeset/manga-metatag-cbr-location.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Metatagging a manga `.cbr` now updates the issue's stored file path to the new `.cbz`. ComicTagger cannot write into a RAR archive, so tagging converts the file and deletes the original; the library row used to keep pointing at the deleted `.cbr` even though Have and Status still looked correct. Re-tagging and anything else that opens the file through that path now finds the archive that is actually on disk.

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -12,5 +12,14 @@
       "command": "npm --prefix frontend run dev:vite"
     }
   ],
-  "ports": [8090, 5173]
+  "ports": [
+    {
+      "name": "backend",
+      "port": 8090
+    },
+    {
+      "name": "frontend",
+      "port": 5173
+    }
+  ]
 }

--- a/comicarr/app/manga/rescan.py
+++ b/comicarr/app/manga/rescan.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from comicarr import db, logger
 from comicarr.app.manga.parse import parse_in_series_context
 from comicarr.scanutil import COMIC_EXTENSIONS
+from comicarr.tables import comics as t_comics
 from comicarr.tables import issues as t_issues
 
 MANGA_EXTENSIONS = COMIC_EXTENSIONS
@@ -56,16 +57,64 @@ def parse_folder_files(series, filenames, *, issues=None, series_name=None):
     ]
 
 
-def mark_parsed_files_downloaded(comic_id, files):
+def _same_stem_different_ext(stored_name, filename):
+    stored_stem, stored_ext = os.path.splitext(stored_name)
+    file_stem, file_ext = os.path.splitext(filename)
+    if not stored_stem or not stored_ext or not file_ext:
+        return False
+    return stored_stem == file_stem and stored_ext.lower() != file_ext.lower()
+
+
+def _is_directly_in_directory(filepath, directory):
+    if not filepath or not directory:
+        return False
+    parent = os.path.normpath(os.path.dirname(os.path.abspath(filepath)))
+    root = os.path.normpath(os.path.abspath(directory))
+    return parent == root
+
+
+def _series_directory(comic_id, directory=None):
+    if directory:
+        return directory
+    row = db.select_one(select(t_comics.c.ComicLocation).where(t_comics.c.ComicID == comic_id))
+    if not row:
+        return None
+    return row.get("ComicLocation")
+
+
+def _can_repoint_downloaded_location(directory, stored, filepath):
+    """True when a Downloaded row should follow ``filepath``.
+
+    Same-stem extension change at the series root (``.cbr`` -> ``.cbz``),
+    or the stored basename is gone there and the candidate exists there.
+    Nested leftovers and different-stem matches stay put.
+    """
+    filename = os.path.basename(filepath)
+    stored_name = os.path.basename(stored) if stored else ""
+    if stored_name == filename:
+        return False
+    if not _is_directly_in_directory(filepath, directory):
+        return False
+    if _same_stem_different_ext(stored_name, filename):
+        return True
+    stored_path = os.path.join(directory, stored_name) if directory and stored_name else None
+    stored_missing = not stored_path or not os.path.isfile(stored_path)
+    candidate_path = os.path.join(directory, filename) if directory else None
+    return stored_missing and bool(candidate_path) and os.path.isfile(candidate_path)
+
+
+def mark_parsed_files_downloaded(comic_id, files, *, directory=None):
     """Mark matching chapter/volume rows Downloaded. Returns the mark count.
 
-    Already-Downloaded rows keep their Status. If the file found on disk
-    differs from the stored Location (e.g. metatag exported ``.cbr`` to
-    ``.cbz``), Location is updated to the current filename.
+    Already-Downloaded rows keep their Status. Location is rewritten only
+    for a same-stem extension change at the series root (e.g. metatag
+    exported ``.cbr`` to ``.cbz``), or when the stored basename is gone
+    there and the candidate exists there.
     """
     all_issues = db.select_all(select(t_issues).where(t_issues.c.ComicID == comic_id))
     if not all_issues:
         return 0
+    series_dir = _series_directory(comic_id, directory)
 
     chapter_lookup = {}
     volume_lookup = {}
@@ -98,7 +147,9 @@ def mark_parsed_files_downloaded(comic_id, files):
             matched = volume_lookup.get(int(parsed["volume_number"]), [])
         for issue in matched:
             if issue.get("Status") == "Downloaded":
-                if issue.get("Location") != filename:
+                if issue.get("Location") != filename and _can_repoint_downloaded_location(
+                    series_dir, issue.get("Location"), filepath
+                ):
                     db.upsert(
                         "issues",
                         {"Location": filename},
@@ -133,4 +184,4 @@ def rescan_manga_series(series, *, directory=None):
         return 0
     issue_rows = db.select_all(select(t_issues).where(t_issues.c.ComicID == comic_id))
     parsed = parse_folder_files(series, paths, issues=issue_rows)
-    return mark_parsed_files_downloaded(comic_id, parsed)
+    return mark_parsed_files_downloaded(comic_id, parsed, directory=folder)

--- a/comicarr/app/manga/rescan.py
+++ b/comicarr/app/manga/rescan.py
@@ -57,7 +57,12 @@ def parse_folder_files(series, filenames, *, issues=None, series_name=None):
 
 
 def mark_parsed_files_downloaded(comic_id, files):
-    """Mark matching chapter/volume rows Downloaded. Returns the mark count."""
+    """Mark matching chapter/volume rows Downloaded. Returns the mark count.
+
+    Already-Downloaded rows keep their Status. If the file found on disk
+    differs from the stored Location (e.g. metatag exported ``.cbr`` to
+    ``.cbz``), Location is updated to the current filename.
+    """
     all_issues = db.select_all(select(t_issues).where(t_issues.c.ComicID == comic_id))
     if not all_issues:
         return 0
@@ -93,6 +98,14 @@ def mark_parsed_files_downloaded(comic_id, files):
             matched = volume_lookup.get(int(parsed["volume_number"]), [])
         for issue in matched:
             if issue.get("Status") == "Downloaded":
+                if issue.get("Location") != filename:
+                    db.upsert(
+                        "issues",
+                        {"Location": filename},
+                        {"IssueID": issue["IssueID"]},
+                    )
+                    issue["Location"] = filename
+                    logger.fdebug("[MANGA-RESCAN] Updated location: %s -> %s" % (filename, issue["IssueID"]))
                 continue
             db.upsert(
                 "issues",
@@ -100,6 +113,7 @@ def mark_parsed_files_downloaded(comic_id, files):
                 {"IssueID": issue["IssueID"]},
             )
             issue["Status"] = "Downloaded"
+            issue["Location"] = filename
             count += 1
             logger.fdebug("[MANGA-RESCAN] Marked as downloaded: %s -> %s" % (filename, issue["IssueID"]))
 

--- a/tests/unit/test_manga_force_rescan.py
+++ b/tests/unit/test_manga_force_rescan.py
@@ -186,3 +186,68 @@ def test_mark_parsed_files_downloaded_skips_matching_downloaded_location(monkeyp
     assert row["Status"] == "Downloaded"
     assert row["Location"] == "Naruto 100.cbz"
     assert comic["Have"] == 1
+
+
+def test_mark_parsed_files_downloaded_keeps_chapter_location_when_volume_pack_matches(monkeypatch, tmp_path):
+    (tmp_path / "Naruto c100.cbz").write_bytes(b"chapter")
+    (tmp_path / "Naruto v12.cbz").write_bytes(b"volume")
+    engine = create_engine("sqlite://")
+    metadata.create_all(engine)
+    _seed_manga(
+        engine,
+        tmp_path,
+        status="Downloaded",
+        location="Naruto c100.cbz",
+        have=1,
+    )
+    monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+
+    count = mark_parsed_files_downloaded(
+        "md-naruto",
+        [
+            (str(tmp_path / "Naruto c100.cbz"), {"chapter_number": 100, "volume_number": None}),
+            (str(tmp_path / "Naruto v12.cbz"), {"chapter_number": None, "volume_number": 12}),
+        ],
+    )
+
+    assert count == 0
+    with engine.connect() as conn:
+        row = conn.execute(select(issues).where(issues.c.IssueID == "md-naruto-ch100")).mappings().one()
+        comic = conn.execute(select(comics).where(comics.c.ComicID == "md-naruto")).mappings().one()
+    assert row["Status"] == "Downloaded"
+    assert row["Location"] == "Naruto c100.cbz"
+    assert comic["Have"] == 1
+
+
+def test_force_rescan_ignores_nested_leftover_cbr_when_root_is_cbz(monkeypatch, tmp_path):
+    (tmp_path / "Naruto 12.cbz").write_bytes(b"cbz")
+    leftover = tmp_path / "old"
+    leftover.mkdir()
+    (leftover / "Naruto 12.cbr").write_bytes(b"cbr")
+    engine = create_engine("sqlite://")
+    metadata.create_all(engine)
+    _seed_manga(
+        engine,
+        tmp_path,
+        bare_mode="volumes",
+        status="Downloaded",
+        location="Naruto 12.cbr",
+        have=1,
+    )
+
+    monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+    monkeypatch.setattr(comicarr, "CONFIG", _config(), raising=False)
+    monkeypatch.setattr(
+        updater.filechecker,
+        "FileChecker",
+        MagicMock(side_effect=AssertionError("manga forceRescan must not use FileChecker")),
+    )
+
+    updater.forceRescan("md-naruto")
+
+    with engine.connect() as conn:
+        row = conn.execute(select(issues).where(issues.c.IssueID == "md-naruto-ch100")).mappings().one()
+        comic = conn.execute(select(comics).where(comics.c.ComicID == "md-naruto")).mappings().one()
+    assert row["Status"] == "Downloaded"
+    assert row["Location"] == "Naruto 12.cbz"
+    assert comic["Have"] == 1

--- a/tests/unit/test_manga_force_rescan.py
+++ b/tests/unit/test_manga_force_rescan.py
@@ -16,6 +16,7 @@ from sqlalchemy import create_engine, select
 
 import comicarr
 from comicarr import updater
+from comicarr.app.manga.rescan import mark_parsed_files_downloaded
 from comicarr.tables import comics, issues, metadata
 
 
@@ -32,39 +33,39 @@ def _config():
     )
 
 
-def _seed_manga(engine, tmp_path, *, bare_mode="volumes"):
+def _seed_manga(engine, tmp_path, *, bare_mode="volumes", status="Wanted", location=None, have=None):
+    comic_row = {
+        "ComicID": "md-naruto",
+        "ComicName": "Naruto",
+        "ComicPublisher": "Shueisha",
+        "ComicYear": "1999",
+        "ComicLocation": str(tmp_path),
+        "AlternateSearch": None,
+        "Type": "Print",
+        "Corrected_Type": None,
+        "Status": "Active",
+        "ContentType": "manga",
+        "BareNumberMode": bare_mode,
+    }
+    if have is not None:
+        comic_row["Have"] = have
+    issue_row = {
+        "IssueID": "md-naruto-ch100",
+        "ComicID": "md-naruto",
+        "Issue_Number": "100",
+        "Int_IssueNumber": 100000,
+        "ChapterNumber": "100",
+        "VolumeNumber": "12",
+        "IssueName": "Chapter 100",
+        "IssueDate": "2001-01-01",
+        "Status": status,
+        "forced_file": None,
+    }
+    if location is not None:
+        issue_row["Location"] = location
     with engine.begin() as conn:
-        conn.execute(
-            comics.insert(),
-            {
-                "ComicID": "md-naruto",
-                "ComicName": "Naruto",
-                "ComicPublisher": "Shueisha",
-                "ComicYear": "1999",
-                "ComicLocation": str(tmp_path),
-                "AlternateSearch": None,
-                "Type": "Print",
-                "Corrected_Type": None,
-                "Status": "Active",
-                "ContentType": "manga",
-                "BareNumberMode": bare_mode,
-            },
-        )
-        conn.execute(
-            issues.insert(),
-            {
-                "IssueID": "md-naruto-ch100",
-                "ComicID": "md-naruto",
-                "Issue_Number": "100",
-                "Int_IssueNumber": 100000,
-                "ChapterNumber": "100",
-                "VolumeNumber": "12",
-                "IssueName": "Chapter 100",
-                "IssueDate": "2001-01-01",
-                "Status": "Wanted",
-                "forced_file": None,
-            },
-        )
+        conn.execute(comics.insert(), comic_row)
+        conn.execute(issues.insert(), issue_row)
 
 
 def test_force_rescan_volume_bare_file_marks_chapters_in_that_volume(monkeypatch, tmp_path):
@@ -101,3 +102,87 @@ def test_force_rescan_empty_manga_folder_does_not_crash(monkeypatch, tmp_path):
     with engine.connect() as conn:
         row = conn.execute(select(issues).where(issues.c.IssueID == "md-naruto-ch100")).mappings().one()
     assert row["Status"] == "Wanted"
+
+
+def test_force_rescan_repoints_location_when_cbr_became_cbz(monkeypatch, tmp_path):
+    """Metatag exports .cbr to .cbz; an already-Downloaded row must follow the file."""
+    (tmp_path / "Naruto 12.cbz").write_bytes(b"cbz")
+    engine = create_engine("sqlite://")
+    metadata.create_all(engine)
+    _seed_manga(
+        engine,
+        tmp_path,
+        bare_mode="volumes",
+        status="Downloaded",
+        location="Naruto 12.cbr",
+        have=1,
+    )
+
+    monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+    monkeypatch.setattr(comicarr, "CONFIG", _config(), raising=False)
+    monkeypatch.setattr(
+        updater.filechecker,
+        "FileChecker",
+        MagicMock(side_effect=AssertionError("manga forceRescan must not use FileChecker")),
+    )
+
+    updater.forceRescan("md-naruto")
+
+    with engine.connect() as conn:
+        row = conn.execute(select(issues).where(issues.c.IssueID == "md-naruto-ch100")).mappings().one()
+        comic = conn.execute(select(comics).where(comics.c.ComicID == "md-naruto")).mappings().one()
+    assert row["Status"] == "Downloaded"
+    assert row["Location"] == "Naruto 12.cbz"
+    assert comic["Have"] == 1
+
+
+def test_mark_parsed_files_downloaded_repoints_stale_location_only(monkeypatch, tmp_path):
+    engine = create_engine("sqlite://")
+    metadata.create_all(engine)
+    _seed_manga(
+        engine,
+        tmp_path,
+        status="Downloaded",
+        location="Naruto 100.cbr",
+        have=1,
+    )
+    monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+
+    count = mark_parsed_files_downloaded(
+        "md-naruto",
+        [(str(tmp_path / "Naruto 100.cbz"), {"chapter_number": 100, "volume_number": None})],
+    )
+
+    assert count == 0
+    with engine.connect() as conn:
+        row = conn.execute(select(issues).where(issues.c.IssueID == "md-naruto-ch100")).mappings().one()
+        comic = conn.execute(select(comics).where(comics.c.ComicID == "md-naruto")).mappings().one()
+    assert row["Status"] == "Downloaded"
+    assert row["Location"] == "Naruto 100.cbz"
+    assert comic["Have"] == 1
+
+
+def test_mark_parsed_files_downloaded_skips_matching_downloaded_location(monkeypatch, tmp_path):
+    engine = create_engine("sqlite://")
+    metadata.create_all(engine)
+    _seed_manga(
+        engine,
+        tmp_path,
+        status="Downloaded",
+        location="Naruto 100.cbz",
+        have=1,
+    )
+    monkeypatch.setattr(updater.db, "get_engine", lambda: engine)
+
+    count = mark_parsed_files_downloaded(
+        "md-naruto",
+        [(str(tmp_path / "Naruto 100.cbz"), {"chapter_number": 100, "volume_number": None})],
+    )
+
+    assert count == 0
+    with engine.connect() as conn:
+        row = conn.execute(select(issues).where(issues.c.IssueID == "md-naruto-ch100")).mappings().one()
+        comic = conn.execute(select(comics).where(comics.c.ComicID == "md-naruto")).mappings().one()
+    assert row["Status"] == "Downloaded"
+    assert row["Location"] == "Naruto 100.cbz"
+    assert comic["Have"] == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #826. Metatagging a manga `.cbr` converts it to `.cbz` (ComicTagger cannot write RAR) and deletes the original, but `issues.Location` stayed pointed at the deleted file. Have/Status looked fine, so the damage was silent.

The post-tag reconcile already runs the manga path. `mark_parsed_files_downloaded()` wrote `Status` and `Location` together and skipped any row that was already `Downloaded`, so a rename was never recorded.

## Changes

- When a matched row is already `Downloaded` and the on-disk filename differs from `Location`, upsert `Location` only.
- Leave `Status` (and therefore `Have`) unchanged for those rows.
- Keep the existing `Wanted` → `Downloaded` transition for undownloaded rows.
- Regression tests: volume rescan after `.cbr` → `.cbz`, chapter-level Location-only upsert, and a no-op when Location already matches.

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [ ] No app release impact; no changeset needed (omit rather than "No user-visible behaviour changes.")

## Testing

- [x] Tests pass locally (`pytest tests/unit -v`) — 2816 passed, including the new Location-repoint cases
- [ ] Frontend builds (`cd frontend && npm run build`) — not required; no frontend change
- [x] Backend lint/format (`ruff check comicarr/` and `ruff format --check comicarr/`)
- [x] Frontend lint/format (`cd frontend && npm run lint && npm run format:check`)
- [x] Or one-shot: `npm run lint` (from repo root; requires `uv` + `frontend/node_modules`)
- [x] Manually tested (describe what you tested): unit regression of the reported path — Downloaded row with `Location=*.cbr`, on-disk file is `*.cbz`, rescan updates Location only and leaves Status/Have alone

## Screenshots

<!-- If UI changes, include before/after screenshots -->

## Additional Notes

Scope is this Location-repoint bug only. The `.cursor/environment.json` ports-schema change lives on the base branch and is untouched here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-428a021b-c2ba-4ba7-a721-919548f26f3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-428a021b-c2ba-4ba7-a721-919548f26f3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

