### PR TITLE
fix: Treat a missing NZBGet NZBID as unprobeable, not unreachable

### DIFF
--- a/.changeset/nzbget-missing-nzbid-unprobeable.md
+++ b/.changeset/nzbget-missing-nzbid-unprobeable.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Startup recovery no longer treats a missing NZBGet download id as a downloader outage. Rows that never recorded an NZBID were re-probed on every restart and logged as if NZBGet were unreachable, even when the client was healthy. Recovery now recognises those rows as unprobeable: if the library already shows the download finished they close normally, and if it does not they stay unknown without blaming NZBGet. A real NZBGet connection failure still retries as a transient outage.

--- a/comicarr/app/downloads/recovery.py
+++ b/comicarr/app/downloads/recovery.py
@@ -743,10 +743,16 @@ def _resolve_row(snapshot_row, probes=None, pp_cap=None):
                 "files remain in the download directory (#734)." % rkey
             )
             return "done-unplaced-manual-review"
-        logger.warn(
-            "[RECOVERY] %s -> UNKNOWN (transient downloader outage) — stage "
-            "left UNCHANGED, reclassified next start." % rkey
-        )
+        if details.get("raw_state") == "unprobeable":
+            logger.warn(
+                "[RECOVERY] %s -> UNKNOWN (row has no client id to probe) — "
+                "stage left UNCHANGED, reclassified next start." % rkey
+            )
+        else:
+            logger.warn(
+                "[RECOVERY] %s -> UNKNOWN (transient downloader outage) — stage "
+                "left UNCHANGED, reclassified next start." % rkey
+            )
         return "unknown-unchanged"
 
     if verdict == recovery_classify.COMPLETE:

--- a/comicarr/app/downloads/recovery_classify.py
+++ b/comicarr/app/downloads/recovery_classify.py
@@ -623,10 +623,7 @@ def classify_details(row, probes=None, payload=None):
 
     if has_done_signal(row):
         if raw_state == "unprobeable":
