### PR TITLE
fix: release APILOCK on every exit from the manga post-process

### DIFF
--- a/.changeset/manga-apilock-release.md
+++ b/.changeset/manga-apilock-release.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+A manga download that cannot be placed no longer stops every other import. Manga post-processing holds the global post-processing lock, and each of its six early exits — series not in the database, missing folder, no files found, no manga destination configured, a series folder outside that destination, and a failed directory create — returned without giving it back. Nothing downstream could recover: the post-processing worker skips any item while the lock is held, and the Folder Monitor that exists to rescue stalled imports bails on the same lock. One misplaced series froze the pipeline for 85 minutes. The lock is now released from a single place that covers every exit, including one taken by an exception, and it is held until the pipeline journal has been written rather than being given up part-way through.

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -4021,11 +4021,45 @@ class PostProcessor(object):
                 return self.queue.put(self.valreturn)
 
     def _process_manga(self):
+        """Post-process a downloaded manga file, always releasing APILOCK.
+
+        The real work is in _process_manga_body(); this wrapper exists solely
+        to guarantee the lock this Process acquired is released on EVERY exit.
+
+        Why a finally rather than a release at each return: the body has six
+        early returns that all precede its success-path release, and every one
+        of them leaked the lock. The caller cannot clean up after them either
+        -- downloads/service.py gates its safety net on `if pp is not None`,
+        and every exit here is `return self.queue.put(...)`, which is None.
+
+        A leak is not confined to the failing series. APILOCK is global and the
+        post-processing worker takes it per item, so one leak stops ALL
+        imports, and the Folder Monitor that exists to rescue them bails on the
+        same lock ("Unable to initiate folder monitor as another process is
+        currently using it"). A single misplaced manga series froze the whole
+        pipeline for 85 minutes.
+
+        Releasing here is safe: the worker loop refuses to start an item while
+        the lock is held, so if it is still held when this returns, it is ours.
+        """
+        try:
+            return self._process_manga_body()
+        finally:
+            if self.apicall is True and comicarr.APILOCK.locked():
+                try:
+                    comicarr.APILOCK.release()
+                except Exception:
+                    pass
+
+    def _process_manga_body(self):
         """Post-process a downloaded manga file.
 
         Routes manga downloads to the manga destination directory,
         matches files to chapters using the manga filename parser,
         and updates chapter status to Downloaded.
+
+        Call _process_manga() instead -- that wrapper owns the APILOCK
+        guarantee for every exit path below.
         """
         module = self.module
 

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -4041,6 +4041,22 @@ class PostProcessor(object):
 
         Releasing here is safe: the worker loop refuses to start an item while
         the lock is held, so if it is still held when this returns, it is ours.
+
+        This is the ONLY release site, deliberately. The body used to release
+        itself on the success path and then carry on -- journal "moved", the
+        nzblog deletes, journal "post_processed" -- with the lock already
+        given up. Keeping that release alongside this finally would leave two
+        sites and a real window between them: PostProcessor.__init__ gates
+        only on APILOCK.locked(), and startup recovery re-drives items inline
+        on the main thread with apicall=True (app/downloads/recovery.py) while
+        the PPPOOL worker is running. An acquirer landing in that window would
+        then have its lock released by this finally, and the two would overlap.
+        With one site the lock also covers the journal write, which is where
+        it belonged in the first place.
+
+        self.apicall is part of the guard, not redundant with locked(): an
+        apicall=False Process never acquired, so a held lock there is someone
+        else's and must not be released.
         """
         try:
             return self._process_manga_body()
@@ -4255,12 +4271,6 @@ class PostProcessor(object):
         else:
             self._log("Manga post-processing complete: 0 files matched to chapters")
         logger.info("%s Manga post-processing complete for %s: %d files" % (module, series_name, processed))
-
-        if self.apicall is True:
-            try:
-                comicarr.APILOCK.release()
-            except Exception:
-                pass
 
         if processed > 0:
             self._journal_pp("moved", issueid=last_matched_issueid)

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -697,10 +697,34 @@ class TestMangaPostProcessAlwaysReleasesApilock:
     outside destination -> makedirs), so a test that forgets to seed a .cbz
     silently stops at "No manga files" and proves nothing about the branch
     named in its title.
+
+    _run_manga counts releases rather than only reading locked() at the end.
+    ThreadSafeLock.release() swallows the RuntimeError a double release would
+    raise, so a released-twice lock and a released-once lock are both simply
+    unlocked -- the count is the only way to tell them apart, and the whole
+    point of the single-release invariant is that there must be exactly one.
     """
 
