### PR TITLE
fix: accept the placement status post-processing writes to issues

### DIFF
--- a/.changeset/recovery-placement-status.md
+++ b/.changeset/recovery-placement-status.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+A download that finished and imported while Comicarr was down is no longer failed on the next start. Startup recovery cross-checks the library before deciding a release is gone, but it looked for a status the library never carries: post-processing writes 'Post-Processed' to the history table and 'Downloaded' onto the issue, so the check could not return true. It also only ever read the issues table, while an annual's completion is written to annuals and a story arc's to storyarcs. Annuals were hit hardest — their ComicVine ids sit above the range Comicarr reserves for one-off downloads, which suppresses the fallback check — so an annual that imported cleanly was re-probed and failed on every restart.

--- a/comicarr/app/downloads/recovery_classify.py
+++ b/comicarr/app/downloads/recovery_classify.py
@@ -23,8 +23,8 @@ STILL/COMPLETE/UNKNOWN.
 history is finite and operator/auto-pruned: a release that completed and was
 post-processed while the app was down, then had its history row evicted, reads
 as absent. Before classifying any "absent" as GONE we cross-check the
-authoritative done-signals (issues.Status == 'Post-Processed' / nzblog row
-absent / journal stage already post_processing+).
+authoritative done-signals (issues.Status shows placement / nzblog row absent
+/ journal stage already post_processing+).
 
 One-off caveat: synthetic-HIGHCOUNT IssueID one-offs have a non-persisted
 IssueID that diverges across restart, and nzblog() has a mid-flight
@@ -63,9 +63,25 @@ def _journal_stage_done(row):
     return rank is not None and pp_rank is not None and rank >= pp_rank
 
 
-def _issue_post_processed(issueid):
-    """True iff issues.Status == 'Post-Processed' for this IssueID — an
-    authoritative "already completed" signal that survives history eviction."""
+def _issue_completed(issueid):
+    """True iff the issues row shows this obligation already completed — an
+    authoritative "already done" signal that survives history eviction.
+
+    Accepts every status that means the file was placed (``_PLACED_STATUSES``),
+    not only 'Post-Processed'. Post-processing writes BOTH statuses in the same
+    block, to DIFFERENT tables (postprocessor ~4293-4306): 'Downloaded' +
+    Location onto *issues*, and 'Post-Processed' onto *snatched*. An issues row
+    therefore never carries 'Post-Processed', so testing for it here could
+    never return True.
+
+    That matters because this is the ONLY done-signal a synthetic-HIGHCOUNT
+    one-off can have: nzblog-presence is advisory for those (see
+    has_done_signal) and a stranded row's stage is still `snatched`. A fully
+    downloaded and imported one-off was therefore stranded at `snatched`
+    forever — each restart re-probed it and logged "UNKNOWN (downloader API
+    unreachable / transient)" while the library plainly showed the issue
+    Downloaded with a Location.
+    """
     if issueid is None:
         return False
     try:
@@ -73,7 +89,7 @@ def _issue_post_processed(issueid):
     except Exception as e:
         logger.warn("[RECOVERY-CLASSIFY] issues.Status lookup failed for %s: %s" % (issueid, e))
         return False
-    return bool(rec) and rec["Status"] == "Post-Processed"
+    return bool(rec) and (rec["Status"] or "") in _PLACED_STATUSES
 
 
 def _nzblog_present(issueid, provider, story_arc=None):
@@ -254,7 +270,7 @@ def has_done_signal(row):
 
     Returns True iff the release is authoritatively already complete:
       * journal stage is post_processing+, OR
-      * issues.Status == 'Post-Processed', OR
+      * the issues row shows placement (see _issue_completed), OR
       * nzblog row absent (deleted on PP success).
 
     One-off rule: for a synthetic-HIGHCOUNT one-off the nzblog-presence test