-            logger.fdebug(
-                "[RECOVERY-CLASSIFY] %s unprobeable BUT done-signal present "
-                "-> complete, NOT unknown." % rkey
-            )
+            logger.fdebug("[RECOVERY-CLASSIFY] %s unprobeable BUT done-signal present -> complete, NOT unknown." % rkey)
         else:
             logger.fdebug(
                 "[RECOVERY-CLASSIFY] %s absent in client BUT done-signal present "
@@ -637,8 +634,7 @@ def classify_details(row, probes=None, payload=None):
 
     if raw_state == "unprobeable":
         logger.warn(
-            "[RECOVERY-CLASSIFY] %s -> UNKNOWN (row has no client id to probe) "
-            "— journal stage left unchanged." % rkey
+            "[RECOVERY-CLASSIFY] %s -> UNKNOWN (row has no client id to probe) — journal stage left unchanged." % rkey
         )
         details["verdict"] = UNKNOWN
         return details

--- a/comicarr/app/downloads/recovery_classify.py
+++ b/comicarr/app/downloads/recovery_classify.py
@@ -364,14 +364,19 @@ def _sab_history_or_queue(row, payload=None):
 
 
 def _nzbget_history(row, payload=None):
-    """NZBGet: history lookup by NZBID. Reuses nzbget.NZBGet.historycheck()."""
+    """NZBGet: history lookup by NZBID. Reuses nzbget.NZBGet.historycheck().
+
+    A missing NZBID is a permanent property of the row (nothing to ask the
+    client), so it is ``unprobeable`` — not a transient ``unreachable``.
+    Genuine historycheck failures stay ``unreachable`` (#832).
+    """
     payload = payload if payload is not None else journal.load_payload(row.get("payload_json"))
     payload = payload or {}
     di = payload.get("download_info") or {}
     nzbid = payload.get("NZBID") or di.get("NZBID") or row.get("NZBID")
     if not nzbid:
         logger.warn("[RECOVERY-CLASSIFY] NZBGet row %s has no NZBID to probe." % row.get("release_key"))
-        return "unreachable"
+        return "unprobeable"
     try:
         from comicarr import nzbget
 
@@ -406,7 +411,7 @@ def _nzstat_to_raw(nzstat):
     return "complete"
 
 
-_RAW_PROBE_STATES = frozenset(("still", "complete", "absent", "unreachable"))
+_RAW_PROBE_STATES = frozenset(("still", "complete", "absent", "unreachable", "unprobeable"))
 
 
 def _probe_evidence(raw):
@@ -432,8 +437,14 @@ def _probe_evidence(raw):
     return raw_state, location, name, failed
 
 
-def _empty_details(verdict=UNKNOWN):
-    return {"verdict": verdict, "location": None, "name": None, "failed": None}
+def _empty_details(verdict=UNKNOWN, raw_state=None):
+    return {
+        "verdict": verdict,
+        "location": None,
+        "name": None,
+        "failed": None,
+        "raw_state": raw_state,
+    }
 
 
 def _probe_nzb(row, payload=None):
@@ -542,15 +553,21 @@ def _resolve_downloader(row, payload=None):
 def classify_details(row, probes=None, payload=None):
     """Classify one open journal row and return completion evidence.
 
-    Returns ``{verdict, location, name, failed}``. ``verdict`` is one of
-    STILL/COMPLETE/GONE/UNKNOWN. ``location``/``name``/``failed`` come from a
-    richer SAB/NZBGet probe result when present; they are None when the probe
-    returned only a raw state string. PURE: never mutates the journal.
+    Returns ``{verdict, location, name, failed, raw_state}``. ``verdict`` is
+    one of STILL/COMPLETE/GONE/UNKNOWN. ``location``/``name``/``failed`` come
+    from a richer SAB/NZBGet probe result when present; they are None when
+    the probe returned only a raw state string. ``raw_state`` is the
+    normalized probe vocabulary (including ``unprobeable``) so callers can
+    distinguish a missing client id from a transient outage. PURE: never
+    mutates the journal.
 
     `probes` (test seam): optional {downloader_type: callable(row)->raw}
     overriding the real client-query paths. `raw` is one of
-    "still"/"complete"/"absent"/"unreachable", or a historycheck-shaped dict
-    with ``status`` plus optional ``location``/``name``/``failed``.
+    "still"/"complete"/"absent"/"unreachable"/"unprobeable", or a
+    historycheck-shaped dict with ``status`` plus optional
+    ``location``/``name``/``failed``. ``unprobeable`` means this row has
+    nothing to ask the client (e.g. no NZBID); it is not a transient
+    outage and still receives the done-signal / history-eviction guard.
 
     `payload` (efficiency): the already-decoded payload_json dict, parsed once
     per replay row by the caller and threaded in to avoid re-parsing it for
@@ -580,7 +597,13 @@ def classify_details(row, probes=None, payload=None):
         return _empty_details(UNKNOWN)
 
     raw_state, location, name, failed = _probe_evidence(raw)
-    details = {"verdict": UNKNOWN, "location": location, "name": name, "failed": failed}
+    details = {
+        "verdict": UNKNOWN,
+        "location": location,
+        "name": name,
+        "failed": failed,
+        "raw_state": raw_state,
+    }
 
     if raw_state == "still":
         logger.fdebug("[RECOVERY-CLASSIFY] %s -> still (in client)" % rkey)
@@ -599,11 +622,25 @@ def classify_details(row, probes=None, payload=None):
         return details
 
     if has_done_signal(row):
-        logger.fdebug(
-            "[RECOVERY-CLASSIFY] %s absent in client BUT done-signal present "
-            "(history likely evicted while down) -> complete, NOT gone." % rkey
-        )
+        if raw_state == "unprobeable":
+            logger.fdebug(
+                "[RECOVERY-CLASSIFY] %s unprobeable BUT done-signal present "
+                "-> complete, NOT unknown." % rkey
+            )
+        else:
+            logger.fdebug(
+                "[RECOVERY-CLASSIFY] %s absent in client BUT done-signal present "
+                "(history likely evicted while down) -> complete, NOT gone." % rkey
+            )
         details["verdict"] = COMPLETE
+        return details
+
+    if raw_state == "unprobeable":
+        logger.warn(
+            "[RECOVERY-CLASSIFY] %s -> UNKNOWN (row has no client id to probe) "
+            "— journal stage left unchanged." % rkey
+        )
+        details["verdict"] = UNKNOWN
         return details
 
     logger.warn(

--- a/tests/unit/test_recovery_classify.py
+++ b/tests/unit/test_recovery_classify.py
@@ -313,7 +313,7 @@ def test_classify_never_mutates_journal_for_any_verdict():
     (mark_failed/record_transition are never called from classify())."""
     row = _insert_journal("P1|sab|n", journal.SNATCHED, issueid="P1", provider="sab", downloader_type="nzb")
     with patch.object(journal, "record_transition") as rt:
-        for raw in ("still", "complete", "absent", "unreachable"):
+        for raw in ("still", "complete", "absent", "unreachable", "unprobeable"):
             recovery_classify.classify(row, probes=_probe(raw))
         rt.assert_not_called()
 
@@ -589,3 +589,131 @@ def test_reopen_candidate_story_arc_scoped_to_storyarcs_row():
     assert recovery_classify.false_terminal_reopen_candidate(reopenable) is True
     placed = _terminal_row("R11|nzb.su", "R11", payload={"mode": "story_arc"})
     assert recovery_classify.false_terminal_reopen_candidate(placed) is False
+
+
+# ---------------------------------------------------------------------------
+# #832 — missing NZBID is unprobeable, not a transient NZBGet outage
+# ---------------------------------------------------------------------------
+
+
+def _warn_messages(mock_warn):
+    return [str(call.args[0]) if call.args else str(call) for call in mock_warn.call_args_list]
+
+
+def test_nzbget_missing_nzbid_is_unprobeable_not_unreachable():
+    """A journal row with no NZBID cannot be asked about; that is not a
+    reachability failure. The built-in probe must return unprobeable and
+    must not call historycheck at all."""
+    row = _insert_journal(
+        "oneoff|nzbgeek||0db5cc8c289a08a0",
+        journal.SNATCHED,
+        issueid="900010",
+        provider="nzbgeek",
+        downloader_type="nzbget",
+        payload={"download_info": {}},
+    )
+    with patch("comicarr.nzbget.NZBGet.historycheck") as hist:
+        assert recovery_classify._nzbget_history(row) == "unprobeable"
+        hist.assert_not_called()
+
+
+def test_nzbget_api_failure_is_still_unreachable():
+    """Genuine NZBGet historycheck failures stay transient unreachable."""
+    row = _insert_journal(
+        "N3|nzbget|n",
+        journal.SNATCHED,
+        issueid="N3",
+        provider="nzbgeek",
+        downloader_type="nzbget",
+        payload={"NZBID": 42, "download_info": {"NZBID": 42}},
+    )
+    with patch("comicarr.nzbget.NZBGet.historycheck", side_effect=RuntimeError("connection refused")):
+        assert recovery_classify._nzbget_history(row) == "unreachable"
+        assert recovery_classify.classify(row) == recovery_classify.UNKNOWN
+
+
+def test_unprobeable_with_done_signal_is_complete_not_unknown():
+    """Unprobeable still receives the history-eviction / done-signal guard.
+    A row we cannot ask the client about, but whose library already proves
+    completion, closes as COMPLETE instead of looping as UNKNOWN."""
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="N1", Status="Post-Processed"))
+    row = _insert_journal(
+        "N1|nzbget|n",
+        journal.SNATCHED,
+        issueid="N1",
+        provider="nzbgeek",
+        downloader_type="nzbget",
+        payload={},
+    )
+    with patch("comicarr.nzbget.NZBGet.historycheck") as hist:
+        details = recovery_classify.classify_details(row)
+        assert details["verdict"] == recovery_classify.COMPLETE
+        assert details["raw_state"] == "unprobeable"
+        hist.assert_not_called()
+
+
+def test_unprobeable_without_done_signal_is_unknown_not_gone():
+    """Cannot probe ≠ absent-from-a-reachable-client. Without a done-signal
+    the row stays UNKNOWN (not GONE) and the log does not accuse NZBGet."""
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="N2", Status="Snatched"))
+        conn.execute(nzblog.insert().values(IssueID="N2", PROVIDER="nzbgeek"))
+    row = _insert_journal(
+        "N2|nzbget|n",
+        journal.SNATCHED,
+        issueid="N2",
+        provider="nzbgeek",
+        downloader_type="nzbget",
+        payload={},
+    )
+    before = _journal_row("N2|nzbget|n")
+    with (
+        patch("comicarr.nzbget.NZBGet.historycheck") as hist,
+        patch.object(recovery_classify.logger, "warn") as warn,
+    ):
+        details = recovery_classify.classify_details(row)
+        hist.assert_not_called()
+    assert details["verdict"] == recovery_classify.UNKNOWN
+    assert details["raw_state"] == "unprobeable"
+    assert _journal_row("N2|nzbget|n") == before
+    messages = " ".join(_warn_messages(warn))
+    assert "no NZBID to probe" in messages
+    assert "no client id to probe" in messages
+    assert "downloader API unreachable" not in messages
+
+
+def test_unprobeable_probe_seam_hits_done_signal_not_gone():
+    """Injectable unprobeable follows the same classify path as the built-in
+    missing-NZBID probe: done-signal → COMPLETE; otherwise UNKNOWN, never GONE."""
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="N4", Status="Snatched"))
+        conn.execute(nzblog.insert().values(IssueID="N4", PROVIDER="sab"))
+        conn.execute(issues.insert().values(IssueID="N5", Status="Post-Processed"))
+    open_row = _insert_journal("N4|sab|n", journal.SNATCHED, issueid="N4", provider="sab", downloader_type="nzb")
+    done_row = _insert_journal("N5|sab|n", journal.SNATCHED, issueid="N5", provider="sab", downloader_type="nzb")
+    assert recovery_classify.classify(open_row, probes=_probe("unprobeable")) == recovery_classify.UNKNOWN
+    assert recovery_classify.classify(done_row, probes=_probe("unprobeable")) == recovery_classify.COMPLETE
+    assert recovery_classify.classify(open_row, probes=_probe("absent")) == recovery_classify.GONE
+
+
+def test_nzbget_oneoff_missing_nzbid_is_unknown_without_accusing_client():
+    """Observed #832 shape: synthetic one-off, empty nzbname, no NZBID.
+    nzblog-absence is advisory only for one-offs, so there is no done-signal;
+    the row stays UNKNOWN and must not be labelled a transient outage."""
+    oneoff_key = "oneoff|nzbgeek||0db5cc8c289a08a0"
+    row = _insert_journal(
+        oneoff_key,
+        journal.SNATCHED,
+        issueid="900011",
+        provider="nzbgeek",
+        downloader_type="nzbget",
+        payload={},
+    )
+    assert recovery_classify.has_done_signal(row) is False
+    with patch.object(recovery_classify.logger, "warn") as warn:
+        assert recovery_classify.classify(row) == recovery_classify.UNKNOWN
+    messages = " ".join(_warn_messages(warn))
+    assert "no NZBID to probe" in messages
+    assert "no client id to probe" in messages
+    assert "downloader API unreachable" not in messages

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -552,6 +552,53 @@ def test_unknown_leaves_stage_unchanged(queues):
     assert _drain(queues["pp"]) == []
 
 
