### PR TITLE
fix: Repoint series location when reclassifying as manga

### DIFF
--- a/.changeset/manga-reclassify-location.md
+++ b/.changeset/manga-reclassify-location.md
@@ -1,0 +1,5 @@
+---
+"comicarr": patch
+---
+
+Switching a series to manga now stores it under the manga destination so completed downloads can import. Files already in the old comics folder are not moved.

--- a/.changeset/manga-reclassify-location.md
+++ b/.changeset/manga-reclassify-location.md
@@ -2,4 +2,4 @@
 "comicarr": patch
 ---
 
-Switching a series to manga now stores it under the manga destination so completed downloads can import. Files already in the old comics folder are not moved.
+Switching a series to manga now stores it under the manga destination so completed downloads can import. A series that was already manga but still pointed at the comics folder is repaired on the next import. Files already in the old comics folder are not moved.

--- a/comicarr/app/series/queries.py
+++ b/comicarr/app/series/queries.py
@@ -214,13 +214,23 @@ def update_comic_search_settings(comic_id, values):
 
 
 def get_comic_content_kind(comic_id):
-    """Get the persisted provider-independent content kind for a Series."""
-    return db.select_one(select(t_comics.c.ComicID, t_comics.c.ContentType).where(t_comics.c.ComicID == comic_id))
+    """Get the persisted content kind and location fields for a Series."""
+    return db.select_one(
+        select(
+            t_comics.c.ComicID,
+            t_comics.c.ComicName,
+            t_comics.c.ComicLocation,
+            t_comics.c.ContentType,
+        ).where(t_comics.c.ComicID == comic_id)
+    )
 
 
-def update_comic_content_kind(comic_id, content_type):
-    """Atomically persist only the Series content-kind field."""
-    db.upsert("comics", {"ContentType": content_type}, {"ComicID": comic_id})
+def update_comic_content_kind(comic_id, content_type, comic_location=None):
+    """Atomically persist content kind, and ComicLocation when provided."""
+    values = {"ContentType": content_type}
+    if comic_location is not None:
+        values["ComicLocation"] = comic_location
+    db.upsert("comics", values, {"ComicID": comic_id})
 
 
 def pause_comic(comic_id):

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -31,7 +31,6 @@ from comicarr.app.common.filesystem import is_path_within_allowed_dirs
 from comicarr.app.common.strings import filesafe
 from comicarr.app.core.workers import start_background_thread
 from comicarr.app.series import queries as series_queries