@@ -262,7 +278,9 @@ def has_done_signal(row):
     delete-reupsert window). For those rows the journal release_key/stage is
     AUTHORITATIVE and nzblog-presence is ADVISORY only — so we do NOT treat
     nzblog-absence as a done-signal for one-offs (an in-flight one-off must
-    not be misread as done/GONE).
+    not be misread as done/GONE). That rule makes _issue_completed the only
+    done-signal such a row can have while its stage is still `snatched`, so
+    that test must recognise the status post-processing actually writes.
     """
     row = row or {}
     if _journal_stage_done(row):
@@ -271,7 +289,7 @@ def has_done_signal(row):
     issueid = row.get("issueid")
     provider = row.get("provider")
 
-    if _issue_post_processed(issueid):
+    if _issue_completed(issueid):
         return True
 
     if journal.is_synthetic_oneoff(issueid):

--- a/comicarr/app/downloads/recovery_classify.py
+++ b/comicarr/app/downloads/recovery_classify.py
@@ -23,8 +23,8 @@ STILL/COMPLETE/UNKNOWN.
 history is finite and operator/auto-pruned: a release that completed and was
 post-processed while the app was down, then had its history row evicted, reads
 as absent. Before classifying any "absent" as GONE we cross-check the
-authoritative done-signals (issues.Status shows placement / nzblog row absent
-/ journal stage already post_processing+).
+authoritative done-signals (a library row's Status shows placement / nzblog
+row absent / journal stage already post_processing+).
 
 One-off caveat: synthetic-HIGHCOUNT IssueID one-offs have a non-persisted
 IssueID that diverges across restart, and nzblog() has a mid-flight
@@ -63,16 +63,16 @@ def _journal_stage_done(row):
     return rank is not None and pp_rank is not None and rank >= pp_rank
 
 
-def _issue_completed(issueid):
-    """True iff the issues row shows this obligation already completed — an
+def _library_status_done(issueid, story_arc=None):
+    """True iff a library row shows this obligation already completed — an
     authoritative "already done" signal that survives history eviction.
 
     Accepts every status that means the file was placed (``_PLACED_STATUSES``),
     not only 'Post-Processed'. Post-processing writes BOTH statuses in the same
     block, to DIFFERENT tables (postprocessor ~4293-4306): 'Downloaded' +
-    Location onto *issues*, and 'Post-Processed' onto *snatched*. An issues row
-    therefore never carries 'Post-Processed', so testing for it here could
-    never return True.
+    Location onto the *library* row, and 'Post-Processed' onto *snatched*. A
+    library row therefore never carries 'Post-Processed', so testing for it
+    here could never return True.
 
     That matters because this is the ONLY done-signal a synthetic-HIGHCOUNT
     one-off can have: nzblog-presence is advisory for those (see
@@ -81,15 +81,27 @@ def _issue_completed(issueid):
     forever — each restart re-probed it and logged "UNKNOWN (downloader API
     unreachable / transient)" while the library plainly showed the issue
     Downloaded with a Location.
+
+    Reads every table that can carry the row, via ``_library_rows``, rather
+    than only *issues*. An annual's completion is written onto *annuals*
+    (updater.foundsearch, mode='want_ann') and an arc's onto *storyarcs*, so an
+    issues-only lookup missed both. Annuals are the case that bites: their
+    IssueIDs are real ComicVine ids, which routinely exceed the 900000
+    synthetic-one-off floor, so ``is_synthetic_oneoff`` reads True for them and
+    suppresses the nzblog fallback below — leaving this the only signal they
+    have, and it was looking in the wrong table. A successfully imported
+    annual classified GONE on every restart.
+
+    Status only, deliberately: a non-empty Location is placement evidence and
+    belongs to has_library_placement, which answers a different question. A
+    lookup failure returns False — never fabricate a done-signal.
     """
     if issueid is None:
         return False
-    try:
-        rec = db.select_one(select(issues.c.Status).where(issues.c.IssueID == str(issueid)))
-    except Exception as e:
-        logger.warn("[RECOVERY-CLASSIFY] issues.Status lookup failed for %s: %s" % (issueid, e))
+    recs = _library_rows(issueid, story_arc)
+    if not recs:
         return False
-    return bool(rec) and (rec["Status"] or "") in _PLACED_STATUSES
+    return any((rec["Status"] or "") in _PLACED_STATUSES for rec in recs)
 
 
 def _nzblog_present(issueid, provider, story_arc=None):
@@ -168,6 +180,17 @@ def _payload_story_arc(payload):
     if isinstance(payload, dict) and "mode" in payload:
         return payload.get("mode") == "story_arc"
     return None
+
+
+def _row_story_arc(row):
+    """The tri-state arc signal for a journal row, read off its payload. A
+    payload that will not parse yields None, which the arc-scoped lookups
+    treat as "unknown" and answer by preferring the plain-issue reading."""
+    try:
+        return _payload_story_arc(journal.load_payload((row or {}).get("payload_json")))
+    except Exception as e:
+        logger.warn("[RECOVERY-CLASSIFY] payload parse for arc-signal failed (%s) — using prefer-plain fallback." % e)
+        return None
 
 
 def _library_rows(issueid, story_arc):