+def test_unprobeable_without_done_signal_leaves_stage_without_blaming_client(queues, capture_logs):
+    """#832: a row we cannot probe (no client id) is not a transient
+    downloader outage. Without a done-signal it stays UNKNOWN / snatched
+    and the recovery log must not accuse the client."""
+    rkey = journal.release_key("832", "nzbgeek", nzbname="NoId.cbz")
+    with get_engine().begin() as conn:
+        conn.execute(nzblog.insert().values(IssueID="832", PROVIDER="nzbgeek"))
+        conn.execute(issues.insert().values(IssueID="832", Status="Snatched"))
+    _insert_journal(
+        rkey,
+        journal.SNATCHED,
+        payload={"issueid": "832"},
+        issueid="832",
+        provider="nzbgeek",
+        downloader_type="nzbget",
+    )
+    summary = recovery.replay_pipeline(probes=_probe("unprobeable"))
+    assert _journal_row(rkey)["stage"] == journal.SNATCHED
+    assert _drain(queues["pp"]) == []
+    assert summary["actions"].get("unknown-unchanged") == 1
+    assert "no client id to probe" in capture_logs.text
+    assert "transient downloader outage" not in capture_logs.text
+
+
+def test_unprobeable_with_done_signal_enqueues_pp_not_unknown(queues):
+    """#832: unprobeable still hits the done-signal / eviction guard.
+    History-evicted completion without placement is COMPLETE (same as
+    absent), so recovery re-drives PP instead of looping as a fake outage."""
+    rkey = journal.release_key("832b", "nzbgeek", nzbname="Done.cbz")
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="832b", Status="Snatched"))
+    _insert_journal(
+        rkey,
+        journal.SNATCHED,
+        payload={"issueid": "832b", "provider": "nzbgeek", "nzbname": "Done.cbz"},
+        issueid="832b",
+        provider="nzbgeek",
+        downloader_type="nzbget",
+    )
+    summary = recovery.replay_pipeline(probes=_probe("unprobeable"))
+    row = _journal_row(rkey)
+    assert row["stage"] == journal.DOWNLOADED
+    assert summary["actions"].get("complete-pp-enqueued") == 1
+    assert summary["actions"].get("unknown-unchanged") is None
+    assert len(_drain(queues["pp"])) == 1
+
+
 # ---------------------------------------------------------------------------
 # Two-marker finalizer — decided ONLY by `moved`, no file probe
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_recovery_replay.py
+++ b/tests/unit/test_recovery_replay.py
@@ -23,6 +23,7 @@ and the lock-free (no INIT_LOCK) property.
 import json
 import queue as queue_module
 import types
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import select
@@ -597,6 +598,39 @@ def test_unprobeable_with_done_signal_enqueues_pp_not_unknown(queues):
     assert summary["actions"].get("complete-pp-enqueued") == 1
     assert summary["actions"].get("unknown-unchanged") is None
     assert len(_drain(queues["pp"])) == 1
