### PR TITLE
fix: Restore status colours lost to undefined design tokens

### DIFF
--- a/.changeset/olive-pugs-shave.md
+++ b/.changeset/olive-pugs-shave.md
@@ -8,4 +8,4 @@ In **Settings → Acquisition Health**, badges and stat tiles in the "ready" and
 
 In **manual import**, the "Saved" confirmation was drawn in near-white and was effectively invisible against a light background; it is now green. The **library scan** summary banner lost its green border and tint the same way.
 
-Light mode also renders de-emphasised text correctly again: the separators and small metadata labels on series detail, issue detail, search results, and the releases page were being drawn at full contrast instead of muted.
+Light mode also renders de-emphasised text correctly again: the separators and small metadata labels on series detail, issue detail, search results, and the releases page were being drawn at full contrast instead of muted. Words that were sitting on that same low-contrast token (series-detail labels, empty-state copy, form labels) now use the readable muted colour.

--- a/.changeset/olive-pugs-shave.md
+++ b/.changeset/olive-pugs-shave.md
@@ -1,0 +1,11 @@
+---
+"comicarr": patch
+---
+
+Fixed status colours that were missing or unreadable in several places.
+
+In **Settings → Acquisition Health**, badges and stat tiles in the "ready" and "warning" states were drawn with no colour at all — no green or amber border, tint, or text — so they were indistinguishable from a plain tile. Error-state tiles were unaffected. The confirmation banner and the "Verified build" indicator on the same tab had the same problem.
+
+In **manual import**, the "Saved" confirmation was drawn in near-white and was effectively invisible against a light background; it is now green. The **library scan** summary banner lost its green border and tint the same way.
+
+Light mode also renders de-emphasised text correctly again: the separators and small metadata labels on series detail, issue detail, search results, and the releases page were being drawn at full contrast instead of muted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,4 +103,7 @@ Import order: stdlib → third-party → local (`from comicarr import ...`).
 - Auth: JWT session cookie `comicarr_session`; changing auth secrets invalidates sessions
 - Vite proxy default is 8090 to match `HTTP_PORT`
 
+Frontend design system — tokens, theming, typography, primitives, and the
+visual anti-pattern list — is `DESIGN.md`.
+
 Keep this file aligned with `CLAUDE.md` when architecture changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ Comicarr is built on the foundation of Mylar3 with a completely rebuilt React 19
 
 Domain packages under `comicarr/app/`: `series`, `search`, `attention`, `downloads`, `system`, `dashboard`, `metadata`, `storyarcs`, `weekly`, `opds`, `ai`, plus `core` and `common`.
 
+Anything a user can see is governed by **`DESIGN.md`** — tokens, theming, typography,
+primitives, and the frontend anti-pattern list. Read it before touching
+`frontend/src/index.css` or adding a component.
+
 ## Commands
 
 | Action | Command |
@@ -28,7 +32,7 @@ Domain packages under `comicarr/app/`: `series`, `search`, `attention`, `downloa
 | Run app | `python3 Comicarr.py --nolaunch` |
 | Test backend | `pytest tests/unit -v` |
 | Lint modern backend | `npm run lint:modern` (`comicarr/app` + `Comicarr.py`) |
-| Run every contributor gate | `npm run lint:guards` (`scripts/check_retired_globals.py`, `scripts/check_fail_reason_registry.py`, `scripts/check_upsert_tables.py`, `scripts/check_attention_seam.py`, `scripts/check_support_bundle_terms.py`) |
+| Run every contributor gate | `npm run lint:guards` (`scripts/check_retired_globals.py`, `scripts/check_fail_reason_registry.py`, `scripts/check_upsert_tables.py`, `scripts/check_attention_seam.py`, `scripts/check_support_bundle_terms.py`, `scripts/check_design_tokens.py`, `scripts/check_palette_classes.py`) |
 | Lint all (CI parity) | `npm run lint` |
 | Regenerate settings types | `npm run lint:fix:generated` (after editing the config registry) |
 
@@ -79,6 +83,7 @@ Conventional PR titles keep history readable, but they do not control releases. 
 - **Do NOT import `comicarr.app.attention._*` from outside the module** - ADR-0003 gives Attention one public seam — `read`, `resolve`, `record`, plus the contract types in `__all__` — and calls everything else an implementation detail. `scripts/check_attention_seam.py` (under `lint:guards`) AST-scans `comicarr/` for crossings, including function-local and relative ones. Existing crossings are waived by an allowlist keyed on `(file, private submodule)`, split into permanent internal hooks and deprecated shims; each entry names its removal trigger. The list only ever shrinks — a stale entry fails the guard, so a deleted shim takes its waiver with it. Widening `__all__` is not the fix. Contributor-only gate — no changeset.
 - **Do NOT make a handoff route depend on the download client reaching back into Comicarr** - A handoff delivers the content, never a pointer to Comicarr, and must be verifiable from the client's own response alone (ADR-0002 / #552 / #564). `blackhole` and `watchdir` are the named exceptions to *verifiability* only — they pay for it by staying out of `_RESTART_SAFE_ROUTES`. There is no cheap static signal for "callback URL", so this is a review gate, not a lint one.
 - **Do NOT add per-feature SSE event types** - `activity` is the only narrative channel; `ai_activity`, `restart`, and `shutdown` are the only other listeners in `useServerEvents`. The client invalidates queries from a payload and never accumulates the stream into a list.
+- **Do NOT hardcode a color, or `var()` a token you haven't defined** - Comicarr ships light and dark. A raw Tailwind palette class (`text-green-400`) ignores `.dark` entirely; and CSS fails *open*, so a `var()` naming an undefined property invalidates the whole declaration and the style vanishes silently instead of erroring. Both shipped: `--text-muted` was `.dark`-only (25 lines, 6 files, dead in light mode), `--status-success`/`--status-warning` were never tokens at all (17 usages, and inside `color-mix()` an invalid inner var voids the entire color in *both* themes), and `text-success` resolved to a near-white surface value. `scripts/check_design_tokens.py` now gates the whole class with no allowlist; `scripts/check_palette_classes.py` holds a shrink-only per-file baseline for the 58 remaining palette literals. Use `--status-*` for semantics — the set is exhaustive, there is no `--status-success`. `var(--x, var(--fallback))` is the sanctioned optional-token form. Full rules and drift backlog: `DESIGN.md`. Contributor-only gates — no changeset.
 - **Do NOT finish without linting** - Run `npm run lint` (or `npm run lint:fix` then re-check) before considering work done; do not bypass hooks with `--no-verify`
 
 ## Gotchas

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -221,7 +221,7 @@ changed unilaterally.
 Both gates run under `npm run lint:guards`:
 
 ```bash