-from comicarr.config import get_manga_destination
 from comicarr.tables import annuals, comics, issues, oneoffhistory, storyarcs, weekly
 
 _LIBRARY_ROOT_CONFIG_KEYS = (
@@ -466,6 +465,13 @@ def _location_under_manga_dest(location, manga_dest):
     return is_path_within_allowed_dirs(location, [manga_dest])
 
 
+def _manga_destination():
+    # Lazy import: helpers.py imports this module during comicarr.config init.
+    from comicarr.config import get_manga_destination
+
+    return get_manga_destination()
+
+
 def manga_series_location(series_name, manga_dest):
     """Return ``<manga_dest>/<filesafe(series_name)>``, or None if either is missing."""
     folder = filesafe(series_name) if series_name else ""
@@ -528,7 +534,7 @@ def update_content_kind(ctx, comic_id, content_type):
 
     new_location = None
     if content_type == "manga":
-        new_location, warning = manga_location_for_reclassify(existing, get_manga_destination())
+        new_location, warning = manga_location_for_reclassify(existing, _manga_destination())
         if warning:
             logger.warn(warning)
 

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -500,21 +500,45 @@ def manga_location_for_reclassify(existing, manga_dest):
     if new_location is None:
         if not _series_text(manga_dest):
             return None, (
-                "[SERIES] Reclassified %s as manga, but no manga destination is configured. "
+                "[SERIES] Manga series %s has no manga destination configured. "
                 "ComicLocation was left at %s." % (comic_id, old_location or "(unset)")
             )
         return None, (
-            "[SERIES] Reclassified %s as manga, but the series has no usable name. "
+            "[SERIES] Manga series %s has no usable name. "
             "ComicLocation was left at %s." % (comic_id, old_location or "(unset)")
         )
 
     if old_location and not _paths_equal(old_location, new_location):
         return new_location, (
-            "[SERIES] Reclassified %s (%s) as manga. ComicLocation is now %s "
+            "[SERIES] Manga series %s (%s): ComicLocation is now %s "
             "(under the manga destination). Files already at %s were not moved."
             % (series_name, comic_id, new_location, old_location)
         )
     return new_location, None
+
+
+def persist_manga_location_if_needed(existing, manga_dest=None):
+    """Rewrite and persist ComicLocation when it would fail the manga dest check.
+
+    Used by manga post-processing so an already-manga series that still points
+    at the comics tree is repaired without another operator click. Returns
+    ``(location_to_use, did_repoint)``.
+    """
+    dest = manga_dest if manga_dest is not None else _manga_destination()
+    new_location, warning = manga_location_for_reclassify(existing, dest)
+    if warning:
+        logger.warn(warning)
+    old_location = _series_text((existing or {}).get("ComicLocation"))
+    if new_location is None:
+        return old_location, False
+    comic_id = (existing or {}).get("ComicID")
+    if comic_id:
+        series_queries.update_comic_content_kind(
+            comic_id,
+            (existing or {}).get("ContentType") or "manga",
+            comic_location=new_location,
+        )
+    return new_location, True
 
 
 def update_content_kind(ctx, comic_id, content_type):

--- a/comicarr/app/series/service.py
+++ b/comicarr/app/series/service.py
@@ -28,8 +28,10 @@ from comicarr.app.acquisition.evidence import has_verified_library_file
 from comicarr.app.acquisition.models import AcquisitionIntent, Fulfillment
 from comicarr.app.acquisition.policy import EligibilityInput, evaluate_eligibility, project_legacy_state
 from comicarr.app.common.filesystem import is_path_within_allowed_dirs
+from comicarr.app.common.strings import filesafe
 from comicarr.app.core.workers import start_background_thread
 from comicarr.app.series import queries as series_queries
+from comicarr.config import get_manga_destination
 from comicarr.tables import annuals, comics, issues, oneoffhistory, storyarcs, weekly
 
 _LIBRARY_ROOT_CONFIG_KEYS = (
@@ -445,12 +447,77 @@ def update_search_settings(
     }
 
 
+def _series_text(value):
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _paths_equal(left, right):
+    if not left or not right:
+        return False
+    return os.path.normcase(os.path.realpath(left)) == os.path.normcase(os.path.realpath(right))
+
+
+def _location_under_manga_dest(location, manga_dest):
+    if not location or not manga_dest:
+        return False
+    return is_path_within_allowed_dirs(location, [manga_dest])
+
+
+def manga_series_location(series_name, manga_dest):
+    """Return ``<manga_dest>/<filesafe(series_name)>``, or None if either is missing."""
+    folder = filesafe(series_name) if series_name else ""
+    folder = str(folder).strip() if folder else ""
+    dest = _series_text(manga_dest)
+    if not dest or not folder:
+        return None
+    return os.path.join(dest, folder)
+
+
+def manga_location_for_reclassify(existing, manga_dest):
+    """Decide whether switching to manga must also rewrite ComicLocation.
+
+    Returns ``(new_location_or_None, warning_or_None)``. A None location means
+    leave the stored path unchanged — either it already satisfies the manga
+    destination contract, or we cannot compute a valid replacement.
+    """
+    series_name = _series_text((existing or {}).get("ComicName"))
+    old_location = _series_text((existing or {}).get("ComicLocation"))
+    comic_id = (existing or {}).get("ComicID")
+
+    if _location_under_manga_dest(old_location, manga_dest):
+        return None, None
+
+    new_location = manga_series_location(series_name, manga_dest)
+    if new_location is None:
+        if not _series_text(manga_dest):
+            return None, (
+                "[SERIES] Reclassified %s as manga, but no manga destination is configured. "
+                "ComicLocation was left at %s." % (comic_id, old_location or "(unset)")
+            )
+        return None, (
+            "[SERIES] Reclassified %s as manga, but the series has no usable name. "
+            "ComicLocation was left at %s." % (comic_id, old_location or "(unset)")
+        )
+
+    if old_location and not _paths_equal(old_location, new_location):
+        return new_location, (
+            "[SERIES] Reclassified %s (%s) as manga. ComicLocation is now %s "
+            "(under the manga destination). Files already at %s were not moved."
+            % (series_name, comic_id, new_location, old_location)
+        )
+    return new_location, None
+
+
 def update_content_kind(ctx, comic_id, content_type):
     """Persist an operator-controlled comic-or-manga classification.
 
-    Content kind is deliberately independent of provider identity and legacy
-    publication ``Type``. This write therefore touches only ``ContentType``;
-    provider metadata and issue/annual rows remain unchanged.
+    Content kind is independent of provider identity and legacy publication
+    ``Type``. The write always updates ``ContentType``. Switching to manga also
+    repoints ``ComicLocation`` under the manga destination when the stored path
+    would be refused by manga post-processing. Existing files are not moved.
     """
     if content_type not in ("comic", "manga"):
         return {"success": False, "error": "Content kind must be comic or manga"}
@@ -459,11 +526,32 @@ def update_content_kind(ctx, comic_id, content_type):
     if not existing:
         return {"success": False, "error": "ComicID %s not found in watchlist" % comic_id}
 
-    series_queries.update_comic_content_kind(comic_id, content_type)
+    new_location = None
+    if content_type == "manga":
+        new_location, warning = manga_location_for_reclassify(existing, get_manga_destination())
+        if warning:
+            logger.warn(warning)
+
+    if new_location is not None:
+        series_queries.update_comic_content_kind(comic_id, content_type, comic_location=new_location)
+    else:
+        series_queries.update_comic_content_kind(comic_id, content_type)
+
     updated = series_queries.get_comic_content_kind(comic_id)
     canonical = updated["ContentType"] if updated else content_type
+    current_location = _series_text((updated or {}).get("ComicLocation")) or new_location
     logger.fdebug("[SERIES] Updated content kind for %s: %s" % (comic_id, canonical))
-    return {"success": True, "content_type": canonical}
+    result = {
+        "success": True,
+        "content_type": canonical,
+        "location_repointed": new_location is not None,
+    }
+    if current_location:
+        result["comic_location"] = current_location
+    previous_location = _series_text((existing or {}).get("ComicLocation"))
+    if new_location is not None and previous_location and not _paths_equal(previous_location, new_location):
+        result["previous_location"] = previous_location
+    return result
 
 
 def pause_comic(ctx, comic_id):

--- a/comicarr/postprocessor.py
+++ b/comicarr/postprocessor.py
@@ -4070,7 +4070,14 @@ class PostProcessor(object):
             self.valreturn.append({"self.log": self.log, "mode": "stop"})
             return self.queue.put(self.valreturn)
 
-        series_folder = comicnzb.get("ComicLocation") or os.path.join(manga_dest, helpers.filesafe(series_name))
+        from comicarr.app.series.service import persist_manga_location_if_needed
+
+        series_folder, _repointed = persist_manga_location_if_needed(comicnzb, manga_dest)
+        if not series_folder:
+            series_folder = comicnzb.get("ComicLocation") or os.path.join(manga_dest, helpers.filesafe(series_name))
+        if comicnzb.get("ComicLocation") != series_folder:
+            comicnzb = dict(comicnzb)
+            comicnzb["ComicLocation"] = series_folder
 
         if not os.path.realpath(series_folder).startswith(os.path.realpath(manga_dest)):
             self._log("Series folder is outside manga destination — refusing to write")

--- a/frontend/src/components/series/SeriesContentKind.tsx
+++ b/frontend/src/components/series/SeriesContentKind.tsx
@@ -44,7 +44,9 @@ export function SeriesContentKind({
           </p>
           <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
             Future labels and matching follow this choice. Existing files and
-            issue history stay unchanged.
+            issue history stay unchanged. Switching to manga also stores the
+            series under the manga destination so downloads can import; files
+            already on disk are not moved.
           </p>
         </div>
         <div

--- a/frontend/src/hooks/useSeries.ts
+++ b/frontend/src/hooks/useSeries.ts
@@ -189,8 +189,16 @@ export interface SeriesContentKindInput {
   contentType: ContentType;
 }
 
+export interface SeriesContentKindResult {
+  success: boolean;
+  content_type: ContentType;
+  location_repointed?: boolean;
+  comic_location?: string;
+  previous_location?: string;
+}
+
 export function useUpdateSeriesContentKind(): UseMutationResult<
-  { success: boolean; content_type: ContentType },
+  SeriesContentKindResult,
   Error,
   SeriesContentKindInput
 > {
@@ -198,7 +206,7 @@ export function useUpdateSeriesContentKind(): UseMutationResult<
 
   return useMutation({
     mutationFn: ({ comicId, contentType }) =>
-      apiRequest<{ success: boolean; content_type: ContentType }>(
+      apiRequest<SeriesContentKindResult>(
         "PATCH",
         `/api/series/${comicId}/content-kind`,
         { content_type: contentType },

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -449,14 +449,16 @@ export default function SeriesDetailPage() {
   const handleContentKindChange = async (nextKind: ContentType) => {
     if (!comicId || nextKind === contentKind) return;
     try {
-      await contentKindMutation.mutateAsync({
+      const result = await contentKindMutation.mutateAsync({
         comicId,
         contentType: nextKind,
       });
       addToast({
         type: "success",
         title: "Content kind updated",
-        description: `This series now uses ${nextKind} labels and matching rules.`,
+        description: result.location_repointed
+          ? "This series now uses manga labels. New downloads import under the manga destination. Files already at the previous comics path were not moved."
+          : `This series now uses ${nextKind} labels and matching rules.`,
       });
     } catch {
       addToast({

--- a/frontend/tests/pages/SeriesDetailPage.test.tsx
+++ b/frontend/tests/pages/SeriesDetailPage.test.tsx
@@ -364,7 +364,13 @@ describe("SeriesDetailPage", () => {
       http.patch("/api/series/1/content-kind", async ({ request }) => {
         payload = await request.json();
         contentType = "manga";
-        return HttpResponse.json({ success: true, content_type: "manga" });
+        return HttpResponse.json({
+          success: true,
+          content_type: "manga",
+          location_repointed: true,
+          comic_location: "/manga/Absolute Batman",
+          previous_location: "/comics/Absolute Batman (2024)",
+        });
       }),
     );
     const user = userEvent.setup();
@@ -376,12 +382,18 @@ describe("SeriesDetailPage", () => {
     expect(
       screen.getByText(/Existing files and issue history stay unchanged/),
     ).toBeTruthy();
+    expect(
+      screen.getByText(/stores the series under the manga destination/),
+    ).toBeTruthy();
     screen.getByRole("radio", { name: "Comic" }).focus();
     await user.keyboard("{ArrowRight}");
 
     await waitFor(() => expect(payload).toEqual({ content_type: "manga" }));
     await waitFor(() => expect(detailReads).toBeGreaterThan(1));
     expect(await screen.findByText("Content kind updated")).toBeTruthy();
+    expect(
+      screen.getByText(/Files already at the previous comics path were not moved/),
+    ).toBeTruthy();
     expect(
       screen.getByRole("radio", { name: "Manga" }).getAttribute("aria-checked"),
     ).toBe("true");

--- a/tests/unit/test_manga_postprocessor.py
+++ b/tests/unit/test_manga_postprocessor.py
@@ -21,6 +21,7 @@ Unit tests for manga post-processing in comicarr/postprocessor.py.
 Tests cover the _process_manga() method and the manga branch in Process().
 """
 
+import os
 import queue
 from unittest.mock import MagicMock, patch
 
@@ -301,6 +302,82 @@ class TestProcessMangaNoDestination:
         result = mock_queue.put.call_args[0][0]
         assert result[0]["mode"] == "stop"
         assert "No manga destination" in result[0]["self.log"]
+
+
+class TestProcessMangaHealsMisplacedLocation:
+    """An already-manga series whose ComicLocation still sits under the comics
+    dest used to be refused forever. Heal the path on this import and continue.
+    """
+
+    def test_repoints_comics_location_then_places(self, tmp_path):
+        cbz = tmp_path / "Berserk v1.cbz"
+        cbz.write_bytes(b"fake cbz")
+        comics_dir = tmp_path / "comics" / "Berserk (2003)"
+        comics_dir.mkdir(parents=True)
+        manga_dest = tmp_path / "manga"
+
+        pp, mock_queue = _make_pp(
+            nzb_name="Berserk v1.cbz",
+            nzb_folder=str(tmp_path),
+            comicid="160294",
+        )
+
+        comic_row = {
+            "ComicID": "160294",
+            "ComicName": "Berserk",
+            "ComicLocation": str(comics_dir),
+            "ContentType": "manga",
+        }
+
+        with (
+            patch("comicarr.postprocessor.get_manga_destination", return_value=str(manga_dest)),
+            patch("comicarr.postprocessor.db") as mock_db,
+            patch("comicarr.app.series.queries.update_comic_content_kind") as update,
+        ):
+            mock_db.select_one.side_effect = [comic_row, None, None, None]
+            with patch("comicarr.postprocessor.place", return_value=placement_result()) as placer:
+                pp._process_manga()
+
+        expected = os.path.join(str(manga_dest), "Berserk")
+        update.assert_called_once_with("160294", "manga", comic_location=expected)
+        placer.assert_called_once()
+        assert expected in placer.call_args[0][1]
+        result = mock_queue.put.call_args[0][0]
+        assert "outside manga destination" not in result[0]["self.log"]
+
+    def test_still_refuses_when_name_cannot_build_a_folder(self, tmp_path):
+        cbz = tmp_path / "chapter.cbz"
+        cbz.write_bytes(b"fake cbz")
+        comics_dir = tmp_path / "comics" / "unknown"
+        comics_dir.mkdir(parents=True)
+        manga_dest = tmp_path / "manga"
+
+        pp, mock_queue = _make_pp(
+            nzb_name="chapter.cbz",
+            nzb_folder=str(tmp_path),
+            comicid="160294",
+        )
+
+        comic_row = {
+            "ComicID": "160294",
+            "ComicName": "???",
+            "ComicLocation": str(comics_dir),
+            "ContentType": "manga",
+        }
+
+        with (
+            patch("comicarr.postprocessor.get_manga_destination", return_value=str(manga_dest)),
+            patch("comicarr.postprocessor.db") as mock_db,
+            patch("comicarr.app.series.queries.update_comic_content_kind") as update,
+        ):
+            mock_db.select_one.return_value = comic_row
+            pp._process_manga()
+
+        update.assert_not_called()
+        mock_queue.put.assert_called_once()
+        result = mock_queue.put.call_args[0][0]
+        assert result[0]["mode"] == "stop"
+        assert "outside manga destination" in result[0]["self.log"]
 
 
 class TestProcessMangaFileMove:

--- a/tests/unit/test_series_content_kind_api.py
+++ b/tests/unit/test_series_content_kind_api.py
@@ -58,6 +58,29 @@ def test_content_kind_route_accepts_enum_and_returns_service_result(monkeypatch,
     update.assert_called_once_with(ctx, "160294", content_type)
 
 
+def test_content_kind_route_returns_repointed_location_from_service(monkeypatch):
+    update = MagicMock(
+        return_value={
+            "success": True,
+            "content_type": "manga",
+            "location_repointed": True,
+            "comic_location": "/manga/Berserk",
+            "previous_location": "/comics/Berserk (2003)",
+        }
+    )
+    monkeypatch.setattr(series_router.series_service, "update_content_kind", update)
+
+    response = series_router.update_series_content_kind("160294", {"content_type": "manga"}, SimpleNamespace())
+
+    assert response == {
+        "success": True,
+        "content_type": "manga",
+        "location_repointed": True,
+        "comic_location": "/manga/Berserk",
+        "previous_location": "/comics/Berserk (2003)",
+    }
+
+
 def test_content_kind_route_maps_unknown_series_to_404(monkeypatch):
     monkeypatch.setattr(
         series_router.series_service,

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -414,7 +414,7 @@ def test_update_content_kind_persists_and_returns_canonical_value(monkeypatch, c
     }
     updated = dict(existing, ContentType=content_type)
     rows = iter([existing, updated])
-    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service, "_manga_destination", lambda: "/manga")
     monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
     monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
 
@@ -478,7 +478,7 @@ def test_update_content_kind_repoints_comicvine_series_to_manga_dest(monkeypatch
         "ContentType": "manga",
     }
     rows = iter([existing, updated])
-    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service, "_manga_destination", lambda: "/manga")
     monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
     monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
     monkeypatch.setattr(series_service.logger, "warn", warn)
@@ -510,7 +510,7 @@ def test_update_content_kind_leaves_location_when_already_under_manga_dest(monke
     }
     updated = dict(existing, ContentType="manga")
     rows = iter([existing, updated])
-    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service, "_manga_destination", lambda: "/manga")
     monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
     monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
     monkeypatch.setattr(series_service.logger, "warn", warn)
@@ -538,7 +538,7 @@ def test_update_content_kind_heals_manga_series_still_under_comics_dest(monkeypa
         "ContentType": "manga",
     }
     rows = iter([existing, updated])
-    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service, "_manga_destination", lambda: "/manga")
     monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
     monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
 
@@ -559,7 +559,7 @@ def test_update_content_kind_to_comic_does_not_repoint_location(monkeypatch):
     }
     updated = dict(existing, ContentType="comic")
     rows = iter([existing, updated])
-    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service, "_manga_destination", lambda: "/manga")
     monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
     monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
 
@@ -586,7 +586,7 @@ def test_update_content_kind_sets_manga_location_when_unset_without_orphan_warni
         "ContentType": "manga",
     }
     rows = iter([existing, updated])
-    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service, "_manga_destination", lambda: "/manga")
     monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
     monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
     monkeypatch.setattr(series_service.logger, "warn", warn)
@@ -610,7 +610,7 @@ def test_update_content_kind_leaves_location_when_manga_dest_missing(monkeypatch
     }
     updated = dict(existing, ContentType="manga")
     rows = iter([existing, updated])
-    monkeypatch.setattr(series_service, "get_manga_destination", lambda: None)
+    monkeypatch.setattr(series_service, "_manga_destination", lambda: None)
     monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
     monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
     monkeypatch.setattr(series_service.logger, "warn", warn)

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -406,19 +406,27 @@ def test_search_settings_query_upserts_lowercase_comics_table(monkeypatch):
 @pytest.mark.parametrize("content_type", ["comic", "manga"])
 def test_update_content_kind_persists_and_returns_canonical_value(monkeypatch, content_type):
     update = MagicMock()
-    rows = iter(
-        [
-            {"ComicID": "160294", "ContentType": "comic"},
-            {"ComicID": "160294", "ContentType": content_type},
-        ]
-    )
+    existing = {
+        "ComicID": "160294",
+        "ComicName": "Berserk",
+        "ComicLocation": "/manga/Berserk",
+        "ContentType": "comic",
+    }
+    updated = dict(existing, ContentType=content_type)
+    rows = iter([existing, updated])
+    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
     monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
     monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
 
     result = series_service.update_content_kind(_make_ctx(), "160294", content_type)
 
     update.assert_called_once_with("160294", content_type)
-    assert result == {"success": True, "content_type": content_type}
+    assert result == {
+        "success": True,
+        "content_type": content_type,
+        "location_repointed": False,
+        "comic_location": "/manga/Berserk",
+    }
 
 
 def test_update_content_kind_rejects_unknown_series_without_writing(monkeypatch):
@@ -439,6 +447,206 @@ def test_content_kind_query_updates_only_content_type(monkeypatch):
     series_queries.update_comic_content_kind("160294", "manga")
 
     upsert.assert_called_once_with("comics", {"ContentType": "manga"}, {"ComicID": "160294"})
+
+
+def test_content_kind_query_updates_content_type_and_location(monkeypatch):
+    upsert = MagicMock()
+    monkeypatch.setattr(series_queries.db, "upsert", upsert)
+
+    series_queries.update_comic_content_kind("160294", "manga", comic_location="/manga/Berserk")
+
+    upsert.assert_called_once_with(
+        "comics",
+        {"ContentType": "manga", "ComicLocation": "/manga/Berserk"},
+        {"ComicID": "160294"},
+    )
+
+
+def test_update_content_kind_repoints_comicvine_series_to_manga_dest(monkeypatch):
+    update = MagicMock()
+    warn = MagicMock()
+    existing = {
+        "ComicID": "160294",
+        "ComicName": "Berserk",
+        "ComicLocation": "/comics/Berserk (2003)",
+        "ContentType": "comic",
+    }
+    updated = {
+        "ComicID": "160294",
+        "ComicName": "Berserk",
+        "ComicLocation": "/manga/Berserk",
+        "ContentType": "manga",
+    }
+    rows = iter([existing, updated])
+    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
+    monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
+    monkeypatch.setattr(series_service.logger, "warn", warn)
+
+    result = series_service.update_content_kind(_make_ctx(), "160294", "manga")
+
+    update.assert_called_once_with("160294", "manga", comic_location="/manga/Berserk")
+    assert result == {
+        "success": True,
+        "content_type": "manga",
+        "location_repointed": True,
+        "comic_location": "/manga/Berserk",
+        "previous_location": "/comics/Berserk (2003)",
+    }
+    warn.assert_called_once()
+    message = warn.call_args.args[0]
+    assert "ComicLocation is now /manga/Berserk" in message
+    assert "Files already at /comics/Berserk (2003) were not moved" in message
+
+
+def test_update_content_kind_leaves_location_when_already_under_manga_dest(monkeypatch):
+    update = MagicMock()
+    warn = MagicMock()
+    existing = {
+        "ComicID": "md-1",
+        "ComicName": "Berserk",
+        "ComicLocation": "/manga/Berserk (2003)",
+        "ContentType": "comic",
+    }
+    updated = dict(existing, ContentType="manga")
+    rows = iter([existing, updated])
+    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
+    monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
+    monkeypatch.setattr(series_service.logger, "warn", warn)
+
+    result = series_service.update_content_kind(_make_ctx(), "md-1", "manga")
+
+    update.assert_called_once_with("md-1", "manga")
+    assert result["location_repointed"] is False
+    assert result["comic_location"] == "/manga/Berserk (2003)"
+    warn.assert_not_called()
+
+
+def test_update_content_kind_heals_manga_series_still_under_comics_dest(monkeypatch):
+    update = MagicMock()
+    existing = {
+        "ComicID": "160294",
+        "ComicName": "Berserk",
+        "ComicLocation": "/comics/Berserk (2003)",
+        "ContentType": "manga",
+    }
+    updated = {
+        "ComicID": "160294",
+        "ComicName": "Berserk",
+        "ComicLocation": "/manga/Berserk",
+        "ContentType": "manga",
+    }
+    rows = iter([existing, updated])
+    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
+    monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
+
+    result = series_service.update_content_kind(_make_ctx(), "160294", "manga")
+
+    update.assert_called_once_with("160294", "manga", comic_location="/manga/Berserk")
+    assert result["location_repointed"] is True
+    assert result["comic_location"] == "/manga/Berserk"
+
+
+def test_update_content_kind_to_comic_does_not_repoint_location(monkeypatch):
+    update = MagicMock()
+    existing = {
+        "ComicID": "160294",
+        "ComicName": "Berserk",
+        "ComicLocation": "/manga/Berserk",
+        "ContentType": "manga",
+    }
+    updated = dict(existing, ContentType="comic")
+    rows = iter([existing, updated])
+    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
+    monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
+
+    result = series_service.update_content_kind(_make_ctx(), "160294", "comic")
+
+    update.assert_called_once_with("160294", "comic")
+    assert result["location_repointed"] is False
+    assert result["comic_location"] == "/manga/Berserk"
+
+
+def test_update_content_kind_sets_manga_location_when_unset_without_orphan_warning(monkeypatch):
+    update = MagicMock()
+    warn = MagicMock()
+    existing = {
+        "ComicID": "160294",
+        "ComicName": "Berserk",
+        "ComicLocation": None,
+        "ContentType": "comic",
+    }
+    updated = {
+        "ComicID": "160294",
+        "ComicName": "Berserk",
+        "ComicLocation": "/manga/Berserk",
+        "ContentType": "manga",
+    }
+    rows = iter([existing, updated])
+    monkeypatch.setattr(series_service, "get_manga_destination", lambda: "/manga")
+    monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
+    monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
+    monkeypatch.setattr(series_service.logger, "warn", warn)
+
+    result = series_service.update_content_kind(_make_ctx(), "160294", "manga")
+
+    update.assert_called_once_with("160294", "manga", comic_location="/manga/Berserk")
+    assert result["location_repointed"] is True
+    assert "previous_location" not in result
+    warn.assert_not_called()
+
+
+def test_update_content_kind_leaves_location_when_manga_dest_missing(monkeypatch):
+    update = MagicMock()
+    warn = MagicMock()
+    existing = {
+        "ComicID": "160294",
+        "ComicName": "Berserk",
+        "ComicLocation": "/comics/Berserk (2003)",
+        "ContentType": "comic",
+    }
+    updated = dict(existing, ContentType="manga")
+    rows = iter([existing, updated])
+    monkeypatch.setattr(series_service, "get_manga_destination", lambda: None)
+    monkeypatch.setattr(series_service.series_queries, "get_comic_content_kind", lambda _comic_id: next(rows))
+    monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
+    monkeypatch.setattr(series_service.logger, "warn", warn)
+
+    result = series_service.update_content_kind(_make_ctx(), "160294", "manga")
+
+    update.assert_called_once_with("160294", "manga")
+    assert result["location_repointed"] is False
+    warn.assert_called_once()
+    assert "no manga destination is configured" in warn.call_args.args[0]
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_folder"),
+    [
+        ("Berserk", "Berserk"),
+        ("Batman: The Dark Knight", "Batman The Dark Knight"),
+        ("Solo Leveling", "Solo Leveling"),
+    ],
+)
+def test_manga_series_location_uses_filesafe_name(name, expected_folder):
+    assert series_service.manga_series_location(name, "/manga") == os.path.join("/manga", expected_folder)
+
+
+def test_manga_location_for_reclassify_ignores_dest_prefix_lookalikes():
+    new_location, warning = series_service.manga_location_for_reclassify(
+        {
+            "ComicID": "1",
+            "ComicName": "Berserk",
+            "ComicLocation": "/manga-extra/Berserk",
+        },
+        "/manga",
+    )
+
+    assert new_location == "/manga/Berserk"
+    assert "were not moved" in warning
 
 
 def test_preview_search_all_missing_excludes_owned_future_and_skipped(monkeypatch):

--- a/tests/unit/test_series_domain.py
+++ b/tests/unit/test_series_domain.py
@@ -620,7 +620,7 @@ def test_update_content_kind_leaves_location_when_manga_dest_missing(monkeypatch
     update.assert_called_once_with("160294", "manga")
     assert result["location_repointed"] is False
     warn.assert_called_once()
-    assert "no manga destination is configured" in warn.call_args.args[0]
+    assert "no manga destination configured" in warn.call_args.args[0]
 
 
 @pytest.mark.parametrize(
@@ -647,6 +647,47 @@ def test_manga_location_for_reclassify_ignores_dest_prefix_lookalikes():
 
     assert new_location == "/manga/Berserk"
     assert "were not moved" in warning
+
+
+def test_persist_manga_location_if_needed_writes_when_outside_dest(monkeypatch):
+    update = MagicMock()
+    warn = MagicMock()
+    monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
+    monkeypatch.setattr(series_service.logger, "warn", warn)
+
+    location, did_repoint = series_service.persist_manga_location_if_needed(
+        {
+            "ComicID": "160294",
+            "ComicName": "Berserk",
+            "ComicLocation": "/comics/Berserk (2003)",
+            "ContentType": "manga",
+        },
+        "/manga",
+    )
+
+    assert location == "/manga/Berserk"
+    assert did_repoint is True
+    update.assert_called_once_with("160294", "manga", comic_location="/manga/Berserk")
+    warn.assert_called_once()
+
+
+def test_persist_manga_location_if_needed_skips_when_already_under_dest(monkeypatch):
+    update = MagicMock()
+    monkeypatch.setattr(series_service.series_queries, "update_comic_content_kind", update)
+
+    location, did_repoint = series_service.persist_manga_location_if_needed(
+        {
+            "ComicID": "md-1",
+            "ComicName": "Berserk",
+            "ComicLocation": "/manga/Berserk (2003)",
+            "ContentType": "manga",
+        },
+        "/manga",
+    )
+
+    assert location == "/manga/Berserk (2003)"
+    assert did_repoint is False
+    update.assert_not_called()
 
 
 def test_preview_search_all_missing_excludes_owned_future_and_skipped(monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #836.

Reclassifying a ComicVine series to manga used to write `ContentType` only. Manga post-processing then refused the series because `ComicLocation` still sat under the comics destination, so completed downloads never imported and there was no in-app relocate.

This follows option B: switching to manga also repoints `ComicLocation` to `<manga_destination_dir>/<filesafe(series_name)>` when the stored path is outside the manga destination. If the old path differs, Comicarr logs that the series now lives under the manga dest and that existing files are **not** moved. The switch is not rejected, and this is not a warning-only change.

Native manga already under the manga destination keep their folder (including `$Series ($Year)` names). Switching back to comic does not move the path. #834 / #835 (APILOCK leak from the same misplacement) stays a separate PR.

## Changes

- `update_content_kind` now writes `ComicLocation` when the series is classified as manga and the current folder would fail the manga dest check
- Warns when the old comics path is left behind; does not move files
- Series page copy and success toast mention that existing files stay put
- Tests cover ComicVine reclassify, already-under-dest, healing a broken manga row, missing dest, and filesafe names

## Release Impact

- [x] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [ ] No app release impact; no changeset needed (omit rather than "No user-visible behaviour changes.")

## Testing

- [x] Tests pass locally (`pytest tests/unit -v`) — `tests/unit/test_series_domain.py` + `tests/unit/test_series_content_kind_api.py` (72 passed)
- [x] Frontend tests (`npm --prefix frontend run test:run -- tests/pages/SeriesDetailPage.test.tsx`, 17 passed)
- [x] Backend lint/format (`ruff check comicarr/` and `ruff format --check comicarr/`)
- [x] Frontend lint/format (`cd frontend && npm run lint && npm run format:check`)
- [x] One-shot: `npm run lint` (from repo root)
- [ ] Manually tested in a live library (this change is the location write + log/toast; no relocate UI)

## Screenshots

N/A — location contract on `PATCH /series/{comic_id}/content-kind`. UI copy/toast only.

## Additional Notes

Related #834 / #835 is intentionally not in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aab8b284-b881-41bd-b324-9201e2efae43?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aab8b284-b881-41bd-b324-9201e2efae43&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