+
+
+def test_nzbget_empty_payload_done_signal_matches_absent_via_builtin_probe(queues):
+    """#832: a reconstructed NZBGet row with an empty payload (no NZBID)
+    and no nzblog must go through the built-in `_nzbget_history`
+    unprobeable branch and match absent — COMPLETE / downloaded / PP
+    enqueued — not the #734 unreachable → manual_review path.
+
+    The injectable `unprobeable` seam is not enough: this calls
+    `replay_pipeline()` with no probes so the empty-payload branch
+    cannot drift from classify's raw-state handling."""
+    rkey = journal.release_key("832c", "nzbgeek", nzbname="Reconstructed.cbz")
+    with get_engine().begin() as conn:
+        conn.execute(issues.insert().values(IssueID="832c", Status="Snatched"))
+    _insert_journal(
+        rkey,
+        journal.SNATCHED,
+        payload={},
+        issueid="832c",
+        provider="nzbgeek",
+        downloader_type="nzbget",
+    )
+    with patch("comicarr.nzbget.NZBGet.historycheck") as hist:
+        summary = recovery.replay_pipeline()
+        hist.assert_not_called()
+    row = _journal_row(rkey)
+    assert row["stage"] == journal.DOWNLOADED
+    assert summary["actions"].get("complete-pp-enqueued") == 1
+    assert summary["actions"].get("done-unplaced-manual-review") is None
+    assert summary["actions"].get("unknown-unchanged") is None
+    items = _drain(queues["pp"])
+    assert len(items) == 1
+    assert not (items[0].get("nzb_folder") or items[0].get("nzb_name") or "").strip()
 
 
 # ---------------------------------------------------------------------------