-python3 scripts/check_design_tokens.py    # no var() resolves to nothing
+python3 scripts/check_design_tokens.py    # no var() resolves to nothing; --status-* is exhaustive
 python3 scripts/check_palette_classes.py  # no new palette literals
 ```
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,252 @@
+# DESIGN.md
+
+Design-system contract for the Comicarr frontend. `CLAUDE.md` governs backend and
+repo-wide conventions; this file governs everything a user can see.
+
+Same rule as `CLAUDE.md`: **prefer retrieval-led reasoning.** The system of record
+is `frontend/src/index.css`, not this file's summary of it and not general
+Tailwind/shadcn knowledge. When the two disagree, the stylesheet wins and this
+file is stale — fix it.
+
+## Scope
+
+| Concern | Lives in |
+|---------|----------|
+| Tokens, theming, light/dark | `frontend/src/index.css` |
+| Primitive components | `frontend/src/components/ui/` |
+| Domain components | `frontend/src/components/<domain>/` |
+| shadcn generator config | `frontend/components.json` |
+| Tailwind content globs | `frontend/tailwind.config.js` |
+
+`frontend/tailwind.config.js` is a near-empty v4 stub — it carries content globs
+only. Do not add a `theme.extend` block there; tokens are CSS-first via
+`@theme inline` in `index.css`.
+
+## The stack
+
+- **Tailwind CSS v4**, CSS-first config (`@import "tailwindcss"` + `@theme inline`).
+- **shadcn/ui**, `new-york` style, `neutral` base, `cssVariables: true`.
+- **Base UI** (`@base-ui/react`) for headless primitives. This is the standard.
+- **lucide-react** for icons.
+- **Non-Radix helpers kept deliberately**: `vaul` (drawer), `cmdk` (command),
+  `sonner` (toast), `react-day-picker` (calendar).
+
+### Primitives: Base UI, not Radix
+
+`frontend/.migration/project.md` records the 2026-07-13 Radix → Base UI
+conversion. Its claim that all Radix imports are gone is **no longer accurate** —
+`avatar.tsx`, `bubble.tsx`, and `marker.tsx` still import `@radix-ui/*`, and
+three `@radix-ui/react-*` entries remain in `frontend/package.json`.
+
+New primitives use Base UI. Base UI is not a drop-in for Radix:
+
+- `render` prop, not `asChild`
+- Positioner/Popup parts for portalled overlays
+- transition hooks, not `data-state` animation conventions
+- Tooltip timing is `delay`, not `delayDuration`
+
+## Tokens are the contract
+
+Every color, radius, and font reaches a component through a CSS custom property
+defined in `:root` and overridden in `.dark`. A component that hardcodes a color
+is a component that cannot be themed, and Comicarr ships both themes.
+
+### Brand
+
+| Token | Light | Dark |
+|-------|-------|------|
+| `--primary` | `#e04a0a` | `#ff6a1f` |
+| `--primary-foreground` | `#ffffff` | `#ffffff` |
+| `--gradient-brand` | 135° orange ramp | 135° orange ramp |
+
+Orange is the brand. Note that `--ring` tracks `--primary` in dark but is a
+neutral grey in light — the two themes focus differently. Nothing in the repo
+records whether that was a decision or a drift; treat it as unsettled rather than
+as a pattern to copy.
+
+### Status
+
+`--status-{active,wanted,downloaded,paused,ended,error,skipped}` and their
+`-bg` pairs are **the** semantic color set — ~163 usages across the app, and the
+only vocabulary `StatusBadge` understands. Reach for these whenever the meaning
+is "this item is in state X".
+
+That list is exhaustive. There is no `--status-success` and no
+`--status-warning`; both were invented at call sites and neither ever resolved.
+Success is `--status-active`, warning is `--status-paused`. `check_design_tokens.py`
+now rejects either name.
+
+### Typography
+
+- **UI**: `Inter Tight`, with a system fallback stack. `letter-spacing: -0.005em`
+  on `:root`.
+- **Numeric / metadata**: `JetBrains Mono` via `--font-mono`, with
+  `font-feature-settings: "tnum" 1` so columns of numbers align.
+- **Headings**: `h1`–`h3` are styled in `@layer base`. Don't re-specify size and
+  weight on a heading that the base layer already covers.
+- **No serif fonts.** Not in the app, not in mockups, not in generated assets.
+
+Two utilities exist for the dense mono-label idiom that appears throughout the
+tables and detail pages:
+
+| Utility | Renders |
+|---------|---------|
+| `.mono-label` | 10px mono, uppercase, `0.08em` tracking, muted |
+| `.mono-meta` | 11px mono, muted |
+
+Use them. Hand-rolling `font-mono text-[10px] uppercase tracking-wider
+text-muted-foreground` reproduces `.mono-label` inline and is the single largest
+source of style drift in the codebase (see *Known drift*).
+
+### Radius
+
+`--radius: 0.375rem` with a derived `sm`/`md`/`lg`/`xl`/`2xl`/`3xl`/`4xl` scale in
+`@theme inline`. Use `rounded-md` etc.; don't write `rounded-[6px]`.
+
+### Effects
+
+`.glass-nav`, `.gradient-brand`, `.page-transition`, `.scroll-fade-b`,
+`.shimmer`, `.custom-scrollbar`, `.scrollbar-hide` are the sanctioned effect
+utilities. `.shimmer` already honours `prefers-reduced-motion` — any new motion
+utility must do the same.
+
+## Anti-Patterns / What NOT to Do
+
+- **Do NOT use raw Tailwind palette classes** — `text-green-400`, `bg-red-500`,
+  `border-yellow-500`. They are fixed sRGB values that ignore `.dark` entirely, so
+  a component using them is legible in one theme and wrong in the other. Use a
+  `--status-*` token, or `--destructive` / `--muted-foreground` for the generic
+  cases. 58 such usages predate the gate; `scripts/check_palette_classes.py` holds
+  a per-file baseline that only ever shrinks, so new ones fail CI and fixes must
+  lower the number.
+
+- **Do NOT reintroduce `--success` / `--warning` / `--error` / `--info`.** These
+  were mislabeled leftovers from a pre-token shadcn scaffold — *surface* values
+  wearing *text* names. `--success` was `hsl(210 40% 96.1%)` in light, near-white,
+  and being registered in `@theme inline` meant `text-success` compiled clean and
+  rendered near-invisible; `ImportTable.tsx` printed "Saved" in near-white on a
+  white page. All four are deleted, along with their `--color-*` registrations.
+  Semantic color is `--status-*`.
+
+- **Do NOT define a token in `.dark` only.** A `var()` naming an undefined
+  property makes the whole declaration invalid, so the style vanishes silently
+  instead of failing loudly. Seven tokens were dark-only; `var(--text-muted)` was
+  live in 25 lines across 6 files and did nothing in light mode. A token that
+  genuinely doesn't vary by theme (`--radius`, `--font-mono`,
+  `--glassmorphism-blur`) belongs in `:root` alone, but a `.dark`-only token is
+  always a bug. `scripts/check_design_tokens.py` enforces this, with no allowlist.
+
+- **Do NOT `var()` a token you haven't defined.** Same failure, different cause:
+  `--status-success` and `--status-warning` were never tokens, and 17 call sites
+  asked for them. Most sat inside `color-mix(in oklab, var(--status-success) 36%,
+  transparent)`, where an invalid inner var voids the entire color — those borders
+  and backgrounds were missing in *both* themes, not one. The guard covers this
+  too. `var(--x, var(--fallback))` is the sanctioned way to reference an optional
+  token and is deliberately not flagged.
+
+- **Do NOT reach for `style={{ }}` to apply a token.** Inline styles are how the
+  dark-only-token bug got in and stayed in: they bypass Tailwind, so nothing at
+  build time can tell you the property doesn't resolve. Prefer a utility class;
+  where a token isn't yet Tailwind-registered, `text-[var(--token)]` at least keeps
+  the value in the class layer. 288 inline `style={{` attributes across 50 files.
+
+- **Do NOT add arbitrary font sizes.** `text-[10px]`, `text-[11px]`, `text-[12px]`,
+  and `text-[13px]` account for 369 of the 432 arbitrary sizes in the codebase —
+  four values doing the work of a scale that was never written down. Half-pixel
+  sizes (`text-[12.5px]`, `text-[11.5px]`, `text-[10.5px]`, 30 usages) are
+  rounding noise, not design. Use the Tailwind scale or `.mono-label` / `.mono-meta`.
+
+- **Do NOT add components under `frontend/src/components/custom/`.** All six files
+  there have zero importers, and the directory is in the ESLint `ignores` list — so
+  nothing in it is linted, type-checked in CI, or reachable. New primitives go in
+  `components/ui/`; new domain components go in `components/<domain>/`.
+
+- **Do NOT define a utility around an undefined variable.** `.card-shadow` applied
+  `box-shadow: var(--card-shadow)` with `--card-shadow` defined nowhere — a no-op
+  that read like a working one, on two live card components. It was deleted rather
+  than given a value: removing it is provably no visual change, whereas inventing
+  a shadow would be a design decision. If cards should have shadows, that is a
+  deliberate change to make, not a variable to backfill.
+
+- **Do NOT reintroduce Radix for new work.** See *Primitives* above. The three
+  remaining Radix files are holdouts to migrate, not precedent to follow.
+
+- **Do NOT hand-build a table.** Row identity goes through
+  `@/components/data-table/useTableState` — enforced by `no-restricted-imports` in
+  `frontend/eslint.config.js`. `CLAUDE.md` carries the full rule.
+
+- **Do NOT finish without linting.** `npm run lint` from `frontend/`, per `CLAUDE.md`.
+
+## Known drift
+
+Measured on the current tree. These are a work queue, not a description of the
+target state — the rules above are the target state.
+
+| Drift | Extent | Impact |
+|-------|--------|--------|
+| Arbitrary `text-[Npx]` | 432 usages, 63 files | No typographic scale |
+| Inline `style={{ }}` | 288 attributes, 50 files | Tokens bypass the class layer |
+| Raw Tailwind palette classes | 58 usages, 11 files | Colors don't respond to theme — **gated, shrink-only** |
+| Radix holdouts | `avatar.tsx`, `bubble.tsx`, `marker.tsx` + 3 deps | Two primitive libraries in one app |
+| Dead `components/custom/` | 6 files, 0 importers | Unlinted, unreachable code |
+| Dead `frontend/src/App.css` | 42 lines, imported nowhere | Vite scaffold leftover |
+| Dead `border-card-border` class | removed from 2 cards | `--color-card-border` was never registered, so the class never existed |
+| `--text-muted` contrast | 2.95:1 both themes | Below WCAG AA; see below |
+
+`--text-muted` is used mostly for decorative separators (`/`, `·`) and micro-labels,
+but a few sites give it real words. It sits at 2.95:1 in both themes — that parity
+is deliberate (the light value was tuned to the ratio dark already shipped), but
+2.95:1 is under the 4.5:1 AA threshold for body text and under 3:1 for large text.
+Raising it is a design decision, not a bug fix, so it is recorded here rather than
+changed unilaterally.
+
+### Fixed and now gated
+
+| Was | Extent | Now |
+|-----|--------|-----|
+| `--text-muted` defined in `.dark` only | 25 lines, 6 files | `:root` value added at matching contrast |
+| `--status-success` / `--status-warning` — never tokens | 17 usages, 2 files | Repointed to `--status-active` / `--status-paused` |
+| `text-success` on a near-white token | `ImportTable.tsx` | Repointed to `--status-active` |
+| `--info` on a toast that was otherwise `--status-*` | 2 lines | Repointed to `--status-wanted` |
+| Mislabeled `--success`/`--warning`/`--error`/`--info` | 4 tokens x 2 themes | Deleted, with their `--color-*` registrations |
+| 6 unused dark-only tokens | `--surface-*`, `--border-elevated`, `--text-tertiary`, `--text-disabled` | Deleted |
+| Undefined `--card-shadow` | 1 utility, 2 components | Utility and usages deleted |
+| Radix-era accordion keyframes | 2 keyframes, 2 registrations | Deleted; Base UI animates via `transition-[height]` |
+
+`--border-soft` is deliberately undefined. Its three call sites all write
+`var(--border-soft, var(--border))`, which stays valid without it.
+
+### Verifying
+
+Both gates run under `npm run lint:guards`:
+
+```bash
+python3 scripts/check_design_tokens.py    # no var() resolves to nothing
+python3 scripts/check_palette_classes.py  # no new palette literals
+```
+
+The remaining rows have no gate. Arbitrary font sizes are the obvious next
+candidate, but a baseline of 432 across 63 files is worth less than agreeing the
+scale first — gating a number nobody has decided how to reduce just freezes it.
+
+```bash
+cd frontend
+
+# arbitrary font sizes, by value
+grep -rhoE 'text-\[[0-9.]+px\]' --include='*.tsx' src | sort | uniq -c | sort -rn
+
+# Radix holdouts
+grep -rln '@radix-ui' --include='*.tsx' src
+```
+
+## Changing the design system
+
+1. **Token first.** Add or change the value in `:root` **and** `.dark`.
+2. **Register it** in `@theme inline` as `--color-*` if components should reach it
+   by class name rather than `var()`. The `--status-*` family is currently
+   unregistered, which is why every consumer writes
+   `bg-[var(--status-active-bg)]` instead of `bg-status-active`.
+3. **Check both themes.** Toggle light/dark before opening the PR. Most bugs in
+   *Known drift* are things that look right in exactly one theme.
+4. **Changeset?** Apply the `CLAUDE.md` test: a visible change an *operator* could
+   notice earns one. A token rename with identical rendered output does not.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -191,14 +191,14 @@ target state — the rules above are the target state.
 | Dead `components/custom/` | 6 files, 0 importers | Unlinted, unreachable code |
 | Dead `frontend/src/App.css` | 42 lines, imported nowhere | Vite scaffold leftover |
 | Dead `border-card-border` class | removed from 2 cards | `--color-card-border` was never registered, so the class never existed |
-| `--text-muted` contrast | 2.95:1 both themes | Below WCAG AA; see below |
+| `--text-muted` contrast | 2.95:1 both themes | Decorative only; see below |
 
-`--text-muted` is used mostly for decorative separators (`/`, `·`) and micro-labels,
-but a few sites give it real words. It sits at 2.95:1 in both themes — that parity
-is deliberate (the light value was tuned to the ratio dark already shipped), but
-2.95:1 is under the 4.5:1 AA threshold for body text and under 3:1 for large text.
-Raising it is a design decision, not a bug fix, so it is recorded here rather than
-changed unilaterally.
+`--text-muted` is for decorative separators (`/`, `·`) and 10px uppercase
+micro-labels. It sits at 2.95:1 in both themes — that parity is deliberate (the
+light value was tuned to the ratio dark already shipped). Real words use
+`--muted-foreground` (AA-safe in light at `oklch(0.552 …)`). Raising
+`--text-muted` itself to 4.5:1 would recolour every separator and is still a
+design decision, not a bug fix.
 
 ### Fixed and now gated
 

--- a/frontend/src/components/import/ImportTable.tsx
+++ b/frontend/src/components/import/ImportTable.tsx
@@ -36,7 +36,7 @@ function FileSaveState({ state }: { state: SaveState }) {
     return <span className="text-muted-foreground">Saving...</span>;
   }
   if (state === "saved") {
-    return <span className="text-success">Saved</span>;
+    return <span className="text-[var(--status-active)]">Saved</span>;
   }
   if (state === "error") {
     return <span className="text-destructive">Save failed</span>;

--- a/frontend/src/components/import/LibraryScanSection.tsx
+++ b/frontend/src/components/import/LibraryScanSection.tsx
@@ -297,7 +297,7 @@ function ScanTile({
           {progress.current && (
             <span
               className="truncate ml-auto"
-              style={{ color: "var(--text-muted)" }}
+              style={{ color: "var(--muted-foreground)" }}
             >
               {progress.current}
             </span>

--- a/frontend/src/components/import/LibraryScanSection.tsx
+++ b/frontend/src/components/import/LibraryScanSection.tsx
@@ -214,7 +214,7 @@ function ImportSummary({
 
   return (
     <div
-      className="rounded-[6px] border border-[var(--status-success)]/40 bg-[var(--status-success)]/10 px-3.5 py-3 text-[12px] text-foreground"
+      className="rounded-[6px] border border-[var(--status-active)]/40 bg-[var(--status-active)]/10 px-3.5 py-3 text-[12px] text-foreground"
       role="status"
     >
       Imported {imported} {type} series. The library has been refreshed.

--- a/frontend/src/components/search/ComicCard.tsx
+++ b/frontend/src/components/search/ComicCard.tsx
@@ -88,7 +88,7 @@ export default function ComicCard({ comic }: ComicCardProps) {
   };
 
   return (
-    <div className="bg-card border-card-border card-shadow hover:shadow-lg hover:border-primary/30 transition-all duration-200 group rounded-lg border overflow-hidden flex flex-col h-full">
+    <div className="bg-card hover:shadow-lg hover:border-primary/30 transition-all duration-200 group rounded-lg border overflow-hidden flex flex-col h-full">
       {/* Cover Image */}
       <div className="aspect-[2/3] bg-muted relative overflow-hidden flex-shrink-0">
         {comic.image ? (

--- a/frontend/src/components/series/SeriesCard.tsx
+++ b/frontend/src/components/series/SeriesCard.tsx
@@ -33,7 +33,7 @@ export default function SeriesCard({ comic, onClick }: SeriesCardProps) {
         },
       })}
       onClick={onClick}
