### PR TITLE
docs: point database guidance at the current db helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,20 @@ import comicarr
 comicarr.CONFIG.option_name
 
 from comicarr import db
-db.DBConnection().action("SELECT * FROM table WHERE id=?", [id])
+from comicarr.tables import issues
+from sqlalchemy import select
+
+db.select_one(select(issues).where(issues.c.IssueID == issueid))
+db.upsert("issues", {"Status": "Downloaded"}, {"IssueID": issueid})
+
+# Raw SQL only where a Core expression will not do. `?` placeholders are
+# parameterized; never interpolate values into the string.
+db.raw_select_one("SELECT * FROM issues WHERE IssueID=?", [issueid])
 ```
+
+`db.DBConnection()` is a deprecated compatibility shim for legacy raw-SQL
+callers and will be removed once the query migration finishes. Do not use it in
+new code.
 
 Import order: stdlib → third-party → local (`from comicarr import ...`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ npm run test:run
 - **Always catch specific exceptions** — use `except Exception as e`, never bare `except:`
 - **Logging pattern**: `logger.fdebug('[MODULE-CONTEXT] message')` or `logger.error('[CONTEXT] Error: %s' % e)`
 - **Config access**: `comicarr.CONFIG.option_name`
-- **Database**: Always use parameterized queries — `db.DBConnection().action("SELECT * FROM table WHERE id=?", [id])`
+- **Database**: SQLAlchemy Core expressions through the `db` helpers — `db.select_one(stmt)`, `db.select_all(stmt)`, `db.upsert(table, values, keys)`. When raw SQL is genuinely needed, `db.raw_select_one` / `db.raw_select_all` / `db.raw_execute` take `?` placeholders and parameterize them. Never interpolate values into SQL. `db.DBConnection()` is a deprecated shim awaiting removal — do not use it in new code
 
 ### Frontend (React/TypeScript)
 

--- a/comicarr/CLAUDE.md
+++ b/comicarr/CLAUDE.md
@@ -11,9 +11,12 @@
 - Global config object is initialized at startup
 
 ### Database Queries
-- Import: `from comicarr import db`
-- Usage: `db.DBConnection().action("SELECT * FROM table WHERE id=?", [id])`
-- Always use parameterized queries
+- Import: `from comicarr import db` (plus the table from `comicarr.tables`)
+- Read: `db.select_one(stmt)` / `db.select_all(stmt)` with a SQLAlchemy Core `select()`
+- Write: `db.upsert(table_name, value_dict, key_dict)` — dialect-aware and atomic
+- Raw SQL, only where a Core expression will not do: `db.raw_select_one` / `db.raw_select_all` / `db.raw_execute`, which take `?` placeholders
+- Always use parameterized queries; never interpolate values into SQL
+- `db.DBConnection()` is a deprecated shim for legacy raw-SQL callers, slated for removal — do not use it in new code
 
 ### Adding New Features
 - Prefer `comicarr/app/<domain>/router.py` + `service.py` (+ `queries.py` when needed)


### PR DESCRIPTION
## Summary

The three contributor docs tell new code to query the database through `db.DBConnection().action(...)`. That is the deprecated compatibility shim for legacy raw-SQL callers, and production code has already finished migrating off it, so the docs are the only thing still pointing at the retired path.

`comicarr/db.py:21`, module docstring:

```
  - DBConnection      — deprecated compatibility shim for legacy raw-SQL callers

The compatibility shim (DBConnection) translates raw SQL with ? placeholders
to SQLAlchemy text() queries with :param_N named parameters. It will be
removed once all callers are migrated to SQLAlchemy Core expressions.
```

and the class itself carries `.. deprecated:: Will be removed after Phase 2 query migration is complete. Use SQLAlchemy Core expressions or the public helpers instead.`

The migration looks complete on the production side. `comicarr/` contains no caller of `DBConnection()`; the only ones left repo-wide are in `tests/unit/test_db.py`, exercising the shim itself. Against that, `db.select_one` / `db.select_all` / `db.upsert` have 518 call sites.

Two costs to leaving it as is. A contributor following the docs writes new code onto the path being removed, which grows the very backlog Phase 2 is trying to clear. And automated review reads these files as the house rule: on #814 CodeRabbit raised a Major finding against three lines that already use `db.select_one` / `db.select_all`, citing `CONTRIBUTING.md` as the authority, and asked for them to be moved onto the shim. That will recur on any PR touching a query until the docs change.

## Changes

- `CONTRIBUTING.md:110`, `AGENTS.md:87`, `comicarr/CLAUDE.md:15`: point the database guidance at `db.select_one` / `db.select_all` / `db.upsert`.
- Keep the raw-SQL escape hatch documented as `db.raw_select_one` / `db.raw_select_all` / `db.raw_execute`, so "always use parameterized queries" still has somewhere to land when a Core expression will not do.
- State that `DBConnection()` is deprecated and not for new code, rather than dropping the name silently, so a contributor meeting it in `git log` or an old branch knows which way to go.

The `AGENTS.md` snippet now shows a real read and a real write, since a lone `SELECT` did not show the upsert path that 156 of those call sites use.

## Release Impact

- [ ] User-visible app change; changeset added with `npm run changeset` (operator-facing, outcome-first prose — see CONTRIBUTING.md)
- [x] No app release impact; no changeset needed (omit rather than "No user-visible behaviour changes.")

Documentation only; no file under `comicarr/` changes behaviour.

## Testing

- [x] Tests pass locally (`pytest tests/unit -v`) — 2862 passed, unchanged, no source touched
- [ ] Frontend builds (`cd frontend && npm run build`) — N/A, no frontend change
- [x] Backend lint/format (`ruff check comicarr/` and `ruff format --check comicarr/`) — clean
- [ ] Frontend lint/format — N/A
- [x] Contributor guards (`lint:guards`, all five) — pass
- [x] Manually tested: verified every call written into the docs against the live module rather than trusting the prose. `db.select_one(stmt)`, `db.select_all(stmt)`, `db.upsert(table_name, value_dict, key_dict)`, and the three `raw_*` helpers all resolve with the documented signatures, and the `select(issues).where(...)` example constructs.

## Additional Notes

One thing worth a look while running `lint:guards` locally: it shells out to bare `python3`, and `comicarr/importer.py` uses `match` (3.10+), so on a machine whose `python3` is older the attention-seam gate reports `invalid syntax (importer.py, line 207)` and skips the file. It is not a repo bug and CI is unaffected, but the failure reads like one. Pinning the interpreter, or having the gate say the interpreter is too old, would save the next person the detour. Happy to file it separately if useful.

If you would rather the docs also name the Phase 2 migration explicitly, or drop `DBConnection` from them entirely rather than marking it deprecated, say which and I will adjust.