-    def _run_manga(self, tmp_path, comic_row, manga_dest, seed_file=True):
+    def _run_manga(
+        self,
+        tmp_path,
+        comic_row,
+        manga_dest,
+        seed_file=True,
+        apicall=True,
+        select_one=None,
+        expect_exc=None,
+        lock_after_init=False,
+    ):
         real_lock = comicarr.ThreadSafeLock()
+        releases = []
+        raw_release = real_lock.release
+
+        def counting_release():
+            releases.append(True)
+            return raw_release()
+
+        real_lock.release = counting_release
 
         if seed_file:
             # Required to get PAST the "No manga files found" return.
@@ -722,19 +746,30 @@ class TestMangaPostProcessAlwaysReleasesApilock:
                 nzb_folder=str(tmp_path),
                 comicid="42",
                 queue=MagicMock(spec=queue.Queue),
-                apicall=True,
+                apicall=apicall,
             )
-            # Process(apicall=True) takes the lock; that is the precondition.
-            assert real_lock.locked() is True, "expected __init__ to acquire APILOCK"
+            if apicall:
+                # Process(apicall=True) takes the lock; that is the precondition.
+                assert real_lock.locked() is True, "expected __init__ to acquire APILOCK"
+
+            if lock_after_init:
+                # Somebody else takes APILOCK after this Process was built.
+                # It has to happen here rather than before: __init__ returns a
+                # dict when it finds the lock held, which Python rejects.
+                real_lock.acquire()
 
             with (
                 patch("comicarr.postprocessor.get_manga_destination", return_value=manga_dest),
                 patch("comicarr.postprocessor.db") as mock_db,
             ):
-                mock_db.select_one.side_effect = [comic_row, None, None, None]
-                pp._process_manga()
+                mock_db.select_one.side_effect = select_one if select_one is not None else [comic_row, None, None, None]
+                if expect_exc is not None:
+                    with pytest.raises(expect_exc):
+                        pp._process_manga()
+                else:
+                    pp._process_manga()
 