-      className={`bg-card border-card-border card-shadow hover:shadow-lg hover:border-primary/30 transition-all duration-200 group rounded-lg border overflow-hidden flex flex-col h-full ${onClick ? "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background" : ""}`}
+      className={`bg-card hover:shadow-lg hover:border-primary/30 transition-all duration-200 group rounded-lg border overflow-hidden flex flex-col h-full ${onClick ? "cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background" : ""}`}
     >
       {/* Cover Image */}
       <div className="aspect-[2/3] bg-muted relative overflow-hidden flex-shrink-0">

--- a/frontend/src/components/settings/AcquisitionHealthTab.tsx
+++ b/frontend/src/components/settings/AcquisitionHealthTab.tsx
@@ -142,14 +142,14 @@ function StatusPill({
     { border: string; color: string; background: string }
   > = {
     ready: {
-      border: "color-mix(in oklab, var(--status-success) 36%, transparent)",
-      color: "var(--status-success)",
-      background: "color-mix(in oklab, var(--status-success) 11%, transparent)",
+      border: "color-mix(in oklab, var(--status-active) 36%, transparent)",
+      color: "var(--status-active)",
+      background: "color-mix(in oklab, var(--status-active) 11%, transparent)",
     },
     warning: {
-      border: "color-mix(in oklab, var(--status-warning) 42%, transparent)",
-      color: "var(--status-warning)",
-      background: "color-mix(in oklab, var(--status-warning) 10%, transparent)",
+      border: "color-mix(in oklab, var(--status-paused) 42%, transparent)",
+      color: "var(--status-paused)",
+      background: "color-mix(in oklab, var(--status-paused) 10%, transparent)",
     },
     danger: {
       border: "color-mix(in oklab, var(--status-error) 42%, transparent)",
@@ -185,9 +185,9 @@ function Metric({
 }) {
   const color =
     tone === "ready"
-      ? "var(--status-success)"
+      ? "var(--status-active)"
       : tone === "warning"
-        ? "var(--status-warning)"
+        ? "var(--status-paused)"
         : tone === "danger"
           ? "var(--status-error)"
           : "var(--foreground)";
@@ -217,11 +217,11 @@ function Message({
   tone?: Tone;
 }) {
   const color =
-    tone === "danger" ? "var(--status-error)" : "var(--status-warning)";
+    tone === "danger" ? "var(--status-error)" : "var(--status-paused)";
   const background =
     tone === "danger"
       ? "var(--status-error-bg)"
-      : "color-mix(in oklab, var(--status-warning) 10%, transparent)";
+      : "color-mix(in oklab, var(--status-paused) 10%, transparent)";
   return (
     <div
       className="flex gap-2 rounded-[6px] border px-3 py-2 text-[12px] leading-relaxed"
@@ -711,12 +711,12 @@ export function AcquisitionHealthTab() {
         <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
           {operations.diagnostics.data?.build?.verified ? (
             <span className="inline-flex items-center gap-1">
-              <ShieldCheck className="h-3.5 w-3.5 text-[var(--status-success)]" />
+              <ShieldCheck className="h-3.5 w-3.5 text-[var(--status-active)]" />
               Verified build
             </span>
           ) : (
             <span className="inline-flex items-center gap-1">
-              <CircleAlert className="h-3.5 w-3.5 text-[var(--status-warning)]" />
+              <CircleAlert className="h-3.5 w-3.5 text-[var(--status-paused)]" />
               Build commit is not verified
             </span>
           )}
@@ -1205,10 +1205,10 @@ export function AcquisitionHealthTab() {
           className="flex items-start gap-2 rounded-[6px] border px-3 py-2 text-[12px]"
           style={{
             borderColor:
-              "color-mix(in oklab, var(--status-success) 35%, transparent)",
+              "color-mix(in oklab, var(--status-active) 35%, transparent)",
             background:
-              "color-mix(in oklab, var(--status-success) 10%, transparent)",
-            color: "var(--status-success)",
+              "color-mix(in oklab, var(--status-active) 10%, transparent)",
+            color: "var(--status-active)",
           }}
           aria-live="polite"
         >

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -93,13 +93,15 @@ function Toast({
         style={{ color: "var(--status-error)" }}
       />
     ),
-    info: <Info className="w-5 h-5" style={{ color: "var(--info)" }} />,
+    info: (
+      <Info className="w-5 h-5" style={{ color: "var(--status-wanted)" }} />
+    ),
   };
 
   const styles: Record<ToastType, string> = {
     success: "bg-[var(--status-active-bg)] border-[var(--status-active)]",
     error: "bg-[var(--status-error-bg)] border-[var(--status-error)]",
-    info: "bg-[var(--status-wanted-bg)] border-[var(--info)]",
+    info: "bg-[var(--status-wanted-bg)] border-[var(--status-wanted)]",
   };
 
   const content = message || description;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,9 +31,9 @@
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.967 0.001 286.375);
   --muted-foreground: oklch(0.552 0.016 285.938);
-  /* Dimmer than --muted-foreground: separators, micro-labels. Tuned to the
-     same 2.95:1 contrast the dark theme gives this token, so "muted" reads
-     the same in both. */
+  /* Dimmer than --muted-foreground: separators and 10px micro-labels only.
+     Real words use --muted-foreground. Tuned to the same 2.95:1 contrast the
+     dark theme gives this token, so "muted" reads the same in both. */
   --text-muted: oklch(0.675 0.016 285.938);
   --accent: oklch(0.967 0.001 286.375);
   --accent-foreground: oklch(0.21 0.006 285.885);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,6 +31,10 @@
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.967 0.001 286.375);
   --muted-foreground: oklch(0.552 0.016 285.938);
+  /* Dimmer than --muted-foreground: separators, micro-labels. Tuned to the
+     same 2.95:1 contrast the dark theme gives this token, so "muted" reads
+     the same in both. */
+  --text-muted: oklch(0.675 0.016 285.938);
   --accent: oklch(0.967 0.001 286.375);
   --accent-foreground: oklch(0.21 0.006 285.885);
   --destructive: oklch(0.577 0.245 27.325);
@@ -77,10 +81,6 @@
     oklch(0.67 0.16 58),
     oklch(0.77 0.16 70)
   );
-  --success: hsl(210 40% 96.1%);
-  --warning: hsl(24.6 95% 53.1%);
-  --error: hsl(0 84.2% 60.2%);
-  --info: hsl(198.63 88.66% 48.43%);
 }
 
 body {
@@ -128,30 +128,6 @@ body {
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
   --font-mono: var(--font-mono);
-  --color-success: var(--success);
-  --color-warning: var(--warning);
-  --color-error: var(--error);
-  --color-info: var(--info);
-  --animate-accordion-down: accordion-down 0.2s ease-out;
-  --animate-accordion-up: accordion-up 0.2s ease-out;
-
-  @keyframes accordion-down {
-    from {
-      height: 0;
-    }
-    to {
-      height: var(--radix-accordion-content-height);
-    }
-  }
-
-  @keyframes accordion-up {
-    from {
-      height: var(--radix-accordion-content-height);
-    }
-    to {
-      height: 0;
-    }
-  }
 }
 
 .dark {
@@ -187,14 +163,7 @@ body {
   --sidebar-border: #232834;
   --sidebar-ring: #ff6a1f;
 
-  /* Surface layers */
-  --surface-deep: #0b0d12;
-  --surface-elevated: #181c25;
-  --border-elevated: #232834;
-  --border-soft: #1a1f2a;
-  --text-tertiary: #8a92a5;
   --text-muted: #565d6f;
-  --text-disabled: #3a4050;
 
   /* Status Badges - Dark Mode */
   --status-active: #53d37d;
@@ -217,10 +186,6 @@ body {
 
   /* Gradient */
   --gradient-brand: linear-gradient(135deg, #ff6a1f, #ff8a4c);
-  --success: hsl(217.2 32.6% 17.5%);
-  --warning: hsl(24.6 95% 53.1%);
-  --error: hsl(0 84.2% 60.2%);
-  --info: hsl(198.63 88.66% 48.43%);
 }
 
 @layer base {
@@ -317,10 +282,6 @@ body {
     background-clip: text;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
-  }
-
-  .card-shadow {
-    box-shadow: var(--card-shadow);
   }
 
   .page-transition {

--- a/frontend/src/pages/SeriesDetailPage.tsx
+++ b/frontend/src/pages/SeriesDetailPage.tsx
@@ -628,7 +628,9 @@ export default function SeriesDetailPage() {
             <span style={{ color: "var(--text-muted)" }}>·</span>
             <span
               style={{
-                color: isPaused ? "var(--text-muted)" : "var(--status-active)",
+                color: isPaused
+                  ? "var(--status-paused)"
+                  : "var(--status-active)",
               }}
             >
               ● {isPaused ? "paused" : "ongoing"}
@@ -885,7 +887,9 @@ export default function SeriesDetailPage() {
                     borderTop: index > 1 ? "1px solid var(--border)" : "none",
                   }}
                 >
-                  <span style={{ color: "var(--text-muted)" }}>{label}</span>
+                  <span style={{ color: "var(--muted-foreground)" }}>
+                    {label}
+                  </span>
                   <span>{value}</span>
                 </div>
               ))}
@@ -897,7 +901,7 @@ export default function SeriesDetailPage() {
           >
             <div
               className="mb-2 font-mono text-[10px] uppercase tracking-[0.1em]"
-              style={{ color: "var(--text-muted)" }}
+              style={{ color: "var(--muted-foreground)" }}
             >
               Search options
             </div>
@@ -922,7 +926,9 @@ export default function SeriesDetailPage() {
                 title={title}
                 className="flex cursor-pointer items-center justify-between gap-2 py-1 font-mono text-[10px]"
               >
-                <span style={{ color: "var(--text-muted)" }}>{label}</span>
+                <span style={{ color: "var(--muted-foreground)" }}>
+                  {label}
+                </span>
                 <Checkbox
                   checked={checked}
                   disabled={searchSettingsMutation.isPending}
@@ -936,7 +942,7 @@ export default function SeriesDetailPage() {
             {isManga ? (
               <div className="mt-2 grid gap-2">
                 <label className="grid gap-1 font-mono text-[10px]">
-                  <span style={{ color: "var(--text-muted)" }}>
+                  <span style={{ color: "var(--muted-foreground)" }}>
                     Bare numbers
                   </span>
                   <select
@@ -958,7 +964,9 @@ export default function SeriesDetailPage() {
                   </select>
                 </label>
                 <label className="grid gap-1 font-mono text-[10px]">
-                  <span style={{ color: "var(--text-muted)" }}>Monitor</span>
+                  <span style={{ color: "var(--muted-foreground)" }}>
+                    Monitor
+                  </span>
                   <select
                     aria-label="Monitor"
                     className="h-7 rounded-[5px] border bg-background px-2"
@@ -992,7 +1000,7 @@ export default function SeriesDetailPage() {
         </div>
         <div
           className="font-mono text-[10px] uppercase tracking-[0.08em]"
-          style={{ color: "var(--text-muted)" }}
+          style={{ color: "var(--muted-foreground)" }}
           data-testid="ledger-facets"
         >
           {ledgerFacets.length
@@ -1052,7 +1060,7 @@ export default function SeriesDetailPage() {
           {filteredIssues.length === 0 ? (
             <div
               className="px-5 py-8 text-center font-mono text-[11px]"
-              style={{ color: "var(--text-muted)" }}
+              style={{ color: "var(--muted-foreground)" }}
             >
               no issues to display
             </div>
@@ -1246,7 +1254,7 @@ export default function SeriesDetailPage() {
                     {preview.route?.reason && (
                       <div
                         className="mt-2 font-mono text-[10px]"
-                        style={{ color: "var(--text-muted)" }}
+                        style={{ color: "var(--muted-foreground)" }}
                       >
                         {preview.route.reason}
                       </div>
@@ -1315,7 +1323,7 @@ export default function SeriesDetailPage() {
                     style={{ borderColor: "var(--border)" }}
                   >
                     <div className="flex items-center justify-between gap-2">
-                      <span style={{ color: "var(--text-muted)" }}>
+                      <span style={{ color: "var(--muted-foreground)" }}>
                         run state
                       </span>
                       <span>{run.completion_state}</span>
@@ -1336,7 +1344,7 @@ export default function SeriesDetailPage() {
                 {searchRun.isLoading && (
                   <div
                     className="mt-3 font-mono text-[10px]"
-                    style={{ color: "var(--text-muted)" }}
+                    style={{ color: "var(--muted-foreground)" }}
                   >
                     Checking run outcome…
                   </div>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare-github-release": "node scripts/release/prepare-github-release.mjs",
     "lint": "npm run lint:modern && npm run lint:guards && npm run lint:backend && npm run lint:generated && npm run lint:frontend",
     "lint:modern": "python3 scripts/run_ruff.py modern",
-    "lint:guards": "python3 scripts/check_retired_globals.py && python3 scripts/check_fail_reason_registry.py && python3 scripts/check_upsert_tables.py && python3 scripts/check_attention_seam.py && python3 scripts/check_support_bundle_terms.py",
+    "lint:guards": "python3 scripts/check_retired_globals.py && python3 scripts/check_fail_reason_registry.py && python3 scripts/check_upsert_tables.py && python3 scripts/check_attention_seam.py && python3 scripts/check_support_bundle_terms.py && python3 scripts/check_design_tokens.py && python3 scripts/check_palette_classes.py",
     "lint:backend": "python3 scripts/run_ruff.py check comicarr/ && python3 scripts/run_ruff.py format --check comicarr/",
     "lint:generated": "python3 scripts/generate_config_types.py --check",
     "lint:frontend": "npm --prefix frontend run lint && npm --prefix frontend run format:check",

--- a/scripts/check_design_tokens.py
+++ b/scripts/check_design_tokens.py
@@ -1,0 +1,171 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""CI gate: no ``var()`` in the frontend resolves to nothing.
+
+CSS fails open. A ``var(--x)`` naming a property that was never defined makes
+the *entire declaration* invalid, so the browser drops it and falls back to the
+inherited value. Nothing throws, nothing logs, and the element renders in a
+plausible-looking wrong colour. That is the opposite of how the rest of the
+codebase fails, and it is why every instance of this class shipped:
+
+* ``--text-muted`` was defined in ``.dark`` only. 25 lines across 6 files asked
+  for it; in light mode all 25 silently rendered at inherited contrast.
+* ``--status-success`` and ``--status-warning`` were never tokens at all — the
+  real names are ``--status-active`` and ``--status-paused``. 17 usages, and
+  because most sat inside ``color-mix(in oklab, var(--status-success) 36%,
+  transparent)``, an invalid inner var voided the whole colour: those borders
+  and backgrounds disappeared in *both* themes.
+* ``--card-shadow`` was undefined, so the ``.card-shadow`` utility applied to
+  two card components had never drawn a shadow.
+
+Three checks, one class:
+
+1. Every custom property assigned in ``.dark`` is also assigned in ``:root``.
+   A dark-only token is always a bug — it cannot resolve in light mode. The
+   converse is fine: theme-invariant tokens (``--radius``, ``--font-mono``,
+   ``--glassmorphism-blur``) legitimately live in ``:root`` alone.
+2. Every ``var(--x)`` inside the stylesheet resolves.
+3. Every ``var(--x)`` in component source resolves.
+
+Only the fallback-less form is checked. ``var(--x, var(--border))`` remains a
+valid declaration when ``--x`` is undefined, so it is the sanctioned way to
+reference an optional token — three call sites use it against ``--border-soft``
+and are correct as written.
+
+"Resolves" means the property is assigned *somewhere* in ``frontend/src`` —
+stylesheet or component. Properties set inline on an element (``sidebar.tsx``
+assigns ``--sidebar-width`` in a style object and reads it from descendants)
+are picked up by that same assignment scan, so the cascade keeps working and
+no allowlist is needed. There is deliberately no allowlist here: unlike the
+palette-class backlog, this class is at zero and a regression is always a bug.
+
+Rules and drift backlog: ``DESIGN.md``.
+
+Contributor-facing only — no changeset (CLAUDE.md).
+
+Wire-in: ``npm run lint:guards``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "frontend" / "src"
+STYLESHEET = SRC / "index.css"
+
+SCAN_SUFFIXES = {".css", ".ts", ".tsx"}
+SKIP_DIR_NAMES = {"node_modules", "dist", "__pycache__"}
+
+# `--x:` as a CSS declaration or a JS style-object key ("--x": v / '--x': v).
+ASSIGN_RE = re.compile(r"""["']?(--[A-Za-z0-9_-]+)["']?\s*:""")
+# Only the fallback-less form is dangerous. `var(--x, var(--border))` stays
+# valid when --x is undefined, so it is the sanctioned way to reference an
+# optional token and is deliberately not flagged.
+USE_RE = re.compile(r"var\(\s*(--[A-Za-z0-9_-]+)\s*\)")
+
+
+def _block(css: str, selector: str) -> dict[str, int]:
+    """Property name -> 1-based line number for one top-level block."""
+    match = re.search(re.escape(selector) + r"\s*\{(.*?)\n\}", css, re.S)
+    if match is None:
+        raise SystemExit(f"check_design_tokens: `{selector}` block not found in {STYLESHEET}")
+    base = css[: match.start(1)].count("\n")
+    found: dict[str, int] = {}
+    for line_offset, line in enumerate(match.group(1).splitlines()):
+        for name in ASSIGN_RE.findall(line):
+            found.setdefault(name, base + line_offset + 1)
+    return found
+
+
+def _iter_sources():
+    for path in sorted(SRC.rglob("*")):
+        if not path.is_file() or path.suffix not in SCAN_SUFFIXES:
+            continue
+        if SKIP_DIR_NAMES.intersection(path.parts):
+            continue
+        yield path
+
+
+def main() -> int:
+    if not STYLESHEET.is_file():
+        raise SystemExit(f"check_design_tokens: {STYLESHEET} not found")
+
+    css = STYLESHEET.read_text(encoding="utf-8")
+    root_tokens = _block(css, ":root")
+    dark_tokens = _block(css, ".dark")
+
+    failures: list[str] = []
+
+    # 1. dark-only tokens
+    dark_only = sorted(set(dark_tokens) - set(root_tokens))
+    if dark_only:
+        failures.append("Defined in `.dark` but not `:root` — these vanish in light mode:")
+        for name in dark_only:
+            failures.append(f"  frontend/src/index.css:{dark_tokens[name]}: {name}")
+        failures.append("  Give each a `:root` value, or delete it if nothing uses it.")
+
+    # 2 & 3. unresolvable var() references
+    assigned: set[str] = set()
+    uses: list[tuple[str, int, str]] = []
+    for path in _iter_sources():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        rel = path.relative_to(ROOT).as_posix()
+        assigned.update(ASSIGN_RE.findall(text))
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for name in USE_RE.findall(line):
+                uses.append((rel, lineno, name))
+
+    dangling = [(rel, lineno, name) for rel, lineno, name in uses if name not in assigned]
+    if dangling:
+        if failures:
+            failures.append("")
+        failures.append("`var()` on a property that is never assigned — the whole declaration is dropped:")
+        for rel, lineno, name in dangling:
+            near = _suggest(name, assigned)
+            failures.append(f"  {rel}:{lineno}: {name}{near}")
+
+    if not failures:
+        print(
+            "Design token guard: ok "
+            f"({len(root_tokens)} :root, {len(dark_tokens)} .dark, {len(uses)} var() references)"
+        )
+        return 0
+
+    print("\n".join(failures), file=sys.stderr)
+    print("", file=sys.stderr)
+    print("CSS fails open: an unresolvable var() renders as inherited, not as an error.", file=sys.stderr)
+    print("See DESIGN.md -> 'Tokens are the contract'.", file=sys.stderr)
+    return 1
+
+
+def _suggest(name: str, assigned: set[str]) -> str:
+    """Offer the closest defined token — these bugs are usually near-misses."""
+    import difflib
+
+    close = difflib.get_close_matches(name, sorted(assigned), n=1, cutoff=0.7)
+    return f" — did you mean {close[0]}?" if close else ""
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_design_tokens.py
+++ b/scripts/check_design_tokens.py
@@ -33,14 +33,18 @@ codebase fails, and it is why every instance of this class shipped:
 * ``--card-shadow`` was undefined, so the ``.card-shadow`` utility applied to
   two card components had never drawn a shadow.
 
-Three checks, one class:
+Four checks, one class:
 
 1. Every custom property assigned in ``.dark`` is also assigned in ``:root``.
    A dark-only token is always a bug — it cannot resolve in light mode. The
    converse is fine: theme-invariant tokens (``--radius``, ``--font-mono``,
    ``--glassmorphism-blur``) legitimately live in ``:root`` alone.
-2. Every ``var(--x)`` inside the stylesheet resolves.
-3. Every ``var(--x)`` in component source resolves.
+2. Every ``var(--x)`` inside the stylesheet resolves, including across newlines
+   (``var(\\n  --x\\n)`` is valid CSS and used to slip past a line-by-line scan).
+3. Every ``var(--x)`` in component source resolves, same rule.
+4. Every ``--status-*`` assignment and ``var(--status-*)`` reference is in the
+   documented exhaustive set. Defining ``--status-success`` in both theme blocks
+   used to satisfy checks 1–3 and still ship a name that is not a token.
 
 Only the fallback-less form is checked. ``var(--x, var(--border))`` remains a
 valid declaration when ``--x`` is undefined, so it is the sanctioned way to
@@ -78,8 +82,25 @@ SKIP_DIR_NAMES = {"node_modules", "dist", "__pycache__"}
 ASSIGN_RE = re.compile(r"""["']?(--[A-Za-z0-9_-]+)["']?\s*:""")
 # Only the fallback-less form is dangerous. `var(--x, var(--border))` stays
 # valid when --x is undefined, so it is the sanctioned way to reference an
-# optional token and is deliberately not flagged.
+# optional token and is deliberately not flagged. `\s*` is why this must run
+# over the whole file, not splitlines: `var(\n  --x\n)` is valid CSS.
 USE_RE = re.compile(r"var\(\s*(--[A-Za-z0-9_-]+)\s*\)")
+
+# DESIGN.md "Status" — exhaustive. There is no --status-success / --status-warning.
+STATUS_STEMS = (
+    "active",
+    "wanted",
+    "downloaded",
+    "paused",
+    "ended",
+    "error",
+    "skipped",
+)
+STATUS_TOKENS = frozenset(f"--status-{stem}{suffix}" for stem in STATUS_STEMS for suffix in ("", "-bg"))
+
+
+def _line_at(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
 
 
 def _block(css: str, selector: str) -> dict[str, int]:
@@ -122,21 +143,53 @@ def main() -> int:
             failures.append(f"  frontend/src/index.css:{dark_tokens[name]}: {name}")
         failures.append("  Give each a `:root` value, or delete it if nothing uses it.")
 
-    # 2 & 3. unresolvable var() references
+    # 2 & 3. unresolvable var() references. Scan the whole file so a var() that
+    # wraps its name across newlines still counts — CSS allows that, and the
+    # browser still drops the declaration if the name is undefined.
     assigned: set[str] = set()
     uses: list[tuple[str, int, str]] = []
+    unknown_status: list[tuple[str, int, str]] = []
+    seen_unknown: set[tuple[str, int, str]] = set()
+
+    def _note_unknown_status(rel: str, lineno: int, name: str) -> None:
+        if name.startswith("--status-") and name not in STATUS_TOKENS:
+            key = (rel, lineno, name)
+            if key not in seen_unknown:
+                seen_unknown.add(key)
+                unknown_status.append(key)
+
     for path in _iter_sources():
         try:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
         rel = path.relative_to(ROOT).as_posix()
-        assigned.update(ASSIGN_RE.findall(text))
-        for lineno, line in enumerate(text.splitlines(), 1):
-            for name in USE_RE.findall(line):
-                uses.append((rel, lineno, name))
+        for match in ASSIGN_RE.finditer(text):
+            name = match.group(1)
+            assigned.add(name)
+            _note_unknown_status(rel, _line_at(text, match.start()), name)
+        for match in USE_RE.finditer(text):
+            name = match.group(1)
+            lineno = _line_at(text, match.start())
+            uses.append((rel, lineno, name))
+            _note_unknown_status(rel, lineno, name)
 
-    dangling = [(rel, lineno, name) for rel, lineno, name in uses if name not in assigned]
+    if unknown_status:
+        if failures:
+            failures.append("")
+        failures.append(
+            "Unknown `--status-*` token — the set is exhaustive "
+            f"({', '.join(STATUS_STEMS)} and their `-bg` pairs; see DESIGN.md):"
+        )
+        for rel, lineno, name in unknown_status:
+            near = _suggest(name, STATUS_TOKENS)
+            failures.append(f"  {rel}:{lineno}: {name}{near}")
+
+    dangling = [
+        (rel, lineno, name)
+        for rel, lineno, name in uses
+        if name not in assigned and (rel, lineno, name) not in seen_unknown
+    ]
     if dangling:
         if failures:
             failures.append("")
@@ -147,8 +200,7 @@ def main() -> int:
 
     if not failures:
         print(
-            "Design token guard: ok "
-            f"({len(root_tokens)} :root, {len(dark_tokens)} .dark, {len(uses)} var() references)"
+            f"Design token guard: ok ({len(root_tokens)} :root, {len(dark_tokens)} .dark, {len(uses)} var() references)"
         )
         return 0
 
@@ -159,7 +211,7 @@ def main() -> int:
     return 1
 
 
-def _suggest(name: str, assigned: set[str]) -> str:
+def _suggest(name: str, assigned: set[str] | frozenset[str]) -> str:
     """Offer the closest defined token — these bugs are usually near-misses."""
     import difflib
 

--- a/scripts/check_palette_classes.py
+++ b/scripts/check_palette_classes.py
@@ -56,8 +56,12 @@ SRC = ROOT / "frontend" / "src"
 SCAN_SUFFIXES = {".ts", ".tsx"}
 SKIP_DIR_NAMES = {"node_modules", "dist", "__pycache__"}
 
+# Longer directional suffixes first so `border-ss-red-500` is not eaten as `border-s`.
 _UTILITIES = (
-    "text|bg|border|ring|from|to|via|decoration|outline|shadow|accent|caret|divide|fill|stroke"
+    r"(?:text|bg|from|to|via|decoration|outline|shadow|accent|caret|fill|stroke|placeholder)"
+    r"|border(?:-ss|-se|-es|-ee|-tl|-tr|-bl|-br|-s|-e|-[trblxy])?"
+    r"|divide(?:-[xy])?"
+    r"|ring(?:-offset)?"
 )
 _PALETTES = (
     "gray|slate|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|"
@@ -126,10 +130,7 @@ def main() -> int:
             stale.append(f"  {rel}: clean now — delete the entry ({allowed} recorded)")
 
     if not regressions and not stale:
-        print(
-            f"Palette class guard: ok ({sum(counts.values())} legacy usages "
-            f"in {len(counts)} file(s), none new)"
-        )
+        print(f"Palette class guard: ok ({sum(counts.values())} legacy usages in {len(counts)} file(s), none new)")
         return 0
 
     if regressions:

--- a/scripts/check_palette_classes.py
+++ b/scripts/check_palette_classes.py
@@ -1,0 +1,153 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""CI gate: no new raw Tailwind palette classes in the frontend.
+
+Comicarr ships light and dark. A palette literal — ``text-green-400``,
+``bg-red-500`` — is a fixed sRGB value with no dark-mode counterpart, so it
+ignores ``.dark`` entirely: the component is legible in the theme its author
+had open and wrong in the other. Unlike an unresolvable ``var()`` (see
+``check_design_tokens.py``) this renders *something* in both themes, which is
+why it accumulates without anyone filing a bug.
+
+Semantic colour belongs to the ``--status-*`` family; ``--destructive`` and
+``--muted-foreground`` cover the generic cases. Both are theme-aware.
+
+This gate is a ratchet, not a cliff. 58 usages across 11 files predate it, so
+the baseline below records the per-file count and the check fails when a count
+*rises* or a new file appears. It also fails when a count *falls* without the
+baseline being updated: a stale entry is a lie about the debt, and forcing the
+edit is what makes the number monotonically decrease. Same contract as the
+allowlist in ``check_attention_seam.py`` — the list only ever shrinks.
+
+To clear an entry: replace the literals with tokens, then lower the number
+here (or delete the line at zero).
+
+Rules and drift backlog: ``DESIGN.md``.
+
+Contributor-facing only — no changeset (CLAUDE.md).
+
+Wire-in: ``npm run lint:guards``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "frontend" / "src"
+
+SCAN_SUFFIXES = {".ts", ".tsx"}
+SKIP_DIR_NAMES = {"node_modules", "dist", "__pycache__"}
+
+_UTILITIES = (
+    "text|bg|border|ring|from|to|via|decoration|outline|shadow|accent|caret|divide|fill|stroke"
+)
+_PALETTES = (
+    "gray|slate|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|"
+    "teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose"
+)
+PALETTE_RE = re.compile(rf"\b(?:{_UTILITIES})-(?:{_PALETTES})-(?:50|[1-9]00|950)\b")
+
+# Paths are relative to frontend/src. This list only ever shrinks.
+BASELINE: dict[str, int] = {
+    "components/ai/ActivityFeedEntry.tsx": 13,
+    "components/import/ConfidenceBadge.tsx": 12,
+    "components/import/ImportTable.tsx": 3,
+    "components/import/MatchModal.tsx": 3,
+    "components/migration/MigrationWizard.tsx": 9,
+    "components/queue/BulkActionBar.tsx": 2,
+    "components/settings/AiTab.tsx": 2,
+    "components/storyarcs/ArcGenerator.tsx": 2,
+    "components/storyarcs/ArcIssueRow.tsx": 7,
+    "components/storyarcs/ArcIssueTable.tsx": 4,
+    "pages/StoryArcDetailPage.tsx": 1,
+}
+
+
+def _scan() -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for path in sorted(SRC.rglob("*")):
+        if not path.is_file() or path.suffix not in SCAN_SUFFIXES:
+            continue
+        if SKIP_DIR_NAMES.intersection(path.parts):
+            continue
+        try:
+            found = PALETTE_RE.findall(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+        if found:
+            counts[path.relative_to(SRC).as_posix()] = len(found)
+    return counts
+
+
+def _examples(rel: str, limit: int = 3) -> str:
+    text = (SRC / rel).read_text(encoding="utf-8")
+    seen: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), 1):
+        for hit in PALETTE_RE.findall(line):
+            if len(seen) < limit:
+                seen.append(f"{rel}:{lineno}: {hit}")
+    return "\n".join(f"      {s}" for s in seen)
+
+
+def main() -> int:
+    counts = _scan()
+    regressions: list[str] = []
+    stale: list[str] = []
+
+    for rel, found in sorted(counts.items()):
+        allowed = BASELINE.get(rel, 0)
+        if found > allowed:
+            label = f"{found} (baseline {allowed})" if allowed else f"{found}, file not in baseline"
+            regressions.append(f"  {rel}: {label}")
+            regressions.append(_examples(rel))
+        elif found < allowed:
+            stale.append(f"  {rel}: {found} now, baseline says {allowed} — lower it")
+
+    for rel, allowed in sorted(BASELINE.items()):
+        if rel not in counts:
+            stale.append(f"  {rel}: clean now — delete the entry ({allowed} recorded)")
+
+    if not regressions and not stale:
+        print(
+            f"Palette class guard: ok ({sum(counts.values())} legacy usages "
+            f"in {len(counts)} file(s), none new)"
+        )
+        return 0
+
+    if regressions:
+        print("New raw Tailwind palette classes — these ignore dark mode:", file=sys.stderr)
+        print("\n".join(regressions), file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Use a --status-* token, or --destructive / --muted-foreground.", file=sys.stderr)
+    if stale:
+        if regressions:
+            print("", file=sys.stderr)
+        print("Stale baseline in scripts/check_palette_classes.py:", file=sys.stderr)
+        print("\n".join(stale), file=sys.stderr)
+        print("", file=sys.stderr)
+        print("The baseline records real debt; update it so the count keeps falling.", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("See DESIGN.md -> 'Anti-Patterns / What NOT to Do'.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_design_token_guard.py
+++ b/tests/unit/test_design_token_guard.py
@@ -1,0 +1,115 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for scripts/check_design_tokens.py — unresolvable var() and invented --status-*."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "check_design_tokens.py"
+
+_MIN_CSS = """\
+:root {
+  --foreground: black;
+  --border: gray;
+  --status-active: green;
+}
+.dark {
+  --foreground: white;
+  --border: silver;
+  --status-active: lime;
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def guard():
+    spec = importlib.util.spec_from_file_location("check_design_tokens", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def _point_at(guard, monkeypatch, tmp_path, css, extra_files=None):
+    src = tmp_path / "frontend" / "src"
+    src.mkdir(parents=True)
+    (src / "index.css").write_text(css, encoding="utf-8")
+    for rel, content in (extra_files or {}).items():
+        path = src / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    monkeypatch.setattr(guard, "ROOT", tmp_path)
+    monkeypatch.setattr(guard, "SRC", src)
+    monkeypatch.setattr(guard, "STYLESHEET", src / "index.css")
+
+
+def test_real_tree_passes(guard):
+    """The repository is clean — this is the regression gate for the token contract."""
+    assert guard.main() == 0
+
+
+def test_status_set_is_the_documented_exhaustive_list(guard):
+    assert guard.STATUS_TOKENS == {
+        f"--status-{stem}{suffix}"
+        for stem in (
+            "active",
+            "wanted",
+            "downloaded",
+            "paused",
+            "ended",
+            "error",
+            "skipped",
+        )
+        for suffix in ("", "-bg")
+    }
+
+
+def test_invented_status_token_defined_in_both_themes_is_rejected(guard, tmp_path, monkeypatch, capsys):
+    """Assigning --status-success in :root and .dark is not enough to make it a token."""
+    css = _MIN_CSS.replace(
+        "  --status-active: green;\n",
+        "  --status-active: green;\n  --status-success: lime;\n",
+    ).replace(
+        "  --status-active: lime;\n",
+        "  --status-active: lime;\n  --status-success: lime;\n",
+    )
+    extra = {"Badge.tsx": 'export const c = "var(--status-success)";\n'}
+    _point_at(guard, monkeypatch, tmp_path, css, extra)
+    assert guard.main() == 1
+    err = capsys.readouterr().err
+    assert "--status-success" in err
+    assert "Unknown `--status-*` token" in err
+
+
+def test_multiline_var_reference_is_rejected(guard, tmp_path, monkeypatch, capsys):
+    extra = {"Box.tsx": ("export const c = {\n  color: `var(\n    --no-such-token\n  )`,\n};\n")}
+    _point_at(guard, monkeypatch, tmp_path, _MIN_CSS, extra)
+    assert guard.main() == 1
+    err = capsys.readouterr().err
+    assert "--no-such-token" in err
+
+
+def test_optional_fallback_form_is_not_flagged(guard, tmp_path, monkeypatch):
+    extra = {"Box.tsx": 'export const c = "var(--border-soft, var(--border))";\n'}
+    _point_at(guard, monkeypatch, tmp_path, _MIN_CSS, extra)
+    assert guard.main() == 0

--- a/tests/unit/test_palette_class_guard.py
+++ b/tests/unit/test_palette_class_guard.py
@@ -1,0 +1,76 @@
+#  Copyright (C) 2025–2026 Comicarr contributors
+#
+#  This file is part of Comicarr.
+#
+#  Comicarr is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Comicarr is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Comicarr.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for scripts/check_palette_classes.py — shrink-only raw Tailwind palette ratchet."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "check_palette_classes.py"
+
+
+@pytest.fixture(scope="module")
+def guard():
+    spec = importlib.util.spec_from_file_location("check_palette_classes", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def test_real_tree_passes(guard):
+    """The repository matches the recorded baseline — no new palette literals."""
+    assert guard.main() == 0
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        "text-red-500",
+        "bg-green-400",
+        "border-red-500",
+        "border-t-red-500",
+        "border-x-red-500",
+        "divide-red-500",
+        "divide-x-red-500",
+        "ring-red-500",
+        "ring-offset-red-500",
+        "placeholder-red-500",
+        "border-ss-rose-50",
+    ],
+)
+def test_palette_re_matches_supported_color_utilities(guard, cls):
+    assert guard.PALETTE_RE.search(cls), cls
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        "border-t-2",
+        "ring-offset-2",
+        "text-primary",
+        "bg-status-active",
+        "placeholder",
+    ],
+)
+def test_palette_re_ignores_non_palette_utilities(guard, cls):
+    assert not guard.PALETTE_RE.search(cls), cls


### PR DESCRIPTION
Writing down the design system surfaced a class of bug that CSS fails silently on: a `var()` naming an undefined property invalidates the whole declaration, so the style vanishes instead of erroring. This fixes every instance, adds two gates so the class can't come back, and lands `DESIGN.md` as the contract.

## What's changing

- **Fixes status colours that were missing or unreadable.** `--text-muted` was defined in `.dark` only, so 25 lines across 6 files rendered at inherited contrast in light mode. `--status-success` and `--status-warning` were never tokens at all — 17 usages, and since most sit inside `color-mix(in oklab, var(--status-success) 36%, transparent)` the invalid inner var voided the entire colour, leaving Acquisition Health's "ready" and "warning" badges and tiles as plain boxes in *both* themes. The mislabeled `--success`/`--warning`/`--error`/`--info` quartet (shadcn *surface* values wearing *text* names, registered in `@theme inline`, so `text-success` compiled clean and rendered near-white on a white page) is deleted. Carries a patch changeset.
- **Adds two contributor gates under `lint:guards`.** `check_design_tokens.py` closes the whole class — no `.dark`-only tokens, no fallback-less `var()` naming an unassigned property — with no allowlist, because the class is now at zero. `check_palette_classes.py` holds a shrink-only per-file baseline over the 58 remaining raw Tailwind palette literals; counts that rise *or* fall without updating the baseline both fail, same ratchet as `check_attention_seam.py`.
- **Adds `DESIGN.md`.** Tokens, theming, typography, primitives, and an anti-pattern list in `CLAUDE.md`'s style, plus a drift table with the numbers and the commands that reproduce them. Pointers from `CLAUDE.md` and `AGENTS.md`.

## Notes for review

- `.card-shadow` had never drawn a shadow (`--card-shadow` undefined) on two live card components. I **deleted** it rather than backfilling a value — removing it is provably no visual change, inventing a shadow is a design decision. **If cards are meant to have shadows, that's a real gap and it's your call.**
- `--border-soft` stays undefined on purpose: its three call sites all write `var(--border-soft, var(--border))`, which is valid without it. The guard deliberately permits that fallback form.
- Recorded but not changed: `--text-muted` sits at 2.95:1 in both themes, under the AA threshold. The new light value was matched to the ratio dark already shipped so the themes agree; raising both is a design decision, not a bug fix.

## Verification

`npm run lint` clean (0 errors, 21 pre-existing `react-refresh` warnings), `tsc --noEmit` clean, 470/470 frontend tests pass. Production build confirms the removed tokens are absent from the compiled CSS and `--text-muted` ships in both themes. Both guards were tested against real regressions in each direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored clear status colours for acquisition health badges, metrics, confirmation banners, and build verification indicators.
  - Updated manual import confirmations to display in green.
  - Restored the green styling on library scan summaries.
  - Improved muted text and separator contrast in light mode across series, issue, search, and releases pages.
  - Corrected informational toast icon and border colours.
- **Style**
  - Simplified search and series card styling by removing unnecessary shadow and border treatments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->