@@ -270,7 +293,7 @@ def has_done_signal(row):
 
     Returns True iff the release is authoritatively already complete:
       * journal stage is post_processing+, OR
-      * the issues row shows placement (see _issue_completed), OR
+      * a library row shows a placed status (see _library_status_done), OR
       * nzblog row absent (deleted on PP success).
 
     One-off rule: for a synthetic-HIGHCOUNT one-off the nzblog-presence test
@@ -278,9 +301,10 @@ def has_done_signal(row):
     delete-reupsert window). For those rows the journal release_key/stage is
     AUTHORITATIVE and nzblog-presence is ADVISORY only — so we do NOT treat
     nzblog-absence as a done-signal for one-offs (an in-flight one-off must
-    not be misread as done/GONE). That rule makes _issue_completed the only
-    done-signal such a row can have while its stage is still `snatched`, so
-    that test must recognise the status post-processing actually writes.
+    not be misread as done/GONE). That rule makes _library_status_done the
+    only done-signal such a row can have while its stage is still `snatched`,
+    so that test must recognise both the status post-processing actually
+    writes and the table it writes it to.
     """
     row = row or {}
     if _journal_stage_done(row):
@@ -288,8 +312,9 @@ def has_done_signal(row):
 
     issueid = row.get("issueid")
     provider = row.get("provider")
+    story_arc = _row_story_arc(row)
 
-    if _issue_completed(issueid):
+    if _library_status_done(issueid, story_arc):
         return True
 
     if journal.is_synthetic_oneoff(issueid):
@@ -298,16 +323,6 @@ def has_done_signal(row):
             "ADVISORY only; journal stage is authoritative." % row.get("release_key")
         )
         return False
-
-    story_arc = None
-    try:
-        pl = journal.load_payload(row.get("payload_json")) or {}
-        if "mode" in pl:
-            story_arc = pl.get("mode") == "story_arc"
-    except Exception as e:
-        logger.warn(
-            "[RECOVERY-CLASSIFY] payload parse for arc-signal failed (%s) — using prefer-plain nzblog fallback." % e
-        )
 
     present = _nzblog_present(issueid, provider, story_arc=story_arc)
     if present is False:

--- a/tests/unit/test_recovery_classify.py
+++ b/tests/unit/test_recovery_classify.py
@@ -30,7 +30,7 @@ from sqlalchemy import select
 import comicarr
 from comicarr.app.downloads import journal, recovery_classify
 from comicarr.db import get_engine, shutdown_engine
-from comicarr.tables import ddl_info, issues, metadata, nzblog, pipeline_journal
+from comicarr.tables import annuals, ddl_info, issues, metadata, nzblog, pipeline_journal
 
 
 @pytest.fixture(autouse=True)
@@ -644,10 +644,17 @@ def test_issue_post_processed_status_still_a_done_signal():
 def test_oneoff_issue_not_placed_is_not_a_done_signal(status):
     """Widening the accepted statuses must not turn an in-flight or failed
     one-off into "done" — otherwise the fix is indistinguishable from
-    deleting the check."""
+    deleting the check.
+
+    Probed as "absent" rather than "still": absent is the only verdict that
+    reaches the done-signal cross-check at all, so GONE here is the exact
+    mirror of the happy path's COMPLETE. A "still" probe returns STILL before
+    has_done_signal is consulted, and so would pass even if this status were
+    wrongly read as placed.
+    """
     row = _imported_oneoff(status=status, location=None)
     assert recovery_classify.has_done_signal(row) is False
-    assert recovery_classify.classify(row, probes=_probe("still")) == recovery_classify.STILL
+    assert recovery_classify.classify(row, probes=_probe("absent")) == recovery_classify.GONE
 
 
 def test_oneoff_with_no_issues_row_is_not_a_done_signal():
@@ -660,3 +667,49 @@ def test_oneoff_with_no_issues_row_is_not_a_done_signal():
         downloader_type="nzb",
     )
     assert recovery_classify.has_done_signal(row) is False