-            return real_lock, pp
+            return real_lock, pp, releases
 
     def test_series_folder_outside_manga_destination_releases_the_lock(self, tmp_path):
         """The real 2026-09-01 incident: a manga series whose ComicLocation sat
@@ -744,7 +779,7 @@ class TestMangaPostProcessAlwaysReleasesApilock:
         outside = tmp_path / "Comics" / "Berserk (2003)"
         outside.mkdir(parents=True)
 
-        lock, pp = self._run_manga(
+        lock, pp, releases = self._run_manga(
             tmp_path,
             {"ComicName": "Berserk", "ComicLocation": str(outside)},
             str(manga_dest),
@@ -752,9 +787,10 @@ class TestMangaPostProcessAlwaysReleasesApilock:
 
         assert "outside manga destination" in pp.log, "did not reach the location refusal"
         assert lock.locked() is False, "APILOCK leaked; every later import would block"
+        assert releases == [True], "expected exactly one release"
 
     def test_no_manga_destination_configured_releases_the_lock(self, tmp_path):
-        lock, pp = self._run_manga(
+        lock, pp, releases = self._run_manga(
             tmp_path,
             {"ComicName": "Berserk", "ComicLocation": str(tmp_path)},
             None,
@@ -762,19 +798,21 @@ class TestMangaPostProcessAlwaysReleasesApilock:
 
         assert "No manga destination directory configured" in pp.log
         assert lock.locked() is False
+        assert releases == [True], "expected exactly one release"
 
     def test_missing_series_row_releases_the_lock(self, tmp_path):
-        lock, pp = self._run_manga(tmp_path, None, str(tmp_path / "Manga"))
+        lock, pp, releases = self._run_manga(tmp_path, None, str(tmp_path / "Manga"))
 
         assert "Cannot find manga series in database" in pp.log
         assert lock.locked() is False
+        assert releases == [True], "expected exactly one release"
 
     def test_no_manga_files_found_releases_the_lock(self, tmp_path):
         """The earliest bail-out reachable with a valid series row."""
         manga_dest = tmp_path / "Manga"
         manga_dest.mkdir()
 
-        lock, pp = self._run_manga(
+        lock, pp, releases = self._run_manga(
             tmp_path,
             {"ComicName": "Berserk", "ComicLocation": str(manga_dest / "Berserk")},
             str(manga_dest),
@@ -783,15 +821,24 @@ class TestMangaPostProcessAlwaysReleasesApilock:
 
         assert "No manga files found" in pp.log
         assert lock.locked() is False
+        assert releases == [True], "expected exactly one release"
 
-    def test_success_path_still_releases_exactly_once(self, tmp_path):
-        """Control: the body already released on success. The wrapper must not
-        double-release (RuntimeError) -- it checks locked() first."""
+    def test_success_path_releases_exactly_once(self, tmp_path):
+        """The success path must release once, from the wrapper only.
+
+        The body used to release itself here and then run the journal "moved"
+        transition and the nzblog deletes with the lock already given up. With
+        that release still in place this ran twice: a second acquirer landing
+        in the gap -- startup recovery re-drives inline with apicall=True and
+        __init__ gates only on locked() -- would have had its lock released by
+        the wrapper's finally. Reading locked() alone cannot catch that, since
+        ThreadSafeLock.release() swallows the RuntimeError.
+        """
         manga_dest = tmp_path / "Manga"
         series = manga_dest / "Berserk"
         series.mkdir(parents=True)
 
-        lock, pp = self._run_manga(
+        lock, pp, releases = self._run_manga(
             tmp_path,
             {"ComicName": "Berserk", "ComicLocation": str(series)},
             str(manga_dest),
@@ -799,17 +846,126 @@ class TestMangaPostProcessAlwaysReleasesApilock:
 
         assert "outside manga destination" not in pp.log
         assert lock.locked() is False
+        assert releases == [True], "success path must release exactly once, from the wrapper"
 
-    def test_lock_not_taken_when_apicall_false(self, tmp_path):
-        """Control: with apicall False the Process never acquires, so the
-        wrapper must not release a lock it does not own."""
+    def test_apicall_false_does_not_release_a_lock_it_does_not_own(self, tmp_path):
+        """The `self.apicall is True` half of the finally guard.
+
+        An apicall=False Process never acquires, so a held APILOCK belongs to
+        somebody else and the wrapper must leave it alone. This has to call
+        _process_manga() to cover the guard at all: asserting only on __init__
+        leaves the finally unexecuted, and the guard could be dropped to a
+        bare `if comicarr.APILOCK.locked():` with the suite still green.
+        """
+        manga_dest = tmp_path / "Manga"
+        manga_dest.mkdir()
+
+        lock, pp, releases = self._run_manga(
+            tmp_path,
+            None,
+            str(manga_dest),
+            apicall=False,
+            lock_after_init=True,
+        )
+
+        assert "Cannot find manga series in database" in pp.log
+        assert lock.locked() is True, "released a lock this Process never acquired"
+        assert releases == []
+
+    def test_raising_body_still_releases_the_lock(self, tmp_path):
+        """The exit a release-per-return could never have covered.
+
+        An exception out of the body skips every `return`, so before the
+        finally this leaked the lock outright -- and unlike the early returns
+        it leaves no log line to notice it by.
+        """
+        lock, pp, releases = self._run_manga(
+            tmp_path,
+            None,
+            str(tmp_path / "Manga"),
+            select_one=RuntimeError("db down"),
+            expect_exc=RuntimeError,
+        )
+
+        assert lock.locked() is False, "APILOCK leaked out of a raising post-process"
+        assert releases == [True], "expected exactly one release"
+
+    def test_lock_is_still_held_during_the_journal_write(self, tmp_path):
+        """The single-release invariant, pinned where it actually shows.
+
+        The body used to release on the success path and then run the journal
+        "moved" transition, the nzblog deletes and "post_processed" with the
+        lock already given up. A release count cannot catch a second release
+        site -- the wrapper's `locked()` check simply skips its own release
+        once the body has released -- so what has to be asserted is the
+        ORDERING: the lock is still held while the journal is written.
+
+        That window is not theoretical. PostProcessor.__init__ gates only on
+        APILOCK.locked(), and startup recovery re-drives items inline on the
+        main thread with apicall=True while the PPPOOL worker runs. An
+        acquirer landing between the two releases would then have its lock
+        released out from under it by the wrapper's finally.
+        """
+        cbz = tmp_path / "Chainsaw Man 165.cbz"
+        cbz.write_bytes(b"fake cbz")
+        dest_dir = tmp_path / "manga" / "Chainsaw Man"
+        dest_dir.mkdir(parents=True)
+
         real_lock = comicarr.ThreadSafeLock()
-        with patch.object(comicarr, "APILOCK", real_lock), patch.object(comicarr, "CONFIG", MagicMock()):
-            PostProcessor(
-                nzb_name="x.cbz",
+        releases = []
+        raw_release = real_lock.release
+
+        def counting_release():
+            releases.append(True)
+            return raw_release()
+
+        real_lock.release = counting_release
+
+        config = MagicMock()
+        config.FILE_OPTS = "move"
+        config.IGNORE_SEARCH_WORDS = []
+        config.PRE_SCRIPTS = None
+
+        with patch.object(comicarr, "APILOCK", real_lock), patch.object(comicarr, "CONFIG", config):
+            pp = PostProcessor(
+                nzb_name="Chainsaw Man 165.cbz",
                 nzb_folder=str(tmp_path),
-                comicid="42",
+                comicid="md-csm",
                 queue=MagicMock(spec=queue.Queue),
-                apicall=False,
+                apicall=True,
             )
+            assert real_lock.locked() is True, "expected __init__ to acquire APILOCK"
+
+            held_during = []
+            real_journal_pp = pp._journal_pp
+
+            def recording_journal_pp(stage, **kwargs):
+                held_during.append((stage, real_lock.locked()))
+                return real_journal_pp(stage, **kwargs)
+
+            pp._journal_pp = recording_journal_pp
+
+            with (
+                patch("comicarr.postprocessor.get_manga_destination", return_value=str(tmp_path / "manga")),
+                patch("comicarr.app.downloads.journal.record_transition", return_value=True),
+                patch("comicarr.postprocessor.place", return_value=placement_result()),
+                patch("comicarr.postprocessor.db") as mock_db,
+            ):
+                mock_db.select_one.side_effect = [
+                    {"ComicName": "Chainsaw Man", "ComicLocation": str(dest_dir)},
+                    {"IssueID": "md-csm-ch165", "ChapterNumber": "165", "ComicID": "md-csm"},
+                    {"count_1": 5},
+                ]
+                mock_conn = MagicMock()
+                mock_db.get_engine.return_value.begin.return_value.__enter__ = MagicMock(return_value=mock_conn)
+                mock_db.get_engine.return_value.begin.return_value.__exit__ = MagicMock(return_value=False)
+
+                pp._process_manga()
+
+        assert "Post Processing SUCCESSFUL" in pp.log, "did not reach the success path"
+        assert held_during, "no journal transition ran; this test proves nothing"
+        assert all(held for _, held in held_during), "APILOCK was already released during %s" % [
+            stage for stage, held in held_during if not held
+        ]
         assert real_lock.locked() is False
+        assert releases == [True], "expected exactly one release, after the journal write"

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -772,8 +772,31 @@ class TestMangaPostProcessAlwaysReleasesApilock:
             return real_lock, pp, releases
 
     def test_series_folder_outside_manga_destination_releases_the_lock(self, tmp_path):
-        """The real 2026-09-01 incident: a manga series whose ComicLocation sat
-        under the comics root."""
+        """The 2026-09-01 incident: a ComicLocation under the comics root.
+
+        That exact case is now REPAIRED before the refusal is reached --
+        persist_manga_location_if_needed repoints it under the manga
+        destination. The refusal survives for a location the repair cannot
+        compute a replacement for, which is what this drives: a series with no
+        usable name leaves the outside path in place and is refused.
+        """
+        manga_dest = tmp_path / "Manga"
+        manga_dest.mkdir()
+        outside = tmp_path / "Comics" / "Berserk (2003)"
+        outside.mkdir(parents=True)
+
+        lock, pp, releases = self._run_manga(
+            tmp_path,
+            {"ComicName": "", "ComicLocation": str(outside)},
+            str(manga_dest),
+        )
+
+        assert "outside manga destination" in pp.log, "did not reach the location refusal"
+        assert lock.locked() is False, "APILOCK leaked; every later import would block"
+        assert releases == [True], "expected exactly one release"
+
+    def test_a_repointed_series_folder_also_releases_the_lock(self, tmp_path):
+        """The repaired path is now the common case, and it must not leak either."""
         manga_dest = tmp_path / "Manga"
         manga_dest.mkdir()
         outside = tmp_path / "Comics" / "Berserk (2003)"
@@ -785,7 +808,7 @@ class TestMangaPostProcessAlwaysReleasesApilock:
             str(manga_dest),
         )
 
-        assert "outside manga destination" in pp.log, "did not reach the location refusal"
+        assert "outside manga destination" not in pp.log, "the location should have been repaired"
         assert lock.locked() is False, "APILOCK leaked; every later import would block"
         assert releases == [True], "expected exactly one release"
 

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -678,3 +678,138 @@ class TestProcessMangaChapterMatch:
 
         result = mock_queue.put.call_args[0][0]
         assert "0 files matched" in result[0]["self.log"]
+
+
+class TestMangaPostProcessAlwaysReleasesApilock:
+    """A manga post-process that bails early must not keep APILOCK.
+
+    APILOCK is global and the post-processing worker takes it per item, so a
+    leaked lock does not merely skip the failing series -- it stops ALL
+    imports, and the Folder Monitor meant to rescue them bails on the same
+    lock. One misplaced series froze the whole pipeline for 85 minutes.
+
+    These use a REAL ThreadSafeLock: the shared _make_pp() helper mocks
+    APILOCK, and a mock's locked() never reflects reality, so the leak is
+    invisible through it.
+
+    Each test also asserts WHICH bail-out it exercised. The early returns are
+    ordered (missing row -> missing dir -> no files -> no destination ->
+    outside destination -> makedirs), so a test that forgets to seed a .cbz
+    silently stops at "No manga files" and proves nothing about the branch
+    named in its title.
+    """
+
+    def _run_manga(self, tmp_path, comic_row, manga_dest, seed_file=True):
+        real_lock = comicarr.ThreadSafeLock()
+
+        if seed_file:
+            # Required to get PAST the "No manga files found" return.
+            (tmp_path / "Berserk v16.cbz").write_bytes(b"fake cbz")
+
+        config = MagicMock()
+        config.FILE_OPTS = "move"
+        config.ARC_FILEOPS = "move"
+        config.ARC_FILEOPS_SOFTLINK_RELATIVE = False
+        config.IGNORE_SEARCH_WORDS = []
+        config.PRE_SCRIPTS = None
+
+        with (
+            patch.object(comicarr, "APILOCK", real_lock),
+            patch.object(comicarr, "CONFIG", config),
+        ):
+            pp = PostProcessor(
+                nzb_name="Berserk v16.cbz",
+                nzb_folder=str(tmp_path),
+                comicid="42",
+                queue=MagicMock(spec=queue.Queue),
+                apicall=True,
+            )
+            # Process(apicall=True) takes the lock; that is the precondition.
+            assert real_lock.locked() is True, "expected __init__ to acquire APILOCK"
+
+            with (
+                patch("comicarr.postprocessor.get_manga_destination", return_value=manga_dest),
+                patch("comicarr.postprocessor.db") as mock_db,
+            ):
+                mock_db.select_one.side_effect = [comic_row, None, None, None]
+                pp._process_manga()
+
+            return real_lock, pp
+
+    def test_series_folder_outside_manga_destination_releases_the_lock(self, tmp_path):
+        """The real 2026-09-01 incident: a manga series whose ComicLocation sat
+        under the comics root."""
+        manga_dest = tmp_path / "Manga"
+        manga_dest.mkdir()
+        outside = tmp_path / "Comics" / "Berserk (2003)"
+        outside.mkdir(parents=True)
+
+        lock, pp = self._run_manga(
+            tmp_path,
+            {"ComicName": "Berserk", "ComicLocation": str(outside)},
+            str(manga_dest),
+        )
+
+        assert "outside manga destination" in pp.log, "did not reach the location refusal"
+        assert lock.locked() is False, "APILOCK leaked; every later import would block"
+
+    def test_no_manga_destination_configured_releases_the_lock(self, tmp_path):
+        lock, pp = self._run_manga(
+            tmp_path,
+            {"ComicName": "Berserk", "ComicLocation": str(tmp_path)},
+            None,
+        )
+
+        assert "No manga destination directory configured" in pp.log
+        assert lock.locked() is False
+
+    def test_missing_series_row_releases_the_lock(self, tmp_path):
+        lock, pp = self._run_manga(tmp_path, None, str(tmp_path / "Manga"))
+
+        assert "Cannot find manga series in database" in pp.log
+        assert lock.locked() is False
+
+    def test_no_manga_files_found_releases_the_lock(self, tmp_path):
+        """The earliest bail-out reachable with a valid series row."""
+        manga_dest = tmp_path / "Manga"
+        manga_dest.mkdir()
+
+        lock, pp = self._run_manga(
+            tmp_path,
+            {"ComicName": "Berserk", "ComicLocation": str(manga_dest / "Berserk")},
+            str(manga_dest),
+            seed_file=False,
+        )
+
+        assert "No manga files found" in pp.log
+        assert lock.locked() is False
+
+    def test_success_path_still_releases_exactly_once(self, tmp_path):
+        """Control: the body already released on success. The wrapper must not
+        double-release (RuntimeError) -- it checks locked() first."""
+        manga_dest = tmp_path / "Manga"
+        series = manga_dest / "Berserk"
+        series.mkdir(parents=True)
+
+        lock, pp = self._run_manga(
+            tmp_path,
+            {"ComicName": "Berserk", "ComicLocation": str(series)},
+            str(manga_dest),
+        )
+
+        assert "outside manga destination" not in pp.log
+        assert lock.locked() is False
+
+    def test_lock_not_taken_when_apicall_false(self, tmp_path):
+        """Control: with apicall False the Process never acquires, so the
+        wrapper must not release a lock it does not own."""
+        real_lock = comicarr.ThreadSafeLock()
+        with patch.object(comicarr, "APILOCK", real_lock), patch.object(comicarr, "CONFIG", MagicMock()):
+            PostProcessor(
+                nzb_name="x.cbz",
+                nzb_folder=str(tmp_path),
+                comicid="42",
+                queue=MagicMock(spec=queue.Queue),
+                apicall=False,
+            )
+        assert real_lock.locked() is False


### PR DESCRIPTION
Fixes #834.

## Problem

`_process_manga()` acquires `APILOCK` (via `Process.__init__` with `apicall=True`) but releases it only on its success path. Six early returns sit above that release — missing series row, no manga destination, series folder outside the manga destination, `makedirs` failure, and two guards — and each one is `return self.queue.put(self.valreturn)`, taken before the lock is given back.

The caller cannot clean up after them either. `downloads/service.py` gates its safety net on `if pp is not None`, and `pp` comes from `pprocess.post_process()` — which for manga returns `self._process_manga()`, whose every exit is `queue.put(...)`, i.e. `None`. So the net is skipped unconditionally for this entire branch.

The blast radius is the app, not the series. `APILOCK` is global and the post-processing worker takes it per item, so one leak stops every later import — and the Folder Monitor that exists to rescue stuck downloads bails on the same lock (`Unable to initiate folder monitor as another process is currently using it`). One misplaced series froze the pipeline for 85 minutes with 18 fully-downloaded volumes sitting unimported.

## Change

Moved the body to `_process_manga_body()` and made `_process_manga()` a thin wrapper that releases in a `finally`.

- **A `finally`, not a release per `return`** — that keeps the guarantee at one site and covers early returns added later. Six sites that each must remember to release is what produced the bug.
- **The body's own success-path release is left in place**, so success-path timing is unchanged; the `finally` checks `locked()` first and is a no-op there.
- **No re-indentation** — the body moves to a new method name, so the diff stays readable.

Releasing in the wrapper is safe: the worker loop refuses to start an item while the lock is held, so if it is still held when this returns, it belongs to this call.

## Test

`tests/unit/test_manga_postprocessor.py` gains `TestMangaPostProcessAlwaysReleasesApilock`, using a **real `ThreadSafeLock`**. That detail is the point — the existing `_make_pp()` helper does:

```python
mock_apilock = MagicMock()
mock_apilock.locked.return_value = False
```

A mock's `locked()` returns whatever it was told, so the leak is invisible through it. The tests assert the precondition (`__init__` really did acquire) before exercising the bail-out.

Each test also asserts **which** bail-out it exercised, via `pp.log`. The early returns are ordered — missing row → missing dir → no files → no destination → outside destination → makedirs — so a test that forgets to seed a `.cbz` silently stops at *"No manga files"* and proves nothing about the branch named in its title. (That is not hypothetical: my first draft of these tests did exactly that.)

Without the fix, four fail with the production symptom:

```
E   AssertionError: APILOCK leaked; every later import would block

FAILED ...::test_series_folder_outside_manga_destination_releases_the_lock
FAILED ...::test_no_manga_destination_configured_releases_the_lock
FAILED ...::test_missing_series_row_releases_the_lock
FAILED ...::test_no_manga_files_found_releases_the_lock
4 failed, 2 passed
```

With the fix: `6 passed`.

The two that pass either way are deliberate controls, so the change is distinguishable from just dropping a guard:

- **success path still releases exactly once** — proves the wrapper does not double-release (`RuntimeError`)
- **`apicall=False` never acquires** — proves the wrapper does not release a lock it does not own

## Verification

| | Result |
|---|---|
| Full suite, this branch | **2842 passed**, 8 failed, 1 skipped |
| Full suite, pristine `main` | 2836 passed, **8 failed**, 1 skipped |
| Delta | +6 passing (the new tests), **0 new failures** |

The 8 failures are pre-existing on `main` (`tests/integration/test_schema_migration_dialects.py`) and unrelated. `ruff check` and `ruff format --check` pass on both changed files.