@@ -1318,12 +1352,15 @@ def _issue_row(issueid, status="Snatched", location=None):
 
 
 def test_done_signal_without_placement_is_not_marked_post_processed(queues):
-    """#734 repro: reconstructed snatched row, nzblog ABSENT (done-signal),
-    but the issue row is still Snatched with no Location — no import ever
-    ran. The downloader cannot be probed (reconstructed payload has no
-    client id). The row must NOT become `post_processed`; it must be
-    quarantined to manual_review so the operator sees needs_attention
-    instead of a false import/succeeded."""
+    """#734 repro: done-signal (nzblog ABSENT) + no placement + the
+    downloader probe is transiently unreachable. The row must NOT become
+    `post_processed`; it is quarantined to manual_review so the operator
+    sees needs_attention instead of a false import/succeeded.
+
+    A reconstructed NZBGet row with no client id is a different state
+    (`unprobeable`) and matches absent — see
+    test_nzbget_empty_payload_done_signal_matches_absent_via_builtin_probe.
+    This test injects `unreachable` for the genuine outage path only."""
     rkey = journal.release_key("734", "nzb.su", nzbname="Ghosted.001.cbz")
     _issue_row("734")
     _insert_journal(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #832. A journal row with no `NZBID` was classified as a transient NZBGet outage (`unreachable` → `UNKNOWN`) and re-probed on every restart, even when NZBGet was healthy and other rows closed fine.

A missing NZBID is a permanent property of the row, not a reachability failure. The missing-id branch now returns a separate `unprobeable` raw state that falls through to the `has_done_signal()` history-eviction guard instead of short-circuiting to UNKNOWN. Genuine NZBGet API/exception failures stay `unreachable`.

## Changes

- `_nzbget_history()` returns `unprobeable` when the row has no NZBID, and still returns `unreachable` when `historycheck()` fails.
- `classify_details()` sends `unprobeable` through the done-signal cross-check: done-signal → `COMPLETE`; otherwise `UNKNOWN` (not `GONE`, and not "downloader API unreachable").
- Recovery replay logs "row has no client id to probe" for that UNKNOWN path instead of "transient downloader outage".
- Unit coverage for the built-in NZBGet probe, the injectable `unprobeable` seam, and the replay actions.
- Review follow-up: a replay that calls the real `_nzbget_history` with an empty payload (no `probes=` seam) so a reconstructed NZBGet row with no NZBID and no nzblog stays pinned to the same COMPLETE / PP-enqueue path as `absent`. The #734 `unreachable` → `manual_review` test remains the transient-outage case only.

Related #830 restores the done-signal for imported one-offs and is not folded in here.

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [ ] No app release impact; no changeset needed (omit rather than "No user-visible behaviour changes.")

## Testing

- [x] Tests pass locally (`pytest tests/unit -v`) — `tests/unit/test_recovery_classify.py` + `tests/unit/test_recovery_replay.py`: **96 passed**
- [ ] Frontend builds (`cd frontend && npm run build`) — N/A, backend-only
- [x] Backend lint/format (`ruff check comicarr/` and `ruff format --check comicarr/`) — `lint:modern` + ruff check/format on the changed files
- [ ] Frontend lint/format (`cd frontend && npm run lint && npm run format:check`) — N/A, backend-only
- [x] Contributor guards (`lint:guards` subset: retired globals, fail_reason registry, upsert tables, attention seam)
- [ ] Or one-shot: `npm run lint` (from repo root; requires `uv` + `frontend/node_modules`)
- [x] Manually tested (describe what you tested): exercised the built-in `_nzbget_history` missing-NZBID and API-failure paths plus replay of `unprobeable` with and without a done-signal, including a no-probes empty-payload replay (no live NZBGet)

## Screenshots

N/A — backend recovery classification only.

## Additional Notes

Unprobeable without a done-signal still returns UNKNOWN and is reclassified next start. That is intentional: we cannot ask the client and we cannot prove completion, so we must not mark the row `GONE`. The diagnosis no longer accuses a healthy NZBGet, and rows that *can* prove completion now close.

A reconstructed NZBGet row with no NZBID and no nzblog is treated like history-evicted `absent`: marked `downloaded` and put on `PP_QUEUE` even when the folder is unknown. Post-process validation owns the missing-folder quarantine. That is distinct from a genuine `unreachable` probe, which still takes the #734 `manual_review` path.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c8eab4f-b266-4e8a-96ca-7c19eacb86ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c8eab4f-b266-4e8a-96ca-7c19eacb86ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup recovery for downloads without a recorded NZBGet ID.
  * Completed downloads are now recognized when the library confirms completion.
  * Incomplete or unverifiable downloads remain marked as unknown without incorrectly reporting an NZBGet outage.
  * Genuine NZBGet connection failures continue to be retried as temporary outages.

* **Tests**
  * Added coverage for recovery behavior with missing download IDs, completed items, and connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->