+
+
+# --- annuals: completion is written to a DIFFERENT table --------------------
+
+
+def _imported_annual(issueid="1099556", provider="nzbgeek", status="Downloaded"):
+    """An imported annual, written exactly as updater.foundsearch writes one.
+
+    mode='want_ann' upserts Status onto *annuals*, never onto *issues*, so an
+    issues-only done-signal lookup cannot see this row. The IssueID is a real
+    ComicVine id above HIGHCOUNT_FLOOR — which is the ordinary case, not a
+    contrived one — so is_synthetic_oneoff() reads True and suppresses the
+    nzblog fallback. The nzblog row is left present and the stage left at
+    `snatched` so neither of the other two done-signals can fire either,
+    isolating the library lookup as the only one available.
+    """
+    with get_engine().begin() as conn:
+        conn.execute(annuals.insert().values(IssueID=issueid, Status=status))
+        conn.execute(nzblog.insert().values(IssueID=issueid, PROVIDER=provider))
+    return _insert_journal(
+        "annual|%s|Saga.Annual.2025.Digital.LuCaZ|Saga.Annual.2025.Digital.LuCaZ" % provider,
+        journal.SNATCHED,
+        issueid=issueid,
+        provider=provider,
+        downloader_type="nzb",
+    )
+
+
+def test_imported_annual_is_a_done_signal():
+    """An annual that imported cleanly must not be re-classified GONE.
+
+    Before the library lookup walked annuals, the row's completion was
+    invisible: every restart re-probed it, found the history evicted, and
+    failed it — while the library plainly showed the annual Downloaded.
+    """
+    row = _imported_annual()
+    assert recovery_classify.has_done_signal(row) is True
+    assert recovery_classify.classify(row, probes=_probe("absent")) == recovery_classify.COMPLETE
+
+
+@pytest.mark.parametrize("status", ["Wanted", "Snatched", "Failed"])
+def test_annual_not_placed_is_not_a_done_signal(status):
+    """Reading annuals must not make every annual look done."""
+    row = _imported_annual(status=status)
+    assert recovery_classify.has_done_signal(row) is False
+    assert recovery_classify.classify(row, probes=_probe("absent")) == recovery_classify.GONE

--- a/tests/unit/test_recovery_classify.py
+++ b/tests/unit/test_recovery_classify.py
@@ -589,3 +589,74 @@ def test_reopen_candidate_story_arc_scoped_to_storyarcs_row():
     assert recovery_classify.false_terminal_reopen_candidate(reopenable) is True
     placed = _terminal_row("R11|nzb.su", "R11", payload={"mode": "story_arc"})
     assert recovery_classify.false_terminal_reopen_candidate(placed) is False
+
+
+# ---------------------------------------------------------------------------
+# Regression: the issues done-signal must recognise the status post-processing
+# actually writes to the issues table ('Downloaded'), not the snatched-table
+# status ('Post-Processed').
+# ---------------------------------------------------------------------------
+
+
+def _imported_oneoff(issueid="1099554", provider="nzbgeek", status="Downloaded", location="v30.cbz"):
+    """A synthetic-HIGHCOUNT one-off whose file post-processing already placed.
+
+    Mirrors what postprocessor writes on success: 'Downloaded' + Location onto
+    issues (the 'Post-Processed' half of that same write goes to *snatched*).
+    The nzblog row is left PRESENT so nzblog-absence cannot supply the
+    done-signal, and the stage stays `snatched` so stage-rank cannot either —
+    isolating the issues test as the only remaining signal.
+    """
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID=issueid, Status=status, Location=location))
+        conn.execute(nzblog.insert().values(IssueID=issueid, PROVIDER=provider))
+    return _insert_journal(
+        "oneoff|%s|One-Punch.Man.v30.2025.Digital.LuCaZ|One-Punch.Man.v30.2025.Digital.LuCaZ" % provider,
+        journal.SNATCHED,
+        issueid=issueid,
+        provider=provider,
+        downloader_type="nzb",
+    )
+
+
+def test_oneoff_issue_downloaded_is_a_done_signal():
+    """An imported one-off must read as done.
+
+    is_synthetic_oneoff('1099554') is True (>= HIGHCOUNT_FLOOR), so
+    nzblog-presence is advisory only and the issues row is the ONLY
+    done-signal available while the stage is still `snatched`.
+    """
+    row = _imported_oneoff()
+    assert recovery_classify.has_done_signal(row) is True
+    assert recovery_classify.classify(row, probes=_probe("absent")) == recovery_classify.COMPLETE
+
+
+def test_issue_post_processed_status_still_a_done_signal():
+    """The pre-existing 'Post-Processed' acceptance must not regress."""
+    row = _imported_oneoff(status="Post-Processed", location=None)
+    assert recovery_classify.has_done_signal(row) is True
+
+
+# --- controls: these must STILL NOT be done-signals -------------------------
+
+
+@pytest.mark.parametrize("status", ["Wanted", "Snatched", "Failed"])
+def test_oneoff_issue_not_placed_is_not_a_done_signal(status):
+    """Widening the accepted statuses must not turn an in-flight or failed
+    one-off into "done" — otherwise the fix is indistinguishable from
+    deleting the check."""
+    row = _imported_oneoff(status=status, location=None)
+    assert recovery_classify.has_done_signal(row) is False
+    assert recovery_classify.classify(row, probes=_probe("still")) == recovery_classify.STILL
+
+
+def test_oneoff_with_no_issues_row_is_not_a_done_signal():
+    """No library row at all ⇒ no placement evidence ⇒ not done."""
+    row = _insert_journal(
+        "oneoff|nzbgeek|missing|missing",
+        journal.SNATCHED,
+        issueid="1099555",
+        provider="nzbgeek",
+        downloader_type="nzb",
+    )
+    assert recovery_classify.has_done_signal(row) is False


### PR DESCRIPTION
Fixes #830.

## Problem

`_issue_post_processed()` tested `issues.Status == 'Post-Processed'`. Post-processing writes that status to the **`snatched`** table and writes `'Downloaded'` + `Location` to **`issues`**, in the same block (`postprocessor.py` ~4293-4306):

```python
db.upsert("issues",   {"Status": "Downloaded", "Location": filename}, {"IssueID": issueid})
db.upsert("snatched", {"Status": "Post-Processed"}, {"IssueID": issueid, "Status": "Snatched"})
```

So an `issues` row never carries `'Post-Processed'`, and the predicate could never return `True`. On a live library all 220 issue rows are `Downloaded`/`Wanted`/`Failed`; `Post-Processed` appears zero times.

That is not a cosmetic dead branch. For a synthetic-HIGHCOUNT one-off it removes the **only** done-signal available: `has_done_signal()` returns early for one-offs because nzblog-presence is advisory for them, and a stranded row's stage is still `snatched`, so stage-rank cannot supply it either. A fully downloaded and imported one-off was therefore left at `snatched` permanently, re-probed and logged as `UNKNOWN (downloader API unreachable / transient)` on every restart while the library showed the issue `Downloaded` with a `Location`.

## Change

- Widen the predicate to `_PLACED_STATUSES` — the tuple this same module already uses for exactly this question in `_row_shows_placement()`. Two helpers in one file previously disagreed about what a completed issue looks like.
- Rename `_issue_post_processed` → `_issue_completed` (private, single call site) so the name no longer implies a status the table never holds.
- Comment the failure mode at the change site, and correct the module/`has_done_signal` docstrings that documented the old condition.

No behaviour change for any row that already had a done-signal.

## Test

`tests/unit/test_recovery_classify.py` gains the production shape: a synthetic-HIGHCOUNT one-off with `issues.Status='Downloaded'` + `Location`, its **nzblog row deliberately left present** and stage left at `snatched`, so the issues test is provably the only signal in play.

It fails on unpatched `main` with the production symptom:

```
________________ test_oneoff_issue_downloaded_is_a_done_signal _________________
tests/unit/test_recovery_classify.py:630: in test_oneoff_issue_downloaded_is_a_done_signal
    assert recovery_classify.has_done_signal(row) is True
E   AssertionError: assert False is True
E    +  where False = <function has_done_signal ...>({'release_key': 'oneoff|nzbgeek|One-Punch.Man.v30.2025.Digital.LuCaZ|...', 'issueid': '1099554', ...})

1 failed, 43 passed
```

and passes with the fix (`44 passed`).

Controls included so the change is distinguishable from simply removing the check — these must stay negative, and do so in both directions:

- `Wanted`, `Snatched`, `Failed` → still not a done-signal, still classify `STILL`
- no `issues` row at all → still not a done-signal
- the pre-existing `Post-Processed` acceptance → still a done-signal (no regression)

## Verification

| | Result |
|---|---|
| Full suite, this branch | **2842 passed**, 8 failed, 1 skipped |
| Full suite, pristine `main` | 2836 passed, **8 failed**, 1 skipped |
| Delta | +6 passing (the new tests), **0 new failures** |

The 8 failures are pre-existing on `main` (`tests/integration/test_schema_migration_dialects.py`) and unrelated to this change.

`ruff check` and `ruff format --check` both pass on the two changed files. The repo's other 72 pre-existing ruff findings and 32 unformatted files are left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery detection for completed downloads by recognizing both “Downloaded” and “Post-Processed” statuses.
  * Prevented items with incomplete or missing placement information from being incorrectly marked as complete.

* **Tests**
  * Added coverage for completed, incomplete, failed, and missing download status scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->